### PR TITLE
feat(website): launch positioning, SEO pages, and hero redesign

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -26,6 +26,14 @@ const year = 2026;
         <a href="/docs/#security">Security</a>
       </div>
       <div>
+        <h4>Compare</h4>
+        <a href="/compare/mongodb-compass-alternative/">vs MongoDB Compass</a>
+        <a href="/compare/studio-3t-alternative/">vs Studio 3T</a>
+        <a href="/compare/robo-3t-alternative/">vs Robo 3T</a>
+        <a href="/compare/nosqlbooster-alternative/">vs NoSQLBooster</a>
+        <a href="/mongodb-gui-for-linux/">MongoDB GUI for Linux</a>
+      </div>
+      <div>
         <h4>Project</h4>
         <a href={SITE.repo} target="_blank" rel="noopener">GitHub</a>
         <a href={SITE.releases} target="_blank" rel="noopener">Releases</a>

--- a/website/src/consts.ts
+++ b/website/src/consts.ts
@@ -1,7 +1,7 @@
 // Single source of truth for site-wide constants.
 export const SITE = {
   name: 'MQLens',
-  tagline: 'Studio 3T power for MongoDB — free, native, and private',
+  tagline: 'The MongoDB GUI that does it all — free, native, and private',
   description:
     'MQLens is a free, native, cross-platform MongoDB GUI with the power of paid tools: every auth mode (SCRAM, X.509, AWS, Kerberos, LDAP), TLS/SSH/proxy, aggregation pipelines with explain plans, bulk edit, index/view management, schema analysis, GridFS, an embedded mongosh, and an AI query assistant. Credentials are encrypted locally with zero telemetry. Apache-2.0.',
   url: 'https://mqlens.com',

--- a/website/src/consts.ts
+++ b/website/src/consts.ts
@@ -1,9 +1,9 @@
 // Single source of truth for site-wide constants.
 export const SITE = {
   name: 'MQLens',
-  tagline: 'A fast, native desktop GUI for MongoDB',
+  tagline: 'Studio 3T power for MongoDB — free, native, and private',
   description:
-    'MQLens is a fast, native cross-platform desktop GUI for MongoDB. Connect with full TLS/SSH/proxy support, browse data, build queries and aggregation pipelines, read explain plans, manage indexes and views, and run an embedded mongosh — with credentials encrypted behind a master password.',
+    'MQLens is a free, native, cross-platform MongoDB GUI with the power of paid tools: every auth mode (SCRAM, X.509, AWS, Kerberos, LDAP), TLS/SSH/proxy, aggregation pipelines with explain plans, bulk edit, index/view management, schema analysis, GridFS, an embedded mongosh, and an AI query assistant. Credentials are encrypted locally with zero telemetry. Apache-2.0.',
   url: 'https://mqlens.com',
   repo: 'https://github.com/mqlens/mqlens-mongodb',
   releases: 'https://github.com/mqlens/mqlens-mongodb/releases',

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -47,6 +47,21 @@ const ogImage = new URL('/og.png', SITE.url).href;
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+
+    <!-- Structured data for rich results -->
+    <script type="application/ld+json" set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": SITE.name,
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "macOS, Windows, Linux",
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+      "url": SITE.url,
+      "description": SITE.description,
+    })} />
+
+    <!-- Privacy-friendly analytics (no cookies, no in-app telemetry) -->
+    <script defer data-domain="mqlens.com" src="https://plausible.io/js/script.outbound-links.js"></script>
   </head>
   <body>
     <Nav />

--- a/website/src/pages/compare/mongodb-compass-alternative.astro
+++ b/website/src/pages/compare/mongodb-compass-alternative.astro
@@ -1,0 +1,233 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Download from '../../components/Download.astro';
+import { SITE } from '../../consts';
+---
+
+<BaseLayout
+  title="Free MongoDB Compass alternative"
+  description="MQLens is a free, native MongoDB GUI that runs lighter than Compass, collects zero telemetry, and ships every auth mode and advanced feature — all Apache-2.0."
+>
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container hero-inner">
+      <span class="eyebrow">Open source · {SITE.license}</span>
+      <h1>A free MongoDB Compass alternative.<br /><span class="grad">Native, private, and full-featured.</span></h1>
+      <p class="lede">
+        MongoDB Compass is the official GUI and a solid choice — but it runs on Electron, collects
+        usage telemetry by default, and ships no AI query assistant or SSH tunnel support in its
+        free Community edition. MQLens covers all of that and more, in a tiny native app built with
+        Tauri/Rust. Credentials are encrypted locally; zero data leaves your machine.
+      </p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#download">Download for free</a>
+        <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">Star on GitHub ★</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Comparison table -->
+  <section class="section">
+    <div class="container">
+      <div class="sec-head">
+        <span class="eyebrow">Side by side</span>
+        <h2>MQLens vs MongoDB Compass</h2>
+        <p>Both tools are free. Here is where they differ.</p>
+      </div>
+      <div class="table-wrap">
+        <table class="cmp-table">
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th class="col-us">{SITE.name}</th>
+              <th>MongoDB Compass</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Price</td>
+              <td class="col-us">Free (Apache-2.0)</td>
+              <td>Free (SSPL / proprietary)</td>
+            </tr>
+            <tr>
+              <td>Runtime</td>
+              <td class="col-us">Native (Tauri/Rust + WebView) ~14 MB</td>
+              <td>Electron (Chromium + Node.js) ~200 MB+</td>
+            </tr>
+            <tr>
+              <td>Telemetry</td>
+              <td class="col-us">Zero — none collected, none sent</td>
+              <td>Usage telemetry on by default (opt-out)</td>
+            </tr>
+            <tr>
+              <td>Credential storage</td>
+              <td class="col-us">AES-256-GCM encrypted + biometric unlock</td>
+              <td>Stored per OS keychain or plaintext</td>
+            </tr>
+            <tr>
+              <td>SSH tunnel</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (added in recent versions)</td>
+            </tr>
+            <tr>
+              <td>SOCKS5 proxy</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Auth: SCRAM-SHA-1/256</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: X.509</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: MONGODB-AWS (IAM)</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: GSSAPI / Kerberos</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: LDAP (PLAIN)</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Aggregation pipeline editor</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Visual explain plans</td>
+              <td class="col-us">Yes (find + aggregate)</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Bulk edit (update-many / delete-many)</td>
+              <td class="col-us">Yes — guarded confirmation</td>
+              <td>Limited</td>
+            </tr>
+            <tr>
+              <td>Schema analysis</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>GridFS browser</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Embedded mongosh</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>AI query assistant</td>
+              <td class="col-us">Yes — bring your own key, stays in backend</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Linux package formats</td>
+              <td class="col-us">.deb + AppImage</td>
+              <td>.deb + .rpm + .tar.gz</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- Honest assessment -->
+  <section class="section honest">
+    <div class="container honest-inner">
+      <span class="eyebrow">Fair assessment</span>
+      <h2>When MongoDB Compass is the better choice</h2>
+      <p>
+        Compass is the <strong>official</strong> MongoDB tool — maintained by the same team that builds
+        the database. If you rely on tight Atlas integration, need the latest MongoDB-specific UI
+        features the moment they ship, or your organization's security policy requires vendor-supported
+        software, Compass is the right call.
+      </p>
+      <p>
+        Compass also has a large community, extensive documentation, and is deeply familiar to most
+        MongoDB developers. If you are already comfortable with it and have no complaints, switching
+        tools has a real onboarding cost.
+      </p>
+      <p>
+        MQLens makes most sense if you want a lighter binary, zero telemetry without having to dig
+        through settings, biometric-protected credentials, an SSH tunnel, SOCKS5 proxy, GridFS
+        browsing, or an AI assistant — features Compass either lacks or gates.
+      </p>
+    </div>
+  </section>
+
+  <!-- Download CTA -->
+  <section class="section-tight" id="download">
+    <div class="container">
+      <h2 class="dl-heading">Try {SITE.name} — it's free</h2>
+      <Download />
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero {
+    padding: 96px 0 72px;
+    background:
+      radial-gradient(1100px 480px at 50% -140px, hsla(200, 90%, 50%, 0.20), transparent 70%),
+      radial-gradient(900px 460px at 92% 120%, hsla(268, 85%, 65%, 0.12), transparent 70%);
+    border-bottom: 1px solid var(--border);
+  }
+  .hero-inner { text-align: center; max-width: 820px; margin: 0 auto; }
+  .hero h1 { font-size: clamp(2.2rem, 6vw, 3.4rem); margin: 18px 0 0; font-weight: 700; }
+  .grad {
+    background: linear-gradient(100deg, var(--accent-bright), var(--accent-teal));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .lede { font-size: 1.12rem; color: var(--text-dim); margin: 22px auto 0; max-width: 680px; }
+  .hero-cta { display: flex; gap: 12px; justify-content: center; margin-top: 30px; flex-wrap: wrap; }
+
+  .sec-head { text-align: center; max-width: 640px; margin: 0 auto 48px; }
+  .sec-head h2 { font-size: clamp(1.8rem, 4vw, 2.4rem); margin: 12px 0 0; }
+  .sec-head p { color: var(--text-dim); margin-top: 14px; }
+
+  .table-wrap { overflow-x: auto; }
+  .cmp-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+  }
+  .cmp-table th,
+  .cmp-table td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+  }
+  .cmp-table thead th {
+    background: var(--bg-soft);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+  }
+  .cmp-table tbody tr:hover { background: var(--bg-soft); }
+  .col-us { color: var(--accent-bright); font-weight: 500; }
+  .cmp-table thead .col-us { color: var(--accent-bright); }
+
+  .honest { background: var(--bg-soft); border-block: 1px solid var(--border); }
+  .honest-inner { max-width: 720px; margin: 0 auto; }
+  .honest-inner h2 { font-size: clamp(1.6rem, 3.5vw, 2.2rem); margin: 12px 0 20px; }
+  .honest-inner p { color: var(--text-dim); margin-bottom: 16px; line-height: 1.7; }
+
+  .dl-heading { text-align: center; margin: 0 0 28px; font-size: 1.6rem; }
+</style>

--- a/website/src/pages/compare/mongodb-compass-alternative.astro
+++ b/website/src/pages/compare/mongodb-compass-alternative.astro
@@ -14,10 +14,10 @@ import { SITE } from '../../consts';
       <span class="eyebrow">Open source · {SITE.license}</span>
       <h1>A free MongoDB Compass alternative.<br /><span class="grad">Native, private, and full-featured.</span></h1>
       <p class="lede">
-        MongoDB Compass is the official GUI and a solid choice — but it runs on Electron, collects
-        usage telemetry by default, and ships no AI query assistant or SSH tunnel support in its
-        free Community edition. MQLens covers all of that and more, in a tiny native app built with
-        Tauri/Rust. Credentials are encrypted locally; zero data leaves your machine.
+        MongoDB Compass is the official GUI — but it runs on Electron (heavy), collects usage
+        telemetry by default, and has no AI query assistant or SOCKS5 proxy support. MQLens ships
+        all of that in a 14 MB native Tauri/Rust app. Credentials are encrypted with AES-256-GCM
+        and unlockable via biometrics. Zero telemetry. Apache-2.0 and $0.
       </p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="#download">Download for free</a>
@@ -151,20 +151,9 @@ import { SITE } from '../../consts';
       <span class="eyebrow">Fair assessment</span>
       <h2>When MongoDB Compass is the better choice</h2>
       <p>
-        Compass is the <strong>official</strong> MongoDB tool — maintained by the same team that builds
-        the database. If you rely on tight Atlas integration, need the latest MongoDB-specific UI
-        features the moment they ship, or your organization's security policy requires vendor-supported
-        software, Compass is the right call.
-      </p>
-      <p>
-        Compass also has a large community, extensive documentation, and is deeply familiar to most
-        MongoDB developers. If you are already comfortable with it and have no complaints, switching
-        tools has a real onboarding cost.
-      </p>
-      <p>
-        MQLens makes most sense if you want a lighter binary, zero telemetry without having to dig
-        through settings, biometric-protected credentials, an SSH tunnel, SOCKS5 proxy, GridFS
-        browsing, or an AI assistant — features Compass either lacks or gates.
+        Compass is the <strong>official</strong> MongoDB tool — if your organization requires
+        vendor-supported software, tight Atlas integration, or you simply want the tool built by
+        the same team that builds the database, Compass is the right call.
       </p>
     </div>
   </section>

--- a/website/src/pages/compare/mongodb-compass-alternative.astro
+++ b/website/src/pages/compare/mongodb-compass-alternative.astro
@@ -14,10 +14,10 @@ import { SITE } from '../../consts';
       <span class="eyebrow">Open source · {SITE.license}</span>
       <h1>A free MongoDB Compass alternative.<br /><span class="grad">Native, private, and full-featured.</span></h1>
       <p class="lede">
-        MongoDB Compass is the official GUI — but it runs on Electron (heavy), collects usage
-        telemetry by default, and has no AI query assistant or SOCKS5 proxy support. MQLens ships
-        all of that in a 14 MB native Tauri/Rust app. Credentials are encrypted with AES-256-GCM
-        and unlockable via biometrics. Zero telemetry. Apache-2.0 and $0.
+        MongoDB Compass is the official GUI — but it runs on Electron (heavy) and collects usage
+        telemetry by default. MQLens delivers every auth mode and advanced feature in a 14 MB native
+        Tauri/Rust app. Credentials are encrypted with AES-256-GCM and unlockable via biometrics.
+        Zero telemetry. Apache-2.0 and $0.
       </p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="#download">Download for free</a>
@@ -68,11 +68,6 @@ import { SITE } from '../../consts';
               <td>SSH tunnel</td>
               <td class="col-us">Yes</td>
               <td>Yes (added in recent versions)</td>
-            </tr>
-            <tr>
-              <td>SOCKS5 proxy</td>
-              <td class="col-us">Yes</td>
-              <td>No</td>
             </tr>
             <tr>
               <td>Auth: SCRAM-SHA-1/256</td>
@@ -128,11 +123,6 @@ import { SITE } from '../../consts';
               <td>Embedded mongosh</td>
               <td class="col-us">Yes</td>
               <td>Yes</td>
-            </tr>
-            <tr>
-              <td>AI query assistant</td>
-              <td class="col-us">Yes — bring your own key, stays in backend</td>
-              <td>No</td>
             </tr>
             <tr>
               <td>Linux package formats</td>

--- a/website/src/pages/compare/nosqlbooster-alternative.astro
+++ b/website/src/pages/compare/nosqlbooster-alternative.astro
@@ -14,10 +14,10 @@ import { SITE } from '../../consts';
       <span class="eyebrow">Open source · {SITE.license}</span>
       <h1>No paywalled features. Ever.<br /><span class="grad">A free NoSQLBooster alternative.</span></h1>
       <p class="lede">
-        NoSQLBooster offers a free tier, but its most useful features — aggregation pipeline
-        editor, SSH tunnels, advanced query options — are locked behind a paid licence. MQLens
-        ships everything in one completely free, Apache-2.0 package. No paywalls, no feature
-        tiers, no nagware. Just a full-power native MongoDB GUI that costs nothing.
+        NoSQLBooster is freemium — a limited free tier with paid upgrades for full capabilities.
+        MQLens ships everything in one completely free, Apache-2.0 package. No paywalls, no
+        feature tiers, no nagware. Native Tauri/Rust, 14 MB, every auth mode, SSH tunnel, SOCKS5,
+        aggregation pipelines, biometric-protected credentials, and an AI assistant. $0, forever.
       </p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="#download">Download for free</a>
@@ -70,34 +70,14 @@ import { SITE } from '../../consts';
               <td>OS-level storage</td>
             </tr>
             <tr>
