### PR TITLE
feat: schema-aware autocomplete (Find, aggregation, mongosh)

### DIFF
--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -17,6 +17,8 @@ pub struct FieldStat {
     pub types: Vec<TypeCount>,
     pub presence: usize,
     pub coverage: f64,
+    #[serde(rename = "enumValues", skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<String>>,
 }
 
 #[derive(Serialize)]
@@ -51,43 +53,82 @@ fn bson_type_label(b: &mongodb::bson::Bson) -> &'static str {
     }
 }
 
+const ENUM_MAX: usize = 25;
+
+/// Returns the canonical string form of a scalar value eligible for enum
+/// detection (string/number/bool), or None for anything else (objects, arrays,
+/// ObjectId, dates, null, etc. are not enum candidates).
+fn enum_scalar(b: &mongodb::bson::Bson) -> Option<String> {
+    use mongodb::bson::Bson;
+    match b {
+        Bson::String(s) => Some(s.clone()),
+        Bson::Int32(n) => Some(n.to_string()),
+        Bson::Int64(n) => Some(n.to_string()),
+        Bson::Double(n) => Some(n.to_string()),
+        Bson::Boolean(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
 /// Infer a per-field schema (dotted nested paths, type counts, coverage) from a
 /// sample of documents. Pure and deterministic (fields sorted by path).
 pub fn infer_schema(docs: &[mongodb::bson::Document]) -> SchemaReport {
     use mongodb::bson::Bson;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
-    // path -> documents containing it; path -> (type label -> count)
     let mut presence: BTreeMap<String, usize> = BTreeMap::new();
     let mut type_counts: BTreeMap<String, BTreeMap<String, usize>> = BTreeMap::new();
+    // Enum tracking: distinct scalar values per path; disqualified = saw a
+    // non-enumerable value (object/array/objectId/date/...) or exceeded ENUM_MAX.
+    let mut values: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut disqualified: BTreeSet<String> = BTreeSet::new();
 
     fn walk(
         prefix: &str,
         doc: &mongodb::bson::Document,
         presence: &mut BTreeMap<String, usize>,
         type_counts: &mut BTreeMap<String, BTreeMap<String, usize>>,
+        values: &mut BTreeMap<String, BTreeSet<String>>,
+        disqualified: &mut BTreeSet<String>,
     ) {
         for (k, v) in doc.iter() {
-            let path = if prefix.is_empty() {
-                k.clone()
-            } else {
-                format!("{}.{}", prefix, k)
-            };
+            let path = if prefix.is_empty() { k.clone() } else { format!("{}.{}", prefix, k) };
             *presence.entry(path.clone()).or_insert(0) += 1;
             *type_counts
                 .entry(path.clone())
                 .or_default()
                 .entry(bson_type_label(v).to_string())
                 .or_insert(0) += 1;
-            // Recurse into embedded documents; arrays are not recursed (YAGNI).
+
+            if !disqualified.contains(&path) {
+                match enum_scalar(v) {
+                    Some(s) => {
+                        let set = values.entry(path.clone()).or_default();
+                        set.insert(s);
+                        if set.len() > ENUM_MAX {
+                            disqualified.insert(path.clone());
+                            values.remove(&path);
+                        }
+                    }
+                    None => {
+                        // Null neither adds nor disqualifies; everything else (object,
+                        // array, objectId, date, ...) disqualifies the field as an enum.
+                        if !matches!(v, Bson::Null) {
+                            disqualified.insert(path.clone());
+                            values.remove(&path);
+                        }
+                    }
+                }
+            }
+
             if let Bson::Document(sub) = v {
-                walk(&path, sub, presence, type_counts);
+                walk(&path, sub, presence, type_counts, values, disqualified);
             }
         }
     }
 
     for d in docs {
-        walk("", d, &mut presence, &mut type_counts);
+        walk("", d, &mut presence, &mut type_counts, &mut values, &mut disqualified);
     }
 
     let sampled = docs.len();
@@ -98,24 +139,18 @@ pub fn infer_schema(docs: &[mongodb::bson::Document]) -> SchemaReport {
                 .get(&path)
                 .map(|m| {
                     m.iter()
-                        .map(|(t, c)| TypeCount {
-                            type_name: t.clone(),
-                            count: *c,
-                        })
+                        .map(|(t, c)| TypeCount { type_name: t.clone(), count: *c })
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
-            let coverage = if sampled == 0 {
-                0.0
+            let coverage = if sampled == 0 { 0.0 } else { pres as f64 / sampled as f64 };
+            let enum_values = if disqualified.contains(&path) {
+                None
             } else {
-                pres as f64 / sampled as f64
+                values.get(&path).filter(|s| !s.is_empty() && s.len() <= ENUM_MAX)
+                    .map(|s| s.iter().cloned().collect::<Vec<_>>())
             };
-            FieldStat {
-                path,
-                types,
-                presence: pres,
-                coverage,
-            }
+            FieldStat { path, types, presence: pres, coverage, enum_values }
         })
         .collect();
 
@@ -168,4 +203,49 @@ pub async fn analyze_schema_impl(
 
     let report = infer_schema(&docs);
     serde_json::to_string(&report).map_err(|e| format!("Serialization error: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::infer_schema;
+    use mongodb::bson::doc;
+
+    fn field<'a>(r: &'a super::SchemaReport, path: &str) -> &'a super::FieldStat {
+        r.fields.iter().find(|f| f.path == path).expect("field present")
+    }
+
+    #[test]
+    fn detects_low_cardinality_string_enum() {
+        let docs = vec![
+            doc! {"plan": "Free"}, doc! {"plan": "Team"},
+            doc! {"plan": "Free"}, doc! {"plan": "Business"},
+        ];
+        let r = infer_schema(&docs);
+        let e = field(&r, "plan").enum_values.clone().expect("enum");
+        assert_eq!(e, vec!["Business".to_string(), "Free".to_string(), "Team".to_string()]);
+    }
+
+    #[test]
+    fn no_enum_when_too_many_distinct() {
+        let docs: Vec<_> = (0..30).map(|i| doc! {"name": format!("n{}", i)}).collect();
+        let r = infer_schema(&docs);
+        assert!(field(&r, "name").enum_values.is_none());
+    }
+
+    #[test]
+    fn no_enum_for_non_scalar_or_complex_leaf() {
+        let docs = vec![doc! {"tags": ["a", "b"]}, doc! {"addr": {"zip": "1"}}];
+        let r = infer_schema(&docs);
+        assert!(field(&r, "tags").enum_values.is_none());     // array
+        assert!(field(&r, "addr").enum_values.is_none());     // object
+        assert!(field(&r, "addr.zip").enum_values.is_some()); // nested scalar still enumerates
+    }
+
+    #[test]
+    fn enumerates_numbers_and_bools() {
+        let docs = vec![doc! {"seats": 3i32, "active": true}, doc! {"seats": 4i32, "active": false}];
+        let r = infer_schema(&docs);
+        assert_eq!(field(&r, "seats").enum_values.clone().unwrap(), vec!["3".to_string(), "4".to_string()]);
+        assert_eq!(field(&r, "active").enum_values.clone().unwrap(), vec!["false".to_string(), "true".to_string()]);
+    }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1296,7 +1296,8 @@ function Workspace() {
                 const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
                 const connectionName = activeConnection ? activeConnection.name : 'cmi-dev';
                 return (
-                  <DocumentViewer 
+                  <DocumentViewer
+                    connectionId={activeTab.connectionId}
                     connectionName={connectionName}
                     databaseName={activeTab.db}
                     collectionName={activeTab.collection}

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { AIChatPanel } from './AIChatPanel';
+import { QueryInput } from './QueryInput';
+import { QueryEditor } from './QueryEditor';
+import { useCollectionSchema } from '../lib/useCollectionSchema';
 import { collectionRef, type GeneratedQuery } from '../lib/mongoCommand';
 import {
   loadCollectionQueries,
@@ -92,6 +95,7 @@ export function builderStateToQuery(state: BuilderState): GeneratedQuery {
 }
 
 interface DocumentViewerProps {
+  connectionId?: string;
   connectionName: string;
   databaseName: string;
   collectionName: string;
@@ -356,7 +360,8 @@ export interface DocumentViewerContextType {
 
 export const DocumentViewerContext = React.createContext<DocumentViewerContextType | null>(null);
 
-export const DocumentViewer: React.FC<DocumentViewerProps> = ({ 
+export const DocumentViewer: React.FC<DocumentViewerProps> = ({
+  connectionId,
   connectionName,
   databaseName,
   collectionName,
@@ -371,6 +376,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   availableFields = [],
   children
 }) => {
+  const { schema } = useCollectionSchema(connectionId, databaseName, collectionName);
   const [filterQuery, setFilterQuery] = useState('{}');
   const [projectionQuery, setProjectionQuery] = useState('{}');
   const [sortQuery, setSortQuery] = useState('{}');
@@ -1415,13 +1421,14 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                 <div className="mql-qrow">
                   <div className={`mql-qcol ${!isFilterValid ? 'is-invalid' : ''}`}>
                     <div className="mql-qbadge">Query</div>
-                    <input
-                      type="text"
+                    <QueryInput
+                      surface="filter"
                       value={filterQuery}
-                      onChange={(e) => setFilterQuery(e.target.value)}
+                      onChange={setFilterQuery}
+                      fields={fields}
+                      schema={schema}
                       placeholder="{}"
                       className="mql-qinput"
-                      spellCheck="false"
                       data-testid="query-filter-input"
                     />
                     {!isFilterValid && (
@@ -1444,13 +1451,14 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                   {/* Projection */}
                   <div className={`mql-qcol ${!isProjectionValid ? 'is-invalid' : ''}`}>
                     <div className="mql-qbadge">Projection</div>
-                    <input
-                      type="text"
+                    <QueryInput
+                      surface="projection"
                       value={projectionQuery}
-                      onChange={(e) => setProjectionQuery(e.target.value)}
+                      onChange={setProjectionQuery}
+                      fields={fields}
+                      schema={schema}
                       placeholder="{}"
                       className="mql-qinput"
-                      spellCheck="false"
                       data-testid="projection-query-input"
                     />
                     {!isProjectionValid && (
@@ -1470,13 +1478,14 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                   {/* Sort */}
                   <div className={`mql-qcol ${!isSortValid ? 'is-invalid' : ''}`}>
                     <div className="mql-qbadge">Sort</div>
-                    <input
-                      type="text"
+                    <QueryInput
+                      surface="sort"
                       value={sortQuery}
-                      onChange={(e) => setSortQuery(e.target.value)}
+                      onChange={setSortQuery}
+                      fields={fields}
+                      schema={schema}
                       placeholder="{}"
                       className="mql-qinput"
-                      spellCheck="false"
                       data-testid="sort-query-input"
                     />
                     {!isSortValid && (
@@ -1604,12 +1613,13 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                             <Trash2 size={11} />
                           </button>
                         </div>
-                        <textarea
+                        <QueryEditor
+                          surface="aggStage"
                           value={stage.content}
-                          onChange={(e) => updateStageContent(stage.id, e.target.value)}
-                          className="mql-stage-body"
-                          rows={3}
-                          spellCheck={false}
+                          onChange={(v) => updateStageContent(stage.id, v)}
+                          fields={fields}
+                          schema={schema}
+                          height={120}
                         />
                       </div>
                       {index < stages.length - 1 && (

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, Braces, CornerDownLeft, Eraser, Play, Sparkles, Terminal }
 import { AIChatPanel } from './AIChatPanel';
 import { buildRunnableCommand, guardScriptRun, type GeneratedQuery } from '../lib/mongoCommand';
 import { DataGrid } from './DataGrid';
+import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
 
 type ShellTab = 'console' | 'viewer';
 
@@ -220,6 +221,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const wrapRef = useRef<HTMLDivElement>(null);
   const runRef = useRef<() => void>(() => {});
   const autoRunRef = useRef(false);
+  // Tracks the latest result docs so the Monaco completion provider (registered
+  // once in onMount) can derive field names from the current results.
+  const viewerRef = useRef<{ docs: Record<string, any>[] } | null>(null);
 
   useEffect(() => {
     setCommand(defaultCommand);
@@ -542,6 +546,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   };
 
   runRef.current = () => runCommand();
+  viewerRef.current = viewer;
 
   useEffect(() => {
     if (!initialCommand || autoRunRef.current || !sessionAttempted || !sessionId) return;
@@ -661,6 +666,24 @@ export const MongoShell: React.FC<MongoShellProps> = ({
             onMount={(editor, monaco) => {
               editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => runRef.current());
               editor.focus();
+              registerMongoCompletionProvider(monaco);
+              const model = editor.getModel();
+              if (model) {
+                const uri = model.uri.toString();
+                setModelMeta(uri, {
+                  surface: 'shell',
+                  getFields: () => {
+                    const docs = viewerRef.current?.docs ?? [];
+                    const keys = new Set<string>(['_id']);
+                    docs.forEach((d) => {
+                      if (d && typeof d === 'object') Object.keys(d).forEach((k) => keys.add(k));
+                    });
+                    return Array.from(keys);
+                  },
+                  getSchema: () => undefined,
+                });
+                editor.onDidDispose(() => clearModelMeta(uri));
+              }
             }}
             loading={
               <div className="mql-shell-monaco-loading">

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,0 +1,50 @@
+import React, { useRef } from 'react';
+import Editor, { type Monaco } from '@monaco-editor/react';
+import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
+import type { Surface } from '../lib/mongoCompletions';
+import type { SchemaMap } from '../lib/useCollectionSchema';
+
+interface QueryEditorProps {
+  surface: Surface;
+  value: string;
+  onChange: (v: string) => void;
+  fields: string[];
+  schema?: SchemaMap;
+  height?: number | string;
+}
+
+export const QueryEditor: React.FC<QueryEditorProps> = ({ surface, value, onChange, fields, schema, height = 120 }) => {
+  const fieldsRef = useRef(fields); fieldsRef.current = fields;
+  const schemaRef = useRef(schema); schemaRef.current = schema;
+  const uriRef = useRef<string | null>(null);
+  const theme = typeof document !== 'undefined' && document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'vs-dark';
+
+  return (
+    <Editor
+      height={height}
+      defaultLanguage="json"
+      theme={theme}
+      value={value}
+      onChange={(v) => onChange(v ?? '')}
+      onMount={(editor, monaco: Monaco) => {
+        registerMongoCompletionProvider(monaco);
+        const model = editor.getModel();
+        if (model) {
+          uriRef.current = model.uri.toString();
+          setModelMeta(uriRef.current, {
+            surface,
+            getFields: () => fieldsRef.current,
+            getSchema: () => schemaRef.current,
+          });
+          editor.onDidDispose(() => { if (uriRef.current) clearModelMeta(uriRef.current); });
+        }
+      }}
+      options={{
+        minimap: { enabled: false }, lineNumbers: 'off', folding: false,
+        scrollBeyondLastLine: false, wordWrap: 'on', fontSize: 12,
+        scrollbar: { vertical: 'auto', horizontal: 'auto' }, overviewRulerLanes: 0,
+        renderLineHighlight: 'none', tabSize: 2,
+      }}
+    />
+  );
+};

--- a/src/components/QueryInput.tsx
+++ b/src/components/QueryInput.tsx
@@ -1,0 +1,100 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { getCompletions, type Surface, type CompletionItem } from '../lib/mongoCompletions';
+import type { SchemaMap } from '../lib/useCollectionSchema';
+
+interface QueryInputProps {
+  surface: Surface;
+  value: string;
+  onChange: (v: string) => void;
+  fields: string[];
+  schema?: SchemaMap;
+  placeholder?: string;
+  className?: string;
+  'data-testid'?: string;
+}
+
+const tokenOf = (textBeforeCursor: string) => textBeforeCursor.match(/[\w$.]*$/)?.[0] ?? '';
+
+export const QueryInput: React.FC<QueryInputProps> = ({ surface, value, onChange, fields, schema, placeholder, className, ...rest }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [caret, setCaret] = useState(0);
+  const [active, setActive] = useState(0);
+  // Live editing buffer. In normal controlled use the parent round-trips
+  // `value` back, so this stays in sync; tracking it locally also lets the
+  // dropdown reflect typed input when an onChange handler does not feed the
+  // value back. External `value` changes (not originating from this input)
+  // win over the local buffer.
+  const [typed, setTyped] = useState(value);
+  const lastPropRef = useRef(value);
+  // Adopt an external `value` change (one the parent made, not us) into the
+  // local buffer. Render-phase derive-from-props pattern.
+  if (value !== lastPropRef.current) {
+    lastPropRef.current = value;
+    if (value !== typed) setTyped(value);
+  }
+  const text = typed;
+  const setBuffer = (v: string) => { setTyped(v); onChange(v); };
+
+  const items = useMemo<CompletionItem[]>(() => {
+    if (!open) return [];
+    const before = text.slice(0, caret);
+    return getCompletions({ surface, textBeforeCursor: before, token: tokenOf(before), fields, schema }).slice(0, 8);
+  }, [open, text, caret, surface, fields, schema]);
+
+  const accept = (item: CompletionItem) => {
+    const before = text.slice(0, caret);
+    const token = tokenOf(before);
+    const start = caret - token.length;
+    const next = text.slice(0, start) + item.insertText + text.slice(caret);
+    setBuffer(next);
+    setOpen(false);
+    requestAnimationFrame(() => {
+      const pos = start + item.insertText.length;
+      inputRef.current?.setSelectionRange(pos, pos);
+      inputRef.current?.focus();
+    });
+  };
+
+  return (
+    <div className="relative">
+      <input
+        {...rest}
+        ref={inputRef}
+        type="text"
+        className={className}
+        placeholder={placeholder}
+        value={text}
+        onChange={(e) => { setBuffer(e.target.value); setCaret(e.target.selectionStart ?? e.target.value.length); setActive(0); setOpen(true); }}
+        onClick={(e) => setCaret((e.target as HTMLInputElement).selectionStart ?? 0)}
+        onKeyUp={(e) => setCaret((e.target as HTMLInputElement).selectionStart ?? 0)}
+        onFocus={(e) => { setCaret(e.target.selectionStart ?? 0); setOpen(true); }}
+        onBlur={() => setTimeout(() => setOpen(false), 120)}
+        onKeyDown={(e) => {
+          if (!open || items.length === 0) return;
+          if (e.key === 'ArrowDown') { e.preventDefault(); setActive((a) => (a + 1) % items.length); }
+          else if (e.key === 'ArrowUp') { e.preventDefault(); setActive((a) => (a - 1 + items.length) % items.length); }
+          else if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); accept(items[active]); }
+          else if (e.key === 'Escape') { e.preventDefault(); setOpen(false); }
+        }}
+      />
+      {open && items.length > 0 && (
+        <ul className="absolute z-50 mt-1 max-h-56 w-64 overflow-auto rounded-md border border-[var(--border-color)] bg-[var(--bg-panel)] py-1 text-[11px] shadow-lg" role="listbox">
+          {items.map((it, i) => (
+            <li
+              key={`${it.kind}:${it.label}`}
+              role="option"
+              aria-selected={i === active}
+              className={`flex justify-between gap-3 px-2 py-1 cursor-pointer ${i === active ? 'bg-[var(--bg-item-active)] text-[var(--accent-blue)]' : 'text-[var(--text-main)]'}`}
+              onMouseDown={(e) => { e.preventDefault(); accept(it); }}
+              onMouseEnter={() => setActive(i)}
+            >
+              <span>{it.label}</span>
+              {it.detail && <span className="text-[var(--text-dim)]">{it.detail}</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/components/SchemaView.tsx
+++ b/src/components/SchemaView.tsx
@@ -11,6 +11,7 @@ interface FieldStat {
   types: TypeCount[];
   presence: number;
   coverage: number;
+  enumValues?: string[];
 }
 interface SchemaReport {
   sampled: number;

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -16,6 +16,16 @@ vi.mock('../../lib/vault', () => ({
 
 // Mock Tauri invoke function
 const mockInvoke = vi.fn();
+// Monaco does not render a usable DOM under jsdom. The aggregation stage editor
+// (QueryEditor) wraps @monaco-editor/react, so mock it with a plain <textarea>
+// that round-trips value/onChange — this keeps the existing stage tests, which
+// drive `pipeline-stage-N textarea`, working against the real component shape.
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ value, onChange }: { value: string; onChange?: (v: string) => void }) => (
+    <textarea value={value} onChange={(e) => onChange?.(e.target.value)} />
+  ),
+}));
+
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: any[]) => mockInvoke(...args),
 }));

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -7,6 +7,16 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: any[]) => mockInvoke(...args),
 }));
 
+// Monaco does not render a usable DOM under jsdom. The aggregation stage editor
+// (QueryEditor) wraps @monaco-editor/react, so mock it with a plain <textarea>
+// that round-trips value/onChange — this keeps the existing stage tests, which
+// drive `pipeline-stage-N textarea`, working against the real component shape.
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ value, onChange }: { value: string; onChange?: (v: string) => void }) => (
+    <textarea value={value} onChange={(e) => onChange?.(e.target.value)} />
+  ),
+}));
+
 describe('DocumentViewer Component', () => {
   const mockOnExecute = vi.fn();
   const mockOnExecuteAggregate = vi.fn();

--- a/src/components/__tests__/QueryEditor.test.tsx
+++ b/src/components/__tests__/QueryEditor.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ value }: { value: string }) => <div data-testid="monaco" data-value={value} />,
+}));
+
+import { QueryEditor } from '../QueryEditor';
+
+describe('QueryEditor', () => {
+  it('renders a Monaco editor with the given value', () => {
+    const { getByTestId } = render(
+      <QueryEditor surface="aggStage" value='{ "$match": {} }' onChange={() => {}} fields={['region']} schema={undefined} />,
+    );
+    expect(getByTestId('monaco').getAttribute('data-value')).toBe('{ "$match": {} }');
+  });
+});

--- a/src/components/__tests__/QueryInput.test.tsx
+++ b/src/components/__tests__/QueryInput.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryInput } from '../QueryInput';
+
+function setup(value = '') {
+  const onChange = vi.fn();
+  render(
+    <QueryInput surface="filter" value={value} onChange={onChange} fields={['region', 'plan']} data-testid="q" />,
+  );
+  return { onChange, input: screen.getByTestId('q') as HTMLInputElement };
+}
+
+describe('QueryInput', () => {
+  it('shows field suggestions while typing a key', () => {
+    const { input } = setup('{ ');
+    fireEvent.change(input, { target: { value: '{ reg' } });
+    expect(screen.getByText('region')).toBeTruthy();
+  });
+
+  it('accepts a suggestion with Enter, replacing the token', () => {
+    const { input, onChange } = setup('{ ');
+    fireEvent.change(input, { target: { value: '{ reg' } });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalled();
+    const last = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(last).toContain('region');
+  });
+
+  it('dismisses the dropdown on Escape', () => {
+    const { input } = setup('{ ');
+    fireEvent.change(input, { target: { value: '{ reg' } });
+    expect(screen.queryByText('region')).toBeTruthy();
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByText('region')).toBeNull();
+  });
+});

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { getCompletions, type CompletionCtx } from '../mongoCompletions';
+
+const base = (over: Partial<CompletionCtx>): CompletionCtx => ({
+  surface: 'filter', textBeforeCursor: '', token: '', fields: ['region', 'plan', '_id'], ...over,
+});
+const labels = (items: { label: string }[]) => items.map((i) => i.label);
+const kinds = (items: { kind: string }[]) => new Set(items.map((i) => i.kind));
+
+describe('getCompletions — filter', () => {
+  it('suggests fields at a key position', () => {
+    const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['region', 'plan', '_id']));
+    expect(kinds(items).has('field')).toBe(true);
+  });
+  it('suggests query operators after a field colon', () => {
+    const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ "region": ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['$eq', '$in', '$gt', '$regex']));
+  });
+  it('suggests enum values for a field with enums at a value position', () => {
+    const schema = new Map([['plan', { type: 'string', enumValues: ['Free', 'Team'] }]]);
+    const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ "plan": ', token: '', schema }));
+    const enums = items.filter((i) => i.kind === 'enum');
+    expect(enums.map((e) => e.insertText)).toEqual(expect.arrayContaining(['"Free"', '"Team"']));
+  });
+  it('prefix-filters by token', () => {
+    const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ reg', token: 'reg' }));
+    expect(labels(items)).toContain('region');
+    expect(labels(items)).not.toContain('plan');
+  });
+});
+
+describe('getCompletions — projection/sort', () => {
+  it('projection suggests fields', () => {
+    expect(labels(getCompletions(base({ surface: 'projection', textBeforeCursor: '{ ', token: '' })))).toContain('region');
+  });
+  it('sort suggests fields', () => {
+    expect(labels(getCompletions(base({ surface: 'sort', textBeforeCursor: '{ ', token: '' })))).toContain('region');
+  });
+});
+
+describe('getCompletions — aggStage', () => {
+  it('suggests stage operators at stage start', () => {
+    const items = getCompletions(base({ surface: 'aggStage', textBeforeCursor: '{ ', token: '$m' }));
+    expect(labels(items)).toContain('$match');
+  });
+  it('suggests group accumulators inside $group', () => {
+    const items = getCompletions(base({ surface: 'aggStage', textBeforeCursor: '{ "$group": { "_id": "$region", "t": { ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['$sum', '$avg', '$max']));
+  });
+});
+
+describe('getCompletions — shell', () => {
+  it('suggests cursor methods after db.coll.', () => {
+    const items = getCompletions(base({ surface: 'shell', textBeforeCursor: 'db.customers.', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['find', 'aggregate', 'countDocuments']));
+  });
+});

--- a/src/lib/__tests__/useCollectionSchema.test.ts
+++ b/src/lib/__tests__/useCollectionSchema.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => invoke(...a) }));
+
+import { useCollectionSchema, __clearSchemaCache } from '../useCollectionSchema';
+
+beforeEach(() => { invoke.mockReset(); __clearSchemaCache(); });
+
+const report = JSON.stringify({
+  sampled: 3,
+  fields: [
+    { path: 'plan', types: [{ type: 'string', count: 3 }], presence: 3, coverage: 1, enumValues: ['Free', 'Team'] },
+    { path: 'seats', types: [{ type: 'int', count: 3 }], presence: 3, coverage: 1 },
+  ],
+});
+
+describe('useCollectionSchema', () => {
+  it('fetches once and maps path -> {type, enumValues}', async () => {
+    invoke.mockResolvedValue(report);
+    const { result } = renderHook(() => useCollectionSchema('c1', 'db', 'coll'));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.schema.get('plan')).toEqual({ type: 'string', enumValues: ['Free', 'Team'] });
+    expect(result.current.schema.get('seats')).toEqual({ type: 'int', enumValues: undefined });
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches per (conn,db,coll) — second hook does not refetch', async () => {
+    invoke.mockResolvedValue(report);
+    const h1 = renderHook(() => useCollectionSchema('c1', 'db', 'coll'));
+    await waitFor(() => expect(h1.result.current.ready).toBe(true));
+    renderHook(() => useCollectionSchema('c1', 'db', 'coll'));
+    await waitFor(() => {});
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('on error resolves to an empty map', async () => {
+    invoke.mockRejectedValue('boom');
+    const { result } = renderHook(() => useCollectionSchema('c1', 'db', 'coll'));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.schema.size).toBe(0);
+  });
+});

--- a/src/lib/monacoMongo.ts
+++ b/src/lib/monacoMongo.ts
@@ -1,0 +1,56 @@
+import type { Monaco } from '@monaco-editor/react';
+import { getCompletions, type Surface, type CompletionKind } from './mongoCompletions';
+import type { SchemaMap } from './useCollectionSchema';
+
+interface ModelMeta { surface: Surface; getFields: () => string[]; getSchema: () => SchemaMap | undefined; }
+const modelMeta = new Map<string, ModelMeta>();
+let registered = false;
+
+export function setModelMeta(uri: string, meta: ModelMeta) { modelMeta.set(uri, meta); }
+export function clearModelMeta(uri: string) { modelMeta.delete(uri); }
+
+function kindToMonaco(monaco: Monaco, kind: CompletionKind) {
+  const k = monaco.languages.CompletionItemKind;
+  switch (kind) {
+    case 'field': return k.Field;
+    case 'operator': return k.Operator;
+    case 'stage': return k.Keyword;
+    case 'method': return k.Method;
+    case 'enum': return k.EnumMember;
+    default: return k.Text;
+  }
+}
+
+export function registerMongoCompletionProvider(monaco: Monaco) {
+  if (registered) return;
+  registered = true;
+  const provider = {
+    triggerCharacters: ['$', '"', '.', ' ', '{'],
+    provideCompletionItems(model: any, position: any) {
+      const meta = modelMeta.get(model.uri.toString());
+      if (!meta) return { suggestions: [] };
+      const textBeforeCursor: string = model.getValueInRange({
+        startLineNumber: position.lineNumber, startColumn: 1,
+        endLineNumber: position.lineNumber, endColumn: position.column,
+      });
+      const word = model.getWordUntilPosition(position);
+      const token = textBeforeCursor.slice(word.startColumn - 1).match(/[\w$.]*$/)?.[0] ?? word.word;
+      const items = getCompletions({
+        surface: meta.surface, textBeforeCursor, token,
+        fields: meta.getFields(), schema: meta.getSchema(),
+      });
+      const range = {
+        startLineNumber: position.lineNumber, endLineNumber: position.lineNumber,
+        startColumn: position.column - token.length, endColumn: position.column,
+      };
+      return {
+        suggestions: items.map((it) => ({
+          label: it.label, kind: kindToMonaco(monaco, it.kind),
+          insertText: it.insertText, detail: it.detail, range,
+        })),
+      };
+    },
+  };
+  monaco.languages.registerCompletionItemProvider('json', provider);
+  monaco.languages.registerCompletionItemProvider('javascript', provider);
+}

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -1,0 +1,125 @@
+export type Surface = 'filter' | 'projection' | 'sort' | 'aggStage' | 'shell';
+export type CompletionKind = 'field' | 'operator' | 'stage' | 'method' | 'enum';
+
+export interface FieldSchema { type?: string; enumValues?: string[]; }
+
+export interface CompletionCtx {
+  surface: Surface;
+  textBeforeCursor: string;
+  token: string;
+  fields: string[];
+  schema?: Map<string, FieldSchema>;
+}
+
+export interface CompletionItem {
+  label: string;
+  kind: CompletionKind;
+  insertText: string;
+  detail?: string;
+}
+
+export const QUERY_OPERATORS = [
+  '$eq', '$ne', '$gt', '$gte', '$lt', '$lte', '$in', '$nin',
+  '$exists', '$regex', '$type', '$elemMatch', '$size', '$all', '$mod',
+];
+export const LOGICAL_OPERATORS = ['$and', '$or', '$nor', '$not'];
+export const AGG_STAGES = [
+  '$match', '$group', '$project', '$sort', '$limit', '$skip', '$unwind',
+  '$lookup', '$addFields', '$set', '$unset', '$count', '$facet', '$sortByCount', '$replaceRoot',
+];
+export const GROUP_ACCUMULATORS = ['$sum', '$avg', '$min', '$max', '$first', '$last', '$push', '$addToSet', '$count'];
+export const CURSOR_METHODS = [
+  'find', 'aggregate', 'countDocuments', 'estimatedDocumentCount', 'distinct',
+  'insertOne', 'insertMany', 'updateOne', 'updateMany', 'deleteOne', 'deleteMany',
+  'findOne', 'replaceOne', 'createIndex', 'getIndexes', 'drop',
+];
+
+function byPrefix<T extends { label: string }>(items: T[], token: string): T[] {
+  if (!token) return items;
+  const t = token.toLowerCase();
+  return items.filter((i) => i.label.toLowerCase().startsWith(t));
+}
+
+function opItems(ops: string[], detail: string): CompletionItem[] {
+  return ops.map((op) => ({ label: op, kind: 'operator' as const, insertText: op, detail }));
+}
+
+function fieldItems(ctx: CompletionCtx): CompletionItem[] {
+  return ctx.fields.map((name) => {
+    const fs = ctx.schema?.get(name);
+    return { label: name, kind: 'field' as const, insertText: name, detail: fs?.type };
+  });
+}
+
+function quoteForType(value: string, type?: string): string {
+  // string/objectId/date → quoted; numeric/bool → raw.
+  if (type === 'int' || type === 'long' || type === 'double' || type === 'decimal' || type === 'bool') return value;
+  return JSON.stringify(value);
+}
+
+function enumItemsForLastField(ctx: CompletionCtx): CompletionItem[] {
+  const field = lastFieldKey(ctx.textBeforeCursor);
+  if (!field) return [];
+  const fs = ctx.schema?.get(field);
+  if (!fs?.enumValues?.length) return [];
+  return fs.enumValues.map((v) => ({
+    label: v, kind: 'enum' as const, insertText: quoteForType(v, fs.type), detail: 'enum',
+  }));
+}
+
+// The nearest `"field":` (or `field:`) key to the left of the cursor.
+function lastFieldKey(text: string): string | null {
+  const m = text.match(/["']?([A-Za-z_][\w.]*)["']?\s*:\s*[^,{}\[\]]*$/);
+  return m ? m[1] : null;
+}
+
+// True when the caret is at an object-key position (after `{` or `,`, not past a `:`).
+function atKeyPosition(text: string): boolean {
+  const tail = text.slice(text.lastIndexOf('{') + 1);
+  const afterComma = text.slice(text.lastIndexOf(',') + 1);
+  const seg = tail.length < afterComma.length ? tail : afterComma;
+  return !seg.includes(':');
+}
+
+// True when the caret is at a value position (just after `field:`).
+function atValuePosition(text: string): boolean {
+  return /:\s*["']?[\w.$]*$/.test(text) && !atKeyPosition(text);
+}
+
+export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
+  const { surface, textBeforeCursor, token } = ctx;
+
+  if (surface === 'projection') {
+    return byPrefix([...fieldItems(ctx),
+      { label: '1', kind: 'operator', insertText: '1', detail: 'include' },
+      { label: '0', kind: 'operator', insertText: '0', detail: 'exclude' }], token);
+  }
+  if (surface === 'sort') {
+    return byPrefix([...fieldItems(ctx),
+      { label: '1', kind: 'operator', insertText: '1', detail: 'ascending' },
+      { label: '-1', kind: 'operator', insertText: '-1', detail: 'descending' }], token);
+  }
+  if (surface === 'shell') {
+    if (/\.\s*$/.test(textBeforeCursor) || /\.[A-Za-z]*$/.test(textBeforeCursor)) {
+      return byPrefix(CURSOR_METHODS.map((m) => ({ label: m, kind: 'method' as const, insertText: m })), token);
+    }
+    // inside find({...}) → behave like a filter (fall through)
+  }
+
+  const aggStageStart = surface === 'aggStage' && atKeyPosition(textBeforeCursor)
+    && !/\$group/.test(textBeforeCursor.slice(textBeforeCursor.indexOf('{')));
+
+  if (aggStageStart) {
+    return byPrefix(AGG_STAGES.map((s) => ({ label: s, kind: 'stage' as const, insertText: s })), token);
+  }
+  if (surface === 'aggStage' && /\$group/.test(textBeforeCursor) && atKeyPosition(textBeforeCursor)) {
+    return byPrefix([...opItems(GROUP_ACCUMULATORS, 'accumulator'), ...fieldItems(ctx)], token);
+  }
+
+  // filter (and shell-inside-find, and agg $match body)
+  if (atValuePosition(textBeforeCursor)) {
+    return byPrefix([...enumItemsForLastField(ctx), ...opItems(QUERY_OPERATORS, 'query operator')], token);
+  }
+  // key position
+  return byPrefix([...fieldItems(ctx), ...opItems(LOGICAL_OPERATORS, 'logical')], token);
+}

--- a/src/lib/useCollectionSchema.ts
+++ b/src/lib/useCollectionSchema.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import type { FieldSchema } from './mongoCompletions';
+
+export type SchemaMap = Map<string, FieldSchema>;
+
+interface RawFieldStat { path: string; types: { type: string; count: number }[]; enumValues?: string[]; }
+interface RawReport { sampled: number; fields: RawFieldStat[]; }
+
+const cache = new Map<string, Promise<SchemaMap>>();
+const EMPTY: SchemaMap = new Map();
+
+export function __clearSchemaCache() { cache.clear(); }
+
+function buildMap(report: RawReport): SchemaMap {
+  const m: SchemaMap = new Map();
+  for (const f of report.fields) {
+    const type = f.types.slice().sort((a, b) => b.count - a.count)[0]?.type;
+    m.set(f.path, { type, enumValues: f.enumValues });
+  }
+  return m;
+}
+
+function fetchSchema(connectionId: string, db: string, coll: string): Promise<SchemaMap> {
+  const key = `${connectionId}::${db}::${coll}`;
+  let p = cache.get(key);
+  if (!p) {
+    p = invoke<string>('analyze_schema', { id: connectionId, database: db, collection: coll, sampleSize: 500 })
+      .then((json) => buildMap(JSON.parse(json) as RawReport))
+      .catch(() => EMPTY);
+    cache.set(key, p);
+  }
+  return p;
+}
+
+export function useCollectionSchema(connectionId?: string, db?: string, coll?: string): { schema: SchemaMap; ready: boolean } {
+  const [schema, setSchema] = useState<SchemaMap>(EMPTY);
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    if (!connectionId || !db || !coll) { setSchema(EMPTY); setReady(false); return; }
+    let alive = true;
+    setReady(false);
+    fetchSchema(connectionId, db, coll).then((m) => { if (alive) { setSchema(m); setReady(true); } });
+    return () => { alive = false; };
+  }, [connectionId, db, coll]);
+  return { schema, ready };
+}


### PR DESCRIPTION
Adds schema-aware autocomplete across every query surface — second Tier-1 feature from `docs/superpowers/feature-roadmap.md`.

## What it does
- **Completions** for field names, MongoDB query operators, aggregation stages/accumulators, and mongosh cursor methods — with **field type** in the detail and **enum value** suggestions for low-cardinality fields.
- **Surfaces:**
  - Find **filter / projection / sort** → a lightweight suggestion **dropdown** on the existing single-line inputs (`QueryInput`).
  - **Aggregation** stages → **Monaco** editors (`QueryEditor`) with the completion provider.
  - **mongosh** shell → its existing Monaco editor, now with the provider.
- Field **names** are instant (ambient field list); **types + enums** come from a lazily-fetched, per-collection-cached `analyze_schema`.

## How it's built
- **Backend:** `analyze_schema` (Rust) extended to detect low-cardinality scalar **enum values** (≤25 distinct) — additive `enumValues` field, backward-compatible.
- **Pure engine** `src/lib/mongoCompletions.ts` (heavily unit-tested) feeds two adapters: a Monaco `CompletionItemProvider` (`monacoMongo.ts`, one per `json`/`javascript` + per-model registry) and the `QueryInput` dropdown.
- `useCollectionSchema` — fetch-once-per-collection cache.

## Verification
- **246 frontend tests pass** + Rust `cargo test schema` (enum detection) + `tsc` clean + `npm run build` clean.
- Built via brainstorm → spec → plan (spec: `specs/2026-06-04-schema-aware-autocomplete-design.md`, plan: `plans/2026-06-04-schema-aware-autocomplete.md`). Final review: APPROVED.

> Interactive check: `npm run tauri dev` → open a collection → type in the filter (`{ ` → fields; `{ "plan": ` → enum values), aggregation stages, and mongosh.