### PR TITLE
feat(results): colored Table + document-modal polish

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -444,16 +444,6 @@ export const DataGrid: React.FC<DataGridProps> = ({
     return Array.from(keys);
   }, [documents]);
 
-  const renderCellContent = (val: any): string => {
-    if (val === null || val === undefined) return '';
-    if (typeof val === 'object') {
-      if (val.$oid) return val.$oid;
-      if (val.$date) return typeof val.$date === 'string' ? val.$date : JSON.stringify(val.$date);
-      return JSON.stringify(val);
-    }
-    return String(val);
-  };
-
   const isBsonObject = (val: any): boolean => {
     if (val === null || val === undefined) return false;
     return (
@@ -540,6 +530,34 @@ export const DataGrid: React.FC<DataGridProps> = ({
           <span className="text-syntax-number">{val.toString()}</span>)
         </>
       );
+    }
+    return <span>{String(val)}</span>;
+  };
+
+  // Colored Table cell — same syntax palette as the Tree/JSON views (strings,
+  // numbers, booleans, BSON types) so the Table is visually consistent.
+  const renderColoredCell = (val: any): React.ReactNode => {
+    if (val === null || val === undefined) return '';
+    if (typeof val === 'string') return <span className="text-syntax-string">{val}</span>;
+    if (typeof val === 'number') return <span className="text-syntax-number">{String(val)}</span>;
+    if (typeof val === 'boolean') return <span className="text-syntax-boolean font-bold">{val ? 'true' : 'false'}</span>;
+    if (typeof val === 'object') {
+      if (isBsonObject(val)) return renderBsonValueNode(val);
+      if (typeof val.$oid === 'string') return <span className="text-syntax-string">{val.$oid}</span>;
+      if (val.$date !== undefined) {
+        const s =
+          typeof val.$date === 'string'
+            ? val.$date
+            : val.$date?.$numberLong
+              ? new Date(Number(val.$date.$numberLong)).toISOString()
+              : JSON.stringify(val.$date);
+        return <span className="text-syntax-string">{s}</span>;
+      }
+      if (val.$numberLong !== undefined) return <span className="text-syntax-number">{String(val.$numberLong)}</span>;
+      if (val.$numberDecimal !== undefined) return <span className="text-syntax-number">{String(val.$numberDecimal)}</span>;
+      if (val.$numberInt !== undefined) return <span className="text-syntax-number">{String(val.$numberInt)}</span>;
+      if (val.$numberDouble !== undefined) return <span className="text-syntax-number">{String(val.$numberDouble)}</span>;
+      return <span className="text-[var(--text-dim)]">{JSON.stringify(val)}</span>;
     }
     return <span>{String(val)}</span>;
   };
@@ -859,7 +877,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
             style={{ width: '180px', flexShrink: 0 }}
             onContextMenu={(e) => openCtxMenu(e, rawDoc, col, rawDoc[col])}
           >
