### PR TITLE
Fix macOS biometric keychain entitlements

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.application-identifier</key>
+    <string>P47FFYLJ43.com.mqlens.app</string>
+    <key>com.apple.developer.team-identifier</key>
+    <string>P47FFYLJ43</string>
+    <key>keychain-access-groups</key>
+    <array>
+      <string>P47FFYLJ43.com.mqlens.app</string>
+    </array>
+  </dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,6 +41,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
+      "entitlements": "Entitlements.plist",
       "infoPlist": "Info.plist"
     }
   }


### PR DESCRIPTION
## Summary
- add production macOS entitlements for the MQLens keychain access group
- configure Tauri macOS bundles to use the entitlement file

## Validation
- `plutil -lint src-tauri/Entitlements.plist`
- parsed `src-tauri/tauri.conf.json` as JSON
- `gitnexus_detect_changes(scope: "staged")` reported low risk with no affected execution flows