-              <td>Auth: SCRAM-SHA-1/256</td>
-              <td class="col-us">Yes</td>
-              <td>Yes</td>
-            </tr>
-            <tr>
-              <td>Auth: X.509</td>
-              <td class="col-us">Yes</td>
-              <td>Yes (paid tier)</td>
-            </tr>
-            <tr>
-              <td>Auth: MONGODB-AWS (IAM)</td>
-              <td class="col-us">Yes</td>
-              <td>Yes (paid tier)</td>
-            </tr>
-            <tr>
-              <td>Auth: GSSAPI / Kerberos</td>
-              <td class="col-us">Yes</td>
-              <td>Yes (paid tier)</td>
-            </tr>
-            <tr>
-              <td>Auth: LDAP (PLAIN)</td>
-              <td class="col-us">Yes</td>
-              <td>Yes (paid tier)</td>
+              <td>Authentication support</td>
+              <td class="col-us">SCRAM-SHA-1/256, X.509, MONGODB-AWS, GSSAPI/Kerberos, LDAP — all mechanisms, always free</td>
+              <td>Available; check nosqlbooster.com for current free vs paid tier boundaries</td>
             </tr>
             <tr>
               <td>SSH tunnel</td>
-              <td class="col-us">Yes</td>
-              <td>Yes (paid tier)</td>
+              <td class="col-us">Yes — always free</td>
+              <td>Available; check nosqlbooster.com for current free vs paid tier boundaries</td>
             </tr>
             <tr>
               <td>SOCKS5 proxy</td>
@@ -106,13 +86,13 @@ import { SITE } from '../../consts';
             </tr>
             <tr>
               <td>Aggregation pipeline editor</td>
-              <td class="col-us">Yes</td>
-              <td>Yes (paid tier)</td>
+              <td class="col-us">Yes — always free</td>
+              <td>Available; check nosqlbooster.com for current free vs paid tier boundaries</td>
             </tr>
             <tr>
               <td>Visual explain plans</td>
-              <td class="col-us">Yes (find + aggregate)</td>
-              <td>Yes (paid tier)</td>
+              <td class="col-us">Yes (find + aggregate) — always free</td>
+              <td>Available; check nosqlbooster.com for current free vs paid tier boundaries</td>
             </tr>
             <tr>
               <td>Bulk edit (update-many / delete-many)</td>
@@ -131,8 +111,8 @@ import { SITE } from '../../consts';
             </tr>
             <tr>
               <td>GridFS browser</td>
-              <td class="col-us">Yes</td>
-              <td>Yes (paid tier)</td>
+              <td class="col-us">Yes — always free</td>
+              <td>Available; check nosqlbooster.com for current free vs paid tier boundaries</td>
             </tr>
             <tr>
               <td>Embedded shell</td>
@@ -152,9 +132,6 @@ import { SITE } from '../../consts';
           </tbody>
         </table>
       </div>
-      <p class="table-note">
-        Feature availability in NoSQLBooster's free vs paid tiers is based on their published pricing page. Verify current tier limits at nosqlbooster.com.
-      </p>
     </div>
   </section>
 
@@ -164,20 +141,9 @@ import { SITE } from '../../consts';
       <span class="eyebrow">Fair assessment</span>
       <h2>When NoSQLBooster is the better choice</h2>
       <p>
-        NoSQLBooster has a genuinely excellent fluent query API, a powerful built-in code editor
-        with MongoDB-specific IntelliSense, and a task scheduler for automating recurring queries.
-        If those productivity features are core to your daily workflow, the paid tier delivers
-        real value.
-      </p>
-      <p>
-        NoSQLBooster also ships SQL query support for MongoDB, which MQLens does not currently
-        offer. If your team migrates from a relational background and wants to keep querying in SQL
-        while learning MQL, that feature alone can justify the licence cost.
-      </p>
-      <p>
-        MQLens is the right pick when you want every advanced capability — SSH tunnels, all auth
-        modes, aggregation pipelines, AI assistant — without spending money or hitting a paywall
-        six months in when a free trial expires.
+        If your team needs SQL-to-MQL query support, NoSQLBooster-specific IntelliSense, or a
+        built-in task scheduler — and is comfortable paying for a licence — NoSQLBooster's feature
+        set may justify the cost.
       </p>
     </div>
   </section>

--- a/website/src/pages/compare/nosqlbooster-alternative.astro
+++ b/website/src/pages/compare/nosqlbooster-alternative.astro
@@ -1,0 +1,252 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Download from '../../components/Download.astro';
+import { SITE } from '../../consts';
+---
+
+<BaseLayout
+  title="Free NoSQLBooster alternative"
+  description="MQLens delivers every feature NoSQLBooster paywalls — aggregation pipelines, SSH tunnel, all auth modes, AI assistant — in a fully free, open-source, native app. Apache-2.0."
+>
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container hero-inner">
+      <span class="eyebrow">Open source · {SITE.license}</span>
+      <h1>No paywalled features. Ever.<br /><span class="grad">A free NoSQLBooster alternative.</span></h1>
+      <p class="lede">
+        NoSQLBooster offers a free tier, but its most useful features — aggregation pipeline
+        editor, SSH tunnels, advanced query options — are locked behind a paid licence. MQLens
+        ships everything in one completely free, Apache-2.0 package. No paywalls, no feature
+        tiers, no nagware. Just a full-power native MongoDB GUI that costs nothing.
+      </p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#download">Download for free</a>
+        <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">Star on GitHub ★</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Comparison table -->
+  <section class="section">
+    <div class="container">
+      <div class="sec-head">
+        <span class="eyebrow">Side by side</span>
+        <h2>MQLens vs NoSQLBooster</h2>
+        <p>No feature tiers. Every capability ships in the free build.</p>
+      </div>
+      <div class="table-wrap">
+        <table class="cmp-table">
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th class="col-us">{SITE.name}</th>
+              <th>NoSQLBooster</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Price</td>
+              <td class="col-us">Free (Apache-2.0, always)</td>
+              <td>Freemium — limited free tier, paid for full features</td>
+            </tr>
+            <tr>
+              <td>Source available</td>
+              <td class="col-us">Yes — full source on GitHub</td>
+              <td>No (proprietary)</td>
+            </tr>
+            <tr>
+              <td>Runtime / installer size</td>
+              <td class="col-us">Native (Tauri/Rust + WebView) ~14 MB</td>
+              <td>Electron-based, larger footprint</td>
+            </tr>
+            <tr>
+              <td>Telemetry</td>
+              <td class="col-us">Zero</td>
+              <td>Usage data collected per privacy policy</td>
+            </tr>
+            <tr>
+              <td>Credential encryption</td>
+              <td class="col-us">AES-256-GCM + Argon2id, biometric unlock</td>
+              <td>OS-level storage</td>
+            </tr>
+            <tr>
+              <td>Auth: SCRAM-SHA-1/256</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: X.509</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (paid tier)</td>
+            </tr>
+            <tr>
+              <td>Auth: MONGODB-AWS (IAM)</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (paid tier)</td>
+            </tr>
+            <tr>
+              <td>Auth: GSSAPI / Kerberos</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (paid tier)</td>
+            </tr>
+            <tr>
+              <td>Auth: LDAP (PLAIN)</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (paid tier)</td>
+            </tr>
+            <tr>
+              <td>SSH tunnel</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (paid tier)</td>
+            </tr>
+            <tr>
+              <td>SOCKS5 proxy</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Aggregation pipeline editor</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (paid tier)</td>
+            </tr>
+            <tr>
+              <td>Visual explain plans</td>
+              <td class="col-us">Yes (find + aggregate)</td>
+              <td>Yes (paid tier)</td>
+            </tr>
+            <tr>
+              <td>Bulk edit (update-many / delete-many)</td>
+              <td class="col-us">Yes — guarded confirmation</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Schema analysis</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Index management</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>GridFS browser</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (paid tier)</td>
+            </tr>
+            <tr>
+              <td>Embedded shell</td>
+              <td class="col-us">Yes — real mongosh binary</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>AI query assistant</td>
+              <td class="col-us">Yes — bring your own key, stays in backend</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>macOS / Windows / Linux</td>
+              <td class="col-us">Yes — all three</td>
+              <td>Yes — all three</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="table-note">
+        Feature availability in NoSQLBooster's free vs paid tiers is based on their published pricing page. Verify current tier limits at nosqlbooster.com.
+      </p>
+    </div>
+  </section>
+
+  <!-- Honest assessment -->
+  <section class="section honest">
+    <div class="container honest-inner">
+      <span class="eyebrow">Fair assessment</span>
+      <h2>When NoSQLBooster is the better choice</h2>
+      <p>
+        NoSQLBooster has a genuinely excellent fluent query API, a powerful built-in code editor
+        with MongoDB-specific IntelliSense, and a task scheduler for automating recurring queries.
+        If those productivity features are core to your daily workflow, the paid tier delivers
+        real value.
+      </p>
+      <p>
+        NoSQLBooster also ships SQL query support for MongoDB, which MQLens does not currently
+        offer. If your team migrates from a relational background and wants to keep querying in SQL
+        while learning MQL, that feature alone can justify the licence cost.
+      </p>
+      <p>
+        MQLens is the right pick when you want every advanced capability — SSH tunnels, all auth
+        modes, aggregation pipelines, AI assistant — without spending money or hitting a paywall
+        six months in when a free trial expires.
+      </p>
+    </div>
+  </section>
+
+  <!-- Download CTA -->
+  <section class="section-tight" id="download">
+    <div class="container">
+      <h2 class="dl-heading">Try {SITE.name} — no tier, no paywall</h2>
+      <Download />
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero {
+    padding: 96px 0 72px;
+    background:
+      radial-gradient(1100px 480px at 50% -140px, hsla(200, 90%, 50%, 0.20), transparent 70%),
+      radial-gradient(900px 460px at 92% 120%, hsla(268, 85%, 65%, 0.12), transparent 70%);
+    border-bottom: 1px solid var(--border);
+  }
+  .hero-inner { text-align: center; max-width: 820px; margin: 0 auto; }
+  .hero h1 { font-size: clamp(2.2rem, 6vw, 3.4rem); margin: 18px 0 0; font-weight: 700; }
+  .grad {
+    background: linear-gradient(100deg, var(--accent-bright), var(--accent-teal));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .lede { font-size: 1.12rem; color: var(--text-dim); margin: 22px auto 0; max-width: 680px; }
+  .hero-cta { display: flex; gap: 12px; justify-content: center; margin-top: 30px; flex-wrap: wrap; }
+
+  .sec-head { text-align: center; max-width: 640px; margin: 0 auto 48px; }
+  .sec-head h2 { font-size: clamp(1.8rem, 4vw, 2.4rem); margin: 12px 0 0; }
+  .sec-head p { color: var(--text-dim); margin-top: 14px; }
+
+  .table-wrap { overflow-x: auto; }
+  .cmp-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+  }
+  .cmp-table th,
+  .cmp-table td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+  }
+  .cmp-table thead th {
+    background: var(--bg-soft);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+  }
+  .cmp-table tbody tr:hover { background: var(--bg-soft); }
+  .col-us { color: var(--accent-bright); font-weight: 500; }
+  .cmp-table thead .col-us { color: var(--accent-bright); }
+  .table-note {
+    color: var(--text-dim);
+    font-size: 0.82rem;
+    margin-top: 14px;
+    font-style: italic;
+  }
+
+  .honest { background: var(--bg-soft); border-block: 1px solid var(--border); }
+  .honest-inner { max-width: 720px; margin: 0 auto; }
+  .honest-inner h2 { font-size: clamp(1.6rem, 3.5vw, 2.2rem); margin: 12px 0 20px; }
+  .honest-inner p { color: var(--text-dim); margin-bottom: 16px; line-height: 1.7; }
+
+  .dl-heading { text-align: center; margin: 0 0 28px; font-size: 1.6rem; }
+</style>

--- a/website/src/pages/compare/robo-3t-alternative.astro
+++ b/website/src/pages/compare/robo-3t-alternative.astro
@@ -14,12 +14,12 @@ import { SITE } from '../../consts';
       <span class="eyebrow">Open source · {SITE.license}</span>
       <h1>Beyond Robo 3T.<br /><span class="grad">Modern, maintained, and full-featured.</span></h1>
       <p class="lede">
-        Robo 3T (formerly Robomongo) was beloved for being lightweight and free, but its development
-        has slowed significantly since being acquired by Studio 3T, and it lacks support for many
-        modern MongoDB features. MQLens picks up that torch: still free, still native and lightweight
-        (~14 MB), but with full-power features Robo 3T never shipped — aggregation pipelines,
-        visual explain plans, every auth mode, encrypted credentials, SSH tunnel, SOCKS5 proxy,
-        GridFS, schema analysis, and an AI query assistant.
+        Robo 3T (formerly Robomongo) earned a loyal following for being free and lightweight — but
+        development has stalled and it lacks many features modern teams now expect. MQLens carries
+        that torch forward: still free, still native and tiny (~14 MB), but with full power Robo 3T
+        never shipped — aggregation pipelines, visual explain plans, every auth mode, encrypted
+        credentials with biometric unlock, SSH tunnel, SOCKS5 proxy, GridFS, schema analysis,
+        and an AI query assistant. Apache-2.0, zero telemetry.
       </p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="#download">Download for free</a>
@@ -72,29 +72,9 @@ import { SITE } from '../../consts';
               <td>Limited — connection strings stored with minimal protection</td>
             </tr>
             <tr>
-              <td>Auth: SCRAM-SHA-1/256</td>
-              <td class="col-us">Yes</td>
-              <td>Yes</td>
-            </tr>
-            <tr>
-              <td>Auth: X.509</td>
-              <td class="col-us">Yes</td>
-              <td>Limited</td>
-            </tr>
-            <tr>
-              <td>Auth: MONGODB-AWS (IAM)</td>
-              <td class="col-us">Yes</td>
-              <td>No</td>
-            </tr>
-            <tr>
-              <td>Auth: GSSAPI / Kerberos</td>
-              <td class="col-us">Yes</td>
-              <td>No</td>
-            </tr>
-            <tr>
-              <td>Auth: LDAP (PLAIN)</td>
-              <td class="col-us">Yes</td>
-              <td>No</td>
+              <td>Authentication support</td>
+              <td class="col-us">SCRAM-SHA-1/256, X.509, MONGODB-AWS, GSSAPI/Kerberos, LDAP — all mechanisms</td>
+              <td>Basic auth; development has slowed and it lacks many auth features modern teams expect</td>
             </tr>
             <tr>
               <td>SSH tunnel</td>
@@ -168,20 +148,8 @@ import { SITE } from '../../consts';
       <span class="eyebrow">Fair assessment</span>
       <h2>When Robo 3T is still worth considering</h2>
       <p>
-        Robo 3T earned a loyal following because it was genuinely fast and uncluttered. If you are
-        running an older MongoDB deployment (3.x–4.x) and you only need basic document browsing and
-        a shell, Robo 3T's simple interface gets out of the way and still works fine for that
-        workflow.
-      </p>
-      <p>
-        There is also something to be said for familiarity — if you have years of muscle memory
-        built up with Robo 3T's interface, switching tools has a real cost even if the new tool is
-        objectively more capable. Only you can weigh that trade-off.
-      </p>
-      <p>
-        That said, if you regularly use MongoDB 5.0+ features, need Kerberos or AWS IAM auth,
-        want to build aggregation pipelines visually, or need your connection profiles to survive
-        a laptop wipe with credentials intact, MQLens is worth a try.
+        If you are on an older MongoDB deployment, only need basic document browsing and a shell,
+        and already have years of Robo 3T muscle memory — it still works for that narrow workflow.
       </p>
     </div>
   </section>

