### PR TITLE
fix(macos): embed Developer ID provisioning profile for biometric unlock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,18 @@ jobs:
           echo "${{ secrets.APPLE_API_KEY_P8 }}" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
           echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
 
+      # The biometry feature needs restricted keychain entitlements, which macOS
+      # only grants if a matching Developer ID provisioning profile is embedded in
+      # the bundle. tauri.conf.json's bundle.macOS.files copies this file into
+      # Contents/embedded.provisionprofile *before* Tauri signs, so the signature
+      # seals it. Without it the signed app is killed on launch (AMFI error -413).
+      # The profile must be issued for the same Developer ID cert that
+      # APPLE_SIGNING_IDENTITY resolves to, or AMFI rejects it.
+      - name: Prepare provisioning profile (macOS signing)
+        if: matrix.platform == 'macos-latest' && env.ENABLE_MAC_SIGNING == 'true'
+        run: |
+          echo "${{ secrets.APPLE_PROVISIONING_PROFILE }}" | base64 --decode > src-tauri/embedded.provisionprofile
+
       # Stable -> mqlens-v<version>. Dev -> a unique semver pre-release carrying
       # the build's short SHA (e.g. mqlens-v0.1.0-dev.a1b2c3d) so every dev build
       # gets its own tag and nothing collides with the `dev` branch name.

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,13 @@ GO-LIVE.md
 CLAUDE.md
 AGENTS.md
 
-# Local-only: per-developer macOS signing config for testing biometric unlock
-# (contains a personal Apple Development identity; not for the shared repo)
+# Local-only: per-developer macOS signing override (auto-merged by Tauri on
+# macOS for `tauri dev`/`tauri build`). Pins the local Developer ID cert the
+# embedded provisioning profile is issued for; not for the shared repo / CI.
+src-tauri/tauri.macos.conf.json
 src-tauri/Entitlements.dev.plist
-src-tauri/tauri.dev.conf.json
+
+# Developer ID provisioning profile required to launch signed builds (restricted
+# keychain entitlements). Supplied via the APPLE_PROVISIONING_PROFILE secret in
+# CI and decoded to this path before bundling; keep it out of the repo.
+src-tauri/embedded.provisionprofile

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -3,12 +3,12 @@
 <plist version="1.0">
   <dict>
     <key>com.apple.application-identifier</key>
-    <string>P47FFYLJ43.com.mqlens.app</string>
+    <string>AN39B58NZQ.com.mqlens.app</string>
     <key>com.apple.developer.team-identifier</key>
-    <string>P47FFYLJ43</string>
+    <string>AN39B58NZQ</string>
     <key>keychain-access-groups</key>
     <array>
-      <string>P47FFYLJ43.com.mqlens.app</string>
+      <string>AN39B58NZQ.com.mqlens.app</string>
     </array>
   </dict>
 </plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,10 @@
     ],
     "macOS": {
       "entitlements": "Entitlements.plist",
-      "infoPlist": "Info.plist"
+      "infoPlist": "Info.plist",
+      "files": {
+        "embedded.provisionprofile": "embedded.provisionprofile"
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem
Signed macOS builds were killed the instant they launched (AMFI `-413 "No matching profile found"`) — the "app won't open once signed" symptom. No release build with the biometric feature could actually run.

## Root cause
`tauri-plugin-biometry` uses the macOS **data-protection keychain**, which forces three **restricted** entitlements (`application-identifier`, `team-identifier`, `keychain-access-groups`). macOS only grants restricted entitlements when the app embeds a matching **provisioning profile** — Developer ID builds had none. Two compounding bugs:
1. `Entitlements.plist` hardcoded team `P47FFYLJ43` (the Apple Development team's OU) while release signs with the Developer ID cert, team `AN39B58NZQ`.
2. No provisioning profile was embedded anywhere (local or CI).

## Fix
- **`Entitlements.plist`** — correct team prefix to `AN39B58NZQ` (the Developer ID team that actually signs releases).
- **`tauri.conf.json`** — `bundle.macOS.files` copies `embedded.provisionprofile` into `Contents/` *before* Tauri codesigns, so the signature seals it. (Tauri v2 desktop has no `provisioningProfile` config field or post-bundle hook, so `files` is the mechanism.)
- **`release.yml`** — decode the `APPLE_PROVISIONING_PROFILE` secret to `src-tauri/embedded.provisionprofile` before bundling (macOS + signing only).
- **`.gitignore`** — keep the per-developer profile and the auto-merged `tauri.macos.conf.json` signing override local.

Verified locally: a stock `tauri build` now embeds the profile, passes `codesign --verify --strict`, and **launches**.

## ⚠️ Required before this works in CI
1. Add repo secret **`APPLE_PROVISIONING_PROFILE`** = base64 of the Developer ID profile.
2. Ensure **`APPLE_SIGNING_IDENTITY` / `APPLE_CERTIFICATE`** resolve to the *same cert the profile is issued for* (`2C6C8A88…`). Signing with a different Developer ID cert still triggers `-413`.

## Notes
- `npm run tauri dev` runs the unsigned debug binary, so biometrics can't be tested there — use `tauri build -- --bundles app`.