### PR TITLE
refactor(rust): extract state.rs (module-split slice 2)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,20 +16,12 @@ mod mock_db;
 pub mod queries;
 pub mod ssh_tunnel;
 mod vault;
+mod state;
 mod window;
+pub use state::{AppState, LockExt};
 pub use window::target_window_size;
 #[cfg(test)]
 mod tests;
-
-/// Lock a std mutex, mapping a poisoned lock to an error instead of panicking.
-trait LockExt<T> {
-    fn lock_safe(&self) -> Result<std::sync::MutexGuard<'_, T>, String>;
-}
-impl<T> LockExt<T> for std::sync::Mutex<T> {
-    fn lock_safe(&self) -> Result<std::sync::MutexGuard<'_, T>, String> {
-        self.lock().map_err(|_| "internal state lock poisoned".to_string())
-    }
-}
 
 /// Connect + server-selection timeout for the main (non-test) connection path.
 const MAIN_CONNECT_TIMEOUT_SECS: u64 = 10;
@@ -44,40 +36,6 @@ pub fn apply_main_timeouts(opts: &mut mongodb::options::ClientOptions) {
     if opts.server_selection_timeout.is_none() {
         opts.server_selection_timeout =
             Some(std::time::Duration::from_secs(MAIN_CONNECT_TIMEOUT_SECS));
-    }
-}
-
-pub struct AppState {
-    pub connections: Mutex<HashMap<String, Client>>,
-    pub mocks: Mutex<HashMap<String, bool>>,
-    pub mock_indexes: Mutex<HashMap<String, Vec<IndexInfo>>>,
-    pub mongosh_sessions: Mutex<HashMap<String, Arc<MongoshSession>>>,
-    pub tasks: Arc<Mutex<HashMap<String, TaskInfo>>>,
-    // Live SSH tunnels keyed by connection id; dropped on disconnect to tear down.
-    pub ssh_tunnels: Mutex<HashMap<String, ssh_tunnel::SshTunnel>>,
-    // Persisted across polls so CPU usage can be sampled as a delta.
-    pub sys: Mutex<sysinfo::System>,
-    // In-memory vault key; None when locked or uninitialized.
-    pub vault_key: Mutex<Option<[u8; 32]>>,
-}
-
-impl AppState {
-    pub fn new() -> Self {
-        Self {
-            connections: Mutex::new(HashMap::new()),
-            mocks: Mutex::new(HashMap::new()),
-            mock_indexes: Mutex::new(HashMap::new()),
-            mongosh_sessions: Mutex::new(HashMap::new()),
-            tasks: Arc::new(Mutex::new(HashMap::new())),
-            ssh_tunnels: Mutex::new(HashMap::new()),
-            sys: Mutex::new(sysinfo::System::new()),
-            vault_key: Mutex::new(None),
-        }
-    }
-
-    /// The in-memory vault key, or an error if the vault is locked.
-    pub fn require_key(&self) -> Result<[u8; 32], String> {
-        self.vault_key.lock_safe()?.ok_or_else(|| "vault is locked".to_string())
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,0 +1,50 @@
+//! Shared application state and a poison-safe mutex helper.
+
+use crate::{ssh_tunnel, IndexInfo, MongoshSession, TaskInfo};
+use mongodb::Client;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Lock a std mutex, mapping a poisoned lock to an error instead of panicking.
+pub trait LockExt<T> {
+    fn lock_safe(&self) -> Result<std::sync::MutexGuard<'_, T>, String>;
+}
+impl<T> LockExt<T> for std::sync::Mutex<T> {
+    fn lock_safe(&self) -> Result<std::sync::MutexGuard<'_, T>, String> {
+        self.lock().map_err(|_| "internal state lock poisoned".to_string())
+    }
+}
+
+pub struct AppState {
+    pub connections: Mutex<HashMap<String, Client>>,
+    pub mocks: Mutex<HashMap<String, bool>>,
+    pub mock_indexes: Mutex<HashMap<String, Vec<IndexInfo>>>,
+    pub mongosh_sessions: Mutex<HashMap<String, Arc<MongoshSession>>>,
+    pub tasks: Arc<Mutex<HashMap<String, TaskInfo>>>,
+    // Live SSH tunnels keyed by connection id; dropped on disconnect to tear down.
+    pub ssh_tunnels: Mutex<HashMap<String, ssh_tunnel::SshTunnel>>,
+    // Persisted across polls so CPU usage can be sampled as a delta.
+    pub sys: Mutex<sysinfo::System>,
+    // In-memory vault key; None when locked or uninitialized.
+    pub vault_key: Mutex<Option<[u8; 32]>>,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self {
+            connections: Mutex::new(HashMap::new()),
+            mocks: Mutex::new(HashMap::new()),
+            mock_indexes: Mutex::new(HashMap::new()),
+            mongosh_sessions: Mutex::new(HashMap::new()),
+            tasks: Arc::new(Mutex::new(HashMap::new())),
+            ssh_tunnels: Mutex::new(HashMap::new()),
+            sys: Mutex::new(sysinfo::System::new()),
+            vault_key: Mutex::new(None),
+        }
+    }
+
+    /// The in-memory vault key, or an error if the vault is locked.
+    pub fn require_key(&self) -> Result<[u8; 32], String> {
+        self.vault_key.lock_safe()?.ok_or_else(|| "vault is locked".to_string())
+    }
+}


### PR DESCRIPTION
Moves `AppState` + the `LockExt` mutex helper into `state.rs`, re-exported from lib.rs so nothing else changes. cargo test green (60). Verified before commit this time.