### PR TITLE
feat: Chart view + move Export/Import to the top toolbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "lucide-react": "^1.16.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-window": "^2.2.7"
+        "react-window": "^2.2.7",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -1081,6 +1082,42 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1442,7 +1479,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tauri-apps/api": {
@@ -1839,6 +1881,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1857,7 +1962,7 @@
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1890,6 +1995,12 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2217,6 +2328,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2249,8 +2369,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2289,6 +2530,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -2345,6 +2592,16 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -2407,6 +2664,12 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -2491,6 +2754,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2499,6 +2772,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2920,9 +3202,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2944,6 +3248,36 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -2958,6 +3292,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2967,6 +3316,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.4",
@@ -3112,6 +3467,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3255,6 +3616,37 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lucide-react": "^1.16.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-window": "^2.2.7"
+    "react-window": "^2.2.7",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1305,6 +1305,8 @@ function Workspace() {
                     onExplain={handleExplainQuery}
                     onExplainAggregate={handleExplainAggregate}
                     onOpenShell={(command) => handleOpenShell(activeTab.connectionId, activeTab.db, activeTab.collection, command)}
+                    onOpenExport={() => handleOpenExportTab(activeTab)}
+                    onImport={handleImport}
                     loading={activeTab.loading}
                     availableFields={availableFields}
                   >
@@ -1330,8 +1332,6 @@ function Workspace() {
                           onInsertDocument={handleInsertDocument}
                           onEditDocument={handleEditDocument}
                           onDeleteDocument={handleDeleteDocument}
-                          onOpenExport={() => handleOpenExportTab(activeTab)}
-                          onImport={handleImport}
                           onAnalyzeSchema={() => handleOpenSchemaTab(activeTab.connectionId, activeTab.db, activeTab.collection)}
                           onUpdateMany={handleUpdateMany}
                           onDeleteMany={handleDeleteMany}

--- a/src/components/ChartView.tsx
+++ b/src/components/ChartView.tsx
@@ -1,0 +1,190 @@
+import React, { useMemo, useRef, useState, useEffect } from 'react';
+import {
+  ResponsiveContainer, BarChart, Bar, LineChart, Line, AreaChart, Area,
+  PieChart, Pie, Cell, ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+} from 'recharts';
+import { Download } from 'lucide-react';
+import {
+  inferFields, buildChartData, type ChartMode, type Measure, type ChartType, type FieldInfo,
+} from '../lib/chartData';
+import { exportSvgToPng } from '../lib/exportPng';
+
+interface ChartViewProps {
+  documents: Array<Record<string, any>>;
+  columns: string[];
+  density?: 'roomy' | 'cozy' | 'compact';
+}
+
+const ACCENT_VARS = ['--accent-blue', '--accent-teal', '--accent-green', '--accent-amber', '--accent-purple', '--accent-red'];
+const MEASURES: Measure[] = ['count', 'sum', 'avg', 'min', 'max'];
+const TYPES: ChartType[] = ['bar', 'line', 'area', 'pie', 'scatter'];
+
+function cssVar(name: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback;
+  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return v || fallback;
+}
+
+const selectCls =
+  'bg-[var(--bg-base)] border border-[var(--border-color)] rounded text-[11px] text-[var(--text-main)] px-1.5 py-1';
+const tabCls = (active: boolean) =>
+  `px-2 py-1 rounded text-[11px] font-medium transition-all cursor-pointer ${active ? 'bg-[var(--bg-item-active)] text-[var(--accent-blue)]' : 'text-[var(--text-muted)] hover:text-[var(--text-main)]'}`;
+
+export const ChartView: React.FC<ChartViewProps> = ({ documents, columns }) => {
+  const fields = useMemo<FieldInfo[]>(() => inferFields(documents, columns), [documents, columns]);
+  const numericFields = useMemo(() => fields.filter((f) => f.kind === 'numeric').map((f) => f.name), [fields]);
+  const firstCategorical = fields.find((f) => f.kind !== 'numeric')?.name ?? columns[0] ?? '';
+
+  const [mode, setMode] = useState<ChartMode>('aggregate');
+  const [chartType, setChartType] = useState<ChartType>('bar');
+  const [xField, setXField] = useState<string>(firstCategorical);
+  const [measure, setMeasure] = useState<Measure>('count');
+  const [measureField, setMeasureField] = useState<string>(numericFields[0] ?? '');
+  const [rawYField, setRawYField] = useState<string>(numericFields[0] ?? '');
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  // Reset invalid selections when the result set (fields) changes.
+  useEffect(() => {
+    if (!columns.includes(xField)) setXField(firstCategorical);
+    if (measureField && !numericFields.includes(measureField)) setMeasureField(numericFields[0] ?? '');
+    if (rawYField && !numericFields.includes(rawYField)) setRawYField(numericFields[0] ?? '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columns.join(','), numericFields.join(',')]);
+
+  const palette = useMemo(
+    () => ACCENT_VARS.map((v, i) => cssVar(v, ['#38bdf8', '#14b8a6', '#22c55e', '#f59e0b', '#a855f7', '#ef4444'][i])),
+    [],
+  );
+  const axisColor = cssVar('--text-muted', '#9aa4b2');
+  const gridColor = cssVar('--border-color', '#2a2f3a');
+
+  const effectiveType: ChartType = mode === 'raw' && chartType === 'pie' ? 'bar' : chartType;
+  const data = useMemo(
+    () => buildChartData(documents, { mode, xField, measure, measureField, rawYField }),
+    [documents, mode, xField, measure, measureField, rawYField],
+  );
+
+  if (!documents || documents.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-[var(--text-dim)] p-8" data-testid="chart-view">
+        Run a query to chart its results.
+      </div>
+    );
+  }
+
+  const needsNumeric =
+    (mode === 'raw' && !rawYField) ||
+    (mode === 'aggregate' && measure !== 'count' && !measureField);
+  const noNumericAtAll = numericFields.length === 0;
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 min-w-0" data-testid="chart-view">
+      {/* Control bar */}
+      <div className="flex items-center gap-2 flex-wrap px-3 py-2 border-b border-[var(--border-color)] text-[var(--text-muted)]">
+        <div className="flex items-center bg-[var(--bg-base)] border border-[var(--border-color)] rounded-md p-0.5">
+          <button aria-label="Aggregate" className={tabCls(mode === 'aggregate')} onClick={() => setMode('aggregate')}>Aggregate</button>
+          <button aria-label="Raw" className={tabCls(mode === 'raw')} onClick={() => setMode('raw')}>Raw</button>
+        </div>
+
+        <label className="flex items-center gap-1 text-[11px]">X axis
+          <select aria-label="X axis" className={selectCls} value={xField} onChange={(e) => setXField(e.target.value)}>
+            {columns.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </label>
+
+        {mode === 'aggregate' ? (
+          <>
+            <label className="flex items-center gap-1 text-[11px]">Measure
+              <select aria-label="Measure" className={selectCls} value={measure} onChange={(e) => setMeasure(e.target.value as Measure)}>
+                {MEASURES.map((m) => <option key={m} value={m}>{m}</option>)}
+              </select>
+            </label>
+            {measure !== 'count' && (
+              <label className="flex items-center gap-1 text-[11px]">Field
+                <select aria-label="Measure field" className={selectCls} value={measureField} onChange={(e) => setMeasureField(e.target.value)}>
+                  <option value="">—</option>
+                  {numericFields.map((c) => <option key={c} value={c}>{c}</option>)}
+                </select>
+              </label>
+            )}
+          </>
+        ) : (
+          <label className="flex items-center gap-1 text-[11px]">Y axis
+            <select aria-label="Y axis" className={selectCls} value={rawYField} onChange={(e) => setRawYField(e.target.value)}>
+              <option value="">—</option>
+              {numericFields.map((c) => <option key={c} value={c}>{c}</option>)}
+            </select>
+          </label>
+        )}
+
+        <label className="flex items-center gap-1 text-[11px]">Type
+          <select aria-label="Chart type" className={selectCls} value={chartType} onChange={(e) => setChartType(e.target.value as ChartType)}>
+            {TYPES.map((t) => <option key={t} value={t} disabled={mode === 'raw' && t === 'pie'}>{t}</option>)}
+          </select>
+        </label>
+
+        <button
+          aria-label="Export PNG"
+          className="ml-auto flex items-center gap-1 text-[11px] px-2 py-1 rounded border border-[var(--border-color)] hover:text-[var(--text-main)]"
+          onClick={() => {
+            const svg = chartRef.current?.querySelector('svg');
+            if (svg) exportSvgToPng(svg as SVGSVGElement, 'chart.png', cssVar('--bg-base', '#0a0e14'));
+          }}
+        >
+          <Download size={12} /> PNG
+        </button>
+      </div>
+
+      {/* Chart area */}
+      <div ref={chartRef} className="flex-1 min-h-0 min-w-0 p-3">
+        {noNumericAtAll && mode === 'raw' ? (
+          <div className="h-full flex items-center justify-center text-[var(--text-dim)]">No numeric field in these results to plot.</div>
+        ) : needsNumeric ? (
+          <div className="h-full flex items-center justify-center text-[var(--text-dim)]">Pick a numeric field to chart.</div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            {renderChart(effectiveType, data.points, palette, axisColor, gridColor)}
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Caveat */}
+      <div className="px-3 py-1.5 border-t border-[var(--border-color)] text-[10px] text-[var(--text-dim)]">
+        Charting {data.total} loaded document{data.total === 1 ? '' : 's'} — increase the page-size limit to chart more.
+        {data.truncated > 0 && ` (+${data.truncated} more ${mode === 'aggregate' ? 'categories' : 'points'} not shown)`}
+      </div>
+    </div>
+  );
+};
+
+function renderChart(
+  type: ChartType,
+  points: Array<{ x: string | number; y: number }>,
+  palette: string[],
+  axisColor: string,
+  gridColor: string,
+): React.ReactElement {
+  const axes = (
+    <>
+      <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+      <XAxis dataKey="x" stroke={axisColor} tick={{ fill: axisColor, fontSize: 11 }} />
+      <YAxis stroke={axisColor} tick={{ fill: axisColor, fontSize: 11 }} />
+      <Tooltip contentStyle={{ background: 'var(--bg-panel)', border: '1px solid var(--border-color)', color: 'var(--text-main)' }} />
+    </>
+  );
+  if (type === 'line') return <LineChart data={points}>{axes}<Line type="monotone" dataKey="y" stroke={palette[0]} dot={false} /></LineChart>;
+  if (type === 'area') return <AreaChart data={points}>{axes}<Area type="monotone" dataKey="y" stroke={palette[0]} fill={palette[0]} fillOpacity={0.3} /></AreaChart>;
+  if (type === 'scatter') return <ScatterChart>{axes}<Scatter data={points} dataKey="y" fill={palette[0]} /></ScatterChart>;
+  if (type === 'pie') {
+    return (
+      <PieChart>
+        <Tooltip contentStyle={{ background: 'var(--bg-panel)', border: '1px solid var(--border-color)', color: 'var(--text-main)' }} />
+        <Legend />
+        <Pie data={points} dataKey="y" nameKey="x" outerRadius="80%" label>
+          {points.map((_, i) => <Cell key={i} fill={palette[i % palette.length]} />)}
+        </Pie>
+      </PieChart>
+    );
+  }
+  return <BarChart data={points}>{axes}<Bar dataKey="y" fill={palette[0]} /></BarChart>;
+}

--- a/src/components/ChartView.tsx
+++ b/src/components/ChartView.tsx
@@ -55,8 +55,8 @@ export const ChartView: React.FC<ChartViewProps> = ({ documents, columns }) => {
     () => ACCENT_VARS.map((v, i) => cssVar(v, ['#38bdf8', '#14b8a6', '#22c55e', '#f59e0b', '#a855f7', '#ef4444'][i])),
     [],
   );
-  const axisColor = cssVar('--text-muted', '#9aa4b2');
-  const gridColor = cssVar('--border-color', '#2a2f3a');
+  const axisColor = useMemo(() => cssVar('--text-muted', '#9aa4b2'), []);
+  const gridColor = useMemo(() => cssVar('--border-color', '#2a2f3a'), []);
 
   const effectiveType: ChartType = mode === 'raw' && chartType === 'pie' ? 'bar' : chartType;
   const data = useMemo(
@@ -172,8 +172,8 @@ function renderChart(
       <Tooltip contentStyle={{ background: 'var(--bg-panel)', border: '1px solid var(--border-color)', color: 'var(--text-main)' }} />
     </>
   );
-  if (type === 'line') return <LineChart data={points}>{axes}<Line type="monotone" dataKey="y" stroke={palette[0]} dot={false} /></LineChart>;
-  if (type === 'area') return <AreaChart data={points}>{axes}<Area type="monotone" dataKey="y" stroke={palette[0]} fill={palette[0]} fillOpacity={0.3} /></AreaChart>;
+  if (type === 'line') return <LineChart data={points}>{axes}<Line type="monotone" dataKey="y" stroke={palette[0]} dot={false} isAnimationActive={false} /></LineChart>;
+  if (type === 'area') return <AreaChart data={points}>{axes}<Area type="monotone" dataKey="y" stroke={palette[0]} fill={palette[0]} fillOpacity={0.3} isAnimationActive={false} /></AreaChart>;
   if (type === 'scatter') {
     const numericX = points.length > 0 && points.every((p) => typeof p.x === 'number');
     return (
@@ -182,7 +182,7 @@ function renderChart(
         <XAxis dataKey="x" type={numericX ? 'number' : 'category'} stroke={axisColor} tick={{ fill: axisColor, fontSize: 11 }} />
         <YAxis dataKey="y" type="number" stroke={axisColor} tick={{ fill: axisColor, fontSize: 11 }} />
         <Tooltip contentStyle={{ background: 'var(--bg-panel)', border: '1px solid var(--border-color)', color: 'var(--text-main)' }} />
-        <Scatter data={points} dataKey="y" fill={palette[0]} />
+        <Scatter data={points} dataKey="y" fill={palette[0]} isAnimationActive={false} />
       </ScatterChart>
     );
   }
@@ -191,11 +191,11 @@ function renderChart(
       <PieChart>
         <Tooltip contentStyle={{ background: 'var(--bg-panel)', border: '1px solid var(--border-color)', color: 'var(--text-main)' }} />
         <Legend />
-        <Pie data={points} dataKey="y" nameKey="x" outerRadius="80%" label>
+        <Pie data={points} dataKey="y" nameKey="x" outerRadius="80%" label isAnimationActive={false}>
           {points.map((_, i) => <Cell key={i} fill={palette[i % palette.length]} />)}
         </Pie>
       </PieChart>
     );
   }
-  return <BarChart data={points}>{axes}<Bar dataKey="y" fill={palette[0]} /></BarChart>;
+  return <BarChart data={points}>{axes}<Bar dataKey="y" fill={palette[0]} isAnimationActive={false} /></BarChart>;
 }

--- a/src/components/ChartView.tsx
+++ b/src/components/ChartView.tsx
@@ -174,7 +174,18 @@ function renderChart(
   );
   if (type === 'line') return <LineChart data={points}>{axes}<Line type="monotone" dataKey="y" stroke={palette[0]} dot={false} /></LineChart>;
   if (type === 'area') return <AreaChart data={points}>{axes}<Area type="monotone" dataKey="y" stroke={palette[0]} fill={palette[0]} fillOpacity={0.3} /></AreaChart>;
-  if (type === 'scatter') return <ScatterChart>{axes}<Scatter data={points} dataKey="y" fill={palette[0]} /></ScatterChart>;
+  if (type === 'scatter') {
+    const numericX = points.length > 0 && points.every((p) => typeof p.x === 'number');
+    return (
+      <ScatterChart>
+        <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+        <XAxis dataKey="x" type={numericX ? 'number' : 'category'} stroke={axisColor} tick={{ fill: axisColor, fontSize: 11 }} />
+        <YAxis dataKey="y" type="number" stroke={axisColor} tick={{ fill: axisColor, fontSize: 11 }} />
+        <Tooltip contentStyle={{ background: 'var(--bg-panel)', border: '1px solid var(--border-color)', color: 'var(--text-main)' }} />
+        <Scatter data={points} dataKey="y" fill={palette[0]} />
+      </ScatterChart>
+    );
+  }
   if (type === 'pie') {
     return (
       <PieChart>

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect, useContext } from 'react';
 import { DocumentViewerContext } from './DocumentViewer';
 import { List } from 'react-window';
-import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Download, Upload, Table2, BarChart3 } from 'lucide-react';
+import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3 } from 'lucide-react';
 import { ChartView } from './ChartView';
 import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
 
@@ -15,8 +15,6 @@ interface DataGridProps {
   onInsertDocument?: () => void;
   onEditDocument?: (doc: Record<string, any>) => void;
   onDeleteDocument?: (doc: Record<string, any>) => void;
-  onOpenExport?: () => void;
-  onImport?: () => void;
   onAnalyzeSchema?: () => void;
   onUpdateMany?: () => void;
   onDeleteMany?: () => void;
@@ -325,8 +323,6 @@ export const DataGrid: React.FC<DataGridProps> = ({
   onInsertDocument,
   onEditDocument,
   onDeleteDocument,
-  onOpenExport,
-  onImport,
   onAnalyzeSchema,
   onUpdateMany,
   onDeleteMany,
@@ -988,29 +984,6 @@ export const DataGrid: React.FC<DataGridProps> = ({
             >
               <Plus size={12} />
               <span>Insert</span>
-            </button>
-          )}
-          {activeTab === 'results' && onOpenExport && (
-            <button
-              type="button"
-              onClick={onOpenExport}
-              className="flex items-center gap-1.5 px-2 py-1 rounded text-[11px] font-medium border border-[var(--border-color)] text-[var(--text-muted)] hover:text-[var(--text-main)] hover:bg-[var(--bg-item-hover)] cursor-pointer transition-all"
-              title="Open export workspace"
-              data-testid="export-btn"
-            >
-              <Download size={12} />
-              <span>Export</span>
-            </button>
-          )}
-          {activeTab === 'results' && onImport && (
-            <button
-              onClick={onImport}
-              className="flex items-center gap-1.5 px-2 py-1 rounded text-[11px] font-medium border border-[var(--border-color)] text-[var(--text-muted)] hover:text-[var(--text-main)] hover:bg-[var(--bg-item-hover)] cursor-pointer transition-all"
-              title="Import documents from a file"
-              data-testid="import-btn"
-            >
-              <Upload size={12} />
-              <span>Import</span>
             </button>
           )}
           {activeTab === 'results' && onAnalyzeSchema && (

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useMemo, useEffect, useContext } from 'react';
 import { DocumentViewerContext } from './DocumentViewer';
 import { List } from 'react-window';
-import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Download, Upload, Table2 } from 'lucide-react';
+import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Download, Upload, Table2, BarChart3 } from 'lucide-react';
+import { ChartView } from './ChartView';
 import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
 
 interface DataGridProps {
@@ -28,7 +29,7 @@ interface DataGridProps {
   onPageSizeChange?: (newLimit: number) => void;
 }
 
-type ViewMode = 'table' | 'tree' | 'json';
+type ViewMode = 'table' | 'tree' | 'json' | 'chart';
 
 interface ExplainNode {
   name: string;
@@ -1080,6 +1081,16 @@ export const DataGrid: React.FC<DataGridProps> = ({
                 <Braces size={12} />
                 <span>JSON</span>
               </button>
+
+              <button
+                role="button"
+                aria-label="Chart"
+                onClick={() => setViewMode('chart')}
+                className={`px-2 py-1 rounded flex items-center gap-1.5 text-[11px] font-medium transition-all cursor-pointer ${viewMode === 'chart' ? 'bg-[var(--bg-item-active)] text-[var(--accent-blue)]' : 'text-[var(--text-muted)] hover:text-[var(--text-main)]'}`}
+              >
+                <BarChart3 size={12} />
+                <span>Chart</span>
+              </button>
             </div>
           ) : activeTab === 'explain' ? (
             /* Explain Tools */
@@ -1147,6 +1158,8 @@ export const DataGrid: React.FC<DataGridProps> = ({
               />
             </div>
           </div>
+        ) : viewMode === 'chart' ? (
+          <ChartView documents={parsedDocs} columns={columns} density={density} />
         ) : (
           <div className="flex-1 overflow-auto flex flex-col min-w-0">
             {viewMode === 'table' && (

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -30,6 +30,8 @@ import {
   Check,
   ChevronDown,
   Plus,
+  Download,
+  Upload,
   X
 } from 'lucide-react';
 
@@ -99,6 +101,8 @@ interface DocumentViewerProps {
   // Explain a full aggregation pipeline (M1). Receives the pipeline as a JSON string.
   onExplainAggregate?: (pipeline: string) => Promise<string>;
   onOpenShell?: (command: string) => void;
+  onOpenExport?: () => void;
+  onImport?: () => void;
   loading: boolean;
   availableFields?: string[];
   children?: React.ReactNode;
@@ -361,6 +365,8 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   onExplain,
   onExplainAggregate,
   onOpenShell,
+  onOpenExport,
+  onImport,
   loading,
   availableFields = [],
   children
@@ -1305,7 +1311,31 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
 
         {/* AI Helper & Visual query builder */}
         <div className="flex items-center gap-1.5">
-          <button 
+          {onOpenExport && (
+            <button
+              type="button"
+              onClick={onOpenExport}
+              className="query-plane-btn"
+              data-testid="export-btn"
+              title="Open export workspace"
+            >
+              <Download size={11} />
+              <span>Export</span>
+            </button>
+          )}
+          {onImport && (
+            <button
+              type="button"
+              onClick={onImport}
+              className="query-plane-btn"
+              data-testid="import-btn"
+              title="Import documents from a file"
+            >
+              <Upload size={11} />
+              <span>Import</span>
+            </button>
+          )}
+          <button
             onClick={() => {
               const newOpen = !isAIHelperOpen;
               setIsAIHelperOpen(newOpen);

--- a/src/components/__tests__/ChartView.test.tsx
+++ b/src/components/__tests__/ChartView.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChartView } from '../ChartView';
+
+const docs = [
+  { region: 'NA', seats: 3, spend: 100 },
+  { region: 'EU', seats: 4, spend: 200 },
+  { region: 'NA', seats: 5, spend: 50 },
+];
+const columns = ['region', 'seats', 'spend'];
+
+describe('ChartView', () => {
+  it('renders the control bar with mode and type controls', () => {
+    render(<ChartView documents={docs} columns={columns} />);
+    expect(screen.getByLabelText('Aggregate')).toBeTruthy();
+    expect(screen.getByLabelText('Raw')).toBeTruthy();
+    expect(screen.getByLabelText('Chart type')).toBeTruthy();
+  });
+
+  it('populates the X-axis picker with all fields', () => {
+    render(<ChartView documents={docs} columns={columns} />);
+    const x = screen.getByLabelText('X axis') as HTMLSelectElement;
+    const opts = Array.from(x.options).map((o) => o.value);
+    expect(opts).toEqual(expect.arrayContaining(['region', 'seats', 'spend']));
+  });
+
+  it('shows the caveat with the loaded document count', () => {
+    render(<ChartView documents={docs} columns={columns} />);
+    expect(screen.getByText(/Charting 3 loaded/i)).toBeTruthy();
+  });
+
+  it('shows an empty message when there are no documents', () => {
+    render(<ChartView documents={[]} columns={[]} />);
+    expect(screen.getByText(/Run a query to chart/i)).toBeTruthy();
+  });
+
+  it('in Raw mode with no numeric field selected, prompts for a numeric field', () => {
+    render(<ChartView documents={[{ name: 'a' }]} columns={['name']} />);
+    fireEvent.click(screen.getByLabelText('Raw'));
+    expect(screen.getByText(/no numeric field/i)).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -246,4 +246,10 @@ describe('DataGrid Component', () => {
     rerender(<DataGrid documents={[{ _id: 1 }]} />);
     expect(screen.queryByTestId('pager')).not.toBeInTheDocument();
   });
+
+  it('switches to the chart view when the Chart toggle is clicked', () => {
+    render(<DataGrid documents={[{ region: 'NA', seats: 3 }, { region: 'EU', seats: 4 }]} />);
+    fireEvent.click(screen.getByLabelText('Chart'));
+    expect(screen.getByTestId('chart-view')).toBeTruthy();
+  });
 });

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -200,14 +200,6 @@ describe('DataGrid Component', () => {
     expect(screen.queryByTestId('query-code-tab')).toBeNull();
   });
 
-  it('opens the export workspace from the toolbar', () => {
-    const onOpenExport = vi.fn();
-    render(<DataGrid documents={mockDocuments} onOpenExport={onOpenExport} />);
-
-    fireEvent.click(screen.getByTestId('export-btn'));
-    expect(onOpenExport).toHaveBeenCalledTimes(1);
-  });
-
   it('renders a pager footer and fires page callbacks', () => {
     const onPageChange = vi.fn();
     const onPageSizeChange = vi.fn();

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -43,6 +43,28 @@ describe('DocumentViewer Component', () => {
     expect(screen.getByText('Limit')).toBeInTheDocument();
   });
 
+  it('renders Export/Import in the top toolbar and fires their handlers', () => {
+    const onOpenExport = vi.fn();
+    const onImport = vi.fn();
+    render(
+      <DocumentViewer
+        connectionName="test-conn"
+        databaseName="test-db"
+        collectionName="test-coll"
+        onExecute={mockOnExecute}
+        onExplain={mockOnExplain}
+        onOpenExport={onOpenExport}
+        onImport={onImport}
+        loading={false}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('export-btn'));
+    expect(onOpenExport).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId('import-btn'));
+    expect(onImport).toHaveBeenCalledTimes(1);
+  });
+
   it('performs JSON validation on typing', async () => {
     render(
       <DocumentViewer

--- a/src/lib/__tests__/chartData.test.ts
+++ b/src/lib/__tests__/chartData.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { Int32, Double, Long, Decimal128 } from 'bson';
+import { toNumber, inferFields } from '../chartData';
+
+describe('toNumber', () => {
+  it('unwraps plain numbers and BSON numeric types', () => {
+    expect(toNumber(5)).toBe(5);
+    expect(toNumber(new Int32(7))).toBe(7);
+    expect(toNumber(new Double(2.5))).toBe(2.5);
+    expect(toNumber(new Long(42))).toBe(42);
+    expect(toNumber(Decimal128.fromString('3.14'))).toBeCloseTo(3.14);
+  });
+  it('returns NaN for non-numeric values', () => {
+    expect(Number.isNaN(toNumber('abc'))).toBe(true);
+    expect(Number.isNaN(toNumber(null))).toBe(true);
+    expect(Number.isNaN(toNumber({}))).toBe(true);
+  });
+});
+
+describe('inferFields', () => {
+  const docs = [
+    { region: 'NA', seats: new Int32(3), createdAt: new Date('2025-01-01'), name: 'Acme' },
+    { region: 'EU', seats: new Int32(4), createdAt: new Date('2025-02-01'), name: 'Beta' },
+  ];
+  it('classifies numeric, date, and categorical fields', () => {
+    const fields = inferFields(docs, ['region', 'seats', 'createdAt', 'name']);
+    const kind = (n: string) => fields.find((f) => f.name === n)!.kind;
+    expect(kind('seats')).toBe('numeric');
+    expect(kind('createdAt')).toBe('date');
+    expect(kind('region')).toBe('categorical');
+    expect(kind('name')).toBe('categorical');
+  });
+  it('treats an all-missing field as categorical', () => {
+    const fields = inferFields([{ a: 1 }, { a: 2 }], ['a', 'ghost']);
+    expect(fields.find((f) => f.name === 'ghost')!.kind).toBe('categorical');
+  });
+});

--- a/src/lib/__tests__/chartData.test.ts
+++ b/src/lib/__tests__/chartData.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Int32, Double, Long, Decimal128 } from 'bson';
 import { toNumber, inferFields } from '../chartData';
 import { aggregate, CATEGORY_CAP } from '../chartData';
+import { rawSeries, buildChartData, POINT_CAP } from '../chartData';
 
 describe('toNumber', () => {
   it('unwraps plain numbers and BSON numeric types', () => {
@@ -66,5 +67,40 @@ describe('aggregate', () => {
     const { points, truncated } = aggregate(many, 'k', 'count');
     expect(points.length).toBe(CATEGORY_CAP);
     expect(truncated).toBe(5);
+  });
+});
+
+describe('rawSeries', () => {
+  const docs = [
+    { seats: 3, spend: 100 },
+    { seats: 4, spend: 'oops' }, // y NaN -> dropped
+    { seats: 5, spend: 200 },
+  ];
+  it('maps numeric x/y and drops NaN-y rows', () => {
+    const { points } = rawSeries(docs, 'seats', 'spend');
+    expect(points).toEqual([{ x: 3, y: 100 }, { x: 5, y: 200 }]);
+  });
+  it('keeps categorical x as a label', () => {
+    const { points } = rawSeries([{ region: 'NA', spend: 100 }], 'region', 'spend');
+    expect(points[0]).toEqual({ x: 'NA', y: 100 });
+  });
+  it('caps points and reports truncation', () => {
+    const many = Array.from({ length: POINT_CAP + 3 }, (_, i) => ({ x: i, y: i }));
+    const { points, truncated } = rawSeries(many, 'x', 'y');
+    expect(points.length).toBe(POINT_CAP);
+    expect(truncated).toBe(3);
+  });
+});
+
+describe('buildChartData', () => {
+  const docs = [{ region: 'NA', spend: 10 }, { region: 'NA', spend: 20 }];
+  it('dispatches to aggregate', () => {
+    const d = buildChartData(docs, { mode: 'aggregate', xField: 'region', measure: 'count' });
+    expect(d.points[0]).toEqual({ x: 'NA', y: 2 });
+  });
+  it('dispatches to raw and returns empty when no y field', () => {
+    expect(buildChartData(docs, { mode: 'raw', xField: 'region', measure: 'count' }).points).toEqual([]);
+    const d = buildChartData(docs, { mode: 'raw', xField: 'spend', measure: 'count', rawYField: 'spend' });
+    expect(d.points.length).toBe(2);
   });
 });

--- a/src/lib/__tests__/chartData.test.ts
+++ b/src/lib/__tests__/chartData.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Int32, Double, Long, Decimal128 } from 'bson';
 import { toNumber, inferFields } from '../chartData';
+import { aggregate, CATEGORY_CAP } from '../chartData';
 
 describe('toNumber', () => {
   it('unwraps plain numbers and BSON numeric types', () => {
@@ -33,5 +34,37 @@ describe('inferFields', () => {
   it('treats an all-missing field as categorical', () => {
     const fields = inferFields([{ a: 1 }, { a: 2 }], ['a', 'ghost']);
     expect(fields.find((f) => f.name === 'ghost')!.kind).toBe('categorical');
+  });
+});
+
+describe('aggregate', () => {
+  const docs = [
+    { region: 'NA', spend: 100 },
+    { region: 'NA', spend: 50 },
+    { region: 'EU', spend: 200 },
+    { region: 'EU', spend: undefined },
+    { spend: 10 }, // missing region
+  ];
+  it('counts documents per group, sorted desc', () => {
+    const { points, total } = aggregate(docs, 'region', 'count');
+    expect(total).toBe(5);
+    expect(points[0]).toEqual({ x: 'NA', y: 2 });
+    expect(points.find((p) => p.x === '(missing)')).toEqual({ x: '(missing)', y: 1 });
+  });
+  it('sums a numeric field per group, ignoring non-numeric values', () => {
+    const { points } = aggregate(docs, 'region', 'sum', 'spend');
+    expect(points.find((p) => p.x === 'NA')!.y).toBe(150);
+    expect(points.find((p) => p.x === 'EU')!.y).toBe(200); // undefined ignored
+  });
+  it('computes avg, min, max', () => {
+    expect(aggregate(docs, 'region', 'avg', 'spend').points.find((p) => p.x === 'NA')!.y).toBe(75);
+    expect(aggregate(docs, 'region', 'min', 'spend').points.find((p) => p.x === 'NA')!.y).toBe(50);
+    expect(aggregate(docs, 'region', 'max', 'spend').points.find((p) => p.x === 'NA')!.y).toBe(100);
+  });
+  it('caps categories and reports the truncated count', () => {
+    const many = Array.from({ length: CATEGORY_CAP + 5 }, (_, i) => ({ k: `g${i}` }));
+    const { points, truncated } = aggregate(many, 'k', 'count');
+    expect(points.length).toBe(CATEGORY_CAP);
+    expect(truncated).toBe(5);
   });
 });

--- a/src/lib/chartData.ts
+++ b/src/lib/chartData.ts
@@ -101,3 +101,30 @@ export function aggregate(
   if (truncated > 0) points = points.slice(0, cap);
   return { points, truncated, total: docs.length };
 }
+
+export function rawSeries(
+  docs: Array<Record<string, any>>,
+  xField: string,
+  yField: string,
+  cap = POINT_CAP,
+): ChartData {
+  let points: ChartPoint[] = [];
+  for (const doc of docs) {
+    const y = toNumber(doc?.[yField]);
+    if (Number.isNaN(y)) continue;
+    const xv = doc?.[xField];
+    const xn = toNumber(xv);
+    points.push({ x: Number.isNaN(xn) ? labelOf(xv) : xn, y });
+  }
+  const truncated = Math.max(0, points.length - cap);
+  if (truncated > 0) points = points.slice(0, cap);
+  return { points, truncated, total: docs.length };
+}
+
+export function buildChartData(docs: Array<Record<string, any>>, config: ChartConfig): ChartData {
+  if (config.mode === 'raw') {
+    if (!config.rawYField) return { points: [], truncated: 0, total: docs.length };
+    return rawSeries(docs, config.xField, config.rawYField);
+  }
+  return aggregate(docs, config.xField, config.measure, config.measureField);
+}

--- a/src/lib/chartData.ts
+++ b/src/lib/chartData.ts
@@ -59,3 +59,45 @@ export function labelOf(v: any): string {
   if (isDateValue(v)) return new Date(v as any).toISOString().slice(0, 10);
   return String(v);
 }
+
+export function aggregate(
+  docs: Array<Record<string, any>>,
+  xField: string,
+  measure: Measure,
+  measureField?: string,
+  cap = CATEGORY_CAP,
+): ChartData {
+  const size = new Map<string, number>();
+  const vals = new Map<string, number[]>();
+  for (const doc of docs) {
+    const key = labelOf(doc?.[xField]);
+    size.set(key, (size.get(key) ?? 0) + 1);
+    if (measure !== 'count' && measureField) {
+      const n = toNumber(doc?.[measureField]);
+      if (!Number.isNaN(n)) {
+        const arr = vals.get(key);
+        if (arr) arr.push(n); else vals.set(key, [n]);
+      }
+    }
+  }
+  let points: ChartPoint[] = [];
+  for (const key of size.keys()) {
+    let y = 0;
+    if (measure === 'count') {
+      y = size.get(key)!;
+    } else {
+      const arr = vals.get(key) ?? [];
+      if (arr.length > 0) {
+        if (measure === 'sum') y = arr.reduce((a, b) => a + b, 0);
+        else if (measure === 'avg') y = arr.reduce((a, b) => a + b, 0) / arr.length;
+        else if (measure === 'min') y = Math.min(...arr);
+        else if (measure === 'max') y = Math.max(...arr);
+      }
+    }
+    points.push({ x: key, y });
+  }
+  points.sort((a, b) => b.y - a.y);
+  const truncated = Math.max(0, points.length - cap);
+  if (truncated > 0) points = points.slice(0, cap);
+  return { points, truncated, total: docs.length };
+}

--- a/src/lib/chartData.ts
+++ b/src/lib/chartData.ts
@@ -1,0 +1,61 @@
+import { Int32, Double, Long, Decimal128 } from 'bson';
+
+export type FieldKind = 'numeric' | 'date' | 'categorical';
+export type ChartMode = 'aggregate' | 'raw';
+export type Measure = 'count' | 'sum' | 'avg' | 'min' | 'max';
+export type ChartType = 'bar' | 'line' | 'area' | 'pie' | 'scatter';
+
+export interface FieldInfo { name: string; kind: FieldKind; }
+export interface ChartPoint { x: string | number; y: number; }
+export interface ChartData { points: ChartPoint[]; truncated: number; total: number; }
+export interface ChartConfig {
+  mode: ChartMode;
+  xField: string;
+  measure: Measure;
+  measureField?: string;
+  rawYField?: string;
+}
+
+const SAMPLE = 200;
+export const CATEGORY_CAP = 30;
+export const POINT_CAP = 2000;
+
+export function toNumber(v: any): number {
+  if (v == null) return NaN;
+  if (typeof v === 'number') return v;
+  if (typeof v === 'bigint') return Number(v);
+  if (v instanceof Int32 || v instanceof Double) return v.valueOf();
+  if (v instanceof Long) return v.toNumber();
+  if (v instanceof Decimal128) return Number(v.toString());
+  return NaN;
+}
+
+function isDateValue(v: any): boolean {
+  return v instanceof Date || (v != null && typeof v === 'object' && typeof (v as any).getTime === 'function');
+}
+
+export function inferFields(docs: Array<Record<string, any>>, columns: string[]): FieldInfo[] {
+  return columns.map((name) => {
+    let numeric = 0, date = 0, other = 0, seen = 0;
+    for (let i = 0; i < docs.length && seen < SAMPLE; i++) {
+      const v = docs[i]?.[name];
+      if (v == null) continue;
+      seen++;
+      if (!Number.isNaN(toNumber(v))) numeric++;
+      else if (isDateValue(v)) date++;
+      else other++;
+    }
+    let kind: FieldKind = 'categorical';
+    if (seen > 0) {
+      if (numeric > 0 && numeric >= date && numeric >= other) kind = 'numeric';
+      else if (date > 0 && date >= other) kind = 'date';
+    }
+    return { name, kind };
+  });
+}
+
+export function labelOf(v: any): string {
+  if (v == null) return '(missing)';
+  if (isDateValue(v)) return new Date(v as any).toISOString().slice(0, 10);
+  return String(v);
+}

--- a/src/lib/exportPng.ts
+++ b/src/lib/exportPng.ts
@@ -1,0 +1,33 @@
+// Serialize an <svg> element to a downloaded PNG. Pure DOM; not unit-tested
+// (jsdom has no canvas rasterizer). bg fills the transparent areas.
+export function exportSvgToPng(svg: SVGSVGElement, filename = 'chart.png', bg = '#0a0e14'): void {
+  const rect = svg.getBoundingClientRect();
+  const width = Math.max(1, Math.round(rect.width));
+  const height = Math.max(1, Math.round(rect.height));
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute('width', String(width));
+  clone.setAttribute('height', String(height));
+  clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  const data = new XMLSerializer().serializeToString(clone);
+  const svgBlob = new Blob([data], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(svgBlob);
+  const img = new Image();
+  img.onload = () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      ctx.fillStyle = bg;
+      ctx.fillRect(0, 0, width, height);
+      ctx.drawImage(img, 0, 0, width, height);
+      const a = document.createElement('a');
+      a.href = canvas.toDataURL('image/png');
+      a.download = filename;
+      a.click();
+    }
+    URL.revokeObjectURL(url);
+  };
+  img.onerror = () => URL.revokeObjectURL(url);
+  img.src = url;
+}


### PR DESCRIPTION
Two related result-area UX changes (kept on one branch because both edit the DataGrid toolbar).

## 1. Chart view (new result view)
A fourth result view — **Table | Tree | JSON | Chart** — visualizing the currently-loaded results client-side.
- **Aggregate** (group by X → count/sum/avg/min/max) and **Raw** (plot rows) modes.
- **5 chart types** (bar/line/area/pie/scatter; pie aggregate-only; numeric scatter axis); **PNG export**.
- Loaded-rows caveat + top-30 categories / 2000-point caps with a "+N more" note.
- Pure transforms in `src/lib/chartData.ts` (13 unit tests); `ChartView.tsx` + `exportPng.ts`; wired into `DataGrid.tsx`. Adds `recharts`.
- Animations disabled for instant redraws (perf).

## 2. Move Export/Import to the top query toolbar
Relocated the **Export** and **Import** buttons from the results toolbar (next to Insert/Schema) up into the query action toolbar (Run / Load query row), beside AI Helper / Visual Query Builder. Handlers now flow App → DocumentViewer; DataGrid no longer owns those buttons.

## Verification
- **230 tests pass**, `tsc` clean, frontend build clean.
- Spec/plan: `specs/2026-06-04-chart-view-design.md`, `plans/2026-06-04-chart-view.md`. Final review: APPROVED.

> Interactive check: `npm run tauri dev` → open a collection → Export/Import sit in the top bar; click **Chart** for the new view.