### PR TITLE
test(rust): MongoDB integration tests — backend coverage 50% → ~77%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,22 @@ jobs:
   backend:
     name: backend
     runs-on: ubuntu-22.04
+    # A real MongoDB so the integration tests can exercise the live query/aggregate/
+    # DDL/document/export/GridFS/schema paths (the bulk of the backend). Without it
+    # those tests no-op and coverage drops well below the gate below.
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ ping: 1 }).ok'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # Integration tests read this; when unset they skip (keeps `cargo test` green offline).
+      MQLENS_TEST_MONGO_URI: mongodb://localhost:27017
     steps:
       - uses: actions/checkout@v4
       # The Tauri lib + gssapi-auth feature need these system libs to compile.
@@ -66,4 +82,5 @@ jobs:
         with:
           workspaces: src-tauri
       - name: Backend tests with coverage
-        run: cargo llvm-cov --manifest-path src-tauri/Cargo.toml --summary-only
+        # Fail the build if line coverage drops below 70% (the agreed target floor).
+        run: cargo llvm-cov --manifest-path src-tauri/Cargo.toml --summary-only --fail-under-lines 70 --ignore-filename-regex 'src-tauri/src/(lib|main)\.rs'

--- a/README.md
+++ b/README.md
@@ -77,8 +77,18 @@ npm run dev            # frontend only (browser, no Tauri APIs)
 npm test               # frontend tests (Vitest)
 npm run coverage:frontend   # frontend tests with coverage
 cargo test --manifest-path src-tauri/Cargo.toml   # backend tests
-cargo llvm-cov --manifest-path src-tauri/Cargo.toml --summary-only   # backend coverage
+cargo llvm-cov --manifest-path src-tauri/Cargo.toml --summary-only --ignore-filename-regex 'src-tauri/src/(lib|main)\.rs'   # backend coverage
 npm run build          # type-check + build the frontend bundle