--- a/website/src/pages/compare/robo-3t-alternative.astro
+++ b/website/src/pages/compare/robo-3t-alternative.astro
@@ -1,0 +1,250 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Download from '../../components/Download.astro';
+import { SITE } from '../../consts';
+---
+
+<BaseLayout
+  title="A modern Robo 3T / Robomongo alternative"
+  description="MQLens is a fully-maintained, modern MongoDB GUI that goes far beyond what Robo 3T offered: every auth mode, aggregation pipelines, visual explain plans, SSH tunnel, GridFS, and an AI assistant — all free and Apache-2.0."
+>
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container hero-inner">
+      <span class="eyebrow">Open source · {SITE.license}</span>
+      <h1>Beyond Robo 3T.<br /><span class="grad">Modern, maintained, and full-featured.</span></h1>
+      <p class="lede">
+        Robo 3T (formerly Robomongo) was beloved for being lightweight and free, but its development
+        has slowed significantly since being acquired by Studio 3T, and it lacks support for many
+        modern MongoDB features. MQLens picks up that torch: still free, still native and lightweight
+        (~14 MB), but with full-power features Robo 3T never shipped — aggregation pipelines,
+        visual explain plans, every auth mode, encrypted credentials, SSH tunnel, SOCKS5 proxy,
+        GridFS, schema analysis, and an AI query assistant.
+      </p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#download">Download for free</a>
+        <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">Star on GitHub ★</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Comparison table -->
+  <section class="section">
+    <div class="container">
+      <div class="sec-head">
+        <span class="eyebrow">Side by side</span>
+        <h2>MQLens vs Robo 3T / Robomongo</h2>
+        <p>Lightweight roots, modern capabilities.</p>
+      </div>
+      <div class="table-wrap">
+        <table class="cmp-table">
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th class="col-us">{SITE.name}</th>
+              <th>Robo 3T</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Price</td>
+              <td class="col-us">Free (Apache-2.0)</td>
+              <td>Free</td>
+            </tr>
+            <tr>
+              <td>Actively maintained</td>
+              <td class="col-us">Yes — actively developed</td>
+              <td>Development has slowed significantly</td>
+            </tr>
+            <tr>
+              <td>Runtime / installer size</td>
+              <td class="col-us">Native (Tauri/Rust + WebView) ~14 MB</td>
+              <td>Qt-based, modest footprint</td>
+            </tr>
+            <tr>
+              <td>Telemetry</td>
+              <td class="col-us">Zero</td>
+              <td>Minimal</td>
+            </tr>
+            <tr>
+              <td>Credential encryption</td>
+              <td class="col-us">AES-256-GCM + Argon2id, biometric unlock</td>
+              <td>Limited — connection strings stored with minimal protection</td>
+            </tr>
+            <tr>
+              <td>Auth: SCRAM-SHA-1/256</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: X.509</td>
+              <td class="col-us">Yes</td>
+              <td>Limited</td>
+            </tr>
+            <tr>
+              <td>Auth: MONGODB-AWS (IAM)</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Auth: GSSAPI / Kerberos</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Auth: LDAP (PLAIN)</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>SSH tunnel</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>SOCKS5 proxy</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>TLS / custom CA / client cert</td>
+              <td class="col-us">Yes</td>
+              <td>Basic TLS</td>
+            </tr>
+            <tr>
+              <td>Aggregation pipeline editor</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Visual explain plans</td>
+              <td class="col-us">Yes (find + aggregate)</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Bulk edit (update-many / delete-many)</td>
+              <td class="col-us">Yes — guarded confirmation</td>
+              <td>Limited</td>
+            </tr>
+            <tr>
+              <td>Schema analysis</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Index management</td>
+              <td class="col-us">Yes</td>
+              <td>Basic</td>
+            </tr>
+            <tr>
+              <td>GridFS browser</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Embedded mongosh</td>
+              <td class="col-us">Yes</td>
+              <td>Embedded shell (older mongo shell)</td>
+            </tr>
+            <tr>
+              <td>AI query assistant</td>
+              <td class="col-us">Yes — bring your own key, stays in backend</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>macOS / Windows / Linux</td>
+              <td class="col-us">Yes — all three</td>
+              <td>Yes — all three</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- Honest assessment -->
+  <section class="section honest">
+    <div class="container honest-inner">
+      <span class="eyebrow">Fair assessment</span>
+      <h2>When Robo 3T is still worth considering</h2>
+      <p>
+        Robo 3T earned a loyal following because it was genuinely fast and uncluttered. If you are
+        running an older MongoDB deployment (3.x–4.x) and you only need basic document browsing and
+        a shell, Robo 3T's simple interface gets out of the way and still works fine for that
+        workflow.
+      </p>
+      <p>
+        There is also something to be said for familiarity — if you have years of muscle memory
+        built up with Robo 3T's interface, switching tools has a real cost even if the new tool is
+        objectively more capable. Only you can weigh that trade-off.
+      </p>
+      <p>
+        That said, if you regularly use MongoDB 5.0+ features, need Kerberos or AWS IAM auth,
+        want to build aggregation pipelines visually, or need your connection profiles to survive
+        a laptop wipe with credentials intact, MQLens is worth a try.
+      </p>
+    </div>
+  </section>
+
+  <!-- Download CTA -->
+  <section class="section-tight" id="download">
+    <div class="container">
+      <h2 class="dl-heading">Try {SITE.name} — it's free</h2>
+      <Download />
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero {
+    padding: 96px 0 72px;
+    background:
+      radial-gradient(1100px 480px at 50% -140px, hsla(200, 90%, 50%, 0.20), transparent 70%),
+      radial-gradient(900px 460px at 92% 120%, hsla(268, 85%, 65%, 0.12), transparent 70%);
+    border-bottom: 1px solid var(--border);
+  }
+  .hero-inner { text-align: center; max-width: 820px; margin: 0 auto; }
+  .hero h1 { font-size: clamp(2.2rem, 6vw, 3.4rem); margin: 18px 0 0; font-weight: 700; }
+  .grad {
+    background: linear-gradient(100deg, var(--accent-bright), var(--accent-teal));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .lede { font-size: 1.12rem; color: var(--text-dim); margin: 22px auto 0; max-width: 680px; }
+  .hero-cta { display: flex; gap: 12px; justify-content: center; margin-top: 30px; flex-wrap: wrap; }
+
+  .sec-head { text-align: center; max-width: 640px; margin: 0 auto 48px; }
+  .sec-head h2 { font-size: clamp(1.8rem, 4vw, 2.4rem); margin: 12px 0 0; }
+  .sec-head p { color: var(--text-dim); margin-top: 14px; }
+
+  .table-wrap { overflow-x: auto; }
+  .cmp-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+  }
+  .cmp-table th,
+  .cmp-table td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+  }
+  .cmp-table thead th {
+    background: var(--bg-soft);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+  }
+  .cmp-table tbody tr:hover { background: var(--bg-soft); }
+  .col-us { color: var(--accent-bright); font-weight: 500; }
+  .cmp-table thead .col-us { color: var(--accent-bright); }
+
+  .honest { background: var(--bg-soft); border-block: 1px solid var(--border); }
+  .honest-inner { max-width: 720px; margin: 0 auto; }
+  .honest-inner h2 { font-size: clamp(1.6rem, 3.5vw, 2.2rem); margin: 12px 0 20px; }
+  .honest-inner p { color: var(--text-dim); margin-bottom: 16px; line-height: 1.7; }
+
+  .dl-heading { text-align: center; margin: 0 0 28px; font-size: 1.6rem; }
+</style>

--- a/website/src/pages/compare/studio-3t-alternative.astro
+++ b/website/src/pages/compare/studio-3t-alternative.astro
@@ -1,0 +1,245 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Download from '../../components/Download.astro';
+import { SITE } from '../../consts';
+---
+
+<BaseLayout
+  title="Free Studio 3T alternative"
+  description="MQLens gives you Studio 3T-level power — aggregation pipelines, visual explain plans, every auth mode, SSH tunnel — for free. Apache-2.0, native, zero telemetry."
+>
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container hero-inner">
+      <span class="eyebrow">Open source · {SITE.license}</span>
+      <h1>Full MongoDB power at $0.<br /><span class="grad">A free Studio 3T alternative.</span></h1>
+      <p class="lede">
+        Studio 3T is one of the most capable MongoDB GUIs available, but it requires a paid
+        subscription for the features most teams actually need. MQLens delivers the same depth —
+        aggregation pipelines with visual explain plans, every auth mechanism, TLS/SSH/SOCKS5,
+        bulk edit, schema analysis, GridFS, an embedded mongosh, and an AI query assistant — with
+        no subscription, no licence key, and no Electron overhead. Apache-2.0 and free forever.
+      </p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#download">Download for free</a>
+        <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">Star on GitHub ★</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Comparison table -->
+  <section class="section">
+    <div class="container">
+      <div class="sec-head">
+        <span class="eyebrow">Side by side</span>
+        <h2>MQLens vs Studio 3T</h2>
+        <p>Where full power should not require a subscription.</p>
+      </div>
+      <div class="table-wrap">
+        <table class="cmp-table">
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th class="col-us">{SITE.name}</th>
+              <th>Studio 3T</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Price</td>
+              <td class="col-us">Free (Apache-2.0)</td>
+              <td>Commercial subscription (paid)</td>
+            </tr>
+            <tr>
+              <td>Source available</td>
+              <td class="col-us">Yes — full source on GitHub</td>
+              <td>No (proprietary)</td>
+            </tr>
+            <tr>
+              <td>Runtime / installer size</td>
+              <td class="col-us">Native (Tauri/Rust + WebView) ~14 MB</td>
+              <td>Java-based, larger footprint</td>
+            </tr>
+            <tr>
+              <td>Telemetry</td>
+              <td class="col-us">Zero</td>
+              <td>Usage data collected per privacy policy</td>
+            </tr>
+            <tr>
+              <td>Credential encryption</td>
+              <td class="col-us">AES-256-GCM + Argon2id, biometric unlock</td>
+              <td>OS-level storage</td>
+            </tr>
+            <tr>
+              <td>Auth: SCRAM-SHA-1/256</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: X.509</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: MONGODB-AWS (IAM)</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: GSSAPI / Kerberos</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Auth: LDAP (PLAIN)</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>SSH tunnel</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>SOCKS5 proxy</td>
+              <td class="col-us">Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Aggregation pipeline editor</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (Aggregation Editor is a flagship feature)</td>
+            </tr>
+            <tr>
+              <td>Visual explain plans</td>
+              <td class="col-us">Yes (find + aggregate)</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Bulk edit (update-many / delete-many)</td>
+              <td class="col-us">Yes — guarded confirmation</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Schema analysis</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Index management</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>GridFS browser</td>
+              <td class="col-us">Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Embedded mongosh</td>
+              <td class="col-us">Yes</td>
+              <td>Yes (IntelliShell)</td>
+            </tr>
+            <tr>
+              <td>AI query assistant</td>
+              <td class="col-us">Yes — bring your own key, stays in backend</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>macOS / Windows / Linux</td>
+              <td class="col-us">Yes — all three</td>
+              <td>Yes — all three</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- Honest assessment -->
+  <section class="section honest">
+    <div class="container honest-inner">
+      <span class="eyebrow">Fair assessment</span>
+      <h2>When Studio 3T is the better choice</h2>
+      <p>
+        Studio 3T has been around since 2014 and is arguably the most polished commercial MongoDB
+        GUI available. It ships a SQL-to-MQL translator, a visual query builder with drag-and-drop
+        join support, an IntelliShell with code completion, deep Atlas integration, a built-in
+        data-migration wizard, and team sharing features — functionality that goes well beyond what
+        MQLens currently offers.
+      </p>
+      <p>
+        If your team bills software costs back to a client, needs dedicated enterprise support, or
+        routinely migrates large datasets between deployments, Studio 3T's paid tier is worth the
+        investment. The breadth and maturity of its feature set is genuinely impressive.
+      </p>
+      <p>
+        MQLens makes most sense for individual developers and small teams who want professional-grade
+        daily-driver capabilities at zero cost, without needing the heavier data-migration and team
+        tooling Studio 3T specialises in.
+      </p>
+    </div>
+  </section>
+
+  <!-- Download CTA -->
+  <section class="section-tight" id="download">
+    <div class="container">
+      <h2 class="dl-heading">Try {SITE.name} — it's free</h2>
+      <Download />
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero {
+    padding: 96px 0 72px;
+    background:
+      radial-gradient(1100px 480px at 50% -140px, hsla(200, 90%, 50%, 0.20), transparent 70%),
+      radial-gradient(900px 460px at 92% 120%, hsla(268, 85%, 65%, 0.12), transparent 70%);
+    border-bottom: 1px solid var(--border);
+  }
+  .hero-inner { text-align: center; max-width: 820px; margin: 0 auto; }
+  .hero h1 { font-size: clamp(2.2rem, 6vw, 3.4rem); margin: 18px 0 0; font-weight: 700; }
+  .grad {
+    background: linear-gradient(100deg, var(--accent-bright), var(--accent-teal));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .lede { font-size: 1.12rem; color: var(--text-dim); margin: 22px auto 0; max-width: 680px; }
+  .hero-cta { display: flex; gap: 12px; justify-content: center; margin-top: 30px; flex-wrap: wrap; }
+
+  .sec-head { text-align: center; max-width: 640px; margin: 0 auto 48px; }
+  .sec-head h2 { font-size: clamp(1.8rem, 4vw, 2.4rem); margin: 12px 0 0; }
+  .sec-head p { color: var(--text-dim); margin-top: 14px; }
+
+  .table-wrap { overflow-x: auto; }
+  .cmp-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+  }
+  .cmp-table th,
+  .cmp-table td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+  }
+  .cmp-table thead th {
+    background: var(--bg-soft);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+  }
+  .cmp-table tbody tr:hover { background: var(--bg-soft); }
+  .col-us { color: var(--accent-bright); font-weight: 500; }
+  .cmp-table thead .col-us { color: var(--accent-bright); }
+
+  .honest { background: var(--bg-soft); border-block: 1px solid var(--border); }
+  .honest-inner { max-width: 720px; margin: 0 auto; }
+  .honest-inner h2 { font-size: clamp(1.6rem, 3.5vw, 2.2rem); margin: 12px 0 20px; }
+  .honest-inner p { color: var(--text-dim); margin-bottom: 16px; line-height: 1.7; }
+
+  .dl-heading { text-align: center; margin: 0 0 28px; font-size: 1.6rem; }
+</style>

--- a/website/src/pages/compare/studio-3t-alternative.astro
+++ b/website/src/pages/compare/studio-3t-alternative.astro
@@ -14,11 +14,11 @@ import { SITE } from '../../consts';
       <span class="eyebrow">Open source · {SITE.license}</span>
       <h1>Full MongoDB power at $0.<br /><span class="grad">A free Studio 3T alternative.</span></h1>
       <p class="lede">
-        Studio 3T is one of the most capable MongoDB GUIs available, but it requires a paid
-        subscription for the features most teams actually need. MQLens delivers the same depth —
-        aggregation pipelines with visual explain plans, every auth mechanism, TLS/SSH/SOCKS5,
-        bulk edit, schema analysis, GridFS, an embedded mongosh, and an AI query assistant — with
-        no subscription, no licence key, and no Electron overhead. Apache-2.0 and free forever.
+        Studio 3T is a commercial, Java-based MongoDB GUI that demands a paid subscription. MQLens
+        gives you the same professional depth — aggregation pipelines with visual explain plans,
+        every auth mechanism, TLS/SSH/SOCKS5, bulk edit, schema analysis, GridFS, an embedded
+        mongosh, and an AI query assistant — for $0. No subscription, no licence key, no Electron.
+        Native Tauri/Rust, 14 MB, Apache-2.0, free forever.
       </p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="#download">Download for free</a>
