### PR TITLE
feat(website): redesign download as per-OS cards

### DIFF
--- a/website/src/components/Download.astro
+++ b/website/src/components/Download.astro
@@ -1,57 +1,92 @@
 ---
 import { SITE } from '../consts';
 
-// Per-platform entries. Direct asset links contain the version, so for resilience
-// each button points at the "latest" release page; client-side JS below highlights
-// the visitor's detected platform.
-const platforms = [
-  { id: 'macos-arm', os: 'macOS', detail: 'Apple Silicon', ext: '.dmg', icon: 'apple', match: 'mac-arm' },
-  { id: 'macos-x64', os: 'macOS', detail: 'Intel', ext: '.dmg', icon: 'apple', match: 'mac-intel' },
-  { id: 'windows', os: 'Windows', detail: 'x86_64 · .msi / .exe', ext: '.msi', icon: 'windows', match: 'win' },
-  { id: 'linux-deb', os: 'Linux', detail: 'Debian / Ubuntu · .deb', ext: '.deb', icon: 'linux', match: 'linux' },
-  { id: 'linux-appimage', os: 'Linux', detail: 'AppImage', ext: '.AppImage', icon: 'linux', match: 'linux' },
+// Asset filenames are version-stamped, so direct "latest" links aren't stable;
+// each button points at the latest release page. Sizes are approximate and from
+// the current release. Client-side JS highlights the visitor's detected OS.
+const cards = [
+  {
+    icon: 'windows',
+    os: 'Windows',
+    match: 'win',
+    requires: 'Windows 10 or later (x64)',
+    install: 'Download the installer, run it, and launch MQLens from the Start menu.',
+    primary: { label: '.exe (recommended)', size: '~8 MB' },
+    secondary: { label: '.msi', size: '~12 MB' },
+  },
+  {
+    icon: 'apple',
+    os: 'macOS',
+    match: 'mac',
+    requires: 'macOS 11 (Big Sur) or later',
+    install: 'Download the .dmg, open it, and drag MQLens to your Applications folder.',
+    primary: { label: '.dmg (Apple Silicon)', size: '~13 MB' },
+    secondary: { label: '.dmg (Intel)', size: '~14 MB' },
+  },
+  {
+    icon: 'linux',
+    os: 'Linux',
+    match: 'linux',
+    requires: 'Ubuntu 20.04+, Fedora 36+, or equivalent (x64)',
+    install: 'Debian/Ubuntu: install the .deb. Fedora/RHEL: install the .rpm. An AppImage is also available.',
+    primary: { label: '.deb (Ubuntu/Debian)', size: '~15 MB' },
+    secondary: { label: '.rpm (Fedora/RHEL)', size: '~15 MB' },
+  },
 ];
 ---
 
-<div class="download" id="dl-cards">
-  <div class="dl-grid">
-    {platforms.map((p) => (
-      <a class="dl-card" href={SITE.releasesLatest} data-match={p.match} id={`dl-${p.id}`} target="_blank" rel="noopener">
-        <span class={`os-icon os-${p.icon}`} aria-hidden="true"></span>
-        <span class="dl-text">
-          <strong>{p.os}</strong>
-          <small>{p.detail}</small>
-        </span>
-        <span class="dl-badge" hidden>Detected</span>
-      </a>
+<div class="dl" id="dl-cards">
+  <div class="dl-cards">
+    {cards.map((c) => (
+      <article class="dl-card" data-match={c.match}>
+        <header class="dl-card-head">
+          <span class="dl-os-chip" aria-hidden="true"><span class={`os-icon os-${c.icon}`}></span></span>
+          <h3>{c.os}</h3>
+          <span class="dl-detected" hidden>Detected</span>
+        </header>
+
+        <div class="dl-spec">
+          <span class="dl-label">Requires</span>
+          <p>{c.requires}</p>
+        </div>
+        <div class="dl-spec">
+          <span class="dl-label">Install</span>
+          <p>{c.install}</p>
+        </div>
+
+        <div class="dl-actions">
+          <a class="dl-btn dl-btn-primary" href={SITE.releasesLatest} target="_blank" rel="noopener">
+            <span>{c.primary.label}</span>
+            <span class="dl-size">{c.primary.size}</span>
+          </a>
+          <a class="dl-btn dl-btn-secondary" href={SITE.releasesLatest} target="_blank" rel="noopener">
+            <span>{c.secondary.label}</span>
+            <span class="dl-size">{c.secondary.size}</span>
+          </a>
+        </div>
+      </article>
     ))}
   </div>
-  <p class="dl-note">
-    All builds are GPG-signed; macOS bundles are Apple-notarized.
-    See <a href="/docs/#verifying">verifying downloads</a>.
-    Browse <a href={SITE.releases} target="_blank" rel="noopener">all releases →</a>
+
+  <p class="dl-all">
+    <a href={SITE.releases} target="_blank" rel="noopener">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2 1-.3 2-.4 3-.4s2 .1 3 .4c2.3-1.5 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
+      View all releases on GitHub
+    </a>
   </p>
 </div>
 
 <script>
-  // Highlight the platform matching the visitor's OS and pull it to the front.
   const ua = navigator.userAgent;
-  const platform = (navigator.platform || '').toLowerCase();
   let key = '';
-  if (/Mac/i.test(ua)) {
-    // Apple Silicon vs Intel can't be read reliably from UA; default to Apple Silicon
-    // for modern Macs but still surface Intel as an option.
-    key = 'mac-arm';
-  } else if (/Win/i.test(ua)) {
-    key = 'win';
-  } else if (/Linux|X11/i.test(ua) && !/Android/i.test(ua)) {
-    key = 'linux';
-  }
+  if (/Mac/i.test(ua)) key = 'mac';
+  else if (/Win/i.test(ua)) key = 'win';
+  else if (/Linux|X11/i.test(ua) && !/Android/i.test(ua)) key = 'linux';
   if (key) {
     document.querySelectorAll<HTMLElement>('.dl-card').forEach((card) => {
       if (card.dataset.match === key) {
         card.classList.add('detected');
-        const badge = card.querySelector<HTMLElement>('.dl-badge');
+        const badge = card.querySelector<HTMLElement>('.dl-detected');
         if (badge) badge.hidden = false;
         card.parentElement?.prepend(card);
       }
@@ -60,46 +95,87 @@ const platforms = [
 </script>
 
 <style>
-  .dl-grid {
+  .dl-cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 14px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 22px;
+    margin-top: 40px;
   }
   .dl-card {
     display: flex;
-    align-items: center;
-    gap: 14px;
-    padding: 18px 18px;
+    flex-direction: column;
+    padding: 26px 24px;
     background: var(--bg-card);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    color: var(--text);
-    position: relative;
-    transition: border-color 0.15s ease, transform 0.08s ease;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
   }
-  .dl-card:hover { border-color: var(--accent); transform: translateY(-2px); text-decoration: none; }
   .dl-card.detected { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent) inset; }
-  .dl-text { display: flex; flex-direction: column; }
-  .dl-text strong { font-size: 1.02rem; }
-  .dl-text small { color: var(--text-dim); }
-  .dl-badge {
-    position: absolute;
-    top: 10px;
-    right: 12px;
-    font-size: 0.68rem;
+
+  .dl-card-head { display: flex; align-items: center; gap: 12px; margin-bottom: 22px; }
+  .dl-card-head h3 { margin: 0; font-size: 1.25rem; }
+  .dl-os-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: var(--radius-sm);
+    background: var(--accent-soft);
+    border: 1px solid hsla(200, 90%, 50%, 0.22);
+    flex: none;
+  }
+  .dl-detected {
+    margin-left: auto;
+    font-size: 0.66rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--accent-bright);
     background: var(--accent-soft);
-    padding: 2px 8px;
+    padding: 3px 9px;
     border-radius: 999px;
   }
-  .dl-note { color: var(--text-dim); font-size: 0.9rem; margin-top: 18px; }
+
+  .dl-spec { margin-bottom: 18px; }
+  .dl-label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-faint);
+    margin-bottom: 6px;
+  }
+  .dl-spec p { margin: 0; color: var(--text-dim); line-height: 1.6; font-size: 0.96rem; }
+
+  .dl-actions { display: flex; flex-direction: column; gap: 10px; margin-top: auto; padding-top: 8px; }
+  .dl-btn {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+    font-size: 0.95rem;
+    border: 1px solid transparent;
+    transition: transform 0.08s ease, box-shadow 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  }
+  .dl-btn:hover { text-decoration: none; transform: translateY(-1px); }
+  .dl-btn-primary { background: var(--brand-gradient); color: #fff; box-shadow: var(--shadow-btn); }
+  .dl-btn-primary:hover { background: var(--brand-gradient-hover); box-shadow: var(--shadow-btn-hover); }
+  .dl-btn-secondary { background: var(--bg-elevated); color: var(--text); border-color: var(--border); }
+  .dl-btn-secondary:hover { border-color: var(--accent); }
+  .dl-size { font-size: 0.82rem; font-weight: 500; opacity: 0.8; }
+
+  .dl-all { text-align: center; margin: 34px 0 0; }
+  .dl-all a { display: inline-flex; align-items: center; gap: 8px; color: var(--text-dim); font-weight: 600; }
+  .dl-all a:hover { color: var(--text); text-decoration: none; }
 
   .os-icon {
-    width: 28px;
-    height: 28px;
+    width: 22px;
+    height: 22px;
     flex: none;
     background: var(--accent-bright);
     -webkit-mask-repeat: no-repeat;
@@ -112,4 +188,8 @@ const platforms = [
   .os-apple { -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 512'%3E%3Cpath d='M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 512'%3E%3Cpath d='M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z'/%3E%3C/svg%3E"); }
   .os-windows { -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z'/%3E%3C/svg%3E"); }
   .os-linux { -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M220.8 123.3c1 .5 1.8 1.7 3 1.7 1.1 0 2.8-.4 2.9-1.5.2-1.4-1.9-2.3-3.2-2.9-1.7-.7-3.9-1-5.5-.1-.4.2-.8.7-.6 1.1.3 1.3 2.3 1 3.4 1.6zm-21.9 1.7c1.2 0 2-1.2 3-1.7 1.1-.6 3.1-.4 3.5-1.6.2-.4-.2-.9-.6-1.1-1.6-.9-3.8-.6-5.5.1-1.3.6-3.4 1.5-3.2 2.9.1 1 1.8 1.5 2.8 1.4zM420 403.8c-3.6-4-5.3-11.6-7.2-19.7-1.8-8.1-3.9-16.8-10.5-22.4-1.3-1.1-2.6-2.1-4-2.9-1.3-.8-2.7-1.5-4.1-2 9.2-27.3 5.6-54.5-3.7-79.1-11.4-30.1-31.3-56.4-46.5-74.4-17.1-21.5-33.7-41.9-33.4-72C311.1 85.4 315.7.1 234.8 0 132.4-.2 158 103.4 156.9 135.2c-1.7 23.4-6.4 41.8-22.5 64.7-18.9 22.5-45.5 58.8-58.1 96.7-6 17.9-8.8 36.1-6.2 53.3-2.6 1.9-4.9 4.5-6.7 8.1-3.7 7.1-6.8 16.6-9.5 25.3-1.7 5.6-5.2 7.8-9 10.7-3.8 2.8-8.1 5.8-8.6 12.5-.1 2.1.3 4.4 1.3 6.3-.7-2.4-1-4.9-.8-7.4z'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M220.8 123.3c1 .5 1.8 1.7 3 1.7 1.1 0 2.8-.4 2.9-1.5.2-1.4-1.9-2.3-3.2-2.9-1.7-.7-3.9-1-5.5-.1-.4.2-.8.7-.6 1.1.3 1.3 2.3 1 3.4 1.6zm-21.9 1.7c1.2 0 2-1.2 3-1.7 1.1-.6 3.1-.4 3.5-1.6.2-.4-.2-.9-.6-1.1-1.6-.9-3.8-.6-5.5.1-1.3.6-3.4 1.5-3.2 2.9.1 1 1.8 1.5 2.8 1.4zM420 403.8c-3.6-4-5.3-11.6-7.2-19.7-1.8-8.1-3.9-16.8-10.5-22.4-1.3-1.1-2.6-2.1-4-2.9-1.3-.8-2.7-1.5-4.1-2 9.2-27.3 5.6-54.5-3.7-79.1-11.4-30.1-31.3-56.4-46.5-74.4-17.1-21.5-33.7-41.9-33.4-72C311.1 85.4 315.7.1 234.8 0 132.4-.2 158 103.4 156.9 135.2c-1.7 23.4-6.4 41.8-22.5 64.7-18.9 22.5-45.5 58.8-58.1 96.7-6 17.9-8.8 36.1-6.2 53.3-2.6 1.9-4.9 4.5-6.7 8.1-3.7 7.1-6.8 16.6-9.5 25.3-1.7 5.6-5.2 7.8-9 10.7-3.8 2.8-8.1 5.8-8.6 12.5-.1 2.1.3 4.4 1.3 6.3-.7-2.4-1-4.9-.8-7.4z'/%3E%3C/svg%3E"); }
+
+  @media (max-width: 820px) {
+    .dl-cards { grid-template-columns: 1fr; gap: 16px; }
+  }
 </style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -146,7 +146,11 @@ const screenshots = [
   <!-- Download -->
   <section class="section-tight" id="download">
     <div class="container">
-      <h2 class="dl-heading">Download {SITE.name}</h2>
+      <div class="sec-head">
+        <span class="eyebrow">Download</span>
+        <h2>Download {SITE.name}</h2>
+        <p>Free and open source — no account, no email, no telemetry. Just download and connect.</p>
+      </div>
       <Download />
     </div>
   </section>


### PR DESCRIPTION
Redesigns the download section into per-OS cards (matching the Monghoul reference).

### Changes
- **3 OS cards** — Windows, macOS, Linux — each with:
  - Icon chip + OS name (+ a "Detected" pill on the visitor's platform)
  - **REQUIRES** (e.g. "macOS 11 (Big Sur) or later")
  - **INSTALL** guidance (e.g. "Download the .dmg, open it, and drag MQLens to Applications")
  - A **primary** + **secondary** download button labeled by format with the **real size** pulled from the latest release:
    - Windows: `.exe (recommended) ~8 MB` / `.msi ~12 MB`
    - macOS: `.dmg (Apple Silicon) ~13 MB` / `.dmg (Intel) ~14 MB`
    - Linux: `.deb (Ubuntu/Debian) ~15 MB` / `.rpm (Fedora/RHEL) ~15 MB`
- Kept OS **auto-detection** (highlights and moves the visitor's platform first).
- Added a centered heading + subtext to the section and a "View all releases on GitHub" link.
- Buttons link to the latest-release page (asset filenames are version-stamped, so direct "latest" links aren't stable); sizes are approximate.

### Verification
- `npm run build` passes (13 pages).
- Verified visually: 3 cards render, macOS detected/highlighted on a Mac, primary/secondary buttons with sizes, GitHub link.