### PR TITLE
chore(website): drop Plausible; use Cloudflare Web Analytics

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -60,8 +60,7 @@ const ogImage = new URL('/og.png', SITE.url).href;
       "description": SITE.description,
     })} />
 
-    <!-- Privacy-friendly analytics (no cookies, no in-app telemetry) -->
-    <script defer data-domain="mqlens.com" src="https://plausible.io/js/script.outbound-links.js"></script>
+    <!-- Privacy-friendly analytics: handled by Cloudflare Web Analytics (auto-injected for the proxied site; no cookies, no in-app telemetry) -->
   </head>
   <body>
     <Nav />


### PR DESCRIPTION
The site already gets metrics from Cloudflare Web Analytics, so the Plausible script is redundant.

- Removes the Plausible `script.outbound-links.js` tag from `BaseLayout.astro`.
- Cloudflare auto-injects its beacon for the proxied site, so no replacement script and no token in the repo.
- Still cookie-free, no in-app telemetry — consistent with the privacy positioning.

Verified: `npm run build` passes (12 pages); no `plausible` references remain in `dist/`.