### PR TITLE
test(queries): backend unit tests for query-history store

### DIFF
--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -176,3 +176,53 @@ pub async fn set_default_query(
     store.collections.entry(key).or_default().default = default;
     save_store_to_file(&path, &store)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn entry(q: serde_json::Value, at: &str) -> HistoryEntry {
+        HistoryEntry { query: q, ran_at: at.into() }
+    }
+
+    #[test]
+    fn collection_key_is_stable_and_distinct() {
+        assert_eq!(collection_key("conn", "db", "c"), "conn::db::c");
+        assert_ne!(collection_key("conn", "db", "a"), collection_key("conn", "db", "b"));
+    }
+
+    #[test]
+    fn push_history_prepends_and_caps() {
+        let mut h: Vec<HistoryEntry> = Vec::new();
+        for i in 0..(HISTORY_CAP + 5) {
+            h = push_history(h, entry(json!({ "n": i }), &format!("t{i}")), HISTORY_CAP);
+        }
+        assert_eq!(h.len(), HISTORY_CAP);
+        // Most recent first.
+        assert_eq!(h[0].query, json!({ "n": HISTORY_CAP + 4 }));
+    }
+
+    #[test]
+    fn push_history_dedupes_identical_query_bodies() {
+        let mut h = Vec::new();
+        h = push_history(h, entry(json!({ "filter": { "a": 1 } }), "t1"), HISTORY_CAP);
+        h = push_history(h, entry(json!({ "filter": { "b": 2 } }), "t2"), HISTORY_CAP);
+        h = push_history(h, entry(json!({ "filter": { "a": 1 } }), "t3"), HISTORY_CAP); // dup of t1
+        assert_eq!(h.len(), 2, "identical query collapses to one entry");
+        assert_eq!(h[0].ran_at, "t3", "re-running moves it to the front");
+        assert_eq!(h[1].ran_at, "t2");
+    }
+
+    #[test]
+    fn store_round_trips_through_json() {
+        let mut store = QueryStore::default();
+        let key = collection_key("c", "db", "coll");
+        let cq = store.collections.entry(key.clone()).or_default();
+        cq.saved.push(SavedQuery { id: "1".into(), name: "A".into(), query: json!({}), created_at: "t".into() });
+        cq.default = Some(json!({ "filter": {} }));
+        let text = serde_json::to_string(&store).unwrap();
+        let back: QueryStore = serde_json::from_str(&text).unwrap();
+        assert_eq!(back, store);
+    }
+}


### PR DESCRIPTION
Closes #51 (the feature itself already shipped).

While picking up #51, I found **query history / saved queries is already fully implemented and on `dev`**:
- Backend `queries.rs` (saved/history/default per collection) + 5 registered Tauri commands, `queries.json` store.
- `queryStore.ts` frontend wrapper (with tests).
- DocumentViewer UI: Save, Load (saved dropdown), History dropdown, Set/Clear default.
- App wiring: records history after `execute_mql_query`/`execute_aggregate`, loads the default query on collection open.
- 32 frontend tests pass.

The only gap was **no backend tests**. This PR adds Rust unit tests for `queries.rs`:
- `push_history` — prepend (newest-first), dedup by query body, 20-entry cap
- `collection_key` stability/distinctness
- store JSON serde round-trip

`cargo test queries::` → 4 passed.

(The `docs/superpowers/feature-roadmap.md` entry for #51 is updated locally to mark it shipped; `docs/` is untracked scratch so it's not in this PR.)