### PR TITLE
feat(website): phase 2 — show, don't tell homepage feature rows

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -3,60 +3,61 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Download from '../components/Download.astro';
 import { SITE } from '../consts';
 
-const features = [
+const featureBlocks = [
   {
-    // Lucide: cable
-    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a1 1 0 0 1-1-1v-1a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v1a1 1 0 0 1-1 1"/><path d="M19 15V6.5a1 1 0 0 0-7 0v11a1 1 0 0 1-7 0V9"/><path d="M21 21v-2h-4"/><path d="M3 5h4V3"/><path d="M7 5a1 1 0 0 1 1 1v1a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a1 1 0 0 1 1-1V3"/></svg>',
-    title: 'Every connection mode',
-    body: 'Standalone, replica set, or raw connection string. TLS with system CA, custom CA, or client certificate; SSH tunnel; SOCKS5 proxy. A staged Test Connection reports each real phase: parse → DNS → connect → ping.',
+    title: 'Connect to anything',
+    body: 'Standalone, replica set, or connection string — with every auth mechanism and the network plumbing real deployments actually need.',
+    bullets: [
+      'All auth modes: SCRAM, X.509, MONGODB-AWS (IAM), Kerberos, and LDAP — with the correct $external handling',
+      'TLS (system / custom CA, client cert), SSH tunnel, and SOCKS5 proxy',
+      'Staged Test Connection reports each real phase: parse → DNS → connect → ping',
+    ],
+    img: '/screenshots/mqlens-connection-manager.png',
+    alt: 'MQLens connection manager with a saved local MongoDB connection',
   },
   {
-    // Lucide: shield-check
-    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg>',
-    title: 'All the auth mechanisms',
-    body: 'SCRAM-SHA-1/256, X.509, MONGODB-AWS (IAM with session token), GSSAPI/Kerberos, and LDAP (PLAIN) — with the correct $external plumbing.',
+    title: 'Query and aggregate — visually or in code',
+    body: 'Run find with full controls, build queries with a visual builder, and compose complete aggregation pipelines without leaving the raw view.',
+    bullets: [
+      'Filter, sort, projection, skip, limit, and pagination',
+      'Visual query builder alongside the editable raw query',
+      'Full aggregation pipelines',
+    ],
+    img: '/screenshots/mqlens-visual-builder.png',
+    alt: 'MQLens visual query builder beside MongoDB documents',
   },
   {
-    // Lucide: search
-    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m21 21-4.34-4.34"/><circle cx="11" cy="11" r="8"/></svg>',
-    title: 'Query & aggregate',
-    body: 'find with filter, sort, projection, skip, limit and pagination. A visual query builder, full aggregation pipelines, and explain plans for both find and aggregate rendered as a visual plan tree.',
+    title: 'See exactly what your query does',
+    body: 'Explain plans for both find and aggregate, rendered as a visual tree — plus full index, collection, and view management.',
+    bullets: [
+      'Visual explain-plan tree for find and aggregate',
+      'Create, inspect, and drop indexes with real key patterns and unique / sparse flags',
+      'Create, drop, and rename collections and databases, and build aggregation-backed views',
+    ],
+    img: '/screenshots/mqlens-index-detail.png',
+    alt: 'MQLens index detail view with definition and raw BSON metadata',
   },
   {
-    // Lucide: square-pen
-    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/></svg>',
-    title: 'Edit documents — in bulk',
-    body: 'View, insert, edit, and delete documents. Run update-many / delete-many by filter with a counted, guarded confirmation so you never touch more than you meant to.',
+    title: 'Browse and edit data — safely',
+    body: 'Inspect documents as a table, tree, or JSON, and make changes with guardrails so you never touch more than you meant to.',
+    bullets: [
+      'View, insert, edit, and delete documents',
+      'Guarded bulk update-many / delete-many with a counted confirmation',
+      'Schema analysis: per-field types and coverage, including nested paths',
+    ],
+    img: '/screenshots/mqlens-documents.png',
+    alt: 'MQLens browsing MongoDB customer documents',
   },
   {
-    // Lucide: list-tree
-    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12h-8"/><path d="M21 6H8"/><path d="M21 18h-8"/><path d="M3 6v4c0 1.1.9 2 2 2h3"/><path d="M3 10v6c0 1.1.9 2 2 2h3"/></svg>',
-    title: 'Indexes, collections & views',
-    body: 'Create, inspect, and drop indexes with real key patterns and unique/sparse flags. Create, drop, and rename collections and databases, and build aggregation-backed views.',
-  },
-  {
-    // Lucide: git-branch
-    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>',
-    title: 'Schema analysis',
-    body: 'Sample a collection and see per-field types and presence/coverage — including nested paths — to understand what your data actually looks like.',
-  },
-  {
-    // Lucide: folder-tree
-    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2.5a1 1 0 0 1-.8-.4l-.9-1.2A1 1 0 0 0 15 3h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z"/><path d="M20 21a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-2.9a1 1 0 0 1-.88-.55l-.42-.85a1 1 0 0 0-.92-.6H13a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z"/><path d="M3 5a2 2 0 0 0 2 2h3"/><path d="M3 3v13a2 2 0 0 0 2 2h3"/></svg>',
-    title: 'GridFS & import/export',
-    body: 'Browse files in a GridFS bucket and download them to disk. Import and export JSON and CSV, including full-collection background exports.',
-  },
-  {
-    // Lucide: square-terminal
-    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m7 11 2-2-2-2"/><path d="M11 13h4"/><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/></svg>',
-    title: 'Embedded mongosh',
-    body: 'A real shell backed by an actual mongosh binary, right inside the app — for the moments a GUI cannot reach.',
-  },
-  {
-    // Lucide: sparkles
-    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>',
-    title: 'AI query assistant',
-    body: 'Natural language → MQL, with your choice of provider (Anthropic, OpenAI, Gemini, or local agent CLIs). The API key stays in the backend, out of the frontend.',
+    title: 'Power tools: GridFS, mongosh, and AI',
+    body: 'The extras that round out real workflows — embedded shell, file storage, and an optional AI assistant — without leaving the app.',
+    bullets: [
+      'Browse and download GridFS files; import / export JSON & CSV with background tasks',
+      'Embedded mongosh backed by a real mongosh binary',
+      'AI query assistant with your own provider key, held in the backend',
+    ],
+    img: '/screenshots/mqlens-mongosh.png',
+    alt: 'MQLens embedded mongosh shell',
   },
 ];
 
@@ -74,40 +75,10 @@ const screenshots = [
     body: 'Paste a URI, test the connection, and save local or remote MongoDB profiles.',
   },
   {
-    src: '/screenshots/mqlens-connection-manager.png',
-    alt: 'MQLens connection manager showing a saved local MongoDB connection',
-    title: 'Organize connection profiles',
-    body: 'Group, duplicate, edit, and connect to saved profiles from the connection manager.',
-  },
-  {
-    src: '/screenshots/mqlens-documents.png',
-    alt: 'MQLens browsing MongoDB customer documents from the mqlens_demo database',
-    title: 'Browse real documents',
-    body: 'Inspect JSON documents with pagination, imports, exports, schema analysis, and bulk actions nearby.',
-  },
-  {
-    src: '/screenshots/mqlens-visual-builder.png',
-    alt: 'MQLens visual query builder panel next to MongoDB customer documents',
-    title: 'Build queries visually',
-    body: 'Use rule-based filters, projection, and sort controls without losing the raw query view.',
-  },
-  {
     src: '/screenshots/mqlens-ai-assistant.png',
     alt: 'MQLens AI query assistant panel beside MongoDB customer documents',
     title: 'Ask for MQL in plain language',
     body: 'Draft queries with the AI assistant while keeping the generated query visible and editable.',
-  },
-  {
-    src: '/screenshots/mqlens-index-detail.png',
-    alt: 'MQLens index detail view showing MongoDB index definition and raw BSON metadata',
-    title: 'Inspect indexes',
-    body: 'Review index definitions, constraints, key fields, operational status, and raw metadata.',
-  },
-  {
-    src: '/screenshots/mqlens-mongosh.png',
-    alt: 'MQLens embedded mongosh workspace with query editor and data viewer',
-    title: 'Drop into mongosh',
-    body: 'Run shell commands and inspect returned documents without leaving the desktop workspace.',
   },
   {
     src: '/screenshots/mqlens-gridfs.png',
@@ -188,12 +159,19 @@ const screenshots = [
         <h2>Everything you need to work with MongoDB</h2>
         <p>One cross-platform desktop app — no Atlas account required, no cloud round-trip for your data.</p>
       </div>
-      <div class="feat-grid">
-        {features.map((f) => (
-          <article class="feat-card">
-            <span class="feat-icon" set:html={f.icon} aria-hidden="true"></span>
-            <h3>{f.title}</h3>
-            <p>{f.body}</p>
+      <div class="feature-rows">
+        {featureBlocks.map((f) => (
+          <article class="feature-row">
+            <div class="feature-text">
+              <h3>{f.title}</h3>
+              <p>{f.body}</p>
+              <ul class="feature-bullets">
+                {f.bullets.map((b) => <li>{b}</li>)}
+              </ul>
+            </div>
+            <a class="feature-media" href={f.img} target="_blank" rel="noopener" aria-label={`Open full-size screenshot: ${f.title}`}>
+              <img src={f.img} alt={f.alt} loading="lazy" decoding="async" width="1600" height="1000" />
+            </a>
           </article>
         ))}
       </div>
@@ -205,8 +183,8 @@ const screenshots = [
     <div class="container">
       <div class="sec-head">
         <span class="eyebrow">Gallery</span>
-        <h2>Real screenshots from the desktop app</h2>
-        <p>Captured from the running desktop app against a seeded local MongoDB database with documents, indexes, query tools, AI assistance, and GridFS metadata.</p>
+        <h2>More of the workspace</h2>
+        <p>Captured from the running desktop app against a seeded local MongoDB database — quick start, connection setup, the AI assistant, GridFS, and the encrypted-vault unlock.</p>
       </div>
       <div class="shot-grid">
         {screenshots.map((shot) => (
@@ -357,21 +335,41 @@ gpg --verify MQLens_0.1.0_amd64.deb.asc \
   .sec-head h2 { font-size: clamp(1.8rem, 4vw, 2.4rem); margin: 12px 0 0; }
   .sec-head p { color: var(--text-dim); margin-top: 14px; }
 
-  .feat-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 18px;
+  .feature-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 80px;
+    margin-top: 60px;
   }
-  .feat-card {
-    background: var(--bg-card);
+  .feature-row {
+    display: grid;
+    grid-template-columns: 1fr 1.1fr;
+    gap: 52px;
+    align-items: center;
+  }
+  .feature-row:nth-child(even) .feature-media { order: -1; }
+  .feature-text h3 { font-size: clamp(1.4rem, 2.6vw, 1.85rem); margin: 0 0 14px; letter-spacing: -0.02em; }
+  .feature-text > p { color: var(--text-dim); margin: 0 0 20px; font-size: 1.06rem; line-height: 1.7; }
+  .feature-bullets { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 12px; }
+  .feature-bullets li { position: relative; padding-left: 28px; color: var(--text-dim); line-height: 1.6; }
+  .feature-bullets li::before { content: "✓"; position: absolute; left: 0; top: 0; color: var(--accent-teal); font-weight: 700; }
+  .feature-media {
+    display: block;
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 24px;
-    transition: border-color 0.15s ease, transform 0.08s ease;
+    overflow: hidden;
+    background: var(--bg-card);
+    box-shadow: 0 22px 64px rgba(0, 0, 0, 0.36);
+    transition: border-color 0.15s ease, transform 0.12s ease;
   }
-  .feat-card:hover { border-color: var(--accent); transform: translateY(-2px); }
-  .feat-card h3 { margin: 0 0 10px; font-size: 1.12rem; }
-  .feat-card p { margin: 0; color: var(--text-dim); font-size: 0.95rem; }
+  .feature-media:hover { border-color: var(--accent); transform: translateY(-2px); text-decoration: none; }
+  .feature-media img { display: block; width: 100%; height: auto; }
+
+  @media (max-width: 820px) {
+    .feature-rows { gap: 56px; }
+    .feature-row { grid-template-columns: 1fr; gap: 24px; }
+    .feature-row:nth-child(even) .feature-media { order: 0; }
+  }
 
   .security { background: var(--bg-soft); border-block: 1px solid var(--border); }
   .sec-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: center; }


### PR DESCRIPTION
Phase 2 of the website redesign (`docs/superpowers/plans/2026-06-04-website-redesign.md`). The biggest gap vs Monghoul: our homepage *told* (text-only feature grid) instead of *showing*. This fixes that.

### Changes
- **Feature section rebuilt as 5 alternating image+text rows**, each pairing a capability with a real app screenshot + checkmark bullets:
  1. Connect to anything → connection manager
  2. Query and aggregate (visually or in code) → visual builder
  3. See exactly what your query does → index/explain detail
  4. Browse and edit data safely → documents
  5. Power tools: GridFS, mongosh, AI → mongosh
- **Gallery slimmed + reframed** as "More of the workspace" — removed the 5 screenshots now featured above (no duplication); keeps quick start, new connection, AI assistant, GridFS, and the vault unlock/Touch ID.
- Rows alternate left/right on desktop and stack text-first on mobile.

### Verification
- `npm run build` passes (12 pages).
- Desktop: alternating rows render with real screenshots.
- Mobile (560px): rows stack text-first, hamburger nav intact.

Next: Phase 3 (dedicated `/features` page) + Phase 4 (image optimization).