@@ -162,21 +162,9 @@ import { SITE } from '../../consts';
       <span class="eyebrow">Fair assessment</span>
       <h2>When Studio 3T is the better choice</h2>
       <p>
-        Studio 3T has been around since 2014 and is arguably the most polished commercial MongoDB
-        GUI available. It ships a SQL-to-MQL translator, a visual query builder with drag-and-drop
-        join support, an IntelliShell with code completion, deep Atlas integration, a built-in
-        data-migration wizard, and team sharing features — functionality that goes well beyond what
-        MQLens currently offers.
-      </p>
-      <p>
-        If your team bills software costs back to a client, needs dedicated enterprise support, or
-        routinely migrates large datasets between deployments, Studio 3T's paid tier is worth the
-        investment. The breadth and maturity of its feature set is genuinely impressive.
-      </p>
-      <p>
-        MQLens makes most sense for individual developers and small teams who want professional-grade
-        daily-driver capabilities at zero cost, without needing the heavier data-migration and team
-        tooling Studio 3T specialises in.
+        If your team needs enterprise support, a SQL-to-MQL translator, data-migration wizards, or
+        team-sharing features — and has the budget for a subscription — Studio 3T's deep feature
+        set is genuinely impressive and worth the investment.
       </p>
     </div>
   </section>

--- a/website/src/pages/guides/connect-mongodb-ssh-tunnel.astro
+++ b/website/src/pages/guides/connect-mongodb-ssh-tunnel.astro
@@ -1,0 +1,161 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Download from '../../components/Download.astro';
+import { SITE } from '../../consts';
+---
+
+<BaseLayout
+  title="Connect to MongoDB over an SSH tunnel"
+  description="Step-by-step guide to connecting to a remote MongoDB instance through an SSH tunnel using MQLens — the free native MongoDB GUI. Covers bastion hosts, key-based auth, and the staged Test Connection."
+>
+  <article class="section guide-page">
+    <div class="container guide-inner">
+
+      <header class="guide-header">
+        <span class="eyebrow">How-to guide</span>
+        <h1>Connect to MongoDB over an SSH tunnel</h1>
+        <p class="lede">
+          Most production MongoDB deployments sit behind a private network with no
+          direct inbound port. An SSH tunnel punches through that boundary securely
+          without opening your database to the public internet. MQLens has
+          first-class support for SSH tunneling: enter your bastion details once,
+          and the connection manager handles the tunnel lifetime automatically.
+        </p>
+      </header>
+
+      <section class="guide-body">
+        <h2>Why use an SSH tunnel?</h2>
+        <p>
+          MongoDB typically listens on port 27017. In production you rarely want that
+          port reachable from the public internet. Instead, you place MongoDB on a
+          private subnet accessible only from a bastion (jump) host that accepts SSH
+          on port 22. Your local client then connects to the bastion over SSH, and
+          the bastion forwards traffic to MongoDB — the database never sees a direct
+          connection from your laptop.
+        </p>
+        <p>
+          The result is encrypted transit (SSH) without having to open firewall rules
+          or expose MongoDB's port to the world.
+        </p>
+
+        <h2>What you need before you start</h2>
+        <ul>
+          <li>The <strong>bastion host address</strong> (hostname or IP) and its SSH port (usually 22).</li>
+          <li>A <strong>username</strong> on the bastion (for example, <code>ubuntu</code> or <code>ec2-user</code>).</li>
+          <li>Either an <strong>SSH private key</strong> (RSA, Ed25519, ECDSA — passphrase-protected keys are supported) <em>or</em> a <strong>password</strong> for the bastion user.</li>
+          <li>The MongoDB host and port <em>as seen from the bastion</em> — often <code>localhost:27017</code> if MongoDB runs on the same machine, or a private DNS name like <code>mongo-primary.internal:27017</code>.</li>
+        </ul>
+
+        <h2>Setting up the connection in MQLens</h2>
+        <p>
+          Open MQLens and click <strong>New Connection</strong>. Fill in the MongoDB
+          host and port using the address that is reachable <em>from the bastion</em>,
+          not from your laptop. For example, if MongoDB runs on the same EC2 instance
+          as your bastion, use <code>localhost</code> and port <code>27017</code>.
+        </p>
+        <p>
+          Scroll down to the <strong>SSH Tunnel</strong> section and toggle it on.
+          You will see the following fields:
+        </p>
+        <ul>
+          <li><strong>SSH Host / Port</strong> — the public address of your bastion and its SSH port.</li>
+          <li><strong>SSH Username</strong> — the username on the bastion server.</li>
+          <li><strong>Authentication method</strong> — choose <em>Private Key</em> to browse for a <code>.pem</code> or <code>.key</code> file, or choose <em>Password</em> to type it inline (stored encrypted in the keychain).</li>
+          <li><strong>Private key passphrase</strong> — if your key is passphrase-protected, enter it here; MQLens never stores it in plaintext.</li>
+        </ul>
+        <p>
+          Add your MongoDB credentials (username, password, auth database) in the
+          <strong>Authentication</strong> section as usual. TLS settings also work in
+          combination with SSH tunneling — you can run TLS over the tunnel if your
+          server requires it.
+        </p>
+
+        <h2>Using the staged Test Connection to debug</h2>
+        <p>
+          Before saving, click <strong>Test Connection</strong>. MQLens runs the
+          connection in distinct, named phases and reports the outcome of each one:
+        </p>
+        <ol>
+          <li><strong>Parse</strong> — validates that the URI and all form fields are syntactically correct.</li>
+          <li><strong>DNS</strong> — resolves the bastion hostname to an IP address. A failure here usually means a typo or a VPN that is not active.</li>
+          <li><strong>Connect</strong> — opens the TCP connection to the bastion on its SSH port and completes the SSH handshake. Failures here are typically firewall rules or a wrong port number.</li>
+          <li><strong>Ping</strong> — sends a MongoDB <code>hello</code> (ping) command through the forwarded tunnel. A failure at this stage with the previous steps passing means the tunnel is working but MongoDB is not reachable at the host:port you specified.</li>
+        </ol>
+        <p>
+          This staged output lets you isolate the failure immediately rather than
+          guessing at a generic "connection refused" message. Once all four phases
+          turn green, save the connection. MQLens will re-establish the SSH tunnel
+          automatically on every reconnect.
+        </p>
+
+        <h2>SOCKS5 proxy as an alternative</h2>
+        <p>
+          If your team uses a SOCKS5 proxy (for example, established with
+          <code>ssh -D 1080 user@bastion</code>), MQLens supports that too. Switch
+          the proxy type to <strong>SOCKS5</strong>, point it at
+          <code>127.0.0.1:1080</code>, and leave the SSH tunnel fields empty.
+          The Test Connection phases work identically for proxy connections.
+        </p>
+
+        <div class="cta-block">
+          <p>
+            Download {SITE.name} free — SSH tunneling, TLS, and every auth mode included,
+            no subscription required.
+          </p>
+          <Download />
+        </div>
+      </section>
+
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .guide-inner {
+    max-width: 760px;
+    margin: 0 auto;
+  }
+  .guide-header {
+    margin-bottom: 48px;
+  }
+  .guide-header h1 {
+    font-size: clamp(1.9rem, 4.5vw, 2.8rem);
+    margin: 16px 0 0;
+  }
+  .lede {
+    font-size: 1.1rem;
+    color: var(--text-dim);
+    margin: 20px 0 0;
+    line-height: 1.7;
+  }
+  .guide-body h2 {
+    font-size: 1.4rem;
+    margin: 44px 0 14px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border);
+  }
+  .guide-body p {
+    color: var(--text-dim);
+    margin: 0 0 16px;
+    line-height: 1.75;
+  }
+  .guide-body ul,
+  .guide-body ol {
+    color: var(--text-dim);
+    padding-left: 24px;
+    margin: 0 0 20px;
+    line-height: 1.75;
+  }
+  .guide-body li {
+    margin-bottom: 8px;
+  }
+  .cta-block {
+    margin-top: 56px;
+    padding-top: 40px;
+    border-top: 1px solid var(--border);
+  }
+  .cta-block p {
+    font-size: 1.05rem;
+    margin-bottom: 28px;
+  }
+</style>

--- a/website/src/pages/guides/mongodb-aggregation-gui.astro
+++ b/website/src/pages/guides/mongodb-aggregation-gui.astro
@@ -1,0 +1,230 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Download from '../../components/Download.astro';
+import { SITE } from '../../consts';
+
+const matchExample = `{ "status": "active", "createdAt": { "$gte": { "$date": "2024-01-01T00:00:00Z" } } }`;
+const groupExample = `{
+  "_id": "$region",
+  "totalRevenue": { "$sum": "$amount" },
+  "orderCount": { "$sum": 1 },
+  "avgOrderValue": { "$avg": "$amount" }
+}`;
+const lookupExample = `{
+  "from": "products",
+  "localField": "productId",
+  "foreignField": "_id",
+  "as": "productDetails"
+}`;
+const projectExample = `{
+  "region": 1,
+  "totalRevenue": 1,
+  "avgOrderValue": { "$round": ["$avgOrderValue", 2] },
+  "_id": 0
+}`;
+---
+
+<BaseLayout
+  title="Build MongoDB aggregation pipelines in a GUI"
+  description="Learn how to build, preview, and optimize MongoDB aggregation pipelines stage by stage in MQLens — the free native MongoDB GUI. Covers $match, $group, $lookup, $project, result previews, and explain plans."
+>
+  <article class="section guide-page">
+    <div class="container guide-inner">
+
+      <header class="guide-header">
+        <span class="eyebrow">How-to guide</span>
+        <h1>Build MongoDB aggregation pipelines in a GUI</h1>
+        <p class="lede">
+          MongoDB's aggregation framework is one of the most powerful data-processing
+          tools in any database — but writing correct pipelines in raw JSON is slow
+          and error-prone. MQLens provides a stage-by-stage pipeline builder with live
+          result previews and an integrated explain plan so you can build, test, and
+          optimize pipelines without leaving the app.
+        </p>
+      </header>
+
+      <section class="guide-body">
+        <h2>How the pipeline builder works</h2>
+        <p>
+          An aggregation pipeline is a sequence of stages. Documents flow from the
+          collection into the first stage, are transformed, and the results flow into
+          the next stage. In MQLens, each stage is a separate editor panel. You add
+          stages one by one, give each stage a type (for example <code>$match</code>),
+          and write the stage body as a JSON object. The app evaluates the pipeline up
+          to and including the current stage each time you preview, so you always see
+          the intermediate state of your data.
+        </p>
+
+        <h2>Adding your first stage: $match</h2>
+        <p>
+          Open a collection in MQLens and click the <strong>Aggregation</strong> tab.
+          Click <strong>Add Stage</strong> and select <code>$match</code> from the
+          stage-type dropdown. Enter your filter document:
+        </p>
+        <pre><code set:html={matchExample}></code></pre>
+        <p>
+          Click <strong>Preview</strong> (or press the preview shortcut). MQLens runs
+          the pipeline up to this stage against the real collection and displays the
+          first documents in the result pane. The preview uses a default limit so it
+          never accidentally returns millions of documents.
+        </p>
+        <p>
+          Placing a <code>$match</code> as the first stage is important: MongoDB can
+          use an index on the matched fields when <code>$match</code> comes first,
+          whereas a <code>$match</code> later in the pipeline must scan the full output
+          of all prior stages.
+        </p>
+
+        <h2>Grouping data with $group</h2>
+        <p>
+          Add a second stage and choose <code>$group</code>. The <code>_id</code>
+          field defines the grouping key. Every other field uses an accumulator:
+        </p>
+        <pre><code set:html={groupExample}></code></pre>
+        <p>
+          Preview again to see the grouped result. Because you are building incrementally,
+          you know the <code>$match</code> stage is correct before you add the
+          grouping logic.
+        </p>
+
+        <h2>Joining collections with $lookup</h2>
+        <p>
+          <code>$lookup</code> performs a left-outer join between the pipeline documents
+          and another collection. Add a stage, select <code>$lookup</code>, and fill in
+          the fields:
+        </p>
+        <pre><code set:html={lookupExample}></code></pre>
+        <p>
+          For best performance, ensure the target collection has an index on
+          <code>foreignField</code> (<code>_id</code> is always indexed, but custom
+          foreign fields may not be). The explain plan (see below) will show you
+          immediately whether the lookup is using an index.
+        </p>
+        <p>
+          MQLens also supports the pipeline form of <code>$lookup</code> for
+          correlated subqueries — paste the full stage document directly into the
+          stage editor.
+        </p>
+
+        <h2>Shaping output with $project and $addFields</h2>
+        <p>
+          Use <code>$project</code> to include or exclude fields and compute new ones:
+        </p>
+        <pre><code set:html={projectExample}></code></pre>
+        <p>
+          <code>$addFields</code> is similar but leaves all existing fields intact and
+          only adds or overwrites the specified ones — useful when you want to compute a
+          derived field without rewriting the whole projection.
+        </p>
+        <p>
+          Other commonly used stages in MQLens:
+        </p>
+        <ul>
+          <li><strong>$sort</strong> — sort documents by one or more fields. Add it before <code>$limit</code> for top-N queries.</li>
+          <li><strong>$limit / $skip</strong> — paginate results. Best combined with a preceding <code>$sort</code> on a unique field.</li>
+          <li><strong>$unwind</strong> — flatten an array field into one document per element.</li>
+          <li><strong>$count</strong> — collapse the stream into a single document with a count field.</li>
+          <li><strong>$facet</strong> — run multiple sub-pipelines in parallel and combine their results.</li>
+        </ul>
+
+        <h2>Previewing results at each stage</h2>
+        <p>
+          The key workflow advantage of building pipelines in MQLens is the
+          per-stage preview. At any point you can click the stage number in the
+          left rail to see the output of just that stage. This lets you:
+        </p>
+        <ul>
+          <li>Verify that a <code>$match</code> is returning the documents you expect before you add grouping logic.</li>
+          <li>Confirm that a <code>$lookup</code> is joining correctly before you project away the join fields.</li>
+          <li>Catch shape mismatches (for example, a field named <code>productId</code> in one collection and <code>product_id</code> in another) early.</li>
+        </ul>
+
+        <h2>Getting an explain plan for the pipeline</h2>
+        <p>
+          Once you are happy with the pipeline's correctness, click
+          <strong>Explain Pipeline</strong>. MQLens runs the pipeline with
+          <code>executionStats</code> verbosity and renders a visual plan tree.
+          Each node in the tree shows its stage type, documents examined, and
+          execution time. Look for:
+        </p>
+        <ul>
+          <li>A COLLSCAN in the first stage — signals you need an index on the <code>$match</code> predicate.</li>
+          <li>A high document count entering a <code>$sort</code> without an IXSCAN — this triggers an expensive in-memory sort.</li>
+          <li>A <code>$lookup</code> scanning many keys in the foreign collection — add an index on <code>foreignField</code>.</li>
+        </ul>
+        <p>
+          The visual plan tree makes it easy to see the flow: the collection scan or
+          index scan at the bottom feeds into the first pipeline stage, and the
+          document counts at each stage boundary show you exactly where the pipeline
+          is processing the most data.
+        </p>
+
+        <h2>Saving and re-running pipelines</h2>
+        <p>
+          MQLens saves open pipelines with the connection profile, so your work
+          persists across sessions. You can also copy the full pipeline as a JSON
+          array to paste into your application code or into <code>mongosh</code>.
+        </p>
+
+        <div class="cta-block">
+          <p>
+            Download {SITE.name} free — a full aggregation pipeline builder with live
+            previews and visual explain plans, no Atlas subscription required.
+          </p>
+          <Download />
+        </div>
+      </section>
+
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .guide-inner {
+    max-width: 760px;
+    margin: 0 auto;
+  }
+  .guide-header {
+    margin-bottom: 48px;
+  }
+  .guide-header h1 {
+    font-size: clamp(1.9rem, 4.5vw, 2.8rem);
+    margin: 16px 0 0;
+  }
+  .lede {
+    font-size: 1.1rem;
+    color: var(--text-dim);
+    margin: 20px 0 0;
+    line-height: 1.7;
+  }
+  .guide-body h2 {
+    font-size: 1.4rem;
+    margin: 44px 0 14px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border);
+  }
+  .guide-body p {
+    color: var(--text-dim);
+    margin: 0 0 16px;
+    line-height: 1.75;
+  }
+  .guide-body ul,
+  .guide-body ol {
+    color: var(--text-dim);
+    padding-left: 24px;
+    margin: 0 0 20px;
+    line-height: 1.75;
+  }
+  .guide-body li {
+    margin-bottom: 8px;
+  }
+  .cta-block {
+    margin-top: 56px;
+    padding-top: 40px;
+    border-top: 1px solid var(--border);
+  }
+  .cta-block p {
+    font-size: 1.05rem;
+    margin-bottom: 28px;
+  }
+</style>

