### PR TITLE
refactor(rust): extract window.rs (module-split slice 1)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,17 +45,6 @@ pub fn apply_main_timeouts(opts: &mut mongodb::options::ClientOptions) {
     }
 }
 
-/// First-run window size: ~85% of the monitor's logical area, clamped so it
-/// never drops below the minimum window size or exceeds the monitor itself.
-pub fn target_window_size(monitor_w_px: u32, monitor_h_px: u32, scale: f64) -> (f64, f64) {
-    let scale = if scale <= 0.0 { 1.0 } else { scale };
-    let max_w = monitor_w_px as f64 / scale;
-    let max_h = monitor_h_px as f64 / scale;
-    let w = (max_w * 0.85).clamp(800.0_f64.min(max_w), max_w);
-    let h = (max_h * 0.85).clamp(600.0_f64.min(max_h), max_h);
-    (w, h)
-}
-
 pub struct AppState {
     pub connections: Mutex<HashMap<String, Client>>,
     pub mocks: Mutex<HashMap<String, bool>>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,8 @@ mod mock_db;
 pub mod queries;
 pub mod ssh_tunnel;
 mod vault;
+mod window;
+pub use window::target_window_size;
 #[cfg(test)]
 mod tests;
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1605,22 +1605,6 @@ mod tests {
         }
     }
 
-    // GO-LIVE: first-run window sizing fits the monitor and respects bounds.
-    #[test]
-    fn test_target_window_size_fits_monitor() {
-        use crate::target_window_size;
-        // 4K @ 2x scale -> 85% of logical 1920x1080 = 1632x918.
-        let (w, h) = target_window_size(3840, 2160, 2.0);
-        assert!((w - 1632.0).abs() < 1.0, "w={}", w);
-        assert!((h - 918.0).abs() < 1.0, "h={}", h);
-        // 1280x800 @1x -> 85% = 1088x680 (above the 800x600 floor).
-        let (w2, h2) = target_window_size(1280, 800, 1.0);
-        assert!((w2 - 1088.0).abs() < 1.0 && (h2 - 680.0).abs() < 1.0);
-        // A small monitor never yields a window larger than the monitor.
-        let (w3, h3) = target_window_size(1024, 640, 1.0);
-        assert!(w3 <= 1024.0 && h3 <= 640.0);
-    }
-
     #[tokio::test]
     async fn test_apply_main_timeouts_preserves_uri_values() {
         // M2: timeouts supplied in the URI must win over the 10s default.

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -1,0 +1,31 @@
+//! Main-window sizing helpers.
+
+/// First-run window size: ~85% of the monitor's logical area, clamped so it
+/// never drops below the minimum window size or exceeds the monitor itself.
+pub fn target_window_size(monitor_w_px: u32, monitor_h_px: u32, scale: f64) -> (f64, f64) {
+    let scale = if scale <= 0.0 { 1.0 } else { scale };
+    let max_w = monitor_w_px as f64 / scale;
+    let max_h = monitor_h_px as f64 / scale;
+    let w = (max_w * 0.85).clamp(800.0_f64.min(max_w), max_w);
+    let h = (max_h * 0.85).clamp(600.0_f64.min(max_h), max_h);
+    (w, h)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::target_window_size;
+
+    #[test]
+    fn fits_monitor_and_respects_bounds() {
+        // 4K @ 2x scale -> 85% of logical 1920x1080 = 1632x918.
+        let (w, h) = target_window_size(3840, 2160, 2.0);
+        assert!((w - 1632.0).abs() < 1.0, "w={}", w);
+        assert!((h - 918.0).abs() < 1.0, "h={}", h);
+        // 1280x800 @1x -> 85% = 1088x680 (above the 800x600 floor).
+        let (w2, h2) = target_window_size(1280, 800, 1.0);
+        assert!((w2 - 1088.0).abs() < 1.0 && (h2 - 680.0).abs() < 1.0);
+        // A small monitor never yields a window larger than the monitor.
+        let (w3, h3) = target_window_size(1024, 640, 1.0);
+        assert!(w3 <= 1024.0 && h3 <= 640.0);
+    }
+}


### PR DESCRIPTION
First slice of the lib.rs module split: move window-sizing (`target_window_size` + test) into `window.rs`, re-exported from lib.rs so nothing else changes. cargo test green (60). Subsequent slices: state.rs, db/*, mongosh, exporting, connections split.