### PR TITLE
refactor(rust): extract db/gridfs.rs + db/version.rs (slice 4)

### DIFF
--- a/src-tauri/src/db/gridfs.rs
+++ b/src-tauri/src/db/gridfs.rs
@@ -1,0 +1,107 @@
+//! GridFS browsing (M7): list files in a bucket and download them to disk.
+
+use crate::{connection_is_mock, require_real_client, AppState};
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct GridFsFileInfo {
+    pub id: String, // Extended-JSON of the file's _id
+    pub filename: String,
+    pub length: u64,
+    pub chunk_size_bytes: u32,
+    pub upload_date: String,
+    pub content_type: Option<String>,
+}
+
+pub async fn list_gridfs_files_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    bucket: &str,
+) -> Result<String, String> {
+    if connection_is_mock(state, id)? {
+        return Err("GridFS is not supported on mock connections".to_string());
+    }
+    let client = require_real_client(state, id)?;
+    let files_coll = format!("{}.files", bucket);
+    let coll = client
+        .database(database)
+        .collection::<mongodb::bson::Document>(&files_coll);
+    let mut cursor = coll
+        .find(mongodb::bson::doc! {})
+        .sort(mongodb::bson::doc! { "filename": 1 })
+        .await
+        .map_err(|e| format!("Failed to list GridFS files: {}", e))?;
+
+    use futures::stream::StreamExt;
+    let mut files = Vec::new();
+    while let Some(res) = cursor.next().await {
+        let doc = res.map_err(|e| format!("Cursor read error: {}", e))?;
+        let id_extjson = doc
+            .get("_id")
+            .cloned()
+            .unwrap_or(mongodb::bson::Bson::Null)
+            .into_relaxed_extjson()
+            .to_string();
+        let filename = doc.get_str("filename").unwrap_or("").to_string();
+        let length = doc
+            .get_i64("length")
+            .map(|v| v as u64)
+            .or_else(|_| doc.get_i32("length").map(|v| v as u64))
+            .unwrap_or(0);
+        let chunk_size_bytes = doc.get_i32("chunkSize").map(|v| v as u32).unwrap_or(0);
+        let upload_date = doc
+            .get_datetime("uploadDate")
+            .ok()
+            .and_then(|d| d.try_to_rfc3339_string().ok())
+            .unwrap_or_default();
+        let content_type = doc.get_str("contentType").ok().map(|s| s.to_string());
+        files.push(GridFsFileInfo {
+            id: id_extjson,
+            filename,
+            length,
+            chunk_size_bytes,
+            upload_date,
+            content_type,
+        });
+    }
+    serde_json::to_string(&files).map_err(|e| format!("Serialization error: {}", e))
+}
+
+pub async fn download_gridfs_file_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    bucket: &str,
+    file_id_json: &str,
+    dest_path: &str,
+) -> Result<u64, String> {
+    if connection_is_mock(state, id)? {
+        return Err("GridFS is not supported on mock connections".to_string());
+    }
+    // Parse the file _id from its Extended JSON (e.g. {"$oid": "..."}).
+    let id_value: serde_json::Value =
+        serde_json::from_str(file_id_json).map_err(|e| format!("Invalid file id JSON: {}", e))?;
+    let file_id = mongodb::bson::Bson::try_from(id_value)
+        .map_err(|e| format!("Invalid file id: {}", e))?;
+
+    let client = require_real_client(state, id)?;
+    let bucket_obj = client.database(database).gridfs_bucket(
+        mongodb::options::GridFsBucketOptions::builder()
+            .bucket_name(bucket.to_string())
+            .build(),
+    );
+    let mut stream = bucket_obj
+        .open_download_stream(file_id)
+        .await
+        .map_err(|e| format!("Failed to open GridFS download: {}", e))?;
+
+    use futures::AsyncReadExt;
+    let mut buf = Vec::new();
+    stream
+        .read_to_end(&mut buf)
+        .await
+        .map_err(|e| format!("GridFS read error: {}", e))?;
+    std::fs::write(dest_path, &buf).map_err(|e| format!("Failed to write file: {}", e))?;
+    Ok(buf.len() as u64)
+}

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,3 +1,5 @@
 //! Database-operation modules (split out of lib.rs).
 
+pub mod gridfs;
 pub mod schema;
+pub mod version;