--- a/website/src/pages/guides/read-mongodb-explain-plan.astro
+++ b/website/src/pages/guides/read-mongodb-explain-plan.astro
@@ -1,0 +1,202 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Download from '../../components/Download.astro';
+import { SITE } from '../../consts';
+---
+
+<BaseLayout
+  title="How to read a MongoDB explain plan"
+  description="Understand MongoDB explain output — COLLSCAN vs IXSCAN, stages, docs examined vs returned — and see how MQLens renders it as an interactive visual plan tree for both find queries and aggregation pipelines."
+>
+  <article class="section guide-page">
+    <div class="container guide-inner">
+
+      <header class="guide-header">
+        <span class="eyebrow">How-to guide</span>
+        <h1>How to read a MongoDB explain plan</h1>
+        <p class="lede">
+          MongoDB's explain output tells you exactly how the query engine executes
+          your query: which indexes it uses, how many documents it examines, and where
+          time is spent. Reading raw explain JSON can be intimidating — MQLens renders
+          it as a visual plan tree so the critical information stands out immediately.
+        </p>
+      </header>
+
+      <section class="guide-body">
+        <h2>What explain output actually contains</h2>
+        <p>
+          When you run <code>db.collection.find(&#123;&#8230;&#125;).explain("executionStats")</code>,
+          MongoDB returns a nested document describing the <em>winning plan</em>: the
+          execution strategy the query planner chose from all the candidates it
+          considered. The two most important fields at each stage are:
+        </p>
+        <ul>
+          <li><strong>stage</strong> — what type of work this node performs (see below).</li>
+          <li><strong>nReturned</strong> — documents passed upward to the parent stage.</li>
+          <li><strong>totalDocsExamined</strong> — documents the engine actually read from disk or memory. A large gap between this and <code>nReturned</code> signals a poor index or a missing index.</li>
+          <li><strong>totalKeysExamined</strong> — index keys scanned. Should be close to <code>nReturned</code> for a well-covered query.</li>
+          <li><strong>executionTimeMillis</strong> — wall-clock time for the entire plan.</li>
+        </ul>
+
+        <h2>The most important stage types</h2>
+        <p>
+          MongoDB plans are trees of named stages. Understanding the stage names lets
+          you diagnose problems at a glance:
+        </p>
+        <ul>
+          <li>
+            <strong>COLLSCAN</strong> — a full collection scan. Every document is read
+            and checked against the filter. This is fine for small collections but
+            becomes expensive as data grows. If you see COLLSCAN on a large collection,
+            you are missing an index.
+          </li>
+          <li>
+            <strong>IXSCAN</strong> — an index scan. MongoDB walks the B-tree for the
+            named index. This is what you want. Check <code>indexName</code> to confirm
+            it is the index you expected.
+          </li>
+          <li>
+            <strong>FETCH</strong> — after an IXSCAN, MongoDB fetches the full document
+            from the collection to satisfy fields not covered by the index. If your
+            query only needs indexed fields, a <em>covered query</em> (no FETCH stage)
+            is even faster.
+          </li>
+          <li>
+            <strong>SORT</strong> — an in-memory sort. Appears when no index covers the
+            sort order. Large in-memory sorts can hit MongoDB's 100 MB sort memory
+            limit and fail. Adding a compound index that covers both the filter and
+            the sort fields eliminates this stage.
+          </li>
+          <li>
+            <strong>LIMIT / SKIP</strong> — applied after earlier stages. Seeing SKIP
+            high in a plan that also has COLLSCAN is a common pagination anti-pattern.
+          </li>
+          <li>
+            <strong>OR / AND_SORTED / AND_HASH</strong> — multi-index merge plans. These
+            appear when MongoDB combines results from multiple indexes. They work, but a
+            single well-designed compound index usually outperforms them.
+          </li>
+        </ul>
+
+        <h2>The golden ratio: keys examined vs docs returned</h2>
+        <p>
+          A healthy query has <code>totalKeysExamined &asymp; nReturned</code> and
+          <code>totalDocsExamined &asymp; nReturned</code>. If the engine examines 50,000
+          keys to return 10 documents, the index selectivity is low and you should
+          consider a more specific compound index or a different field order.
+        </p>
+        <p>
+          The <em>index ratio</em> — <code>nReturned / totalKeysExamined</code> — is a
+          quick health metric. Ratios below 0.1 (less than 10% efficiency) almost always
+          warrant an index redesign.
+        </p>
+
+        <h2>Explain plans for aggregation pipelines</h2>
+        <p>
+          Aggregation pipelines produce explain output too, but the structure is
+          different. The planner emits a <code>stages</code> array where each element
+          corresponds to a pipeline stage, and the first stage typically contains an
+          inner <code>queryPlanner</code> that describes the initial document selection.
+          Look for:
+        </p>
+        <ul>
+          <li>
+            Whether the <code>$match</code> at the start of the pipeline uses an IXSCAN.
+            If it falls back to COLLSCAN, move the <code>$match</code> earlier or add
+            an index on the matched field.
+          </li>
+          <li>
+            <code>$sort</code> stages that appear without a backing IXSCAN — these cause
+            in-memory sorts and should be resolved with a compound index that covers both
+            the match predicate and the sort fields.
+          </li>
+          <li>
+            <code>$lookup</code> stages that perform a full scan of the joined collection.
+            Add an index on the <code>foreignField</code> of every <code>$lookup</code>.
+          </li>
+        </ul>
+
+        <h2>Reading explain plans visually in MQLens</h2>
+        <p>
+          Raw explain JSON can be hundreds of lines deep. MQLens renders the plan as an
+          interactive tree: each node shows its stage name, <code>nReturned</code>,
+          documents examined, and execution time. You can expand or collapse branches and
+          immediately see which stage is responsible for the most document reads.
+        </p>
+        <p>
+          To get an explain plan in MQLens:
+        </p>
+        <ol>
+          <li>Open a collection and write your find filter, sort, and projection in the query panel.</li>
+          <li>Click the <strong>Explain</strong> button next to the Run button. MQLens runs the query with <code>executionStats</code> verbosity.</li>
+          <li>The visual plan tree opens in a side panel. COLLSCAN nodes are highlighted in amber; IXSCAN nodes appear in the accent color.</li>
+          <li>For aggregation pipelines, open the pipeline builder, compose your stages, and click <strong>Explain Pipeline</strong>. The tree expands to show each pipeline stage alongside its inner query plan node.</li>
+        </ol>
+        <p>
+          The tree view makes it immediately obvious when a deep nested COLLSCAN is
+          hiding inside an otherwise indexed aggregation pipeline — something that is
+          easy to miss in raw JSON output.
+        </p>
+
+        <div class="cta-block">
+          <p>
+            {SITE.name} is a free, native MongoDB GUI with visual explain plans for both
+            find queries and full aggregation pipelines.
+          </p>
+          <Download />
+        </div>
+      </section>
+
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .guide-inner {
+    max-width: 760px;
+    margin: 0 auto;
+  }
+  .guide-header {
+    margin-bottom: 48px;
+  }
+  .guide-header h1 {
+    font-size: clamp(1.9rem, 4.5vw, 2.8rem);
+    margin: 16px 0 0;
+  }
+  .lede {
+    font-size: 1.1rem;
+    color: var(--text-dim);
+    margin: 20px 0 0;
+    line-height: 1.7;
+  }
+  .guide-body h2 {
+    font-size: 1.4rem;
+    margin: 44px 0 14px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border);
+  }
+  .guide-body p {
+    color: var(--text-dim);
+    margin: 0 0 16px;
+    line-height: 1.75;
+  }
+  .guide-body ul,
+  .guide-body ol {
+    color: var(--text-dim);
+    padding-left: 24px;
+    margin: 0 0 20px;
+    line-height: 1.75;
+  }
+  .guide-body li {
+    margin-bottom: 8px;
+  }
+  .cta-block {
+    margin-top: 56px;
+    padding-top: 40px;
+    border-top: 1px solid var(--border);
+  }
+  .cta-block p {
+    font-size: 1.05rem;
+    margin-bottom: 28px;
+  }
+</style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -84,7 +84,7 @@ const heroDoc = `&#123;
   <section class="hero">
     <div class="container hero-inner">
       <span class="eyebrow">Open source · {SITE.license}</span>
-      <h1>Studio 3T power for MongoDB.<br /><span class="grad">Free, native, and private.</span></h1>
+      <h1>The MongoDB GUI that does it all.<br /><span class="grad">Free, native, and private.</span></h1>
       <p class="lede">
         {SITE.name} is a full-power MongoDB GUI — every auth mode, TLS/SSH/proxy,
         aggregation pipelines with explain plans, bulk edit, schema analysis, GridFS,

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -5,38 +5,56 @@ import { SITE } from '../consts';
 
 const features = [
   {
+    // Lucide: cable
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a1 1 0 0 1-1-1v-1a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v1a1 1 0 0 1-1 1"/><path d="M19 15V6.5a1 1 0 0 0-7 0v11a1 1 0 0 1-7 0V9"/><path d="M21 21v-2h-4"/><path d="M3 5h4V3"/><path d="M7 5a1 1 0 0 1 1 1v1a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a1 1 0 0 1 1-1V3"/></svg>',
     title: 'Every connection mode',
     body: 'Standalone, replica set, or raw connection string. TLS with system CA, custom CA, or client certificate; SSH tunnel; SOCKS5 proxy. A staged Test Connection reports each real phase: parse → DNS → connect → ping.',
   },
   {
+    // Lucide: shield-check
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg>',
     title: 'All the auth mechanisms',
     body: 'SCRAM-SHA-1/256, X.509, MONGODB-AWS (IAM with session token), GSSAPI/Kerberos, and LDAP (PLAIN) — with the correct $external plumbing.',
   },
   {
+    // Lucide: search
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m21 21-4.34-4.34"/><circle cx="11" cy="11" r="8"/></svg>',
     title: 'Query & aggregate',
     body: 'find with filter, sort, projection, skip, limit and pagination. A visual query builder, full aggregation pipelines, and explain plans for both find and aggregate rendered as a visual plan tree.',
   },
   {
+    // Lucide: square-pen
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/></svg>',
     title: 'Edit documents — in bulk',
     body: 'View, insert, edit, and delete documents. Run update-many / delete-many by filter with a counted, guarded confirmation so you never touch more than you meant to.',
   },
   {
+    // Lucide: list-tree
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12h-8"/><path d="M21 6H8"/><path d="M21 18h-8"/><path d="M3 6v4c0 1.1.9 2 2 2h3"/><path d="M3 10v6c0 1.1.9 2 2 2h3"/></svg>',
     title: 'Indexes, collections & views',
     body: 'Create, inspect, and drop indexes with real key patterns and unique/sparse flags. Create, drop, and rename collections and databases, and build aggregation-backed views.',
   },
   {
+    // Lucide: git-branch
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>',
     title: 'Schema analysis',
     body: 'Sample a collection and see per-field types and presence/coverage — including nested paths — to understand what your data actually looks like.',
   },
   {
+    // Lucide: folder-tree
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2.5a1 1 0 0 1-.8-.4l-.9-1.2A1 1 0 0 0 15 3h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z"/><path d="M20 21a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-2.9a1 1 0 0 1-.88-.55l-.42-.85a1 1 0 0 0-.92-.6H13a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z"/><path d="M3 5a2 2 0 0 0 2 2h3"/><path d="M3 3v13a2 2 0 0 0 2 2h3"/></svg>',
     title: 'GridFS & import/export',
     body: 'Browse files in a GridFS bucket and download them to disk. Import and export JSON and CSV, including full-collection background exports.',
   },
   {
+    // Lucide: square-terminal
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m7 11 2-2-2-2"/><path d="M11 13h4"/><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/></svg>',
     title: 'Embedded mongosh',
     body: 'A real shell backed by an actual mongosh binary, right inside the app — for the moments a GUI cannot reach.',
   },
   {
+    // Lucide: sparkles
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>',
     title: 'AI query assistant',
     body: 'Natural language → MQL, with your choice of provider (Anthropic, OpenAI, Gemini, or local agent CLIs). The API key stays in the backend, out of the frontend.',
   },
@@ -88,6 +106,7 @@ const features = [
       <div class="feat-grid">
         {features.map((f) => (
           <article class="feat-card">
+            <span class="feat-icon" set:html={f.icon} aria-hidden="true"></span>
             <h3>{f.title}</h3>
             <p>{f.body}</p>
           </article>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -59,6 +59,24 @@ const features = [
     body: 'Natural language → MQL, with your choice of provider (Anthropic, OpenAI, Gemini, or local agent CLIs). The API key stays in the backend, out of the frontend.',
   },
 ];
+
+// Literal braces/quotes here would be parsed as Astro/JSX expressions in markup,
+// so the query and result JSON are authored as strings and injected via set:html.
+const heroQuery =
+  'db.orders.find(&#123; status: <span class="tok-str">"shipped"</span> &#125;).sort(&#123; createdAt: <span class="tok-num">-1</span> &#125;)';
+
+const heroDoc = `&#123;
+  <span class="tok-key">"_id"</span>: <span class="tok-fn">ObjectId</span>(<span class="tok-str">"66f1c0a4e3b1a2f4d8c91a07"</span>),
+  <span class="tok-key">"status"</span>: <span class="tok-str">"shipped"</span>,
+  <span class="tok-key">"customer"</span>: <span class="tok-str">"ava.nguyen@example.com"</span>,
+  <span class="tok-key">"total"</span>: <span class="tok-num">238.40</span>,
+  <span class="tok-key">"items"</span>: [
+    &#123; <span class="tok-key">"sku"</span>: <span class="tok-str">"KBD-87"</span>, <span class="tok-key">"qty"</span>: <span class="tok-num">1</span> &#125;,
+    &#123; <span class="tok-key">"sku"</span>: <span class="tok-str">"CBL-USBC"</span>, <span class="tok-key">"qty"</span>: <span class="tok-num">2</span> &#125;
+  ],
+  <span class="tok-key">"paid"</span>: <span class="tok-bool">true</span>,
+  <span class="tok-key">"createdAt"</span>: <span class="tok-fn">ISODate</span>(<span class="tok-str">"2026-05-28T14:09:53Z"</span>)
+&#125;`;
 ---
 
 <BaseLayout>