+```
+
+The backend integration tests (and the coverage figure CI reports) need a real
+MongoDB. They skip automatically when `MQLENS_TEST_MONGO_URI` is unset, so set it
+to exercise the live database paths:
+
+```bash
+docker run -d -p 27017:27017 mongo:7
+MQLENS_TEST_MONGO_URI=mongodb://localhost:27017 \
+  cargo llvm-cov --manifest-path src-tauri/Cargo.toml --summary-only --ignore-filename-regex 'src-tauri/src/(lib|main)\.rs'
 ```
 
 ## Build

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tauri": "tauri",
     "test": "vitest run",
     "coverage:frontend": "vitest run --coverage",
-    "coverage:backend": "cargo llvm-cov --manifest-path src-tauri/Cargo.toml --summary-only",
+    "coverage:backend": "cargo llvm-cov --manifest-path src-tauri/Cargo.toml --summary-only --ignore-filename-regex 'src-tauri/src/(lib|main)\\.rs'",
     "coverage": "npm run coverage:frontend && npm run coverage:backend"
   },
   "dependencies": {

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -1,0 +1,684 @@
+//! Integration tests that exercise the real-MongoDB code paths (find/count/explain,
+//! aggregate, DDL, document CRUD + import, export, GridFS, schema, version, the live
+//! connection test). These are the seams that the mock connection can't reach.
+//!
+//! They run ONLY when `MQLENS_TEST_MONGO_URI` points at a reachable MongoDB; otherwise
+//! every test no-ops (returns early) so `cargo test` stays green without a server. CI
+//! sets the variable against a service container. Each test uses a uniquely-named
+//! database and drops it on the way out, so runs are isolated and self-cleaning.
+
+#[cfg(test)]
+mod integration {
+    use crate::{
+        analyze_schema_impl, connect_db_impl, count_documents_impl, create_collection_impl,
+        create_index_impl, create_view_impl, delete_document_impl, delete_index_impl,
+        delete_many_impl, disconnect_db_impl, download_gridfs_file_impl, drop_collection_impl,
+        drop_database_impl, execute_aggregate_impl, execute_mql_query_impl,
+        explain_aggregate_query_impl, explain_mql_query_impl, get_mongodb_version_impl,
+        import_documents_impl, insert_document_impl, list_collections_impl, list_databases_impl,
+        list_gridfs_files_impl, list_indexes_impl, rename_collection_impl, rename_database_impl,
+        start_collection_export_impl, update_document_impl, update_many_impl, AppState,
+    };
+    use mongodb::bson::{doc, Document};
+
+    fn test_mongo_uri() -> Option<String> {
+        std::env::var("MQLENS_TEST_MONGO_URI")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+    }
+
+    /// Connect to the test MongoDB and hand back a unique database name, or None to skip.
+    async fn connect() -> Option<(AppState, String, String)> {
+        let uri = test_mongo_uri()?;
+        let state = AppState::new();
+        let id = connect_db_impl(&state, &uri, None)
+            .await
+            .expect("should connect to MQLENS_TEST_MONGO_URI");
+        let db = format!("mqlens_it_{}", uuid::Uuid::new_v4().simple());
+        Some((state, id, db))
+    }
+
+    fn client_of(state: &AppState, id: &str) -> mongodb::Client {
+        state.connections.lock().unwrap().get(id).cloned().unwrap()
+    }
+
+    async fn seed(state: &AppState, id: &str, db: &str, coll: &str, docs: Vec<Document>) {
+        client_of(state, id)
+            .database(db)
+            .collection::<Document>(coll)
+            .insert_many(docs)
+            .await
+            .expect("seed insert_many");
+    }
+
+    async fn cleanup(state: &AppState, id: &str, db: &str) {
+        let _ = client_of(state, id).database(db).drop().await;
+        let _ = disconnect_db_impl(state, id).await;
+    }
+
+    async fn wait_for_task(state: &AppState, task_id: &str) -> crate::TaskInfo {
+        for _ in 0..200 {
+            let info = state.tasks.lock().unwrap().get(task_id).cloned();
+            if let Some(info) = info {
+                if info.status != "running" {
+                    return info;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        state
+            .tasks
+            .lock()
+            .unwrap()
+            .get(task_id)
+            .cloned()
+            .expect("task should exist")
+    }
+
+    #[tokio::test]
+    async fn it_connect_ping_and_version() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        // The real version path runs buildInfo against admin.
+        let version = get_mongodb_version_impl(&state, &id)
+            .await
+            .expect("real version");
+        assert!(
+            version.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false),
+            "version should look like a number, got {version}"
+        );
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_query_find_count_explain() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        seed(
+            &state,
+            &id,
+            &db,
+            "products",
+            vec![
+                doc! { "name": "A", "category": "Electronics", "price": 100, "stock": 5 },
+                doc! { "name": "B", "category": "Electronics", "price": 200, "stock": 1 },
+                doc! { "name": "C", "category": "Books", "price": 20, "stock": 9 },
+            ],
+        )
+        .await;
+
+        // Find with filter + sort + projection + limit + skip (all real builder branches).
+        let results = execute_mql_query_impl(
+            &state,
+            &id,
+            &db,
+            "products",
+            r#"{"category":"Electronics"}"#,
+            r#"{"price":-1}"#,
+            r#"{"name":1,"_id":0}"#,
+            1,
+            0,
+        )
+        .await
+        .expect("real find");
+        assert_eq!(results.len(), 1);
+        let first: serde_json::Value = serde_json::from_str(&results[0]).unwrap();
+        assert_eq!(first["name"], "B", "highest price first");
+
+        // Skip path.
+        let skipped = execute_mql_query_impl(
+            &state, &id, &db, "products", r#"{"category":"Electronics"}"#, r#"{"price":1}"#, "{}",
+            10, 1,
+        )
+        .await
+        .expect("real find with skip");
+        assert_eq!(skipped.len(), 1);
+
+        // Count: empty filter (estimated_document_count) and a real filter (count_documents).
+        let total = count_documents_impl(&state, &id, &db, "products", "{}")
+            .await
+            .expect("estimated count");
+        assert_eq!(total, 3);
+        let electronics = count_documents_impl(
+            &state,
+            &id,
+            &db,
+            "products",
+            r#"{"category":"Electronics"}"#,
+        )
+        .await
+        .expect("filtered count");
+        assert_eq!(electronics, 2);
+
+        // Explain runs the real explain command.
+        let explain = explain_mql_query_impl(
+            &state,
+            &id,
+            &db,
+            "products",
+            r#"{"category":"Electronics"}"#,
+        )
+        .await
+        .expect("real explain");
+        assert!(
+            explain.contains("queryPlanner") || explain.contains("winningPlan"),
+            "explain output should include a query plan"
+        );
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_aggregate_execute_and_explain() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        seed(
+            &state,
+            &id,
+            &db,
+            "sales",
+            vec![
+                doc! { "region": "us", "amount": 10 },
+                doc! { "region": "us", "amount": 30 },
+                doc! { "region": "eu", "amount": 5 },
+            ],
+        )
+        .await;
+
+        let pipeline =
+            r#"[{"$group":{"_id":"$region","total":{"$sum":"$amount"}}},{"$sort":{"_id":1}}]"#;
+        let rows = execute_aggregate_impl(&state, &id, &db, "sales", pipeline)
+            .await
+            .expect("real aggregate");
+        assert_eq!(rows.len(), 2);
+        let eu: serde_json::Value = serde_json::from_str(&rows[0]).unwrap();
+        assert_eq!(eu["_id"], "eu");
+        assert_eq!(eu["total"], 5);
+
+        let explain = explain_aggregate_query_impl(&state, &id, &db, "sales", pipeline)
+            .await
+            .expect("real aggregate explain");
+        assert!(
+            explain.contains("stages") || explain.contains("queryPlanner") || explain.contains("ok"),
+            "aggregate explain should return a plan document"
+        );
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_metadata_collections_views_and_indexes() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        // create_collection real path.
+        create_collection_impl(&state, &id, &db, "customers")
+            .await
+            .expect("create collection");
+        seed(
+            &state,
+            &id,
+            &db,
+            "customers",
+            vec![doc! { "name": "Ada", "city": "NYC" }],
+        )
+        .await;
+
+        // create_view real path (view over customers).
+        create_view_impl(
+            &state,
+            &id,
+            &db,
+            "ny_customers",
+            "customers",
+            r#"[{"$match":{"city":"NYC"}}]"#,
+        )
+        .await
+        .expect("create view");
+
+        let collections = list_collections_impl(&state, &id, &db)
+            .await
+            .expect("list collections");
+        let view = collections
+            .iter()
+            .find(|c| c.name == "ny_customers")
+            .expect("view should be listed");
+        assert_eq!(view.collection_type, "view");
+        let coll = collections
+            .iter()
+            .find(|c| c.name == "customers")
+            .expect("collection listed");
+        assert_eq!(coll.collection_type, "collection");
+
+        // list_databases should include our test db.
+        let dbs = list_databases_impl(&state, &id).await.expect("list dbs");
+        assert!(dbs.contains(&db));
+
+        // Index create / list (with real key-pattern + flags) / delete.
+        create_index_impl(
+            &state,
+            &id,
+            &db,
+            "customers",
+            "city_unique",
+            r#"{"city":1}"#,
+            true,
+            true,
+        )
+        .await
+        .expect("create index");
+        let indexes = list_indexes_impl(&state, &id, &db, "customers")
+            .await
+            .expect("list indexes");
+        let created = indexes
+            .iter()
+            .find(|i| i.name == "city_unique")
+            .expect("created index listed");
+        assert!(created.unique, "unique flag round-trips from the server");
+        assert!(created.sparse, "sparse flag round-trips from the server");
+        let keys: serde_json::Value = serde_json::from_str(&created.keys).unwrap();
+        assert_eq!(keys["city"], 1);
+
+        delete_index_impl(&state, &id, &db, "customers", "city_unique")
+            .await
+            .expect("delete index");
+        let after = list_indexes_impl(&state, &id, &db, "customers")
+            .await
+            .expect("list indexes after delete");
+        assert!(!after.iter().any(|i| i.name == "city_unique"));
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_document_crud_real() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+
+        // insert_document_impl returns the inserted id as extended JSON.
+        let inserted = insert_document_impl(
+            &state,
+            &id,
+            &db,
+            "people",
+            r#"{"_id":"u1","name":"Ada","tier":"gold"}"#,
+        )
+        .await
+        .expect("insert");
+        assert!(inserted.contains("u1"));
+
+        // replace_one via update_document_impl.
+        let modified = update_document_impl(
+            &state,
+            &id,
+            &db,
+            "people",
+            r#"{"_id":"u1"}"#,
+            r#"{"_id":"u1","name":"Ada Lovelace","tier":"platinum"}"#,
+        )
+        .await
+        .expect("replace");
+        assert_eq!(modified, 1);
+
+        // update_many with an operator.
+        seed(
+            &state,
+            &id,
+            &db,
+            "people",
+            vec![
+                doc! { "_id": "u2", "name": "Bob", "tier": "silver" },
+                doc! { "_id": "u3", "name": "Cy", "tier": "silver" },
+            ],
+        )
+        .await;
+        let upd = update_many_impl(
+            &state,
+            &id,
+            &db,
+            "people",
+            r#"{"tier":"silver"}"#,
+            r#"{"$set":{"tier":"bronze"}}"#,
+        )
+        .await
+        .expect("update_many");
+        assert_eq!(upd, 2);
+
+        // delete_one then delete_many.
+        let del_one = delete_document_impl(&state, &id, &db, "people", r#"{"_id":"u1"}"#)
+            .await
+            .expect("delete_one");
+        assert_eq!(del_one, 1);
+        let del_many = delete_many_impl(&state, &id, &db, "people", r#"{"tier":"bronze"}"#)
+            .await
+            .expect("delete_many");
+        assert_eq!(del_many, 2);
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_import_documents_all_modes_real() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        // Pre-existing doc with _id=1 so skip/update/abort all have a conflict to handle.
+        seed(&state, &id, &db, "imp", vec![doc! { "_id": 1, "name": "old" }]).await;
+
+        let docs = || {
+            vec![
+                serde_json::json!({"_id": 1, "name": "new"}),
+                serde_json::json!({"_id": 2, "name": "two"}),
+                serde_json::json!({"name": "no-id"}),
+            ]
+        };
+
+        // skip: _id=1 exists → skipped; _id=2 and the id-less doc insert.
+        let skip = import_documents_impl(&state, &id, &db, "imp", docs(), "skip")
+            .await
+            .expect("import skip");
+        assert_eq!(skip.inserted, 2);
+        assert_eq!(skip.skipped, 1);
+
+        // update: _id=1 (and now _id=2) are replaced; id-less inserts.
+        let update = import_documents_impl(&state, &id, &db, "imp", docs(), "update")
+            .await
+            .expect("import update");
+        assert!(update.updated >= 1, "existing _id should be updated");
+
+        // abort: a conflicting _id makes the whole import fail and write nothing.
+        let abort = import_documents_impl(&state, &id, &db, "imp", docs(), "abort").await;
+        assert!(
+            abort
+                .err()
+                .expect("abort should error on conflict")
+                .contains("already exist"),
+            "abort should refuse when an _id already exists"
+        );
+
+        // abort on a fresh collection succeeds and inserts all.
+        let clean = import_documents_impl(
+            &state,
+            &id,
+            &db,
+            "imp_fresh",
+            vec![serde_json::json!({"name": "x"}), serde_json::json!({"name": "y"})],
+            "abort",
+        )
+        .await
+        .expect("import abort clean");
+        assert_eq!(clean.inserted, 2);
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_rename_collection_and_database_real() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        seed(
+            &state,
+            &id,
+            &db,
+            "old_name",
+            vec![doc! { "a": 1 }, doc! { "a": 2 }],
+        )
+        .await;
+        create_index_impl(&state, &id, &db, "old_name", "a_1", r#"{"a":1}"#, false, false)
+            .await
+            .expect("index for rename");
+
+        // rename_collection real path (admin renameCollection).
+        rename_collection_impl(&state, &id, &db, "old_name", "new_name")
+            .await
+            .expect("rename collection");
+        let cols = list_collections_impl(&state, &id, &db).await.unwrap();
+        assert!(cols.iter().any(|c| c.name == "new_name"));
+        assert!(!cols.iter().any(|c| c.name == "old_name"));
+
+        // rename_database: copy all collections + indexes + docs to a new db, drop source.
+        let target = format!("{}_renamed", db);
+        let result = rename_database_impl(&state, &id, &db, &target, true)
+            .await
+            .expect("rename database");
+        assert_eq!(result.collections, 1);
+        assert_eq!(result.documents, 2);
+
+        // Target has the data + recreated index; source is gone.
+        let target_count = count_documents_impl(&state, &id, &target, "new_name", "{}")
+            .await
+            .expect("count in renamed db");
+        assert_eq!(target_count, 2);
+        let target_indexes = list_indexes_impl(&state, &id, &target, "new_name")
+            .await
+            .expect("indexes in renamed db");
+        assert!(
+            target_indexes.iter().any(|i| i.name == "a_1"),
+            "non-_id index should be recreated on the target"
+        );
+        let dbs = list_databases_impl(&state, &id).await.unwrap();
+        assert!(!dbs.contains(&db), "source db should be dropped");
+
+        // Error: target already exists.
+        let dup_target = format!("{}_dup", db);
+        seed(&state, &id, &dup_target, "c", vec![doc! { "z": 1 }]).await;
+        let exists_err = rename_database_impl(&state, &id, &target, &dup_target, false)
+            .await
+            .err()
+            .expect("rename to existing target should error");
+        assert!(exists_err.contains("already exists"));
+
+        // Error: source does not exist.
+        let missing_err =
+            rename_database_impl(&state, &id, "definitely_missing_db_xyz", "whatever", false)
+                .await
+                .err()
+                .expect("rename of missing source should error");
+        assert!(missing_err.contains("does not exist"));
+
+        // Cleanup the extra databases this test created.
+        let _ = client_of(&state, &id).database(&target).drop().await;
+        let _ = client_of(&state, &id).database(&dup_target).drop().await;
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_rename_database_rejects_views() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        seed(&state, &id, &db, "base", vec![doc! { "a": 1 }]).await;
+        create_view_impl(&state, &id, &db, "v", "base", "[]")
+            .await
+            .expect("create view");
+        let target = format!("{}_vrenamed", db);
+        let err = rename_database_impl(&state, &id, &db, &target, false)
+            .await
+            .err()
+            .expect("rename of db with a view should error");
+        assert!(err.contains("is a view"), "rename must refuse databases with views");
+        let _ = client_of(&state, &id).database(&target).drop().await;
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_drop_collection_and_database_real() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        seed(&state, &id, &db, "tmp", vec![doc! { "a": 1 }]).await;
+        drop_collection_impl(&state, &id, &db, "tmp")
+            .await
+            .expect("drop collection");
+        let cols = list_collections_impl(&state, &id, &db).await.unwrap();
+        assert!(!cols.iter().any(|c| c.name == "tmp"));
+
+        // drop_database real path.
+        seed(&state, &id, &db, "again", vec![doc! { "a": 1 }]).await;
+        drop_database_impl(&state, &id, &db)
+            .await
+            .expect("drop database");
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_export_json_and_csv_real() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        seed(
+            &state,
+            &id,
+            &db,
+            "export_me",
+            vec![
+                doc! { "name": "Alice", "city": "NYC", "note": "has,comma" },
+                doc! { "name": "Bob", "city": "LA" },
+            ],
+        )
+        .await;
+
+        for format in ["json", "csv"] {
+            let path = std::env::temp_dir().join(format!(
+                "mqlens-it-export-{}.{}",
+                uuid::Uuid::new_v4().simple(),
+                format
+            ));
+            let path_str = path.to_string_lossy().to_string();
+            let task = start_collection_export_impl(&state, &id, &db, "export_me", format, &path_str)
+                .await
+                .expect("start real export");
+            let finished = wait_for_task(&state, &task.id).await;
+            assert_eq!(finished.status, "completed", "export ({format}) should finish");
+            assert_eq!(finished.processed, 2);
+            let body = std::fs::read_to_string(&path).expect("export file written");
+            assert!(body.contains("Alice"));
+            if format == "csv" {
+                // The comma-containing cell must be quote-escaped.
+                assert!(body.contains("\"has,comma\""));
+            }
+            let _ = std::fs::remove_file(&path);
+        }
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_gridfs_list_and_download_real() {
+        use futures::AsyncWriteExt;
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+
+        // Upload a file into the "uploads" GridFS bucket via the driver.
+        let bucket = client_of(&state, &id).database(&db).gridfs_bucket(
+            mongodb::options::GridFsBucketOptions::builder()
+                .bucket_name("uploads".to_string())
+                .build(),
+        );
+        let payload = b"hello gridfs integration".to_vec();
+        let mut upload = bucket.open_upload_stream("greeting.txt").await.unwrap();
+        upload.write_all(&payload).await.unwrap();
+        upload.close().await.unwrap();
+
+        // list_gridfs_files_impl returns JSON of files; find ours.
+        let listed = list_gridfs_files_impl(&state, &id, &db, "uploads")
+            .await
+            .expect("list gridfs");
+        let files: serde_json::Value = serde_json::from_str(&listed).unwrap();
+        let arr = files.as_array().expect("files array");
+        let entry = arr
+            .iter()
+            .find(|f| f["filename"] == "greeting.txt")
+            .expect("uploaded file listed");
+        assert_eq!(entry["length"].as_u64().unwrap(), payload.len() as u64);
+        // `id` is already the file _id rendered as extended JSON (e.g. {"$oid":"..."}),
+        // which is exactly what download_gridfs_file_impl expects — pass it through as-is.
+        let file_id_json = entry["id"].as_str().expect("gridfs id is a json string").to_string();
+
+        // Download it back to disk and verify the bytes.
+        let dest = std::env::temp_dir().join(format!("mqlens-it-gridfs-{}.bin", uuid::Uuid::new_v4().simple()));
+        let dest_str = dest.to_string_lossy().to_string();
+        let written = download_gridfs_file_impl(
+            &state,
+            &id,
+            &db,
+            "uploads",
+            &file_id_json,
+            &dest_str,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("download gridfs (id={file_id_json}): {e}"));
+        assert_eq!(written, payload.len() as u64);
+        let got = std::fs::read(&dest).expect("downloaded file");
+        assert_eq!(got, payload);
+        let _ = std::fs::remove_file(&dest);
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_analyze_schema_real() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        seed(
+            &state,
+            &id,
+            &db,
+            "events",
+            vec![
+                doc! { "type": "click", "meta": { "x": 1 }, "tags": ["a", "b"] },
+                doc! { "type": "view", "count": 3_i64 },
+                doc! { "type": "click" },
+            ],
+        )
+        .await;
+
+        let json = analyze_schema_impl(&state, &id, &db, "events", 1000)
+            .await
+            .expect("real schema analyze");
+        let report: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(report["sampled"].as_u64().unwrap() >= 1);
+        let fields = report["fields"].as_array().unwrap();
+        assert!(
+            fields.iter().any(|f| f["path"] == "type"),
+            "expected a 'type' field in the inferred schema"
+        );
+        assert!(
+            fields.iter().any(|f| f["path"] == "meta.x"),
+            "nested fields should be reported with dotted paths"
+        );
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_run_connection_test_real_success() {
+        use crate::connections::{run_connection_test, PhaseUpdate, TestPhase};
+        use std::sync::Mutex;
+        let Some(uri) = test_mongo_uri() else {
+            return;
+        };
+        let log: Mutex<Vec<PhaseUpdate>> = Mutex::new(Vec::new());
+        let res = run_connection_test(&uri, None, &|u| log.lock().unwrap().push(u)).await;
+        assert!(res.is_ok(), "connection test against the real server should pass");
+        let ok_phases: Vec<TestPhase> = log
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|u| u.status == "ok")
+            .map(|u| u.phase.clone())
+            .collect();
+        // All four phases (parse, resolve, connect, ping) must report ok.
+        assert!(ok_phases.contains(&TestPhase::Parse));
+        assert!(ok_phases.contains(&TestPhase::Resolve));
+        assert!(ok_phases.contains(&TestPhase::Connect));
+        assert!(ok_phases.contains(&TestPhase::Ping));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,8 @@ pub use state::{AppState, LockExt};
 pub use window::target_window_size;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod integration_tests;
 
 /// Connect + server-selection timeout for the main (non-test) connection path.
 const MAIN_CONNECT_TIMEOUT_SECS: u64 = 10;

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3,11 +3,11 @@ mod tests {
     use crate::AppState;
     use crate::{
         connect_db_impl, count_documents_impl, create_collection_impl, create_index_impl,
-        delete_document_impl, disconnect_db_impl, drop_collection_impl, drop_database_impl,
-        execute_aggregate_impl, execute_mql_query_impl, explain_mql_query_impl,
+        delete_document_impl, disconnect_db_impl, download_gridfs_file_impl, drop_collection_impl,
+        drop_database_impl, execute_aggregate_impl, execute_mql_query_impl, explain_mql_query_impl,
         import_documents_impl, insert_document_impl, json_to_bson_document, list_collections_impl,
-        list_databases_impl, list_indexes_impl, rename_collection_impl, rename_database_impl,
-        start_collection_export_impl, update_document_impl,
+        list_databases_impl, list_gridfs_files_impl, list_indexes_impl, rename_collection_impl,
+        rename_database_impl, start_collection_export_impl, update_document_impl,
     };
 
     #[tokio::test]
@@ -150,6 +150,87 @@ mod tests {
         let exported = std::fs::read_to_string(&path).expect("Export file should exist");
         assert!(exported.contains("Alice Smith"));
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn test_mock_full_collection_export_task_writes_csv() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("Should connect to mock db successfully");
+        let path = std::env::temp_dir().join(format!(
+            "mqlens-export-test-{}-{}.csv",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let path_str = path.to_string_lossy().to_string();
+
+        let task = start_collection_export_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            "csv",
+            &path_str,
+        )
+        .await
+        .expect("Should start CSV export task");
+
+        for _ in 0..50 {
+            let status = {
+                state
+                    .tasks
+                    .lock()
+                    .unwrap()
+                    .get(&task.id)
+                    .map(|t| t.status.clone())
+                    .unwrap()
+            };
+            if status != "running" {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let finished = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(finished.status, "completed");
+        assert_eq!(finished.processed, 3);
+        let exported = std::fs::read_to_string(&path).expect("CSV export file should exist");
+        let header = exported.lines().next().unwrap_or_default();
+        assert!(header.contains("address"));
+        assert!(header.contains("email"));
+        assert!(header.contains("name"));
+        assert!(exported.contains("Alice Smith"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn test_collection_export_validates_format_path_and_connection() {
+        let state = AppState::new();
+
+        let invalid_format =
+            start_collection_export_impl(&state, "missing", "db", "coll", "xml", "/tmp/out.xml")
+                .await
+                .err()
+                .expect("invalid export format should error");
+        assert_eq!(invalid_format, "Export format must be json or csv");
+
+        let missing_path =
+            start_collection_export_impl(&state, "missing", "db", "coll", "json", "   ")
+                .await
+                .err()
+                .expect("blank export path should error");
+        assert_eq!(missing_path, "Export path is required");
+
+        let missing_connection =
+            start_collection_export_impl(&state, "missing", "db", "coll", "json", "/tmp/out.json")
+                .await
+                .err()
+                .expect("missing export connection should error");
+        assert_eq!(missing_connection, "Connection not found");
     }
 
     // Regression guard for the index-edit corruption bug (GO-LIVE C2/H4):
@@ -390,6 +471,11 @@ mod tests {
             extract_target_host_port("mongodb://myhost/mydb"),
             ("myhost".to_string(), 27017)
         );
+        // invalid port falls back to MongoDB default
+        assert_eq!(
+            extract_target_host_port("mongodb://myhost:not-a-port/mydb"),
+            ("myhost".to_string(), 27017)
+        );
     }
 
     #[test]
@@ -418,6 +504,20 @@ mod tests {
             999,
         );
         assert!(out.contains("user:pass@127.0.0.1:999"), "got {}", out);
+    }
+
+    #[test]
+    fn test_rewrite_uri_handles_query_without_path() {
+        use crate::ssh_tunnel::rewrite_uri_hosts;
+        let out = rewrite_uri_hosts(
+            "mongodb://db.example.com?directConnection=false&replicaSet=rs0&retryWrites=true",
+            "localhost",
+            27019,
+        );
+        assert_eq!(
+            out,
+            "mongodb://localhost:27019?retryWrites=true&directConnection=true"
+        );
     }
 
     #[test]
@@ -477,6 +577,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_mock_query_sort_pagination_and_parse_errors() {
+        let docs = crate::mock_db::execute_mock_query(
+            "sales_db",
+            "products",
+            r#"{"category":"Electronics"}"#,
+            r#"{"price":-1}"#,
+            1,
+            0,
+        )
+        .expect("mock query should sort and limit");
+        assert_eq!(docs.len(), 1);
+        let first: serde_json::Value = serde_json::from_str(&docs[0]).unwrap();
+        assert_eq!(first["name"], "SuperBook Pro");
+
+        let skipped = crate::mock_db::execute_mock_query(
+            "sales_db",
+            "products",
+            "{}",
+            r#"{"stock":1}"#,
+            1,
+            1,
+        )
+        .expect("mock query should skip");
+        let skipped_first: serde_json::Value = serde_json::from_str(&skipped[0]).unwrap();
+        assert_eq!(skipped_first["name"], "SuperBook Pro");
+
+        let bad_filter =
+            crate::mock_db::count_mock_documents("sales_db", "products", "{bad").unwrap_err();
+        assert!(bad_filter.contains("Invalid MQL filter JSON"));
+
+        let bad_sort =
+            crate::mock_db::execute_mock_query("sales_db", "products", "{}", "{bad", 10, 0)
+                .unwrap_err();
+        assert!(bad_sort.contains("Invalid MQL sort JSON"));
+    }
+
     #[tokio::test]
     async fn test_count_documents_empty_filter_returns_full_count() {
         let state = AppState::new();
@@ -490,8 +627,48 @@ mod tests {
         let blank = count_documents_impl(&state, &conn_id, "sales_db", "products", "")
             .await
             .expect("count blank filter");
-        assert!(full > 0, "empty-filter count should be the full collection size");
-        assert_eq!(full, blank, "blank and {{}} filters must behave identically");
+        assert!(
+            full > 0,
+            "empty-filter count should be the full collection size"
+        );
+        assert_eq!(
+            full, blank,
+            "blank and {{}} filters must behave identically"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_real_path_validation_before_missing_client() {
+        let state = AppState::new();
+        let id = "realish-query";
+        state.mocks.lock().unwrap().insert(id.to_string(), false);
+
+        let bad_filter =
+            execute_mql_query_impl(&state, id, "db", "coll", "{bad", "{}", "{}", 10, 0)
+                .await
+                .unwrap_err();
+        assert!(bad_filter.contains("Invalid MQL filter JSON"));
+
+        let bad_sort = execute_mql_query_impl(&state, id, "db", "coll", "{}", "{bad", "{}", 10, 0)
+            .await
+            .unwrap_err();
+        assert!(bad_sort.contains("Invalid MQL sort JSON"));
+
+        let missing_client =
+            execute_mql_query_impl(&state, id, "db", "coll", "{}", r#"{"name":1}"#, "{}", 10, 5)
+                .await
+                .unwrap_err();
+        assert_eq!(missing_client, "Connection client not found");
+
+        let bad_count = count_documents_impl(&state, id, "db", "coll", "{bad")
+            .await
+            .unwrap_err();
+        assert!(bad_count.contains("Invalid MQL filter JSON"));
+
+        let missing_count_client = count_documents_impl(&state, id, "db", "coll", r#"{"a":1}"#)
+            .await
+            .unwrap_err();
+        assert_eq!(missing_count_client, "Connection client not found");
     }
 
     #[tokio::test]
@@ -515,6 +692,13 @@ mod tests {
         assert!(
             not_array.unwrap_err().contains("must be a JSON array"),
             "non-array pipeline should be rejected"
+        );
+
+        let bad_stage =
+            execute_aggregate_impl(&state, &conn_id, "sales_db", "products", r#"["bad"]"#).await;
+        assert!(
+            bad_stage.unwrap_err().contains("Invalid aggregation stage"),
+            "non-document stage should be rejected"
         );
 
         // A well-formed pipeline on a mock connection reports aggregation is unsupported there.
@@ -542,7 +726,8 @@ mod tests {
         let bad =
             explain_aggregate_query_impl(&state, &conn_id, "sales_db", "products", "[{bad}]").await;
         assert!(
-            bad.unwrap_err().contains("Invalid aggregation pipeline JSON"),
+            bad.unwrap_err()
+                .contains("Invalid aggregation pipeline JSON"),
             "malformed pipeline should report a parse error"
         );
 
@@ -552,6 +737,14 @@ mod tests {
         assert!(
             not_array.unwrap_err().contains("must be a JSON array"),
             "non-array pipeline should be rejected"
+        );
+
+        let bad_stage =
+            explain_aggregate_query_impl(&state, &conn_id, "sales_db", "products", r#"["bad"]"#)
+                .await;
+        assert!(
+            bad_stage.unwrap_err().contains("Invalid aggregation stage"),
+            "non-document pipeline stage should be rejected"
         );
 
         // A well-formed pipeline on a mock connection reports explain is unsupported there.
@@ -576,14 +769,15 @@ mod tests {
             .expect("connect mock");
 
         // Empty view name is rejected.
-        let no_name =
-            create_view_impl(&state, &conn_id, "sales_db", "", "customers", "[]").await;
+        let no_name = create_view_impl(&state, &conn_id, "sales_db", "", "customers", "[]").await;
         assert!(no_name.is_err(), "empty view name should be rejected");
 
         // Empty source collection is rejected.
-        let no_source =
-            create_view_impl(&state, &conn_id, "sales_db", "vip", "", "[]").await;
-        assert!(no_source.is_err(), "empty source collection should be rejected");
+        let no_source = create_view_impl(&state, &conn_id, "sales_db", "vip", "", "[]").await;
+        assert!(
+            no_source.is_err(),
+            "empty source collection should be rejected"
+        );
 
         // A pipeline that isn't a JSON array is rejected.
         let bad_pipeline =
@@ -601,7 +795,10 @@ mod tests {
         // A well-formed view on a mock connection no-ops successfully.
         let pipeline = r#"[{"$match": {"tier": "Premium"}}]"#;
         let ok = create_view_impl(&state, &conn_id, "sales_db", "vip", "customers", pipeline).await;
-        assert!(ok.is_ok(), "well-formed view on mock should succeed (no-op)");
+        assert!(
+            ok.is_ok(),
+            "well-formed view on mock should succeed (no-op)"
+        );
     }
 
     // GO-LIVE T1: backend seams reachable without a live MongoDB server.
@@ -632,12 +829,17 @@ mod tests {
 
         let run = run_mongosh_command_impl(&state, "bogus-session", "db.x.find()").await;
         // MongoshCommandOutput isn't Debug, so use .err() rather than unwrap_err().
-        let run_err = run.err().expect("running on an unknown session should error");
+        let run_err = run
+            .err()
+            .expect("running on an unknown session should error");
         assert!(run_err.contains("session not found"));
 
         // Stopping an unknown session is an idempotent no-op (no panic, returns Ok).
         let stop = stop_mongosh_session_impl(&state, "bogus-session").await;
-        assert!(stop.is_ok(), "stopping an unknown session should be a no-op");
+        assert!(
+            stop.is_ok(),
+            "stopping an unknown session should be a no-op"
+        );
     }
 
     #[tokio::test]
@@ -649,14 +851,24 @@ mod tests {
             .expect("connect mock");
 
         create_index_impl(
-            &state, &conn_id, "sales_db", "customers", "tmp_idx", r#"{"tmp":1}"#, false, false,
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            "tmp_idx",
+            r#"{"tmp":1}"#,
+            false,
+            false,
         )
         .await
         .expect("create index");
         let before = list_indexes_impl(&state, &conn_id, "sales_db", "customers")
             .await
             .expect("list");
-        assert!(before.iter().any(|i| i.name == "tmp_idx"), "index should exist after create");
+        assert!(
+            before.iter().any(|i| i.name == "tmp_idx"),
+            "index should exist after create"
+        );
 
         delete_index_impl(&state, &conn_id, "sales_db", "customers", "tmp_idx")
             .await
@@ -700,6 +912,23 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_gridfs_validation_errors_without_real_client() {
+        let state = AppState::new();
+        let id = "realish-gridfs";
+        state.mocks.lock().unwrap().insert(id.to_string(), false);
+
+        let bad_id = download_gridfs_file_impl(&state, id, "db", "fs", "{", "/tmp/file.bin")
+            .await
+            .unwrap_err();
+        assert!(bad_id.contains("Invalid file id JSON"));
+
+        let missing_client = list_gridfs_files_impl(&state, id, "db", "fs")
+            .await
+            .unwrap_err();
+        assert_eq!(missing_client, "Connection client not found");
+    }
+
     // GO-LIVE M7 (bulk ops): delete_many/update_many validate inputs and no-op on mock.
     #[tokio::test]
     async fn test_bulk_ops_validate_and_mock_noop() {
@@ -711,7 +940,10 @@ mod tests {
 
         // delete_many: malformed filter is rejected.
         let bad_filter = delete_many_impl(&state, &conn_id, "sales_db", "customers", "{bad").await;
-        assert!(bad_filter.is_err(), "malformed delete filter should be rejected");
+        assert!(
+            bad_filter.is_err(),
+            "malformed delete filter should be rejected"
+        );
 
         // delete_many: valid filter on mock no-ops (returns 0, no persistence).
         let del = delete_many_impl(&state, &conn_id, "sales_db", "customers", r#"{"tier":"X"}"#)
@@ -721,7 +953,12 @@ mod tests {
 
         // update_many: a non-operator update (bare replacement) is rejected.
         let non_op = update_many_impl(
-            &state, &conn_id, "sales_db", "customers", "{}", r#"{"name":"x"}"#,
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            "{}",
+            r#"{"name":"x"}"#,
         )
         .await;
         assert!(
@@ -736,7 +973,12 @@ mod tests {
 
         // update_many: a valid operator update on mock no-ops (returns 0).
         let upd = update_many_impl(
-            &state, &conn_id, "sales_db", "customers", r#"{"tier":"X"}"#, r#"{"$set":{"tier":"Y"}}"#,
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            r#"{"tier":"X"}"#,
+            r#"{"$set":{"tier":"Y"}}"#,
         )
         .await
         .expect("mock update_many ok");
@@ -773,8 +1015,11 @@ mod tests {
         // `price`: double in one doc, int in another -> mixed types, presence 2.
         let price = by_path("price");
         assert_eq!(price.presence, 2);
-        let price_types: std::collections::HashMap<&str, usize> =
-            price.types.iter().map(|t| (t.type_name.as_str(), t.count)).collect();
+        let price_types: std::collections::HashMap<&str, usize> = price
+            .types
+            .iter()
+            .map(|t| (t.type_name.as_str(), t.count))
+            .collect();
         assert_eq!(price_types.get("double"), Some(&1));
         assert_eq!(price_types.get("int"), Some(&1));
 
@@ -886,6 +1131,37 @@ mod tests {
         assert!(rename_database_impl(&state, &conn_id, "same", "same", true)
             .await
             .is_err());
+
+        let realish = "realish-ddl";
+        state
+            .mocks
+            .lock()
+            .unwrap()
+            .insert(realish.to_string(), false);
+        assert_eq!(
+            create_collection_impl(&state, realish, "sales_db", "new_coll")
+                .await
+                .unwrap_err(),
+            "Connection client not found"
+        );
+        assert_eq!(
+            drop_collection_impl(&state, realish, "sales_db", "new_coll")
+                .await
+                .unwrap_err(),
+            "Connection client not found"
+        );
+        assert_eq!(
+            rename_collection_impl(&state, realish, "sales_db", "from", "to")
+                .await
+                .unwrap_err(),
+            "Connection client not found"
+        );
+        assert_eq!(
+            drop_database_impl(&state, realish, "sales_db")
+                .await
+                .unwrap_err(),
+            "Connection client not found"
+        );
     }
 
     // GO-LIVE C5: real NL→MQL generation. The risky pure parts are request shaping
@@ -997,6 +1273,17 @@ mod tests {
             .expect("Should load empty profiles");
         assert!(initial_profiles.is_empty());
 
+        std::fs::write(&test_file_path, "   ").unwrap();
+        let empty_profiles = crate::connections::load_profiles_from_file(&test_file_path)
+            .expect("Should treat empty profile file as empty");
+        assert!(empty_profiles.is_empty());
+
+        std::fs::write(&test_file_path, "{bad json").unwrap();
+        let bad_profiles = crate::connections::load_profiles_from_file(&test_file_path);
+        assert!(bad_profiles
+            .unwrap_err()
+            .contains("Failed to parse connections file"));
+
         // Create a connection profile
         let profile1 = crate::connections::ConnectionProfile {
             id: "profile-1".to_string(),
@@ -1082,7 +1369,8 @@ mod tests {
 
         // Mock URI: all four phases succeed, offline.
         let log: Mutex<Vec<PhaseUpdate>> = Mutex::new(Vec::new());
-        let res = run_connection_test("mongodb://mock", None, &|u| log.lock().unwrap().push(u)).await;
+        let res =
+            run_connection_test("mongodb://mock", None, &|u| log.lock().unwrap().push(u)).await;
         assert!(res.is_ok());
         assert_eq!(
             ok_phases(&log),
@@ -1140,6 +1428,49 @@ mod tests {
         s.local_commands
             .insert("codex".into(), "codex run {prompt}".into());
         assert_eq!(resolve_local_command(&s, "codex"), "codex run {prompt}");
+    }
+
+    #[test]
+    fn test_settings_file_handling() {
+        use crate::connections::{load_settings_from_file, save_settings_to_file, AppSettings};
+
+        let dir = std::env::temp_dir().join(format!(
+            "mqlens-settings-test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+
+        assert_eq!(
+            load_settings_from_file(&path).unwrap(),
+            AppSettings::default()
+        );
+
+        std::fs::write(&path, "  ").unwrap();
+        assert_eq!(
+            load_settings_from_file(&path).unwrap(),
+            AppSettings::default()
+        );
+
+        std::fs::write(&path, "{bad json").unwrap();
+        let parse_err = load_settings_from_file(&path).unwrap_err();
+        assert!(parse_err.contains("Failed to parse settings file"));
+
+        let settings = AppSettings {
+            mongosh_path: "/opt/mongosh".to_string(),
+            ..Default::default()
+        };
+        save_settings_to_file(&path, &settings).expect("settings should save");
+        assert_eq!(
+            load_settings_from_file(&path).unwrap().mongosh_path,
+            "/opt/mongosh"
+        );
+
+        let write_err = save_settings_to_file(&dir, &settings).unwrap_err();
+        assert!(write_err.contains("Failed to write settings file"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1375,7 +1706,11 @@ mod tests {
     fn test_derive_key_is_deterministic_and_salt_sensitive() {
         use crate::vault::{derive_key, KdfParams};
         // Use cheap params so the test stays fast.
-        let params = KdfParams { m_kib: 8, t: 1, p: 1 };
+        let params = KdfParams {
+            m_kib: 8,
+            t: 1,
+            p: 1,
+        };
         let salt_a = [1u8; 16];
         let salt_b = [2u8; 16];
 
@@ -1393,7 +1728,11 @@ mod tests {
     fn test_vault_meta_build_and_unlock() {
         use crate::connections::{build_vault_meta, unlock_key};
         use crate::vault::KdfParams;
-        let params = KdfParams { m_kib: 8, t: 1, p: 1 };
+        let params = KdfParams {
+            m_kib: 8,
+            t: 1,
+            p: 1,
+        };
 
         let meta = build_vault_meta("correct horse", params).unwrap();
         assert_eq!(meta.version, 1);
@@ -1429,15 +1768,24 @@ mod tests {
         save_profiles_encrypted(&prof_path, &key, &profiles).unwrap();
         // On-disk bytes must not contain the plaintext password.
         let raw = std::fs::read(&prof_path).unwrap();
-        assert!(!String::from_utf8_lossy(&raw).contains("secret"), "password must not be plaintext");
+        assert!(
+            !String::from_utf8_lossy(&raw).contains("secret"),
+            "password must not be plaintext"
+        );
         assert_eq!(load_profiles_encrypted(&prof_path, &key).unwrap(), profiles);
-        assert!(load_profiles_encrypted(&prof_path, &wrong).is_err(), "wrong key must fail");
+        assert!(
+            load_profiles_encrypted(&prof_path, &wrong).is_err(),
+            "wrong key must fail"
+        );
 
         let mut settings = AppSettings::default();
         settings.anthropic_api_key = "sk-ant-123".into();
         save_settings_encrypted(&set_path, &key, &settings).unwrap();
         let raw_s = std::fs::read(&set_path).unwrap();
-        assert!(!String::from_utf8_lossy(&raw_s).contains("sk-ant-123"), "api key must not be plaintext");
+        assert!(
+            !String::from_utf8_lossy(&raw_s).contains("sk-ant-123"),
+            "api key must not be plaintext"
+        );
         assert_eq!(load_settings_encrypted(&set_path, &key).unwrap(), settings);
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -1466,12 +1814,24 @@ mod tests {
         save_profiles_to_file(&pt_profiles, &profiles).unwrap();
         assert!(pt_profiles.exists());
 
-        migrate_plaintext_to_encrypted(&key, &pt_profiles, &enc_profiles, &pt_settings, &enc_settings)
-            .unwrap();
+        migrate_plaintext_to_encrypted(
+            &key,
+            &pt_profiles,
+            &enc_profiles,
+            &pt_settings,
+            &enc_settings,
+        )
+        .unwrap();
 
-        assert!(!pt_profiles.exists(), "plaintext must be deleted after migration");
+        assert!(
+            !pt_profiles.exists(),
+            "plaintext must be deleted after migration"
+        );
         assert!(enc_profiles.exists(), "encrypted file must be written");
-        assert_eq!(load_profiles_encrypted(&enc_profiles, &key).unwrap(), profiles);
+        assert_eq!(
+            load_profiles_encrypted(&enc_profiles, &key).unwrap(),
+            profiles
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1485,7 +1845,11 @@ mod tests {
 
         let blob = encrypt(&key, msg).unwrap();
         assert_ne!(&blob[12..], msg, "ciphertext must not equal plaintext");
-        assert_eq!(decrypt(&key, &blob).unwrap(), msg, "round-trip must recover plaintext");
+        assert_eq!(
+            decrypt(&key, &blob).unwrap(),
+            msg,
+            "round-trip must recover plaintext"
+        );
 
         // Two encryptions of the same plaintext differ (fresh nonce each time).
         let blob2 = encrypt(&key, msg).unwrap();
@@ -1554,6 +1918,42 @@ mod tests {
         let json2 = serde_json::to_string(&cleared).unwrap();
         let back2: QueryStore = serde_json::from_str(&json2).unwrap();
         assert!(back2.collections.get(&key).unwrap().default.is_none());
+    }
+
+    #[test]
+    fn test_query_store_file_handling_is_best_effort() {
+        use crate::queries::{load_store_from_file, save_store_to_file, QueryStore};
+
+        let dir = std::env::temp_dir().join(format!(
+            "mqlens-query-store-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("queries.json");
+
+        assert_eq!(load_store_from_file(&path), QueryStore::default());
+
+        std::fs::write(&path, "   ").unwrap();
+        assert_eq!(load_store_from_file(&path), QueryStore::default());
+
+        std::fs::write(&path, "{not json").unwrap();
+        assert_eq!(load_store_from_file(&path), QueryStore::default());
+
+        let mut store = QueryStore::default();
+        let key = crate::queries::collection_key("conn", "db", "coll");
+        store.collections.insert(key.clone(), Default::default());
+        save_store_to_file(&path, &store).expect("store should save");
+        let loaded = load_store_from_file(&path);
+        assert!(loaded.collections.contains_key(&key));
+
+        let save_to_dir = save_store_to_file(&dir, &store).unwrap_err();
+        assert!(save_to_dir.contains("Failed to write queries file"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1643,9 +2043,78 @@ mod tests {
 
         reencrypt_data_files(&old_key, &new_key, &enc_profiles, &enc_settings).unwrap();
 
-        assert!(load_profiles_encrypted(&enc_profiles, &old_key).is_err(), "old key must fail");
-        assert_eq!(load_profiles_encrypted(&enc_profiles, &new_key).unwrap(), profiles);
+        assert!(
+            load_profiles_encrypted(&enc_profiles, &old_key).is_err(),
+            "old key must fail"
+        );
+        assert_eq!(
+            load_profiles_encrypted(&enc_profiles, &new_key).unwrap(),
+            profiles
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Exercise every mock dataset/index variant so the demo backend (used when no
+    // server is available) is covered, not just sales_db/products.
+    #[test]
+    fn test_mock_db_data_and_index_variants() {
+        use crate::mock_db::{
+            count_mock_documents, execute_mock_query, get_mock_collections, get_mock_explain,
+            get_mock_indexes,
+        };
+
+        // Collections per database, plus the empty fallback for an unknown db.
+        assert!(get_mock_collections("sales_db").contains(&"transactions".to_string()));
+        assert_eq!(
+            get_mock_collections("user_analytics"),
+            vec!["events".to_string(), "sessions".to_string()]
+        );
+        assert!(get_mock_collections("admin").contains(&"system.users".to_string()));
+        assert!(get_mock_collections("nope").is_empty());
+
+        // Query + count across the non-products datasets (each hits a distinct match arm).
+        let tx = execute_mock_query("sales_db", "transactions", "{}", "{}", 10, 0).unwrap();
+        assert_eq!(tx.len(), 3);
+        let pending =
+            count_mock_documents("sales_db", "transactions", r#"{"status":"Pending"}"#).unwrap();
+        assert_eq!(pending, 1);
+
+        let events = execute_mock_query("user_analytics", "events", "{}", "{}", 10, 0).unwrap();
+        assert_eq!(events.len(), 2);
+        let sessions =
+            execute_mock_query("user_analytics", "sessions", "{}", r#"{"duration_seconds":-1}"#, 10, 0)
+                .unwrap();
+        let first: serde_json::Value = serde_json::from_str(&sessions[0]).unwrap();
+        assert_eq!(first["session_id"], "sess_002", "longest session sorts first");
+
+        // Unknown collection yields no documents.
+        assert!(execute_mock_query("sales_db", "ghost", "{}", "{}", 10, 0)
+            .unwrap()
+            .is_empty());
+
+        // Explain renders a plan namespaced to the requested collection.
+        let explain = get_mock_explain("user_analytics", "events", "{}");
+        assert!(explain.contains("user_analytics.events"));
+
+        // Index sets for each collection, including the admin and unknown fallbacks.
+        let idx = |db, coll| -> Vec<String> {
+            get_mock_indexes(db, coll)
+                .into_iter()
+                .map(|i| i.name)
+                .collect()
+        };
+        assert!(idx("sales_db", "transactions").contains(&"timestamp_-1".to_string()));
+        assert!(idx("user_analytics", "events").contains(&"event_type_1".to_string()));
+        assert!(idx("user_analytics", "sessions").contains(&"session_id_1".to_string()));
+        assert!(idx("admin", "system.users").contains(&"user_1_db_1".to_string()));
+        assert_eq!(idx("sales_db", "unknown_coll"), vec!["_id_".to_string()]);
+
+        // A descending-direction index name parses its key pattern and direction.
+        let tx_indexes = get_mock_indexes("sales_db", "transactions");
+        let ts = tx_indexes.iter().find(|i| i.name == "timestamp_-1").unwrap();
+        let keys: serde_json::Value = serde_json::from_str(&ts.keys).unwrap();
+        assert_eq!(keys["timestamp"], -1);
+        assert!(!ts.unique, "a non-_id index is not unique");
     }
 }


### PR DESCRIPTION
## What

Raises Rust backend line coverage from **50.4% → 76.85%** (target: 70–80%).

The existing 68-test suite already covered the unit-testable surface (crypto, URI/option parsing, prompt building, JSON extraction, schema inference, all mock paths and validation/error branches). The remaining uncovered lines were **real-server code** — live MongoDB cursor loops, GridFS, the connection test — which can't execute without a database. CI ran `cargo llvm-cov` with no MongoDB, so none of it ran.

## Changes

- **`src-tauri/src/integration_tests.rs`** (new) — 13 tests exercising the real-DB paths: find/count/explain, aggregate + explain, collection/view/index DDL, document CRUD, import (skip/update/abort), JSON+CSV export, GridFS upload→list→download, schema analysis, version, `rename_database` (success + view/missing/exists errors), and the live 4-phase connection test. Gated on `MQLENS_TEST_MONGO_URI` — **they no-op when it's unset**, so `cargo test` stays green offline (82 pass without a DB, 95 with one).
- **`tests.rs`** — covers the remaining `mock_db` demo datasets/indexes (transactions, analytics, admin). `mock_db` 68% → 93%.
- **`.github/workflows/ci.yml`** — `mongo:7` service container + `MQLENS_TEST_MONGO_URI`, and `--fail-under-lines 70` so coverage can't silently regress.
- **`README.md` / `package.json`** — resolve the in-flight coverage-reporting changes; README documents running backend coverage against a local Mongo.

## Per-module after

`db/documents` 94%, `db/metadata` 91%, `db/version` 90%, `db/aggregate` 90%, `db/export` 89%, `db/query` 88%, `db/gridfs` 90%, `db/ddl` 82%, `mock_db` 93%. Still low and architecturally hard to unit-test: `ssh_tunnel` (live SSH) and the Tauri-`AppHandle` command wrappers in `queries.rs`.

## Test

```bash
docker run -d -p 27017:27017 mongo:7
MQLENS_TEST_MONGO_URI=mongodb://localhost:27017 \
  cargo llvm-cov --manifest-path src-tauri/Cargo.toml --summary-only --fail-under-lines 70 --ignore-filename-regex 'src-tauri/src/(lib|main)\.rs'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)