### PR TITLE
ci(macos): fail release if provisioning profile is empty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,13 @@ jobs:
         if: matrix.platform == 'macos-latest' && env.ENABLE_MAC_SIGNING == 'true'
         run: |
           echo "${{ secrets.APPLE_PROVISIONING_PROFILE }}" | base64 --decode > src-tauri/embedded.provisionprofile
+          # Fail loudly: an empty/unset secret yields a 0-byte profile that still
+          # signs and notarizes fine but is killed by AMFI on launch (-413). Don't
+          # ship that silently.
+          if [ ! -s src-tauri/embedded.provisionprofile ]; then
+            echo "::error::APPLE_PROVISIONING_PROFILE secret is empty or unset — the signed app would be killed on launch (AMFI -413). Set the secret to the base64 of the Developer ID provisioning profile."
+            exit 1
+          fi
 
       # Stable -> mqlens-v<version>. Dev -> a unique semver pre-release carrying
       # the build's short SHA (e.g. mqlens-v0.1.0-dev.a1b2c3d) so every dev build


### PR DESCRIPTION
## Why
PR #22 wired the provisioning-profile embed but the decode step didn't validate the secret. With `APPLE_PROVISIONING_PROFILE` unset, `base64 --decode` produced a **0-byte** profile. Tauri embedded it, signed it, and it **notarized successfully** (notarization doesn't inspect profile contents) — so release `dev.ecd7c92` shipped a build that AMFI kills on launch (`-413`, the "MQLens can't be opened" dialog).

## Change
The step now fails the build if the decoded profile is empty, so a missing/empty secret can never silently ship a broken notarized build again.

## Note
The `APPLE_PROVISIONING_PROFILE` secret has now been set, so merging this triggers a fresh dev release that embeds the real profile and launches. (Cert already matches: CI signs with `2C6C8A88…`, which is the cert the profile is issued for.)