@@ -78,7 +96,44 @@ const features = [
         <a class="btn btn-primary" href="#download">Download for free</a>
         <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">Star on GitHub ★</a>
       </div>
-      <img src="/demo.gif" alt="MQLens: connect, query, aggregate, and read an explain plan" class="hero-demo" loading="eager" width="1000" onerror="this.style.display='none'" />
+      <div class="app-mock" role="img" aria-label="MQLens querying a prod-cluster: db.orders.find({ status: 'shipped' }) returning a shipped order document with an IXSCAN explain plan">
+        <div class="app-mock-chrome">
+          <div class="app-mock-dots" aria-hidden="true">
+            <span class="dot dot-red"></span>
+            <span class="dot dot-amber"></span>
+            <span class="dot dot-green"></span>
+          </div>
+          <div class="app-mock-title">MQLens — prod-cluster <span class="app-mock-title-dim">(replica set)</span></div>
+        </div>
+        <div class="app-mock-body">
+          <aside class="app-mock-side">
+            <div class="side-tree">
+              <div class="tree-row tree-db">▾ ecommerce</div>
+              <div class="tree-row tree-coll">users</div>
+              <div class="tree-row tree-coll is-active">orders</div>
+              <div class="tree-row tree-coll">products</div>
+              <div class="tree-row tree-db">▸ analytics</div>
+            </div>
+            <div class="side-foot"><span class="side-dot"></span> mongosh</div>
+          </aside>
+          <div class="app-mock-main">
+            <div class="main-tabs" role="tablist">
+              <span class="tab is-active">Documents</span>
+              <span class="tab">Aggregation</span>
+              <span class="tab">Explain</span>
+              <span class="tab">Indexes</span>
+            </div>
+            <div class="query-bar"><span class="query-prompt">&gt;</span><code class="query-code" set:html={heroQuery}></code></div>
+            <pre class="result-json"><code set:html={heroDoc}></code></pre>
+            <div class="explain-chip">
+              <span class="chip-tag">IXSCAN</span>
+              <span class="chip-sep">·</span> 1,204 examined
+              <span class="chip-sep">·</span> 1,204 returned
+              <span class="chip-sep">·</span> <span class="chip-ms">12&#8202;ms</span>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="hero-meta">
         <span>✓ macOS · Windows · Linux</span>
         <span>✓ GPG-signed &amp; notarized builds</span>
@@ -147,7 +202,7 @@ gpg --verify MQLens_0.1.0_amd64.deb.asc \
 
 <style>
   .hero {
-    padding: 96px 0 72px;
+    padding: 96px 0 88px;
     background:
       radial-gradient(1100px 480px at 50% -140px, hsla(200, 90%, 50%, 0.20), transparent 70%),
       radial-gradient(900px 460px at 92% 120%, hsla(268, 85%, 65%, 0.12), transparent 70%);

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -63,20 +63,16 @@ const features = [
 // Literal braces/quotes here would be parsed as Astro/JSX expressions in markup,
 // so the query and result JSON are authored as strings and injected via set:html.
 const heroQuery =
-  'db.orders.find(&#123; status: <span class="tok-str">"shipped"</span> &#125;).sort(&#123; createdAt: <span class="tok-num">-1</span> &#125;)';
+  'db.orders.find(<span class="tok-p">&#123;</span> <span class="tok-key">status</span><span class="tok-p">:</span> <span class="tok-str">"shipped"</span> <span class="tok-p">&#125;</span>)<span class="tok-p">.</span>sort(<span class="tok-p">&#123;</span> <span class="tok-key">createdAt</span><span class="tok-p">:</span> <span class="tok-num">-1</span> <span class="tok-p">&#125;</span>)';
 
-const heroDoc = `&#123;
-  <span class="tok-key">"_id"</span>: <span class="tok-fn">ObjectId</span>(<span class="tok-str">"66f1c0a4e3b1a2f4d8c91a07"</span>),
-  <span class="tok-key">"status"</span>: <span class="tok-str">"shipped"</span>,
-  <span class="tok-key">"customer"</span>: <span class="tok-str">"ava.nguyen@example.com"</span>,
-  <span class="tok-key">"total"</span>: <span class="tok-num">238.40</span>,
-  <span class="tok-key">"items"</span>: [
-    &#123; <span class="tok-key">"sku"</span>: <span class="tok-str">"KBD-87"</span>, <span class="tok-key">"qty"</span>: <span class="tok-num">1</span> &#125;,
-    &#123; <span class="tok-key">"sku"</span>: <span class="tok-str">"CBL-USBC"</span>, <span class="tok-key">"qty"</span>: <span class="tok-num">2</span> &#125;
-  ],
-  <span class="tok-key">"paid"</span>: <span class="tok-bool">true</span>,
-  <span class="tok-key">"createdAt"</span>: <span class="tok-fn">ISODate</span>(<span class="tok-str">"2026-05-28T14:09:53Z"</span>)
-&#125;`;
+const heroDoc = `<span class="tok-p">&#123;</span>
+  <span class="tok-key">_id</span><span class="tok-p">:</span> <span class="tok-fn">ObjectId</span><span class="tok-p">(</span><span class="tok-str">"66f1a2c4e9b…"</span><span class="tok-p">)</span><span class="tok-p">,</span>
+  <span class="tok-key">status</span><span class="tok-p">:</span> <span class="tok-str">"shipped"</span><span class="tok-p">,</span>
+  <span class="tok-key">total</span><span class="tok-p">:</span> <span class="tok-num">248.50</span><span class="tok-p">,</span>
+  <span class="tok-key">paid</span><span class="tok-p">:</span> <span class="tok-bool">true</span><span class="tok-p">,</span>
+  <span class="tok-key">items</span><span class="tok-p">:</span> <span class="tok-p">[</span> <span class="tok-num">3</span> <span class="tok-p">]</span><span class="tok-p">,</span>
+  <span class="tok-key">shippedAt</span><span class="tok-p">:</span> <span class="tok-fn">ISODate</span><span class="tok-p">(</span><span class="tok-str">"2026-05-31"</span><span class="tok-p">)</span>
+<span class="tok-p">&#125;</span>`;
 ---
 
 <BaseLayout>
@@ -103,33 +99,51 @@ const heroDoc = `&#123;
             <span class="dot dot-amber"></span>
             <span class="dot dot-green"></span>
           </div>
-          <div class="app-mock-title">MQLens — prod-cluster <span class="app-mock-title-dim">(replica set)</span></div>
+          <div class="app-mock-title">
+            <span class="am-title-name">MQLens</span>
+            <span class="am-title-sep">·</span>
+            <span class="am-title-live"><span class="am-live-dot"></span> prod-cluster · replica set</span>
+          </div>
         </div>
         <div class="app-mock-body">
           <aside class="app-mock-side">
-            <div class="side-tree">
-              <div class="tree-row tree-db">▾ ecommerce</div>
-              <div class="tree-row tree-coll">users</div>
-              <div class="tree-row tree-coll is-active">orders</div>
-              <div class="tree-row tree-coll">products</div>
-              <div class="tree-row tree-db">▸ analytics</div>
+            <div class="am-side-conn"><span class="am-conn-dot"></span> prod-cluster</div>
+            <div class="am-tree">
+              <div class="am-node am-node-db">
+                <span class="am-db-glyph"></span>
+                <span class="am-caret">▾</span> ecommerce <span class="am-count">· 6</span>
+              </div>
+              <div class="am-children">
+                <div class="am-coll"><span class="am-coll-name">users</span><span class="am-docs">1.2k</span></div>
+                <div class="am-coll is-active"><span class="am-coll-name">orders</span><span class="am-docs">248</span></div>
+                <div class="am-index"><span class="am-idx-glyph">⚿</span> status_-1_createdAt_-1</div>
+                <div class="am-coll"><span class="am-coll-name">products</span><span class="am-docs">89</span></div>
+              </div>
+              <div class="am-node am-node-db">
+                <span class="am-db-glyph"></span>
+                <span class="am-caret">▸</span> analytics
+              </div>
             </div>
-            <div class="side-foot"><span class="side-dot"></span> mongosh</div>
           </aside>
           <div class="app-mock-main">
             <div class="main-tabs" role="tablist">
-              <span class="tab is-active">Documents</span>
+              <span class="tab is-active">Documents <span class="tab-pill">248</span></span>
               <span class="tab">Aggregation</span>
               <span class="tab">Explain</span>
               <span class="tab">Indexes</span>
             </div>
-            <div class="query-bar"><span class="query-prompt">&gt;</span><code class="query-code" set:html={heroQuery}></code></div>
+            <div class="query-bar">
+              <div class="am-seg" aria-hidden="true">
+                <span class="am-seg-item is-active">Find</span>
+                <span class="am-seg-item">Aggregate</span>
+              </div>
+              <code class="query-code" set:html={heroQuery}></code>
+              <button class="am-run" type="button" aria-hidden="true">Run</button>
+            </div>
             <pre class="result-json"><code set:html={heroDoc}></code></pre>
-            <div class="explain-chip">
-              <span class="chip-tag">IXSCAN</span>
-              <span class="chip-sep">·</span> 1,204 examined
-              <span class="chip-sep">·</span> 1,204 returned
-              <span class="chip-sep">·</span> <span class="chip-ms">12&#8202;ms</span>
+            <div class="am-status">
+              <span class="am-status-left">248 documents <span class="am-status-sep">·</span> 12 ms</span>
+              <span class="explain-chip">IXSCAN <span class="chip-sep">·</span> 1,204 examined <span class="chip-sep">·</span> 1,204 returned</span>
             </div>
           </div>
         </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -48,17 +48,19 @@ const features = [
   <section class="hero">
     <div class="container hero-inner">
       <span class="eyebrow">Open source · {SITE.license}</span>
-      <h1>The MongoDB GUI that's<br /><span class="grad">fast, native, and honest.</span></h1>
+      <h1>Studio 3T power for MongoDB.<br /><span class="grad">Free, native, and private.</span></h1>
       <p class="lede">
-        {SITE.name} connects to any real MongoDB deployment and lets you browse, query,
-        aggregate, explain, edit in bulk, manage indexes and views, analyze schemas, and
-        run an embedded <code>mongosh</code> — with credentials encrypted behind a master
-        password. Built with Tauri (Rust) and React.
+        {SITE.name} is a full-power MongoDB GUI — every auth mode, TLS/SSH/proxy,
+        aggregation pipelines with explain plans, bulk edit, schema analysis, GridFS,
+        an embedded <code>mongosh</code>, and an AI query assistant — in a tiny native
+        app (Tauri/Rust, not Electron). Credentials stay encrypted on your machine.
+        Apache-2.0, $0.
       </p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="#download">Download for free</a>
-        <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">View source</a>
+        <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">Star on GitHub ★</a>
       </div>
+      <img src="/demo.gif" alt="MQLens: connect, query, aggregate, and read an explain plan" class="hero-demo" loading="eager" width="1000" />
       <div class="hero-meta">
         <span>✓ macOS · Windows · Linux</span>
         <span>✓ GPG-signed &amp; notarized builds</span>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -60,7 +60,7 @@ const features = [
         <a class="btn btn-primary" href="#download">Download for free</a>
         <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">Star on GitHub ★</a>
       </div>
-      <img src="/demo.gif" alt="MQLens: connect, query, aggregate, and read an explain plan" class="hero-demo" loading="eager" width="1000" />
+      <img src="/demo.gif" alt="MQLens: connect, query, aggregate, and read an explain plan" class="hero-demo" loading="eager" width="1000" onerror="this.style.display='none'" />
       <div class="hero-meta">
         <span>✓ macOS · Windows · Linux</span>
         <span>✓ GPG-signed &amp; notarized builds</span>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -80,7 +80,7 @@ const heroDoc = `<span class="tok-p">&#123;</span>
   <section class="hero">
     <div class="container hero-inner">
       <span class="eyebrow">Open source · {SITE.license}</span>
-      <h1>The MongoDB GUI that does it all.<br /><span class="grad">Free, native, and private.</span></h1>
+      <h1>The MongoDB GUI<br />that does it all.<span class="grad">Free, native, and private.</span></h1>
       <p class="lede">
         {SITE.name} is a full-power MongoDB GUI — every auth mode, TLS/SSH/proxy,
         aggregation pipelines with explain plans, bulk edit, schema analysis, GridFS,
@@ -222,16 +222,27 @@ gpg --verify MQLens_0.1.0_amd64.deb.asc \
       radial-gradient(900px 460px at 92% 120%, hsla(268, 85%, 65%, 0.12), transparent 70%);
     border-bottom: 1px solid var(--border);
   }
-  .hero-inner { text-align: center; max-width: 820px; margin: 0 auto; }
-  .hero h1 { font-size: clamp(2.2rem, 6vw, 3.6rem); margin: 18px 0 0; font-weight: 700; }
+  .hero-inner { text-align: center; max-width: 900px; margin: 0 auto; }
+  .hero h1 {
+    font-size: clamp(2.3rem, 6vw, 3.6rem);
+    line-height: 1.08;
+    letter-spacing: -0.025em;
+    margin: 26px 0 0;
+    font-weight: 700;
+    text-wrap: balance;
+  }
   .grad {
+    display: block;
+    margin-top: 0.22em;
+    line-height: 1.1;
+    padding-bottom: 0.08em;
     background: linear-gradient(100deg, var(--accent-bright), var(--accent-teal));
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
   }
-  .lede { font-size: 1.12rem; color: var(--text-dim); margin: 22px auto 0; max-width: 680px; }
-  .hero-cta { display: flex; gap: 12px; justify-content: center; margin-top: 30px; flex-wrap: wrap; }
+  .lede { font-size: 1.12rem; line-height: 1.72; color: var(--text-dim); margin: 30px auto 0; max-width: 640px; }
+  .hero-cta { display: flex; gap: 12px; justify-content: center; margin-top: 38px; flex-wrap: wrap; }
   .hero-meta {
     display: flex; gap: 22px; justify-content: center; flex-wrap: wrap;
     margin-top: 28px; color: var(--text-dim); font-size: 0.9rem;

--- a/website/src/pages/mongodb-gui-for-linux.astro
+++ b/website/src/pages/mongodb-gui-for-linux.astro
@@ -1,0 +1,272 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Download from '../components/Download.astro';
+import { SITE } from '../consts';
+---
+
+<BaseLayout
+  title="MongoDB GUI for Linux"
+  description="MQLens ships a first-class native Linux build — .deb for Debian/Ubuntu and AppImage for any distro — with zero Electron overhead, every auth mode, SSH tunnel, aggregation pipelines, and more. Free and Apache-2.0."
+>
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container hero-inner">
+      <span class="eyebrow">Open source · {SITE.license} · Linux-first</span>
+      <h1>A native MongoDB GUI for Linux.<br /><span class="grad">First-class, not an afterthought.</span></h1>
+      <p class="lede">
+        Linux users deserve a MongoDB GUI that was built for the platform, not reluctantly ported
+        from macOS. MQLens ships a proper native Linux build — <code>.deb</code> for Debian and
+        Ubuntu, and an <code>.AppImage</code> that runs on virtually any distro — weighing just
+        ~14 MB. No Electron, no bundled Chromium, no bloat. Built with Tauri/Rust and a lean
+        WebView. GPG-signed binaries you can verify before running.
+      </p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#download">Download for Linux</a>
+        <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">Star on GitHub ★</a>
+      </div>
+      <div class="hero-meta">
+        <span>✓ .deb (Debian / Ubuntu)</span>
+        <span>✓ .AppImage (any distro)</span>
+        <span>✓ GPG-signed builds</span>
+        <span>✓ Zero telemetry</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Download CTA (above the fold for Linux visitors) -->
+  <section class="section-tight" id="download">
+    <div class="container">
+      <h2 class="dl-heading">Download {SITE.name} for Linux</h2>
+      <Download />
+    </div>
+  </section>
+
+  <!-- Features section -->
+  <section class="section" id="features">
+    <div class="container">
+      <div class="sec-head">
+        <span class="eyebrow">Everything included</span>
+        <h2>Full MongoDB power on Linux</h2>
+        <p>Every feature, the same native binary, no platform tax.</p>
+      </div>
+      <div class="feat-grid">
+        <article class="feat-card">
+          <h3>Every auth mechanism</h3>
+          <p>SCRAM-SHA-1/256, X.509, MONGODB-AWS (IAM with session token), GSSAPI/Kerberos, and LDAP — with the correct <code>$external</code> database plumbing, working on Linux just as on macOS or Windows.</p>
+        </article>
+        <article class="feat-card">
+          <h3>TLS · SSH tunnel · SOCKS5</h3>
+          <p>Full TLS support with system CA, custom CA, or client certificate. SSH tunnel through a jump host. SOCKS5 proxy for environments where all traffic must route through a proxy.</p>
+        </article>
+        <article class="feat-card">
+          <h3>Aggregation pipelines</h3>
+          <p>Build and execute aggregation pipelines with a multi-stage editor. Visual explain plans rendered as a plan tree for both <code>find</code> and <code>aggregate</code> — so you know exactly what the query engine is doing.</p>
+        </article>
+        <article class="feat-card">
+          <h3>Bulk edit — safely</h3>
+          <p>Run <code>updateMany</code> and <code>deleteMany</code> by filter with a counted, guarded confirmation dialog. See how many documents will be affected before you commit. No surprises.</p>
+        </article>
+        <article class="feat-card">
+          <h3>Biometric-protected credentials</h3>
+          <p>Connection profiles are encrypted with AES-256-GCM (Argon2id key derivation) and unlockable with biometrics — PAM / libsecret on Linux — so credentials survive reboots but never sit in plaintext.</p>
+        </article>
+        <article class="feat-card">
+          <h3>Schema analysis</h3>
+          <p>Sample a collection to see per-field types, nested paths, and presence/coverage across documents. Understand the shape of your data without writing ad hoc queries.</p>
+        </article>
+        <article class="feat-card">
+          <h3>GridFS browser</h3>
+          <p>Browse files stored in GridFS buckets, inspect metadata, and download files to disk — directly from the GUI without resorting to the shell.</p>
+        </article>
+        <article class="feat-card">
+          <h3>Embedded mongosh</h3>
+          <p>A real shell backed by an actual <code>mongosh</code> binary, wired directly into your active connection — for the moments a GUI cannot reach.</p>
+        </article>
+        <article class="feat-card">
+          <h3>AI query assistant</h3>
+          <p>Describe what you need in plain English and get MQL back. Works with Anthropic, OpenAI, Gemini, or a local CLI agent. Your API key stays in the backend process, never in the frontend.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- Verify section — useful for Linux users who take security seriously -->
+  <section class="section security">
+    <div class="container sec-grid">
+      <div>
+        <span class="eyebrow">Security on Linux</span>
+        <h2>GPG-signed — verify before you run</h2>
+        <ul class="checks">
+          <li>Every release binary is GPG-signed. Verify the signature before installing — the KEYS file and <code>.asc</code> detached signatures are published alongside each release.</li>
+          <li>Credentials are encrypted at rest with AES-256-GCM. The Argon2id key derivation makes brute-force impractical even on a stolen disk.</li>
+          <li>Zero telemetry. No crash reporters, no usage pings, no analytics beacons. What happens on your machine stays on your machine.</li>
+        </ul>
+        <a class="btn btn-ghost" href="/docs/#security">Read the security model →</a>
+      </div>
+      <pre><code># Verify the .deb before installing
+gpg --import KEYS
+gpg --verify MQLens_0.1.0_amd64.deb.asc \
+            MQLens_0.1.0_amd64.deb
+
+# Install the .deb
+sudo dpkg -i MQLens_0.1.0_amd64.deb
+
+# Or run the AppImage directly (any distro)
+chmod +x MQLens_0.1.0_x86_64.AppImage
+./MQLens_0.1.0_x86_64.AppImage</code></pre>
+    </div>
+  </section>
+
+  <!-- Comparison: Linux GUI landscape -->
+  <section class="section">
+    <div class="container">
+      <div class="sec-head">
+        <span class="eyebrow">Linux GUI landscape</span>
+        <h2>How MQLens compares on Linux</h2>
+        <p>Most MongoDB GUIs treat Linux as a secondary platform. MQLens does not.</p>
+      </div>
+      <div class="table-wrap">
+        <table class="cmp-table">
+          <thead>
+            <tr>
+              <th>GUI</th>
+              <th>Linux build</th>
+              <th>Runtime</th>
+              <th>Price</th>
+              <th>Telemetry</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="col-us">{SITE.name}</td>
+              <td class="col-us">.deb + AppImage</td>
+              <td class="col-us">Native (Tauri/Rust) ~14 MB</td>
+              <td class="col-us">Free (Apache-2.0)</td>
+              <td class="col-us">Zero</td>
+            </tr>
+            <tr>
+              <td>MongoDB Compass</td>
+              <td>.deb + .rpm + .tar.gz</td>
+              <td>Electron, 200 MB+</td>
+              <td>Free</td>
+              <td>On by default (opt-out)</td>
+            </tr>
+            <tr>
+              <td>Studio 3T</td>
+              <td>.tar.gz</td>
+              <td>Java-based</td>
+              <td>Paid subscription</td>
+              <td>Collected per privacy policy</td>
+            </tr>
+            <tr>
+              <td>Robo 3T</td>
+              <td>.tar.gz</td>
+              <td>Qt-based</td>
+              <td>Free</td>
+              <td>Minimal</td>
+            </tr>
+            <tr>
+              <td>NoSQLBooster</td>
+              <td>AppImage</td>
+              <td>Electron-based</td>
+              <td>Freemium (paid for full features)</td>
+              <td>Collected per privacy policy</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- Final CTA -->
+  <section class="section cta">
+    <div class="container cta-inner">
+      <h2>Point {SITE.name} at your MongoDB cluster.</h2>
+      <p>Free, open source, native Linux binary — yours to inspect and run.</p>
+      <a class="btn btn-primary" href="#download">Download {SITE.name} for Linux</a>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero {
+    padding: 96px 0 72px;
+    background:
+      radial-gradient(1100px 480px at 50% -140px, hsla(200, 90%, 50%, 0.20), transparent 70%),
+      radial-gradient(900px 460px at 92% 120%, hsla(268, 85%, 65%, 0.12), transparent 70%);
+    border-bottom: 1px solid var(--border);
+  }
+  .hero-inner { text-align: center; max-width: 820px; margin: 0 auto; }
+  .hero h1 { font-size: clamp(2.2rem, 6vw, 3.4rem); margin: 18px 0 0; font-weight: 700; }
+  .grad {
+    background: linear-gradient(100deg, var(--accent-bright), var(--accent-teal));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .lede { font-size: 1.12rem; color: var(--text-dim); margin: 22px auto 0; max-width: 680px; }
+  .hero-cta { display: flex; gap: 12px; justify-content: center; margin-top: 30px; flex-wrap: wrap; }
+  .hero-meta {
+    display: flex; gap: 22px; justify-content: center; flex-wrap: wrap;
+    margin-top: 28px; color: var(--text-dim); font-size: 0.9rem;
+  }
+
+  .dl-heading { text-align: center; margin: 0 0 28px; font-size: 1.6rem; }
+
+  .sec-head { text-align: center; max-width: 640px; margin: 0 auto 48px; }
+  .sec-head h2 { font-size: clamp(1.8rem, 4vw, 2.4rem); margin: 12px 0 0; }
+  .sec-head p { color: var(--text-dim); margin-top: 14px; }
+
+  .feat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 18px;
+  }
+  .feat-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+    transition: border-color 0.15s ease, transform 0.08s ease;
+  }
+  .feat-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+  .feat-card h3 { margin: 0 0 10px; font-size: 1.12rem; }
+  .feat-card p { margin: 0; color: var(--text-dim); font-size: 0.95rem; }
+
+  .security { background: var(--bg-soft); border-block: 1px solid var(--border); }
+  .sec-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: center; }
+  .sec-grid h2 { font-size: clamp(1.6rem, 3.5vw, 2.2rem); margin: 12px 0 20px; }
+  .checks { list-style: none; padding: 0; margin: 0 0 24px; }
+  .checks li { position: relative; padding-left: 28px; margin-bottom: 14px; color: var(--text-dim); }
+  .checks li::before { content: "✓"; position: absolute; left: 0; color: var(--accent-bright); font-weight: 700; }
+
+  .table-wrap { overflow-x: auto; }
+  .cmp-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+  }
+  .cmp-table th,
+  .cmp-table td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+  }
+  .cmp-table thead th {
+    background: var(--bg-soft);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+  }
+  .cmp-table tbody tr:hover { background: var(--bg-soft); }
+  .col-us { color: var(--accent-bright); font-weight: 500; }
+
+  .cta-inner { text-align: center; }
+  .cta-inner h2 { font-size: clamp(1.8rem, 4vw, 2.6rem); margin: 0; }
+  .cta-inner p { color: var(--text-dim); margin: 14px 0 26px; }
+
+  @media (max-width: 820px) {
+    .sec-grid { grid-template-columns: 1fr; gap: 28px; }
+  }
+</style>

