### PR TITLE
ci: PR test workflow (frontend + backend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+# Run the test suites on every PR into dev or main so nothing merges red.
+on:
+  pull_request:
+    branches: [dev, main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: frontend
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Type-check & build
+        run: npm run build
+      - name: Unit tests
+        run: npx vitest run
+
+  backend:
+    name: backend
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      # The Tauri lib + gssapi-auth feature need these system libs to compile.
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libssl-dev \
+            libkrb5-dev \
+            clang \
+            libclang-dev \
+            build-essential
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: cargo test
+        run: cargo test --manifest-path src-tauri/Cargo.toml


### PR DESCRIPTION
Adds a CI workflow that runs the frontend suite (tsc + vite build + vitest) and backend `cargo test` on every PR into `dev` or `main`, so nothing merges red. Installs the webkit + krb5/clang deps the gssapi-auth feature needs.