### PR TITLE
feat(app): window auto-size across monitors + Linux app name

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6095,6 +6095,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "tauri-plugin-window-state",
  "tokio",
  "uuid",
 ]
@@ -6239,6 +6240,21 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 mongodb = { version = "3.0.0", features = ["aws-auth", "gssapi-auth"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,17 @@ pub fn apply_main_timeouts(opts: &mut mongodb::options::ClientOptions) {
     }
 }
 
+/// First-run window size: ~85% of the monitor's logical area, clamped so it
+/// never drops below the minimum window size or exceeds the monitor itself.
+pub fn target_window_size(monitor_w_px: u32, monitor_h_px: u32, scale: f64) -> (f64, f64) {
+    let scale = if scale <= 0.0 { 1.0 } else { scale };
+    let max_w = monitor_w_px as f64 / scale;
+    let max_h = monitor_h_px as f64 / scale;
+    let w = (max_w * 0.85).clamp(800.0_f64.min(max_w), max_w);
+    let h = (max_h * 0.85).clamp(600.0_f64.min(max_h), max_h);
+    (w, h)
+}
+
 pub struct AppState {
     pub connections: Mutex<HashMap<String, Client>>,
     pub mocks: Mutex<HashMap<String, bool>>,
@@ -3113,6 +3124,31 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .setup(|app| {
+            use tauri::Manager;
+            if let Some(win) = app.get_webview_window("main") {
+                // First launch (before the window-state plugin has saved anything):
+                // size the window to ~85% of the current monitor and center it.
+                let first_run = app
+                    .path()
+                    .app_config_dir()
+                    .map(|d| !d.join(".window-state.json").exists())
+                    .unwrap_or(true);
+                if first_run {
+                    if let Ok(Some(monitor)) = win.current_monitor() {
+                        let (w, h) = target_window_size(
+                            monitor.size().width,
+                            monitor.size().height,
+                            monitor.scale_factor(),
+                        );
+                        let _ = win.set_size(tauri::LogicalSize::new(w, h));
+                        let _ = win.center();
+                    }
+                }
+            }
+            Ok(())
+        })
         .manage(AppState::new())
         .invoke_handler(tauri::generate_handler![
             connect_db,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1605,6 +1605,22 @@ mod tests {
         }
     }
 
+    // GO-LIVE: first-run window sizing fits the monitor and respects bounds.
+    #[test]
+    fn test_target_window_size_fits_monitor() {
+        use crate::target_window_size;
+        // 4K @ 2x scale -> 85% of logical 1920x1080 = 1632x918.
+        let (w, h) = target_window_size(3840, 2160, 2.0);
+        assert!((w - 1632.0).abs() < 1.0, "w={}", w);
+        assert!((h - 918.0).abs() < 1.0, "h={}", h);
+        // 1280x800 @1x -> 85% = 1088x680 (above the 800x600 floor).
+        let (w2, h2) = target_window_size(1280, 800, 1.0);
+        assert!((w2 - 1088.0).abs() < 1.0 && (h2 - 680.0).abs() < 1.0);
+        // A small monitor never yields a window larger than the monitor.
+        let (w3, h3) = target_window_size(1024, 640, 1.0);
+        assert!(w3 <= 1024.0 && h3 <= 640.0);
+    }
+
     #[tokio::test]
     async fn test_apply_main_timeouts_preserves_uri_values() {
         // M2: timeouts supplied in the URI must win over the 10s default.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MQLens",
+  "mainBinaryName": "MQLens",
   "version": "0.1.0",
   "identifier": "com.mqlens.app",
   "build": {
@@ -15,6 +16,10 @@
         "title": "MQLens",
         "width": 1200,
         "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
+        "resizable": true,
+        "center": true,
         "windowEffects": {
           "effects": ["mica", "sidebar"],
           "state": "active"


### PR DESCRIPTION
Window now adapts to the display: remembers size/position/monitor across launches (tauri-plugin-window-state) and on first run opens at ~85% of the current monitor, centered, resizable with a min size. Also sets `mainBinaryName=MQLens` so Linux shows 'MQLens' instead of 'tauri-app'/'tauri'. Backend 61 tests pass (incl. target_window_size).