--- a/website/src/pages/mongodb-gui-for-linux.astro
+++ b/website/src/pages/mongodb-gui-for-linux.astro
@@ -14,11 +14,13 @@ import { SITE } from '../consts';
       <span class="eyebrow">Open source · {SITE.license} · Linux-first</span>
       <h1>A native MongoDB GUI for Linux.<br /><span class="grad">First-class, not an afterthought.</span></h1>
       <p class="lede">
-        Linux users deserve a MongoDB GUI that was built for the platform, not reluctantly ported
-        from macOS. MQLens ships a proper native Linux build — <code>.deb</code> for Debian and
-        Ubuntu, and an <code>.AppImage</code> that runs on virtually any distro — weighing just
-        ~14 MB. No Electron, no bundled Chromium, no bloat. Built with Tauri/Rust and a lean
-        WebView. GPG-signed binaries you can verify before running.
+        Most MongoDB GUIs treat Linux as an afterthought — heavy Electron bundles, no AppImage,
+        or a ".tar.gz and good luck" situation. MQLens ships a first-class native Linux build:
+        <code>.deb</code> for Debian/Ubuntu and an <code>.AppImage</code> for any distro, weighing
+        just ~14 MB. No Electron, no Chromium, no bloat. Built with Tauri/Rust. Every feature
+        — aggregation pipelines, all auth modes, SSH tunnel, biometric-protected credentials,
+        AI assistant — works on Linux exactly as on macOS or Windows. GPG-signed. Zero telemetry.
+        Apache-2.0, $0.
       </p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="#download">Download for Linux</a>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -124,13 +124,169 @@ pre code { color: var(--text); }
   .section { padding: 60px 0; }
 }
 