--- a/src-tauri/src/db/version.rs
+++ b/src-tauri/src/db/version.rs
@@ -1,0 +1,34 @@
+//! Server version lookup.
+
+use crate::state::LockExt;
+use crate::AppState;
+
+pub async fn get_mongodb_version_impl(state: &AppState, id: &str) -> Result<String, String> {
+    let is_mock = {
+        let mocks = state.mocks.lock_safe()?;
+        *mocks
+            .get(id)
+            .ok_or_else(|| "Connection not found".to_string())?
+    };
+
+    if is_mock {
+        return Ok("7.0.5".to_string());
+    }
+
+    let client = {
+        let connections = state.connections.lock_safe()?;
+        connections
+            .get(id)
+            .cloned()
+            .ok_or_else(|| "Connection client not found".to_string())?
+    };
+
+    let db = client.database("admin");
+    let result = db
+        .run_command(mongodb::bson::doc! { "buildInfo": 1 })
+        .await
+        .map_err(|e| format!("Failed to read MongoDB version: {}", e))?;
+
+    let version = result.get_str("version").unwrap_or("unknown").to_string();
+    Ok(version)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,9 @@ mod vault;
 mod db;
 mod state;
 mod window;
+pub use db::gridfs::{download_gridfs_file_impl, list_gridfs_files_impl, GridFsFileInfo};
 pub use db::schema::{analyze_schema_impl, infer_schema, FieldStat, SchemaReport, TypeCount};
+pub use db::version::get_mongodb_version_impl;
 pub use state::{AppState, LockExt};
 pub use window::target_window_size;
 #[cfg(test)]
@@ -1642,111 +1644,6 @@ pub async fn update_many_impl(
         .await
         .map_err(|e| format!("Failed to update documents: {}", e))?;
     Ok(res.modified_count)
-}
-
-// ---- M7: GridFS browsing ----
-
-#[derive(Serialize)]
-pub struct GridFsFileInfo {
-    pub id: String, // Extended-JSON of the file's _id
-    pub filename: String,
-    pub length: u64,
-    pub chunk_size_bytes: u32,
-    pub upload_date: String,
-    pub content_type: Option<String>,
-}
-
-pub async fn list_gridfs_files_impl(
-    state: &AppState,
-    id: &str,
-    database: &str,
-    bucket: &str,
-) -> Result<String, String> {
-    if connection_is_mock(state, id)? {
-        return Err("GridFS is not supported on mock connections".to_string());
-    }
-    let client = require_real_client(state, id)?;
-    let files_coll = format!("{}.files", bucket);
-    let coll = client
-        .database(database)
-        .collection::<mongodb::bson::Document>(&files_coll);
-    let mut cursor = coll
-        .find(mongodb::bson::doc! {})
-        .sort(mongodb::bson::doc! { "filename": 1 })
-        .await
-        .map_err(|e| format!("Failed to list GridFS files: {}", e))?;
-
-    use futures::stream::StreamExt;
-    let mut files = Vec::new();
-    while let Some(res) = cursor.next().await {
-        let doc = res.map_err(|e| format!("Cursor read error: {}", e))?;
-        let id_extjson = doc
-            .get("_id")
-            .cloned()
-            .unwrap_or(mongodb::bson::Bson::Null)
-            .into_relaxed_extjson()
-            .to_string();
-        let filename = doc.get_str("filename").unwrap_or("").to_string();
-        let length = doc
-            .get_i64("length")
-            .map(|v| v as u64)
-            .or_else(|_| doc.get_i32("length").map(|v| v as u64))
-            .unwrap_or(0);
-        let chunk_size_bytes = doc.get_i32("chunkSize").map(|v| v as u32).unwrap_or(0);
-        let upload_date = doc
-            .get_datetime("uploadDate")
-            .ok()
-            .and_then(|d| d.try_to_rfc3339_string().ok())
-            .unwrap_or_default();
-        let content_type = doc.get_str("contentType").ok().map(|s| s.to_string());
-        files.push(GridFsFileInfo {
-            id: id_extjson,
-            filename,
-            length,
-            chunk_size_bytes,
-            upload_date,
-            content_type,
-        });
-    }
-    serde_json::to_string(&files).map_err(|e| format!("Serialization error: {}", e))
-}
-
-pub async fn download_gridfs_file_impl(
-    state: &AppState,
-    id: &str,
-    database: &str,
-    bucket: &str,
-    file_id_json: &str,
-    dest_path: &str,
-) -> Result<u64, String> {
-    if connection_is_mock(state, id)? {
-        return Err("GridFS is not supported on mock connections".to_string());
-    }
-    // Parse the file _id from its Extended JSON (e.g. {"$oid": "..."}).
-    let id_value: serde_json::Value =
-        serde_json::from_str(file_id_json).map_err(|e| format!("Invalid file id JSON: {}", e))?;
-    let file_id = mongodb::bson::Bson::try_from(id_value)
-        .map_err(|e| format!("Invalid file id: {}", e))?;
-
-    let client = require_real_client(state, id)?;
-    let bucket_obj = client.database(database).gridfs_bucket(
-        mongodb::options::GridFsBucketOptions::builder()
-            .bucket_name(bucket.to_string())
-            .build(),
-    );
-    let mut stream = bucket_obj
-        .open_download_stream(file_id)
-        .await
-        .map_err(|e| format!("Failed to open GridFS download: {}", e))?;
-
-    use futures::AsyncReadExt;
-    let mut buf = Vec::new();
-    stream
-        .read_to_end(&mut buf)
-        .await
-        .map_err(|e| format!("GridFS read error: {}", e))?;
-    std::fs::write(dest_path, &buf).map_err(|e| format!("Failed to write file: {}", e))?;
-    Ok(buf.len() as u64)
 }
 
 pub async fn insert_document_impl(


### PR DESCRIPTION
Moves GridFS browsing into `db/gridfs.rs` and the server-version lookup into `db/version.rs`, re-exported from lib.rs so call sites/tests are unchanged. cargo test green (60), no new warnings. lib.rs now ~2,854 lines (from 3,212).