-            {renderCellContent(rawDoc[col])}
+            {renderColoredCell(rawDoc[col])}
           </div>
         ))}
         {hasRowActions && (

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -1,7 +1,24 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { X, FileJson } from 'lucide-react';
 import Editor from '@monaco-editor/react';
 import { shellToEjson } from '../lib/shellDoc';
+
+// Validate the (shell-syntax) document text: convert to Extended JSON and parse.
+// Returns an error message, or null when valid. Shell types (ISODate/ObjectId/…)
+// are accepted; genuinely malformed input (stray tokens, bad EJSON) is rejected.
+function validateDocument(text: string): string | null {
+  if (!text.trim()) return 'Document is empty.';
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(shellToEjson(text));
+  } catch (e: any) {
+    return `Invalid document: ${e?.message || 'syntax error'}`;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return 'A document must be an object (e.g. { "field": value }).';
+  }
+  return null;
+}
 
 interface DocumentEditModalProps {
   isOpen: boolean;
@@ -21,6 +38,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   const [json, setJson] = useState(initialJson);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const validationError = useMemo(() => validateDocument(json), [json]);
   const theme =
     typeof document !== 'undefined' && document.documentElement.getAttribute('data-theme') === 'light'
       ? 'light'
@@ -37,20 +55,12 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   if (!isOpen) return null;
 
   const handleSave = async () => {
-    // The editor shows mongosh shell types (ISODate(...), ObjectId(...), …);
-    // convert them to Extended JSON before validating and saving.
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    // Convert the shell types (ISODate(...), ObjectId(...), …) to Extended JSON.
     const ejson = shellToEjson(json);
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(ejson);
-    } catch (err: any) {
-      setError(`Invalid document: ${err.message || 'syntax error'}`);
-      return;
-    }
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      setError('A document must be an object (e.g. { "field": value }).');
-      return;
-    }
     setError(null);
     setSaving(true);
     try {
@@ -63,7 +73,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
 
   return (
     <div className="nested-modal-overlay select-none" data-testid="document-edit-modal" onClick={onClose}>
-      <div className="index-modal-container" onClick={(e) => e.stopPropagation()}>
+      <div className="index-modal-container index-modal-container--wide" onClick={(e) => e.stopPropagation()}>
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[var(--border-color)] pb-3 mb-4 select-none">
           <div className="flex items-center gap-2">
@@ -87,10 +97,22 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
             <Editor
               height={360}
               defaultLanguage="javascript"
+              language="javascript"
               theme={theme}
               value={json}
               onChange={(v) => setJson(v ?? '')}
               wrapperProps={{ 'data-testid': 'document-json-input' }}
+              onMount={(_editor, monaco) => {
+                // The document is shown in mongosh shell syntax (ISODate(...),
+                // ObjectId(...)), which is neither valid JSON nor resolvable JS,
+                // so silence both validators to avoid spurious red squiggles.
+                monaco.languages.typescript?.javascriptDefaults?.setDiagnosticsOptions({
+                  noSemanticValidation: true,
+                  noSyntaxValidation: true,
+                  noSuggestionDiagnostics: true,
+                });
+                monaco.languages.json?.jsonDefaults?.setDiagnosticsOptions({ validate: false });
+              }}
               options={{
                 minimap: { enabled: false },
                 lineNumbers: 'on',
@@ -100,10 +122,16 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
                 fontSize: 12.5,
                 tabSize: 2,
                 automaticLayout: true,
-                fixedOverflowWidgets: true,
                 overviewRulerLanes: 0,
                 renderLineHighlight: 'line',
                 padding: { top: 8, bottom: 8 },
+                // No autocomplete in the document editor (avoids stray JS/JSON
+                // suggestions like `JSON` and the mispositioned widget).
+                quickSuggestions: false,
+                suggestOnTriggerCharacters: false,
+                wordBasedSuggestions: 'off',
+                parameterHints: { enabled: false },
+                hover: { enabled: false },
               }}
             />
           </div>
@@ -113,9 +141,9 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
           </span>
         </div>
 
-        {error && (
+        {(error || validationError) && (
           <div className="index-modal-error" data-testid="document-edit-error">
-            {error}
+            {error || validationError}
           </div>
         )}
 
@@ -126,7 +154,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
           <button
             type="button"
             onClick={handleSave}
-            disabled={saving}
+            disabled={saving || !!validationError}
             className="index-modal-btn-primary"
             data-testid="document-save-btn"
           >

--- a/src/components/__tests__/DocumentEditModal.test.tsx
+++ b/src/components/__tests__/DocumentEditModal.test.tsx
@@ -75,6 +75,27 @@ describe('DocumentEditModal', () => {
     expect(screen.getByTestId('document-edit-error')).toBeInTheDocument();
   });
 
+  it('accepts shell types and saves converted Extended JSON', () => {
+    const onSave = vi.fn();
+    render(<DocumentEditModal isOpen mode="insert" initialJson="{}" onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByTestId('document-json-input'), {
+      target: { value: '{ "_id": ObjectId("507f1f77bcf86cd799439011") }' },
+    });
+    expect(screen.queryByTestId('document-edit-error')).toBeNull();
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+    expect(onSave).toHaveBeenCalledWith('{ "_id": {"$oid":"507f1f77bcf86cd799439011"} }');
+  });
+
+  it('flags malformed input (live) and disables Save', () => {
+    const onSave = vi.fn();
+    render(<DocumentEditModal isOpen mode="edit" initialJson="{}" onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByTestId('document-json-input'), { target: { value: '{ "a": 1, j }' } });
+    expect(screen.getByTestId('document-edit-error')).toBeInTheDocument();
+    expect(screen.getByTestId('document-save-btn')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
   it('does not render when closed', () => {
     render(
       <DocumentEditModal

--- a/src/index.css
+++ b/src/index.css
@@ -4683,6 +4683,8 @@ button, input, select, textarea {
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
 }
+/* Wider variant for the document (JSON/shell) editor modal */
+.index-modal-container--wide { width: min(820px, 92vw); }
 
 .index-modal-form {
   display: flex;


### PR DESCRIPTION
Follow-up to #52, which was merged before these last changes landed. Brings the remaining results/editor polish (4 files).

## What
- **Colored Table view** — cells render with the same syntax palette as Tree/JSON (strings, numbers, booleans, BSON types) via `renderColoredCell`; removed the unused `renderCellContent`.
- **Document modal polish:**
  - Widened to 820px so shell values (`ISODate("…")`) fit on one line.
  - Forced `javascript` language + disabled JSON/TS diagnostics → no red squiggles on shell syntax.
  - Disabled Monaco autocomplete in the editor → no stray `JSON` suggestion / mispositioned widget.
  - Added **shell-aware live validation**: malformed input shows an inline error and disables **Save**, while `ISODate(...)`/`ObjectId(...)`/`NumberLong(...)` are accepted.

## Verified
- 267 tests pass (incl. 2 new modal tests: shell accepted+saved as EJSON; malformed flagged + Save disabled), `tsc` clean, `npm run build` clean.
- Branched off the post-#52 `dev`; only the unmerged net changes are included.