-.hero-demo {
-  display: block;
-  width: 100%;
-  max-width: 1000px;
-  margin: 2rem auto 0;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+/* ============================================================
+   Hero app-window mockup — pure CSS product shot of MQLens.
+   No images, no JS. Breaks out of the 820px hero-inner column.
+   ============================================================ */
+.app-mock {
+  width: min(960px, 100%);
+  margin: 44px auto 0;
+  text-align: left;
+  border: 1px solid hsla(200, 90%, 62%, 0.16);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, var(--bg-elevated), var(--bg-card));
+  box-shadow: var(--shadow-card), 0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+  overflow: hidden;
+  font-size: 13px;
+}
+
+/* Window chrome */
+.app-mock-chrome {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 38px;
+  padding: 0 14px;
+  background: linear-gradient(180deg, hsl(222, 20%, 15%), hsl(222, 20%, 12%));
+  border-bottom: 1px solid var(--border);
+}
+.app-mock-dots { display: flex; gap: 8px; }
+.app-mock-dots .dot {
+  width: 11px; height: 11px; border-radius: 50%;
+  box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.25) inset;
+}
+.dot-red { background: hsl(353, 75%, 58%); }
+.dot-amber { background: hsl(38, 92%, 60%); }
+.dot-green { background: hsl(142, 60%, 50%); }
+.app-mock-title {
+  position: absolute;
+  left: 50%; transform: translateX(-50%);
+  font-size: 12px; font-weight: 600;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.app-mock-title-dim { color: var(--text-faint); font-weight: 500; }
+
+/* Body: sidebar + main */
+.app-mock-body { display: grid; grid-template-columns: 178px 1fr; }
+
+/* Sidebar / collection tree */
+.app-mock-side {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 12px 0 0;
+  background: hsla(222, 24%, 5%, 0.55);
+  border-right: 1px solid var(--border);
+  font-family: var(--font);
+  min-height: 248px;
+}
+.tree-row {
+  padding: 5px 16px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tree-row.tree-db { color: var(--text); font-weight: 600; }
+.tree-row.tree-coll { padding-left: 30px; }
+.tree-row.is-active {
+  color: var(--accent-bright);
+  background: var(--accent-soft);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+.side-foot {
+  display: flex; align-items: center; gap: 8px;
+  padding: 11px 16px;
+  margin-top: 12px;
+  border-top: 1px solid var(--border);
+  color: var(--text-faint);
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+.side-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--accent-green);
+  box-shadow: 0 0 7px hsla(142, 70%, 45%, 0.7);
+}
+
+/* Main panel */
+.app-mock-main { padding: 12px 18px 18px; }
+.main-tabs {
+  display: flex; gap: 20px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 14px;
+}
+.main-tabs .tab {
+  padding: 4px 0 9px;
+  color: var(--text-faint);
+  font-size: 12.5px; font-weight: 500;
+}
+.main-tabs .tab.is-active {
+  color: var(--text);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+.query-bar {
+  display: flex; align-items: center; gap: 9px;
+  padding: 9px 12px;
+  background: hsl(222, 26%, 4%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+}
+.query-bar .query-prompt { color: var(--accent-teal); font-family: var(--mono); }
+.query-bar .query-code {
+  font-family: var(--mono);
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.result-json {
+  margin: 14px 0 0;
+  padding: 14px 16px;
+  background: hsl(222, 26%, 4%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+  line-height: 1.5;
+}
+.result-json code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--text-dim);
+  white-space: pre;
+}
+
+/* JSON syntax coloring */
+.tok-key { color: var(--accent-bright); }
+.tok-str { color: var(--accent-teal); }
+.tok-num { color: var(--accent-amber); }
+.tok-bool { color: var(--accent-purple); }
+.tok-fn { color: var(--text-faint); }
+
+.explain-chip {
+  display: inline-flex; align-items: center; gap: 7px;
+  margin-top: 14px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: hsla(142, 70%, 45%, 0.10);
+  border: 1px solid hsla(142, 70%, 45%, 0.30);
+  color: var(--accent-green);
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+.explain-chip .chip-tag { font-weight: 700; letter-spacing: 0.02em; }
+.explain-chip .chip-sep { color: hsla(142, 70%, 45%, 0.5); }
+.explain-chip .chip-ms { color: var(--accent-bright); }
+
+@media (max-width: 720px) {
+  .app-mock { font-size: 12px; }
+  .app-mock-body { grid-template-columns: 1fr; }
+  .app-mock-side { display: none; }
+  .app-mock-main { padding: 12px 14px 16px; }
+  .main-tabs { gap: 14px; overflow-x: auto; }
+  .app-mock-title { display: none; }
 }
 
 /* Feature-card icon chip — enterprise-style rounded square */

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -35,7 +35,7 @@
   --shadow-btn-hover: 0 6px 18px hsla(200, 90%, 50%, 0.28);
   --shadow-card: 0 16px 36px rgba(0, 0, 0, 0.45);
 
-  --max-width: 1080px;
+  --max-width: 1200px;
   /* Radii — app uses small radii; pills only where intended */
   --radius: 12px;
   --radius-sm: 6px;
@@ -131,4 +131,23 @@ pre code { color: var(--text); }
   margin: 2rem auto 0;
   border-radius: 12px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+/* Feature-card icon chip — enterprise-style rounded square */
+.feat-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  margin: 0 0 16px;
+  border-radius: var(--radius);
+  background: hsla(200, 90%, 50%, 0.12);
+  border: 1px solid hsla(200, 90%, 50%, 0.25);
+  color: var(--accent-bright);
+}
+.feat-icon svg {
+  width: 22px;
+  height: 22px;
+  display: block;
 }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -125,30 +125,58 @@ pre code { color: var(--text); }
 }
 
 /* ============================================================
-   Hero app-window mockup — pure CSS product shot of MQLens.
-   No images, no JS. Breaks out of the 820px hero-inner column.
+   Hero app-window mockup — a faithful, pure-CSS product shot of
+   the real MQLens desktop client (dense IDE-style MongoDB GUI).
+   Scoped --m-* tokens mirror the actual app palette; do not reuse
+   the marketing-site tokens here. No images, no JS.
    ============================================================ */
 .app-mock {
-  width: min(960px, 100%);
+  /* Real-app palette */
+  --m-bg: hsl(222, 24%, 6%);
+  --m-chrome: hsla(222, 24%, 5%, 0.92);
+  --m-sidebar: hsla(222, 24%, 5%, 0.85);
+  --m-panel: hsla(222, 20%, 10%, 0.75);
+  --m-item-hover: hsla(220, 20%, 16%, 0.65);
+  --m-item-active: hsl(220, 20%, 20%);
+  --m-border: hsla(220, 15%, 18%, 0.95);
+  --m-guide: hsla(220, 15%, 25%, 0.70);
+  --m-text: hsl(210, 20%, 94%);
+  --m-muted: hsl(215, 12%, 68%);
+  --m-dim: hsl(215, 8%, 48%);
+  --m-blue: hsl(200, 90%, 50%);
+  --m-teal: hsl(175, 85%, 43%);
+  --m-green: hsl(142, 70%, 45%);
+  --m-amber: hsl(38, 92%, 60%);
+  --m-purple: hsl(268, 85%, 65%);
+  --m-red: hsl(350, 80%, 55%);
+  --m-syn-key: hsl(200, 95%, 70%);
+  --m-syn-str: hsl(142, 70%, 75%);
+  --m-syn-num: hsl(38, 92%, 60%);
+  --m-syn-bool: hsl(268, 80%, 75%);
+  --m-syn-null: hsl(215, 8%, 55%);
+  --m-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  width: min(980px, 100%);
   margin: 44px auto 0;
   text-align: left;
-  border: 1px solid hsla(200, 90%, 62%, 0.16);
+  border: 1px solid var(--m-border);
   border-radius: var(--radius);
-  background: linear-gradient(180deg, var(--bg-elevated), var(--bg-card));
-  box-shadow: var(--shadow-card), 0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+  background: var(--m-bg);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.6);
   overflow: hidden;
-  font-size: 13px;
+  color: var(--m-text);
+  font-family: var(--font);
 }
 
-/* Window chrome */
+/* Title bar */
 .app-mock-chrome {
   position: relative;
   display: flex;
   align-items: center;
-  height: 38px;
+  height: 36px;
   padding: 0 14px;
-  background: linear-gradient(180deg, hsl(222, 20%, 15%), hsl(222, 20%, 12%));
-  border-bottom: 1px solid var(--border);
+  background: var(--m-chrome);
+  border-bottom: 1px solid var(--m-border);
 }
 .app-mock-dots { display: flex; gap: 8px; }
 .app-mock-dots .dot {
@@ -161,132 +189,235 @@ pre code { color: var(--text); }
 .app-mock-title {
   position: absolute;
   left: 50%; transform: translateX(-50%);
-  font-size: 12px; font-weight: 600;
-  color: var(--text-dim);
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px; font-weight: 500;
+  color: var(--m-muted);
   white-space: nowrap;
 }
-.app-mock-title-dim { color: var(--text-faint); font-weight: 500; }
+.am-title-name { color: var(--m-text); font-weight: 600; }
+.am-title-sep { color: var(--m-dim); }
+.am-title-live { display: inline-flex; align-items: center; gap: 6px; }
+.am-live-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--m-green);
+  box-shadow: 0 0 7px hsla(142, 70%, 45%, 0.7);
+}
 
 /* Body: sidebar + main */
-.app-mock-body { display: grid; grid-template-columns: 178px 1fr; }
+.app-mock-body { display: flex; }
 
-/* Sidebar / collection tree */
+/* Sidebar / connection + collection tree */
 .app-mock-side {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: 12px 0 0;
-  background: hsla(222, 24%, 5%, 0.55);
-  border-right: 1px solid var(--border);
+  flex: 0 0 225px;
+  padding: 10px 0;
+  background: var(--m-sidebar);
+  border-right: 1px solid var(--m-border);
   font-family: var(--font);
-  min-height: 248px;
+  font-size: 12px;
+  line-height: 1.7;
+  min-height: 320px;
 }
-.tree-row {
-  padding: 5px 16px;
-  color: var(--text-dim);
+.am-side-conn {
+  display: flex; align-items: center; gap: 8px;
+  padding: 4px 14px 8px;
+  color: var(--m-muted);
+}
+.am-conn-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--m-green);
+  box-shadow: 0 0 6px hsla(142, 70%, 45%, 0.6);
+}
+.am-node-db {
+  display: flex; align-items: center; gap: 6px;
+  padding: 3px 14px;
+  color: var(--m-text);
+  white-space: nowrap;
+}
+.am-db-glyph {
+  width: 9px; height: 9px; border-radius: 2px;
+  background: var(--m-amber);
+  box-shadow: 0 0 0 1px hsla(38, 92%, 60%, 0.4) inset;
+}
+.am-caret { color: var(--m-dim); font-size: 9px; }
+.am-count { color: var(--m-dim); font-weight: 400; }
+
+/* Indented collection rows with a vertical tree guide */
+.am-children {
+  position: relative;
+  margin: 2px 0;
+  padding-left: 26px;
+}
+.am-children::before {
+  content: "";
+  position: absolute;
+  left: 21px; top: 2px; bottom: 6px;
+  width: 1px;
+  background: var(--m-guide);
+}
+.am-coll {
+  position: relative;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 3px 14px 3px 4px;
+  color: var(--m-muted);
+  white-space: nowrap;
+}
+.am-coll:hover { background: var(--m-item-hover); }
+.am-coll.is-active {
+  background: var(--m-item-active);
+  color: var(--m-text);
+  box-shadow: inset 2px 0 0 var(--m-blue);
+}
+.am-docs {
+  font-family: var(--m-mono);
+  font-size: 10.5px;
+  color: var(--m-dim);
+}
+.am-index {
+  display: flex; align-items: center; gap: 6px;
+  padding: 2px 14px 2px 4px;
+  color: var(--m-purple);
+  font-family: var(--m-mono);
+  font-size: 10.5px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.tree-row.tree-db { color: var(--text); font-weight: 600; }
-.tree-row.tree-coll { padding-left: 30px; }
-.tree-row.is-active {
-  color: var(--accent-bright);
-  background: var(--accent-soft);
-  box-shadow: inset 2px 0 0 var(--accent);
-}
-.side-foot {
-  display: flex; align-items: center; gap: 8px;
-  padding: 11px 16px;
-  margin-top: 12px;
-  border-top: 1px solid var(--border);
-  color: var(--text-faint);
-  font-family: var(--mono);
-  font-size: 11.5px;
-}
-.side-dot {
-  width: 7px; height: 7px; border-radius: 50%;
-  background: var(--accent-green);
-  box-shadow: 0 0 7px hsla(142, 70%, 45%, 0.7);
-}
+.am-idx-glyph { color: var(--m-purple); }
 
 /* Main panel */
-.app-mock-main { padding: 12px 18px 18px; }
+.app-mock-main { flex: 1; min-width: 0; background: var(--m-bg); }
+
+/* Tab bar */
 .main-tabs {
-  display: flex; gap: 20px;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 14px;
+  display: flex; gap: 22px;
+  padding: 0 16px;
+  background: var(--m-chrome);
+  border-bottom: 1px solid var(--m-border);
 }
 .main-tabs .tab {
-  padding: 4px 0 9px;
-  color: var(--text-faint);
-  font-size: 12.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 9px 0 7px;
+  color: var(--m-muted);
+  font-size: 11.5px; font-weight: 500;
 }
 .main-tabs .tab.is-active {
-  color: var(--text);
-  box-shadow: inset 0 -2px 0 var(--accent);
+  color: var(--m-text);
+  box-shadow: inset 0 -2px 0 var(--m-blue);
+}
+.tab-pill {
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-family: var(--m-mono);
+  font-size: 10px;
+  background: transparent;
+  color: var(--m-dim);
+}
+.main-tabs .tab.is-active .tab-pill {
+  background: hsla(200, 90%, 50%, 0.16);
+  color: var(--m-blue);
 }
 
+/* Query toolbar */
 .query-bar {
-  display: flex; align-items: center; gap: 9px;
-  padding: 9px 12px;
-  background: hsl(222, 26%, 4%);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  overflow-x: auto;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px;
+  background: var(--m-panel);
+  border-bottom: 1px solid var(--m-border);
+  overflow: hidden;
 }
-.query-bar .query-prompt { color: var(--accent-teal); font-family: var(--mono); }
+.am-seg {
+  display: inline-flex;
+  flex: none;
+  border: 1px solid var(--m-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.am-seg-item {
+  padding: 3px 9px;
+  font-size: 11px; font-weight: 500;
+  color: var(--m-muted);
+}
+.am-seg-item.is-active {
+  color: var(--m-text);
+  box-shadow: inset 0 -2px 0 var(--m-blue);
+}
 .query-bar .query-code {
-  font-family: var(--mono);
-  color: var(--text);
+  flex: 1; min-width: 0;
+  font-family: var(--m-mono);
+  font-size: 11.5px;
+  color: var(--m-text);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.am-run {
+  flex: none;
+  padding: 4px 13px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--m-blue);
+  color: hsl(222, 30%, 8%);
+  font-family: var(--font);
+  font-size: 11px; font-weight: 600;
+  cursor: default;
 }
 
+/* Document view */
 .result-json {
-  margin: 14px 0 0;
-  padding: 14px 16px;
-  background: hsl(222, 26%, 4%);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  margin: 0;
+  padding: 14px 18px;
+  background: var(--m-bg);
   overflow-x: auto;
-  line-height: 1.5;
+  line-height: 1.65;
 }
 .result-json code {
-  font-family: var(--mono);
-  font-size: 12.5px;
-  color: var(--text-dim);
+  font-family: var(--m-mono);
+  font-size: 12px;
+  color: var(--m-text);
   white-space: pre;
 }
 
 /* JSON syntax coloring */
-.tok-key { color: var(--accent-bright); }
-.tok-str { color: var(--accent-teal); }
-.tok-num { color: var(--accent-amber); }
-.tok-bool { color: var(--accent-purple); }
-.tok-fn { color: var(--text-faint); }
+.tok-key { color: var(--m-syn-key); }
+.tok-str { color: var(--m-syn-str); }
+.tok-num { color: var(--m-syn-num); }
+.tok-bool { color: var(--m-syn-bool); }
+.tok-null { color: var(--m-syn-null); }
+.tok-fn { color: var(--m-teal); }
+.tok-p { color: var(--m-dim); }
 
+/* Status bar */
+.am-status {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px;
+  height: 28px;
+  padding: 0 14px;
+  background: var(--m-chrome);
+  border-top: 1px solid var(--m-border);
+  font-size: 11px;
+  color: var(--m-muted);
+}
+.am-status-left { font-family: var(--font); }
+.am-status-sep { color: var(--m-dim); }
 .explain-chip {
-  display: inline-flex; align-items: center; gap: 7px;
-  margin-top: 14px;
-  padding: 6px 12px;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 10px;
   border-radius: 999px;
   background: hsla(142, 70%, 45%, 0.10);
-  border: 1px solid hsla(142, 70%, 45%, 0.30);
-  color: var(--accent-green);
-  font-family: var(--mono);
-  font-size: 11.5px;
+  border: 1px solid hsla(142, 70%, 45%, 0.25);
+  color: var(--m-green);
+  font-family: var(--m-mono);
+  font-size: 10.5px;
+  white-space: nowrap;
 }
-.explain-chip .chip-tag { font-weight: 700; letter-spacing: 0.02em; }
 .explain-chip .chip-sep { color: hsla(142, 70%, 45%, 0.5); }
-.explain-chip .chip-ms { color: var(--accent-bright); }
 
 @media (max-width: 720px) {
-  .app-mock { font-size: 12px; }
-  .app-mock-body { grid-template-columns: 1fr; }
+  .app-mock { font-size: 11px; }
   .app-mock-side { display: none; }
-  .app-mock-main { padding: 12px 14px 16px; }
-  .main-tabs { gap: 14px; overflow-x: auto; }
   .app-mock-title { display: none; }
+  .main-tabs { gap: 16px; overflow-x: auto; }
+  .result-json code { font-size: 11px; }
 }
 
 /* Feature-card icon chip — enterprise-style rounded square */

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -123,3 +123,12 @@ pre code { color: var(--text); }
 @media (max-width: 720px) {
   .section { padding: 60px 0; }
 }
+
+.hero-demo {
+  display: block;
+  width: 100%;
+  max-width: 1000px;
+  margin: 2rem auto 0;
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}


### PR DESCRIPTION
Marketing-site work for the cold-start launch (Approach A). All changes are in `website/` (Astro) — no app code touched (every commit verified LOW via `gitnexus_detect_changes`).

## Messaging & hero
- Lead with the wedge **"The MongoDB GUI that does it all — free, native, and private"** (softened from a competitor-named headline; the Studio 3T framing now lives only on the dedicated comparison page).
- Rebalanced hero typography/spacing: deliberate two-line headline break, looser leading, more vertical rhythm.
- **Premium CSS app-window mockup** in the hero that mirrors the real MQLens UI — exact palette (blue-charcoal canvas, sky-blue accent, amber DBs / purple indexes / green live), tree sidebar, Documents/Aggregation/Explain/Indexes tabs, syntax-colored document, green IXSCAN explain chip. Pure HTML/CSS, responsive.

## SEO (compounding layer)
- `SoftwareApplication` JSON-LD structured data in `BaseLayout`.
- 5 comparison/landing pages: Compass / Studio 3T / Robo 3T / NoSQLBooster alternatives + "MongoDB GUI for Linux" (linked from the footer).
- 3 how-to guides: SSH tunnel, explain plans, aggregation GUI.
- Competitor claims kept to **defensible, verifiable facts** only (no unverifiable feature-absence assertions).

## Layout & analytics
- Container widened 1080→1200px; enterprise Lucide icon set on the feature cards.
- Privacy-friendly analytics (Plausible outbound-link script) — **no in-app telemetry**, consistent with the privacy positioning.

## Before merge / publish — follow-ups (not in this PR)
- [ ] Record `website/public/demo.gif` (hero `<img>` is referenced but hidden until added).
- [ ] Create the Plausible account for `mqlens.com` (script is a no-op until then).
- [ ] Fact-check before publishing: NoSQLBooster free/paid tier boundaries; Studio 3T "Java-based"; Robo 3T auth support.
- [ ] Live repo polish (separate): topics, description, Discussions, good-first-issues.

Builds clean (`npm run build`, 12 pages).