### PR TITLE
feat(monitoring): cluster monitoring tab (metrics, current ops, profiler)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ai;
 pub mod connections;
 mod db;
 pub(crate) mod mock_db;
+pub mod monitoring;
 pub mod queries;
 pub mod ssh_tunnel;
 mod state;
@@ -684,6 +685,59 @@ async fn list_indexes(
     list_indexes_impl(&state, &id, &db, &collection).await
 }
 
+// ── Cluster monitoring ────────────────────────────────────────────────────────
+
+#[tauri::command]
+async fn server_status(
+    state: tauri::State<'_, AppState>,
+    id: String,
+) -> Result<monitoring::ServerStatus, String> {
+    monitoring::server_status_impl(&state, &id).await
+}
+
+#[tauri::command]
+async fn current_ops(
+    state: tauri::State<'_, AppState>,
+    id: String,
+) -> Result<Vec<monitoring::CurrentOp>, String> {
+    monitoring::current_ops_impl(&state, &id).await
+}
+
+#[tauri::command]
+async fn kill_op(state: tauri::State<'_, AppState>, id: String, opid: i64) -> Result<(), String> {
+    monitoring::kill_op_impl(&state, &id, opid).await
+}
+
+#[tauri::command]
+async fn get_profiling_status(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+) -> Result<monitoring::ProfilingStatus, String> {
+    monitoring::profiling_status_impl(&state, &id, &database).await
+}
+
+#[tauri::command]
+async fn set_profiling_level(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+    level: i32,
+    slow_ms: i32,
+) -> Result<monitoring::ProfilingStatus, String> {
+    monitoring::set_profiling_level_impl(&state, &id, &database, level, slow_ms).await
+}
+
+#[tauri::command]
+async fn read_profile(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+    limit: i64,
+) -> Result<Vec<monitoring::ProfileEntry>, String> {
+    monitoring::read_profile_impl(&state, &id, &database, limit).await
+}
+
 #[tauri::command]
 async fn execute_mql_query(
     state: tauri::State<'_, AppState>,
@@ -1269,7 +1323,13 @@ pub fn run() {
             queries::save_query,
             queries::delete_saved_query,
             queries::record_history,
-            queries::set_default_query
+            queries::set_default_query,
+            server_status,
+            current_ops,
+            kill_op,
+            get_profiling_status,
+            set_profiling_level,
+            read_profile
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -1,0 +1,413 @@
+//! Cluster monitoring: curated `serverStatus`, current operations (+ kill), and
+//! the database profiler. Live admin/db commands are run against the real client;
+//! mock connections return synthetic data so the dashboard works in demo mode.
+//!
+//! The curation functions (raw BSON `Document` -> typed struct) are pure and
+//! unit-tested; the async `*_impl` wrappers just run the command and curate.
+
+use crate::{connection_is_mock, require_real_client, AppState};
+use mongodb::bson::{doc, Bson, Document};
+use serde::Serialize;
+
+// BSON numbers arrive as Int32 / Int64 / Double; coerce any of them to i64.
+fn num(d: &Document, key: &str) -> i64 {
+    match d.get(key) {
+        Some(Bson::Int32(v)) => *v as i64,
+        Some(Bson::Int64(v)) => *v,
+        Some(Bson::Double(v)) => *v as i64,
+        _ => 0,
+    }
+}
+fn fnum(d: &Document, key: &str) -> f64 {
+    match d.get(key) {
+        Some(Bson::Int32(v)) => *v as f64,
+        Some(Bson::Int64(v)) => *v as f64,
+        Some(Bson::Double(v)) => *v,
+        _ => 0.0,
+    }
+}
+fn sub<'a>(d: &'a Document, key: &str) -> Option<&'a Document> {
+    d.get_document(key).ok()
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Connections {
+    pub current: i64,
+    pub available: i64,
+    pub total_created: i64,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OpCounters {
+    pub insert: i64,
+    pub query: i64,
+    pub update: i64,
+    pub delete: i64,
+    pub getmore: i64,
+    pub command: i64,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Memory {
+    pub resident_mb: i64,
+    pub virtual_mb: i64,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Network {
+    pub bytes_in: i64,
+    pub bytes_out: i64,
+    pub num_requests: i64,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheStats {
+    pub bytes_in_cache: i64,
+    pub max_bytes: i64,
+    pub dirty_bytes: i64,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerStatus {
+    pub host: String,
+    pub version: String,
+    pub uptime_seconds: f64,
+    pub connections: Connections,
+    pub opcounters: OpCounters,
+    pub memory: Memory,
+    pub network: Network,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache: Option<CacheStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repl_set: Option<String>,
+}
+
+/// Curate a raw `serverStatus` document into the dashboard's subset.
+pub fn curate_server_status(raw: &Document) -> ServerStatus {
+    let connections = sub(raw, "connections")
+        .map(|c| Connections {
+            current: num(c, "current"),
+            available: num(c, "available"),
+            total_created: num(c, "totalCreated"),
+        })
+        .unwrap_or_default();
+    let opcounters = sub(raw, "opcounters")
+        .map(|o| OpCounters {
+            insert: num(o, "insert"),
+            query: num(o, "query"),
+            update: num(o, "update"),
+            delete: num(o, "delete"),
+            getmore: num(o, "getmore"),
+            command: num(o, "command"),
+        })
+        .unwrap_or_default();
+    let memory = sub(raw, "mem")
+        .map(|m| Memory { resident_mb: num(m, "resident"), virtual_mb: num(m, "virtual") })
+        .unwrap_or_default();
+    let network = sub(raw, "network")
+        .map(|n| Network {
+            bytes_in: num(n, "bytesIn"),
+            bytes_out: num(n, "bytesOut"),
+            num_requests: num(n, "numRequests"),
+        })
+        .unwrap_or_default();
+    let cache = sub(raw, "wiredTiger")
+        .and_then(|wt| sub(wt, "cache"))
+        .map(|c| CacheStats {
+            bytes_in_cache: num(c, "bytes currently in the cache"),
+            max_bytes: num(c, "maximum bytes configured"),
+            dirty_bytes: num(c, "tracked dirty bytes in the cache"),
+        });
+    let repl_set = sub(raw, "repl").and_then(|r| r.get_str("setName").ok().map(String::from));
+
+    ServerStatus {
+        host: raw.get_str("host").unwrap_or_default().to_string(),
+        version: raw.get_str("version").unwrap_or_default().to_string(),
+        uptime_seconds: fnum(raw, "uptime"),
+        connections,
+        opcounters,
+        memory,
+        network,
+        cache,
+        repl_set,
+    }
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CurrentOp {
+    pub opid: i64,
+    pub op: String,
+    pub ns: String,
+    pub secs_running: i64,
+    pub client: String,
+    pub desc: String,
+    pub command: String,
+}
+
+/// Curate one `inprog` entry into a CurrentOp row.
+pub fn curate_current_op(d: &Document) -> CurrentOp {
+    let command = d
+        .get("command")
+        .map(|c| {
+            let s = c.to_string();
+            if s.len() > 300 { format!("{}…", &s[..300]) } else { s }
+        })
+        .unwrap_or_default();
+    CurrentOp {
+        opid: num(d, "opid"),
+        op: d.get_str("op").unwrap_or_default().to_string(),
+        ns: d.get_str("ns").unwrap_or_default().to_string(),
+        secs_running: num(d, "secs_running"),
+        client: d.get_str("client").unwrap_or_default().to_string(),
+        desc: d.get_str("desc").unwrap_or_default().to_string(),
+        command,
+    }
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfilingStatus {
+    pub level: i64,
+    pub slow_ms: i64,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileEntry {
+    pub op: String,
+    pub ns: String,
+    pub millis: i64,
+    pub ts_ms: i64,
+    pub plan_summary: String,
+    pub command: String,
+}
+
+/// Curate one `system.profile` document into a slow-query row.
+pub fn curate_profile_entry(d: &Document) -> ProfileEntry {
+    let ts_ms = match d.get("ts") {
+        Some(Bson::DateTime(dt)) => dt.timestamp_millis(),
+        _ => 0,
+    };
+    let command = d
+        .get("command")
+        .map(|c| {
+            let s = c.to_string();
+            if s.len() > 300 { format!("{}…", &s[..300]) } else { s }
+        })
+        .unwrap_or_default();
+    ProfileEntry {
+        op: d.get_str("op").unwrap_or_default().to_string(),
+        ns: d.get_str("ns").unwrap_or_default().to_string(),
+        millis: num(d, "millis"),
+        ts_ms,
+        plan_summary: d.get_str("planSummary").unwrap_or_default().to_string(),
+        command,
+    }
+}
+
+// ── Mock data (demo connections) ──────────────────────────────────────────────
+
+fn mock_server_status() -> ServerStatus {
+    ServerStatus {
+        host: "mqlens-demo:27017".into(),
+        version: "7.0.0".into(),
+        uptime_seconds: 86_400.0,
+        connections: Connections { current: 7, available: 838_853, total_created: 412 },
+        opcounters: OpCounters { insert: 1200, query: 53_400, update: 980, delete: 120, getmore: 8400, command: 91_000 },
+        memory: Memory { resident_mb: 412, virtual_mb: 2_810 },
+        network: Network { bytes_in: 8_400_000, bytes_out: 19_200_000, num_requests: 64_000 },
+        cache: Some(CacheStats { bytes_in_cache: 268_435_456, max_bytes: 536_870_912, dirty_bytes: 12_582_912 }),
+        repl_set: None,
+    }
+}
+
+// ── Async command impls ───────────────────────────────────────────────────────
+
+pub async fn server_status_impl(state: &AppState, id: &str) -> Result<ServerStatus, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(mock_server_status());
+    }
+    let client = require_real_client(state, id)?;
+    let raw = client
+        .database("admin")
+        .run_command(doc! { "serverStatus": 1 })
+        .await
+        .map_err(|e| format!("serverStatus failed: {}", e))?;
+    Ok(curate_server_status(&raw))
+}
+
+pub async fn current_ops_impl(state: &AppState, id: &str) -> Result<Vec<CurrentOp>, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(vec![CurrentOp {
+            opid: 10241,
+            op: "query".into(),
+            ns: "sales_db.orders".into(),
+            secs_running: 3,
+            client: "127.0.0.1:51544".into(),
+            desc: "conn412".into(),
+            command: "{ find: \"orders\", filter: { status: \"open\" } }".into(),
+        }]);
+    }
+    let client = require_real_client(state, id)?;
+    let raw = client
+        .database("admin")
+        .run_command(doc! { "currentOp": 1, "active": true })
+        .await
+        .map_err(|e| format!("currentOp failed: {}", e))?;
+    let inprog = raw.get_array("inprog").map_err(|_| "currentOp returned no inprog".to_string())?;
+    let mut ops: Vec<CurrentOp> = inprog
+        .iter()
+        .filter_map(|b| b.as_document())
+        // Skip idle/no-op connections.
+        .filter(|d| d.get_str("op").map(|o| o != "none").unwrap_or(true))
+        .map(curate_current_op)
+        .collect();
+    ops.sort_by(|a, b| b.secs_running.cmp(&a.secs_running));
+    Ok(ops)
+}
+
+pub async fn kill_op_impl(state: &AppState, id: &str, opid: i64) -> Result<(), String> {
+    if connection_is_mock(state, id)? {
+        return Ok(());
+    }
+    let client = require_real_client(state, id)?;
+    client
+        .database("admin")
+        .run_command(doc! { "killOp": 1, "op": opid })
+        .await
+        .map_err(|e| format!("killOp failed: {}", e))?;
+    Ok(())
+}
+
+pub async fn profiling_status_impl(state: &AppState, id: &str, database: &str) -> Result<ProfilingStatus, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(ProfilingStatus { level: 0, slow_ms: 100 });
+    }
+    let client = require_real_client(state, id)?;
+    let raw = client
+        .database(database)
+        .run_command(doc! { "profile": -1 })
+        .await
+        .map_err(|e| format!("get profiling status failed: {}", e))?;
+    Ok(ProfilingStatus { level: num(&raw, "was"), slow_ms: num(&raw, "slowms") })
+}
+
+pub async fn set_profiling_level_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    level: i32,
+    slow_ms: i32,
+) -> Result<ProfilingStatus, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(ProfilingStatus { level: level as i64, slow_ms: slow_ms as i64 });
+    }
+    let client = require_real_client(state, id)?;
+    client
+        .database(database)
+        .run_command(doc! { "profile": level, "slowms": slow_ms })
+        .await
+        .map_err(|e| format!("set profiling level failed: {}", e))?;
+    profiling_status_impl(state, id, database).await
+}
+
+pub async fn read_profile_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    limit: i64,
+) -> Result<Vec<ProfileEntry>, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(vec![ProfileEntry {
+            op: "query".into(),
+            ns: "sales_db.orders".into(),
+            millis: 142,
+            ts_ms: 1_749_427_200_000,
+            plan_summary: "COLLSCAN".into(),
+            command: "{ find: \"orders\", filter: { region: \"EU\" } }".into(),
+        }]);
+    }
+    let client = require_real_client(state, id)?;
+    let mut cursor = client
+        .database(database)
+        .collection::<Document>("system.profile")
+        .find(doc! {})
+        .sort(doc! { "ts": -1 })
+        .limit(limit.clamp(1, 500))
+        .await
+        .map_err(|e| format!("read profile failed (is profiling enabled?): {}", e))?;
+    let mut out = Vec::new();
+    use futures::stream::StreamExt;
+    while let Some(next) = cursor.next().await {
+        match next {
+            Ok(d) => out.push(curate_profile_entry(&d)),
+            Err(e) => return Err(format!("read profile cursor error: {}", e)),
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mongodb::bson::{doc, DateTime};
+
+    #[test]
+    fn curates_server_status_subset() {
+        let raw = doc! {
+            "host": "h:27017", "version": "7.0.0", "uptime": 3600.0,
+            "connections": { "current": 5i32, "available": 100i64, "totalCreated": 42i32 },
+            "opcounters": { "insert": 1i64, "query": 2i64, "update": 3i64, "delete": 4i64, "getmore": 5i64, "command": 6i64 },
+            "mem": { "resident": 200i32, "virtual": 2000i32 },
+            "network": { "bytesIn": 1000i64, "bytesOut": 2000i64, "numRequests": 30i64 },
+            "wiredTiger": { "cache": { "bytes currently in the cache": 1024i64, "maximum bytes configured": 4096i64, "tracked dirty bytes in the cache": 128i64 } },
+            "repl": { "setName": "rs0" },
+        };
+        let s = curate_server_status(&raw);
+        assert_eq!(s.host, "h:27017");
+        assert_eq!(s.version, "7.0.0");
+        assert_eq!(s.uptime_seconds, 3600.0);
+        assert_eq!(s.connections, Connections { current: 5, available: 100, total_created: 42 });
+        assert_eq!(s.opcounters.query, 2);
+        assert_eq!(s.memory, Memory { resident_mb: 200, virtual_mb: 2000 });
+        assert_eq!(s.network.num_requests, 30);
+        assert_eq!(s.cache, Some(CacheStats { bytes_in_cache: 1024, max_bytes: 4096, dirty_bytes: 128 }));
+        assert_eq!(s.repl_set.as_deref(), Some("rs0"));
+    }
+
+    #[test]
+    fn server_status_is_resilient_to_missing_sections() {
+        let s = curate_server_status(&doc! { "host": "h" });
+        assert_eq!(s.host, "h");
+        assert_eq!(s.connections, Connections::default());
+        assert!(s.cache.is_none());
+        assert!(s.repl_set.is_none());
+    }
+
+    #[test]
+    fn curates_current_op_and_truncates_command() {
+        let long = "x".repeat(400);
+        let d = doc! { "opid": 99i32, "op": "query", "ns": "db.c", "secs_running": 4i64, "client": "1.2.3.4", "desc": "conn1", "command": { "find": long } };
+        let op = curate_current_op(&d);
+        assert_eq!(op.opid, 99);
+        assert_eq!(op.ns, "db.c");
+        assert_eq!(op.secs_running, 4);
+        assert!(op.command.ends_with('…'), "long command is truncated");
+    }
+
+    #[test]
+    fn curates_profile_entry_with_timestamp() {
+        let d = doc! { "op": "query", "ns": "db.c", "millis": 142i64, "ts": DateTime::from_millis(1_700_000_000_000), "planSummary": "COLLSCAN", "command": { "find": "c" } };
+        let p = curate_profile_entry(&d);
+        assert_eq!(p.millis, 142);
+        assert_eq!(p.ts_ms, 1_700_000_000_000);
+        assert_eq!(p.plan_summary, "COLLSCAN");
+    }
+}

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -151,15 +151,10 @@ pub struct CurrentOp {
     pub command: String,
 }
 
-/// Curate one `inprog` entry into a CurrentOp row.
+/// Curate one `inprog` entry into a CurrentOp row. The full command is kept (the
+/// UI ellipsizes it in the table and shows it in full in the detail view).
 pub fn curate_current_op(d: &Document) -> CurrentOp {
-    let command = d
-        .get("command")
-        .map(|c| {
-            let s = c.to_string();
-            if s.len() > 300 { format!("{}…", &s[..300]) } else { s }
-        })
-        .unwrap_or_default();
+    let command = d.get("command").map(|c| c.to_string()).unwrap_or_default();
     CurrentOp {
         opid: num(d, "opid"),
         op: d.get_str("op").unwrap_or_default().to_string(),
@@ -195,13 +190,7 @@ pub fn curate_profile_entry(d: &Document) -> ProfileEntry {
         Some(Bson::DateTime(dt)) => dt.timestamp_millis(),
         _ => 0,
     };
-    let command = d
-        .get("command")
-        .map(|c| {
-            let s = c.to_string();
-            if s.len() > 300 { format!("{}…", &s[..300]) } else { s }
-        })
-        .unwrap_or_default();
+    let command = d.get("command").map(|c| c.to_string()).unwrap_or_default();
     ProfileEntry {
         op: d.get_str("op").unwrap_or_default().to_string(),
         ns: d.get_str("ns").unwrap_or_default().to_string(),
@@ -392,14 +381,14 @@ mod tests {
     }
 
     #[test]
-    fn curates_current_op_and_truncates_command() {
+    fn curates_current_op_keeps_full_command() {
         let long = "x".repeat(400);
-        let d = doc! { "opid": 99i32, "op": "query", "ns": "db.c", "secs_running": 4i64, "client": "1.2.3.4", "desc": "conn1", "command": { "find": long } };
+        let d = doc! { "opid": 99i32, "op": "query", "ns": "db.c", "secs_running": 4i64, "client": "1.2.3.4", "desc": "conn1", "command": { "find": long.clone() } };
         let op = curate_current_op(&d);
         assert_eq!(op.opid, 99);
         assert_eq!(op.ns, "db.c");
         assert_eq!(op.secs_running, 4);
-        assert!(op.command.ends_with('…'), "long command is truncated");
+        assert!(op.command.contains(&long), "full command is preserved");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { ExportView } from './components/ExportView';
 import { SchemaView } from './components/SchemaView';
 import { CreateViewView } from './components/CreateViewView';
 import { GridFsView } from './components/GridFsView';
+import { MonitoringView } from './components/MonitoringView';
 import { type ExportTaskInfo } from './components/TaskManager';
 import { VaultGate } from './components/VaultGate';
 import { DialogProvider, useDialogs } from './components/dialogs/DialogProvider';
@@ -24,12 +25,12 @@ import { save, open } from '@tauri-apps/plugin-dialog';
 import { writeTextFile, readTextFile } from '@tauri-apps/plugin-fs';
 import { toJson, toCsv, parseJson, parseCsv } from './lib/dataTransfer';
 import { invoke } from '@tauri-apps/api/core';
-import { FolderCode, X, KeyRound, Play, Settings, Terminal, Rocket, Download, Table2, Eye, HardDrive } from 'lucide-react';
+import { FolderCode, X, KeyRound, Play, Settings, Terminal, Rocket, Download, Table2, Eye, HardDrive, Activity } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 interface QueryTab {
   id: string;
-  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'schema' | 'create-view' | 'gridfs';
+  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'schema' | 'create-view' | 'gridfs' | 'monitoring';
   connectionId: string;
   db: string;
   collection: string;
@@ -489,6 +490,24 @@ function Workspace() {
         connectionId,
         db,
         collection,
+        results: [],
+        loading: false,
+        error: null,
+        explainResult: null,
+      }]);
+    }
+    setActiveTabId(tabId);
+  };
+
+  const handleOpenMonitoringTab = (connectionId: string) => {
+    const tabId = `monitoring.${connectionId}`;
+    if (!tabs.some((t) => t.id === tabId)) {
+      setTabs((prev) => [...prev, {
+        id: tabId,
+        type: 'monitoring',
+        connectionId,
+        db: '',
+        collection: '',
         results: [],
         loading: false,
         error: null,
@@ -1134,6 +1153,7 @@ function Workspace() {
             onCreateIndex={handleOpenIndexModalForCreate}
             onDeleteIndex={handleDeleteIndex}
             onOpenShell={handleOpenShell}
+            onOpenMonitoring={handleOpenMonitoringTab}
             onAnalyzeSchema={handleOpenSchemaTab}
             onCreateView={handleOpenCreateViewTab}
             onOpenGridfs={handleOpenGridfsTab}
@@ -1238,6 +1258,8 @@ function Workspace() {
                         <Eye size={11} className={isActive ? 'text-[var(--accent-blue)]' : 'text-[var(--text-dim)]'} />
                       ) : tab.type === 'gridfs' ? (
                         <HardDrive size={11} className={isActive ? 'text-[var(--accent-blue)]' : 'text-[var(--text-dim)]'} />
+                      ) : tab.type === 'monitoring' ? (
+                        <Activity size={11} className={isActive ? 'text-[var(--accent-blue)]' : 'text-[var(--text-dim)]'} />
                       ) : (
                         <FolderCode size={11} className={isActive ? 'text-[var(--accent-blue)]' : 'text-[var(--text-dim)]'} />
                       )}
@@ -1258,7 +1280,9 @@ function Workspace() {
                                     ? `New View: ${tab.db}`
                                     : tab.type === 'gridfs'
                                       ? `GridFS: ${tab.collection}`
-                                      : tab.collection}
+                                      : tab.type === 'monitoring'
+                                        ? `Monitor: ${connectionNameFor(tab.connectionId)}`
+                                        : tab.collection}
                       </span>
                       <span
                         onClick={(e) => handleCloseTab(e, tab.id)}
@@ -1382,6 +1406,9 @@ function Workspace() {
                   databaseName={activeTab.db}
                   bucket={activeTab.collection}
                 />
+              )}
+              {activeTab && activeTab.type === 'monitoring' && (
+                <MonitoringView connectionId={activeTab.connectionId} />
               )}
               {activeTab && activeTab.type === 'export' && (() => {
                 const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -227,8 +227,11 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
   // Filters
   const [opsSearch, setOpsSearch] = useState('');
   const [opsType, setOpsType] = useState('');
+  const [opsDb, setOpsDb] = useState('');
+  const [opsMinSecs, setOpsMinSecs] = useState(0);
   const [profSearch, setProfSearch] = useState('');
   const [profMinMs, setProfMinMs] = useState(0);
+  const [profOp, setProfOp] = useState('');
 
   // Profiler state
   const [dbs, setDbs] = useState<string[]>([]);
@@ -345,21 +348,29 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
     return { conns, resident, cachePct, opsPerSec, netPerSec };
   }, [samples]);
 
+  const dbOf = (ns: string) => ns.split('.')[0] || '';
   const opTypes = useMemo(() => Array.from(new Set(ops.map((o) => o.op))).sort(), [ops]);
+  const opsDbs = useMemo(() => Array.from(new Set(ops.map((o) => dbOf(o.ns)).filter(Boolean))).sort(), [ops]);
+  const profOpTypes = useMemo(() => Array.from(new Set(profile.map((p) => p.op))).sort(), [profile]);
   const filteredOps = useMemo(() => {
     const q = opsSearch.trim().toLowerCase();
     return ops.filter(
       (o) =>
         (!opsType || o.op === opsType) &&
+        (!opsDb || dbOf(o.ns) === opsDb) &&
+        o.secsRunning >= opsMinSecs &&
         (!q || `${o.ns} ${o.client} ${o.op} ${o.command}`.toLowerCase().includes(q)),
     );
-  }, [ops, opsSearch, opsType]);
+  }, [ops, opsSearch, opsType, opsDb, opsMinSecs]);
   const filteredProfile = useMemo(() => {
     const q = profSearch.trim().toLowerCase();
     return profile.filter(
-      (p) => p.millis >= profMinMs && (!q || `${p.ns} ${p.op} ${p.planSummary} ${p.command}`.toLowerCase().includes(q)),
+      (p) =>
+        p.millis >= profMinMs &&
+        (!profOp || p.op === profOp) &&
+        (!q || `${p.ns} ${p.op} ${p.planSummary} ${p.command}`.toLowerCase().includes(q)),
     );
-  }, [profile, profSearch, profMinMs]);
+  }, [profile, profSearch, profMinMs, profOp]);
 
   const latestOpsPerSec = series.opsPerSec.length ? series.opsPerSec[series.opsPerSec.length - 1] : 0;
   const latestNetPerSec = series.netPerSec.length ? series.netPerSec[series.netPerSec.length - 1] : 0;
@@ -473,6 +484,21 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                   <option value="">All ops</option>
                   {opTypes.map((t) => <option key={t} value={t}>{t}</option>)}
                 </select>
+                <select value={opsDb} onChange={(e) => setOpsDb(e.target.value)} className="mql-mon-select" data-testid="ops-db-filter">
+                  <option value="">All dbs</option>
+                  {opsDbs.map((d) => <option key={d} value={d}>{d}</option>)}
+                </select>
+                <label className="mql-mon-minms">
+                  ≥
+                  <input
+                    type="number"
+                    min={0}
+                    value={opsMinSecs}
+                    onChange={(e) => setOpsMinSecs(Number(e.target.value) || 0)}
+                    data-testid="ops-min-secs"
+                  />
+                  s
+                </label>
                 <span className="mql-mon-count">{filteredOps.length} / {ops.length}</span>
               </div>
               {filteredOps.length === 0 ? (
@@ -569,6 +595,10 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                     data-testid="profiler-search"
                   />
                 </div>
+                <select value={profOp} onChange={(e) => setProfOp(e.target.value)} className="mql-mon-select" data-testid="profiler-type-filter">
+                  <option value="">All ops</option>
+                  {profOpTypes.map((t) => <option key={t} value={t}>{t}</option>)}
+                </select>
                 <label className="mql-mon-minms">
                   ≥
                   <input

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -67,6 +67,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
   const [ops, setOps] = useState<CurrentOp[]>([]);
   const [samples, setSamples] = useState<Sample[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [section, setSection] = useState<'ops' | 'profiler'>('ops');
 
   // Profiler state
   const [dbs, setDbs] = useState<string[]>([]);
@@ -234,51 +235,65 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
         />
       </div>
 
-      {/* Current operations */}
-      <div className="mql-mon-section">
-        <div className="mql-mon-section-head">
-          <span>Current operations ({ops.length})</span>
-        </div>
-        {ops.length === 0 ? (
-          <div className="mql-mon-empty">No active operations.</div>
-        ) : (
-          <table className="mql-mon-table" data-testid="current-ops-table">
-            <thead>
-              <tr>
-                <th>opid</th><th>op</th><th>ns</th><th>secs</th><th>client</th><th>command</th><th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {ops.map((op) => (
-                <tr key={op.opid}>
-                  <td>{op.opid}</td>
-                  <td>{op.op}</td>
-                  <td className="mql-mon-ns">{op.ns}</td>
-                  <td>{op.secsRunning}</td>
-                  <td>{op.client}</td>
-                  <td className="mql-mon-cmd" title={op.command}>{op.command}</td>
-                  <td>
-                    <button
-                      type="button"
-                      className="mql-mon-kill"
-                      title="Kill operation"
-                      data-testid={`kill-op-${op.opid}`}
-                      onClick={() => handleKill(op)}
-                    >
-                      <Skull size={12} />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
+      {/* Tabs: Current operations | Profiler */}
+      <div className="mql-mon-tabs">
+        <button
+          type="button"
+          className={`mql-mon-tab${section === 'ops' ? ' is-active' : ''}`}
+          data-testid="mon-tab-ops"
+          onClick={() => setSection('ops')}
+        >
+          Current operations ({ops.length})
+        </button>
+        <button
+          type="button"
+          className={`mql-mon-tab${section === 'profiler' ? ' is-active' : ''}`}
+          data-testid="mon-tab-profiler"
+          onClick={() => setSection('profiler')}
+        >
+          Profiler &amp; slow queries
+        </button>
       </div>
 
-      {/* Profiler / slow queries */}
-      <div className="mql-mon-section">
-        <div className="mql-mon-section-head">
-          <span>Profiler &amp; slow queries</span>
+      {section === 'ops' ? (
+        <div className="mql-mon-section" data-testid="mon-panel-ops">
+          {ops.length === 0 ? (
+            <div className="mql-mon-empty">No active operations.</div>
+          ) : (
+            <table className="mql-mon-table" data-testid="current-ops-table">
+              <thead>
+                <tr>
+                  <th>opid</th><th>op</th><th>ns</th><th>secs</th><th>client</th><th>command</th><th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {ops.map((op) => (
+                  <tr key={op.opid}>
+                    <td>{op.opid}</td>
+                    <td>{op.op}</td>
+                    <td className="mql-mon-ns">{op.ns}</td>
+                    <td>{op.secsRunning}</td>
+                    <td>{op.client}</td>
+                    <td className="mql-mon-cmd" title={op.command}>{op.command}</td>
+                    <td>
+                      <button
+                        type="button"
+                        className="mql-mon-kill"
+                        title="Kill operation"
+                        data-testid={`kill-op-${op.opid}`}
+                        onClick={() => handleKill(op)}
+                      >
+                        <Skull size={12} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      ) : (
+        <div className="mql-mon-section" data-testid="mon-panel-profiler">
           <div className="mql-mon-profiler-controls">
             <select
               value={profilerDb}
@@ -307,32 +322,32 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
               <RefreshCw size={12} className={profileLoading ? 'animate-spin' : ''} />
             </button>
           </div>
+          {profile.length === 0 ? (
+            <div className="mql-mon-empty">
+              {profiling?.level === 0
+                ? 'Profiling is off for this database. Set level 1 (slow ops) or 2 (all ops) to collect entries.'
+                : 'No profiled operations yet.'}
+            </div>
+          ) : (
+            <table className="mql-mon-table" data-testid="profile-table">
+              <thead>
+                <tr><th>millis</th><th>op</th><th>ns</th><th>plan</th><th>command</th></tr>
+              </thead>
+              <tbody>
+                {profile.map((p, i) => (
+                  <tr key={i}>
+                    <td className={p.millis >= 100 ? 'mql-mon-slow' : ''}>{p.millis}</td>
+                    <td>{p.op}</td>
+                    <td className="mql-mon-ns">{p.ns}</td>
+                    <td>{p.planSummary}</td>
+                    <td className="mql-mon-cmd" title={p.command}>{p.command}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
-        {profile.length === 0 ? (
-          <div className="mql-mon-empty">
-            {profiling?.level === 0
-              ? 'Profiling is off for this database. Set level 1 (slow ops) or 2 (all ops) to collect entries.'
-              : 'No profiled operations yet.'}
-          </div>
-        ) : (
-          <table className="mql-mon-table" data-testid="profile-table">
-            <thead>
-              <tr><th>millis</th><th>op</th><th>ns</th><th>plan</th><th>command</th></tr>
-            </thead>
-            <tbody>
-              {profile.map((p, i) => (
-                <tr key={i}>
-                  <td className={p.millis >= 100 ? 'mql-mon-slow' : ''}>{p.millis}</td>
-                  <td>{p.op}</td>
-                  <td className="mql-mon-ns">{p.ns}</td>
-                  <td>{p.planSummary}</td>
-                  <td className="mql-mon-cmd" title={p.command}>{p.command}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -82,6 +82,64 @@ const OpBadge: React.FC<{ op: string }> = ({ op }) => (
   <span className="mql-mon-op" style={{ ['--op-color' as any]: opColor(op) }}>{op}</span>
 );
 
+// Lightweight syntax highlighter for the (mongosh-ish) command strings shown in
+// the ops/profiler tables — keys, strings, numbers, keywords, and constructor
+// names (ObjectId/ISODate/…) get the same palette as the result views.
+const HighlightedCommand: React.FC<{ text: string }> = ({ text }) => {
+  const nodes = useMemo<React.ReactNode[]>(() => {
+    const out: React.ReactNode[] = [];
+    const n = text.length;
+    let i = 0;
+    let k = 0;
+    const span = (cls: string | undefined, s: string) =>
+      out.push(cls ? <span key={k++} className={cls}>{s}</span> : <React.Fragment key={k++}>{s}</React.Fragment>);
+    while (i < n) {
+      const c = text[i];
+      if (c === '"') {
+        let j = i + 1;
+        while (j < n) {
+          if (text[j] === '\\') { j += 2; continue; }
+          if (text[j] === '"') { j++; break; }
+          j++;
+        }
+        const str = text.slice(i, j);
+        let p = j;
+        while (p < n && /\s/.test(text[p])) p++;
+        span(text[p] === ':' ? 'text-syntax-key' : 'text-syntax-string', str);
+        i = j;
+        continue;
+      }
+      if (/[0-9]/.test(c) || (c === '-' && /[0-9]/.test(text[i + 1] || ''))) {
+        let j = i + 1;
+        while (j < n && /[0-9.]/.test(text[j])) j++;
+        span('text-syntax-number', text.slice(i, j));
+        i = j;
+        continue;
+      }
+      if (/[A-Za-z_$]/.test(c)) {
+        let j = i + 1;
+        while (j < n && /[\w$]/.test(text[j])) j++;
+        const word = text.slice(i, j);
+        if (word === 'true' || word === 'false') span('text-syntax-boolean', word);
+        else if (word === 'null') span('text-syntax-null', word);
+        else {
+          let p = j;
+          while (p < n && /\s/.test(text[p])) p++;
+          span(text[p] === '(' ? 'text-syntax-boolean' : undefined, word);
+        }
+        i = j;
+        continue;
+      }
+      let j = i + 1;
+      while (j < n && !/["0-9A-Za-z_$-]/.test(text[j])) j++;
+      span('text-[var(--text-dim)]', text.slice(i, j));
+      i = j;
+    }
+    return out;
+  }, [text]);
+  return <>{nodes}</>;
+};
+
 // MongoDB error 13 / "not authorized" → the user lacks the privilege.
 const isAuthError = (msg: string): boolean =>
   /not authorized|unauthorized|requires authentication|\(13\)|code 13/i.test(msg);
@@ -381,7 +439,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                         <td className="mql-mon-ns">{op.ns}</td>
                         <td className={op.secsRunning >= 5 ? 'mql-mon-slow' : ''}>{op.secsRunning}</td>
                         <td>{op.client}</td>
-                        <td className="mql-mon-cmd" title={op.command}>{op.command}</td>
+                        <td className="mql-mon-cmd" title={op.command}><HighlightedCommand text={op.command} /></td>
                         <td>
                           <button
                             type="button"
@@ -480,7 +538,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                         <td><OpBadge op={p.op} /></td>
                         <td className="mql-mon-ns">{p.ns}</td>
                         <td>{p.planSummary}</td>
-                        <td className="mql-mon-cmd" title={p.command}>{p.command}</td>
+                        <td className="mql-mon-cmd" title={p.command}><HighlightedCommand text={p.command} /></td>
                       </tr>
                     ))}
                   </tbody>

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,0 +1,338 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { LineChart, Line, ResponsiveContainer, YAxis } from 'recharts';
+import { Activity, RefreshCw, Skull } from 'lucide-react';
+import { formatBytes } from '../lib/format';
+import {
+  serverStatus,
+  currentOps,
+  killOp,
+  getProfilingStatus,
+  setProfilingLevel,
+  readProfile,
+  type ServerStatus,
+  type CurrentOp,
+  type ProfilingStatus,
+  type ProfileEntry,
+} from '../lib/monitoringApi';
+
+interface MonitoringViewProps {
+  connectionId: string;
+}
+
+const POLL_MS = 3000;
+const MAX_SAMPLES = 40;
+
+interface Sample {
+  t: number;
+  status: ServerStatus;
+}
+
+const totalOps = (s: ServerStatus): number => {
+  const o = s.opcounters;
+  return o.insert + o.query + o.update + o.delete + o.getmore + o.command;
+};
+
+const Sparkline: React.FC<{ data: number[]; color: string }> = ({ data, color }) => {
+  if (data.length < 2) return <div className="mql-mon-spark-empty" />;
+  return (
+    <ResponsiveContainer width="100%" height={34}>
+      <LineChart data={data.map((v, i) => ({ i, v }))} margin={{ top: 2, bottom: 2, left: 0, right: 0 }}>
+        <YAxis hide domain={['dataMin', 'dataMax']} />
+        <Line type="monotone" dataKey="v" stroke={color} strokeWidth={1.5} dot={false} isAnimationActive={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};
+
+const MetricCard: React.FC<{ label: string; value: string; sub?: string; series: number[]; color: string }> = ({
+  label,
+  value,
+  sub,
+  series,
+  color,
+}) => (
+  <div className="mql-mon-card">
+    <div className="mql-mon-card-label">{label}</div>
+    <div className="mql-mon-card-value">{value}</div>
+    {sub && <div className="mql-mon-card-sub">{sub}</div>}
+    <div className="mql-mon-spark">
+      <Sparkline data={series} color={color} />
+    </div>
+  </div>
+);
+
+export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) => {
+  const [status, setStatus] = useState<ServerStatus | null>(null);
+  const [ops, setOps] = useState<CurrentOp[]>([]);
+  const [samples, setSamples] = useState<Sample[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Profiler state
+  const [dbs, setDbs] = useState<string[]>([]);
+  const [profilerDb, setProfilerDb] = useState<string>('');
+  const [profiling, setProfiling] = useState<ProfilingStatus | null>(null);
+  const [profile, setProfile] = useState<ProfileEntry[]>([]);
+  const [profileLoading, setProfileLoading] = useState(false);
+
+  // ── Metrics + current-ops polling (paused when the window is hidden) ──────────
+  useEffect(() => {
+    let alive = true;
+    setSamples([]);
+    setStatus(null);
+    const tick = async () => {
+      if (typeof document !== 'undefined' && document.hidden) return;
+      try {
+        const [s, o] = await Promise.all([serverStatus(connectionId), currentOps(connectionId)]);
+        if (!alive) return;
+        setStatus(s);
+        setOps(o);
+        setError(null);
+        setSamples((prev) => [...prev, { t: Date.now(), status: s }].slice(-MAX_SAMPLES));
+      } catch (e: any) {
+        if (alive) setError(String(e?.message || e));
+      }
+    };
+    tick();
+    const iv = setInterval(tick, POLL_MS);
+    return () => {
+      alive = false;
+      clearInterval(iv);
+    };
+  }, [connectionId]);
+
+  // ── Profiler: load db list once, then status + slow queries for the chosen db ─
+  useEffect(() => {
+    let alive = true;
+    invoke<string[]>('list_databases', { id: connectionId })
+      .then((list) => {
+        if (!alive) return;
+        setDbs(list);
+        setProfilerDb((cur) => cur || list.find((d) => !['admin', 'config', 'local'].includes(d)) || list[0] || '');
+      })
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, [connectionId]);
+
+  const refreshProfiler = React.useCallback(async () => {
+    if (!profilerDb) return;
+    setProfileLoading(true);
+    try {
+      const [st, entries] = await Promise.all([
+        getProfilingStatus(connectionId, profilerDb),
+        readProfile(connectionId, profilerDb, 50),
+      ]);
+      setProfiling(st);
+      setProfile(entries);
+    } catch (e: any) {
+      setError(String(e?.message || e));
+    } finally {
+      setProfileLoading(false);
+    }
+  }, [connectionId, profilerDb]);
+
+  useEffect(() => {
+    void refreshProfiler();
+  }, [refreshProfiler]);
+
+  const handleKill = async (op: CurrentOp) => {
+    if (!window.confirm(`Kill operation ${op.opid} on ${op.ns || 'server'}?`)) return;
+    try {
+      await killOp(connectionId, op.opid);
+      setOps(await currentOps(connectionId));
+    } catch (e: any) {
+      setError(String(e?.message || e));
+    }
+  };
+
+  const handleSetLevel = async (level: number) => {
+    try {
+      const st = await setProfilingLevel(connectionId, profilerDb, level, profiling?.slowMs ?? 100);
+      setProfiling(st);
+      void refreshProfiler();
+    } catch (e: any) {
+      setError(String(e?.message || e));
+    }
+  };
+
+  // ── Derived sparkline series ──────────────────────────────────────────────────
+  const series = useMemo(() => {
+    const conns = samples.map((s) => s.status.connections.current);
+    const resident = samples.map((s) => s.status.memory.residentMb);
+    const cachePct = samples.map((s) =>
+      s.status.cache && s.status.cache.maxBytes > 0 ? (s.status.cache.bytesInCache / s.status.cache.maxBytes) * 100 : 0,
+    );
+    const opsPerSec: number[] = [];
+    const netPerSec: number[] = [];
+    for (let i = 1; i < samples.length; i++) {
+      const dt = (samples[i].t - samples[i - 1].t) / 1000 || 1;
+      opsPerSec.push(Math.max(0, (totalOps(samples[i].status) - totalOps(samples[i - 1].status)) / dt));
+      const net = samples[i].status.network;
+      const prevNet = samples[i - 1].status.network;
+      netPerSec.push(Math.max(0, (net.bytesIn + net.bytesOut - prevNet.bytesIn - prevNet.bytesOut) / dt));
+    }
+    return { conns, resident, cachePct, opsPerSec, netPerSec };
+  }, [samples]);
+
+  const latestOpsPerSec = series.opsPerSec.length ? series.opsPerSec[series.opsPerSec.length - 1] : 0;
+  const latestNetPerSec = series.netPerSec.length ? series.netPerSec[series.netPerSec.length - 1] : 0;
+  const cachePctNow = status?.cache && status.cache.maxBytes > 0 ? (status.cache.bytesInCache / status.cache.maxBytes) * 100 : null;
+
+  return (
+    <div className="mql-mon" data-testid="monitoring-view">
+      <div className="mql-mon-header">
+        <Activity size={15} className="text-[var(--accent-blue)]" />
+        <span className="mql-mon-title">Monitoring</span>
+        {status && (
+          <span className="mql-mon-meta">
+            {status.host} · MongoDB {status.version}
+            {status.replSet ? ` · ${status.replSet}` : ''} · up {Math.floor(status.uptimeSeconds / 3600)}h
+          </span>
+        )}
+      </div>
+
+      {error && <div className="mql-mon-error" data-testid="monitoring-error">{error}</div>}
+
+      {/* Metric cards */}
+      <div className="mql-mon-cards">
+        <MetricCard
+          label="Connections"
+          value={status ? String(status.connections.current) : '—'}
+          sub={status ? `${status.connections.available.toLocaleString()} available` : undefined}
+          series={series.conns}
+          color="var(--accent-blue)"
+        />
+        <MetricCard
+          label="Ops / sec"
+          value={status ? Math.round(latestOpsPerSec).toLocaleString() : '—'}
+          sub="all opcounters"
+          series={series.opsPerSec}
+          color="#34d399"
+        />
+        <MetricCard
+          label="Resident memory"
+          value={status ? `${status.memory.residentMb.toLocaleString()} MB` : '—'}
+          sub={status ? `${status.memory.virtualMb.toLocaleString()} MB virtual` : undefined}
+          series={series.resident}
+          color="#f59e0b"
+        />
+        <MetricCard
+          label="Cache used"
+          value={cachePctNow != null ? `${cachePctNow.toFixed(0)}%` : 'n/a'}
+          sub={status?.cache ? `${formatBytes(status.cache.bytesInCache)} / ${formatBytes(status.cache.maxBytes)}` : undefined}
+          series={series.cachePct}
+          color="#a78bfa"
+        />
+        <MetricCard
+          label="Network"
+          value={status ? `${formatBytes(latestNetPerSec)}/s` : '—'}
+          sub={status ? `${formatBytes(status.network.bytesIn + status.network.bytesOut)} total` : undefined}
+          series={series.netPerSec}
+          color="#22d3ee"
+        />
+      </div>
+
+      {/* Current operations */}
+      <div className="mql-mon-section">
+        <div className="mql-mon-section-head">
+          <span>Current operations ({ops.length})</span>
+        </div>
+        {ops.length === 0 ? (
+          <div className="mql-mon-empty">No active operations.</div>
+        ) : (
+          <table className="mql-mon-table" data-testid="current-ops-table">
+            <thead>
+              <tr>
+                <th>opid</th><th>op</th><th>ns</th><th>secs</th><th>client</th><th>command</th><th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {ops.map((op) => (
+                <tr key={op.opid}>
+                  <td>{op.opid}</td>
+                  <td>{op.op}</td>
+                  <td className="mql-mon-ns">{op.ns}</td>
+                  <td>{op.secsRunning}</td>
+                  <td>{op.client}</td>
+                  <td className="mql-mon-cmd" title={op.command}>{op.command}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="mql-mon-kill"
+                      title="Kill operation"
+                      data-testid={`kill-op-${op.opid}`}
+                      onClick={() => handleKill(op)}
+                    >
+                      <Skull size={12} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Profiler / slow queries */}
+      <div className="mql-mon-section">
+        <div className="mql-mon-section-head">
+          <span>Profiler &amp; slow queries</span>
+          <div className="mql-mon-profiler-controls">
+            <select
+              value={profilerDb}
+              onChange={(e) => setProfilerDb(e.target.value)}
+              data-testid="profiler-db-select"
+              className="mql-mon-select"
+            >
+              {dbs.map((d) => <option key={d} value={d}>{d}</option>)}
+            </select>
+            <span className="mql-mon-level">
+              Level:
+              {[0, 1, 2].map((lvl) => (
+                <button
+                  key={lvl}
+                  type="button"
+                  className={`mql-mon-level-btn${profiling?.level === lvl ? ' is-active' : ''}`}
+                  data-testid={`profiler-level-${lvl}`}
+                  onClick={() => handleSetLevel(lvl)}
+                >
+                  {lvl}
+                </button>
+              ))}
+            </span>
+            {profiling && <span className="mql-mon-slowms">slow ≥ {profiling.slowMs}ms</span>}
+            <button type="button" className="mql-mon-refresh" onClick={() => void refreshProfiler()} title="Refresh">
+              <RefreshCw size={12} className={profileLoading ? 'animate-spin' : ''} />
+            </button>
+          </div>
+        </div>
+        {profile.length === 0 ? (
+          <div className="mql-mon-empty">
+            {profiling?.level === 0
+              ? 'Profiling is off for this database. Set level 1 (slow ops) or 2 (all ops) to collect entries.'
+              : 'No profiled operations yet.'}
+          </div>
+        ) : (
+          <table className="mql-mon-table" data-testid="profile-table">
+            <thead>
+              <tr><th>millis</th><th>op</th><th>ns</th><th>plan</th><th>command</th></tr>
+            </thead>
+            <tbody>
+              {profile.map((p, i) => (
+                <tr key={i}>
+                  <td className={p.millis >= 100 ? 'mql-mon-slow' : ''}>{p.millis}</td>
+                  <td>{p.op}</td>
+                  <td className="mql-mon-ns">{p.ns}</td>
+                  <td>{p.planSummary}</td>
+                  <td className="mql-mon-cmd" title={p.command}>{p.command}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { LineChart, Line, ResponsiveContainer, YAxis } from 'recharts';
-import { Activity, RefreshCw, Skull, Lock } from 'lucide-react';
+import { Activity, RefreshCw, Skull, Lock, Network, Gauge, MemoryStick, Database, ArrowDownUp, Search } from 'lucide-react';
 import { formatBytes } from '../lib/format';
 import {
   serverStatus,
@@ -45,21 +45,41 @@ const Sparkline: React.FC<{ data: number[]; color: string }> = ({ data, color })
   );
 };
 
-const MetricCard: React.FC<{ label: string; value: string; sub?: string; series: number[]; color: string }> = ({
-  label,
-  value,
-  sub,
-  series,
-  color,
-}) => (
-  <div className="mql-mon-card">
-    <div className="mql-mon-card-label">{label}</div>
+const MetricCard: React.FC<{
+  label: string;
+  value: string;
+  sub?: string;
+  series: number[];
+  color: string;
+  icon: React.ReactNode;
+}> = ({ label, value, sub, series, color, icon }) => (
+  <div className="mql-mon-card" style={{ ['--card-color' as any]: color }}>
+    <div className="mql-mon-card-top">
+      <span className="mql-mon-card-icon">{icon}</span>
+      <span className="mql-mon-card-label">{label}</span>
+    </div>
     <div className="mql-mon-card-value">{value}</div>
     {sub && <div className="mql-mon-card-sub">{sub}</div>}
     <div className="mql-mon-spark">
       <Sparkline data={series} color={color} />
     </div>
   </div>
+);
+
+// Color-code operation types so the tables read at a glance.
+const OP_COLORS: Record<string, string> = {
+  query: '#38bdf8',
+  command: '#94a3b8',
+  getmore: '#22d3ee',
+  insert: '#34d399',
+  update: '#f59e0b',
+  remove: '#f87171',
+  delete: '#f87171',
+  none: '#64748b',
+};
+const opColor = (op: string): string => OP_COLORS[op?.toLowerCase()] ?? '#a78bfa';
+const OpBadge: React.FC<{ op: string }> = ({ op }) => (
+  <span className="mql-mon-op" style={{ ['--op-color' as any]: opColor(op) }}>{op}</span>
 );
 
 // MongoDB error 13 / "not authorized" → the user lacks the privilege.
@@ -92,6 +112,12 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
   const [opsErr, setOpsErr] = useState<string | null>(null);
   const [profilerErr, setProfilerErr] = useState<string | null>(null);
   const [section, setSection] = useState<'ops' | 'profiler'>('ops');
+
+  // Filters
+  const [opsSearch, setOpsSearch] = useState('');
+  const [opsType, setOpsType] = useState('');
+  const [profSearch, setProfSearch] = useState('');
+  const [profMinMs, setProfMinMs] = useState(0);
 
   // Profiler state
   const [dbs, setDbs] = useState<string[]>([]);
@@ -208,6 +234,22 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
     return { conns, resident, cachePct, opsPerSec, netPerSec };
   }, [samples]);
 
+  const opTypes = useMemo(() => Array.from(new Set(ops.map((o) => o.op))).sort(), [ops]);
+  const filteredOps = useMemo(() => {
+    const q = opsSearch.trim().toLowerCase();
+    return ops.filter(
+      (o) =>
+        (!opsType || o.op === opsType) &&
+        (!q || `${o.ns} ${o.client} ${o.op} ${o.command}`.toLowerCase().includes(q)),
+    );
+  }, [ops, opsSearch, opsType]);
+  const filteredProfile = useMemo(() => {
+    const q = profSearch.trim().toLowerCase();
+    return profile.filter(
+      (p) => p.millis >= profMinMs && (!q || `${p.ns} ${p.op} ${p.planSummary} ${p.command}`.toLowerCase().includes(q)),
+    );
+  }, [profile, profSearch, profMinMs]);
+
   const latestOpsPerSec = series.opsPerSec.length ? series.opsPerSec[series.opsPerSec.length - 1] : 0;
   const latestNetPerSec = series.netPerSec.length ? series.netPerSec[series.netPerSec.length - 1] : 0;
   const cachePctNow = status?.cache && status.cache.maxBytes > 0 ? (status.cache.bytesInCache / status.cache.maxBytes) * 100 : null;
@@ -234,6 +276,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
           <div className="mql-mon-cards">
             <MetricCard
               label="Connections"
+              icon={<Network size={14} />}
               value={status ? String(status.connections.current) : '—'}
               sub={status ? `${status.connections.available.toLocaleString()} available` : undefined}
               series={series.conns}
@@ -241,6 +284,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
             />
             <MetricCard
               label="Ops / sec"
+              icon={<Gauge size={14} />}
               value={status ? Math.round(latestOpsPerSec).toLocaleString() : '—'}
               sub="all opcounters"
               series={series.opsPerSec}
@@ -248,6 +292,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
             />
             <MetricCard
               label="Resident memory"
+              icon={<MemoryStick size={14} />}
               value={status ? `${status.memory.residentMb.toLocaleString()} MB` : '—'}
               sub={status ? `${status.memory.virtualMb.toLocaleString()} MB virtual` : undefined}
               series={series.resident}
@@ -255,6 +300,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
             />
             <MetricCard
               label="Cache used"
+              icon={<Database size={14} />}
               value={cachePctNow != null ? `${cachePctNow.toFixed(0)}%` : 'n/a'}
               sub={status?.cache ? `${formatBytes(status.cache.bytesInCache)} / ${formatBytes(status.cache.maxBytes)}` : undefined}
               series={series.cachePct}
@@ -262,6 +308,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
             />
             <MetricCard
               label="Network"
+              icon={<ArrowDownUp size={14} />}
               value={status ? `${formatBytes(latestNetPerSec)}/s` : '—'}
               sub={status ? `${formatBytes(status.network.bytesIn + status.network.bytesOut)} total` : undefined}
               series={series.netPerSec}
@@ -300,36 +347,58 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
           ) : ops.length === 0 ? (
             <div className="mql-mon-empty">No active operations.</div>
           ) : (
-            <table className="mql-mon-table" data-testid="current-ops-table">
-              <thead>
-                <tr>
-                  <th>opid</th><th>op</th><th>ns</th><th>secs</th><th>client</th><th>command</th><th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {ops.map((op) => (
-                  <tr key={op.opid}>
-                    <td>{op.opid}</td>
-                    <td>{op.op}</td>
-                    <td className="mql-mon-ns">{op.ns}</td>
-                    <td>{op.secsRunning}</td>
-                    <td>{op.client}</td>
-                    <td className="mql-mon-cmd" title={op.command}>{op.command}</td>
-                    <td>
-                      <button
-                        type="button"
-                        className="mql-mon-kill"
-                        title="Kill operation"
-                        data-testid={`kill-op-${op.opid}`}
-                        onClick={() => handleKill(op)}
-                      >
-                        <Skull size={12} />
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <>
+              <div className="mql-mon-filters">
+                <div className="mql-mon-search">
+                  <Search size={12} />
+                  <input
+                    value={opsSearch}
+                    onChange={(e) => setOpsSearch(e.target.value)}
+                    placeholder="Filter by ns, client, or command…"
+                    data-testid="ops-search"
+                  />
+                </div>
+                <select value={opsType} onChange={(e) => setOpsType(e.target.value)} className="mql-mon-select" data-testid="ops-type-filter">
+                  <option value="">All ops</option>
+                  {opTypes.map((t) => <option key={t} value={t}>{t}</option>)}
+                </select>
+                <span className="mql-mon-count">{filteredOps.length} / {ops.length}</span>
+              </div>
+              {filteredOps.length === 0 ? (
+                <div className="mql-mon-empty">No operations match the filter.</div>
+              ) : (
+                <table className="mql-mon-table" data-testid="current-ops-table">
+                  <thead>
+                    <tr>
+                      <th>opid</th><th>op</th><th>ns</th><th>secs</th><th>client</th><th>command</th><th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredOps.map((op) => (
+                      <tr key={op.opid}>
+                        <td>{op.opid}</td>
+                        <td><OpBadge op={op.op} /></td>
+                        <td className="mql-mon-ns">{op.ns}</td>
+                        <td className={op.secsRunning >= 5 ? 'mql-mon-slow' : ''}>{op.secsRunning}</td>
+                        <td>{op.client}</td>
+                        <td className="mql-mon-cmd" title={op.command}>{op.command}</td>
+                        <td>
+                          <button
+                            type="button"
+                            className="mql-mon-kill"
+                            title="Kill operation"
+                            data-testid={`kill-op-${op.opid}`}
+                            onClick={() => handleKill(op)}
+                          >
+                            <Skull size={12} />
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </>
           )}
         </div>
       ) : (
@@ -373,22 +442,51 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                 : 'No profiled operations yet.'}
             </div>
           ) : (
-            <table className="mql-mon-table" data-testid="profile-table">
-              <thead>
-                <tr><th>millis</th><th>op</th><th>ns</th><th>plan</th><th>command</th></tr>
-              </thead>
-              <tbody>
-                {profile.map((p, i) => (
-                  <tr key={i}>
-                    <td className={p.millis >= 100 ? 'mql-mon-slow' : ''}>{p.millis}</td>
-                    <td>{p.op}</td>
-                    <td className="mql-mon-ns">{p.ns}</td>
-                    <td>{p.planSummary}</td>
-                    <td className="mql-mon-cmd" title={p.command}>{p.command}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <>
+              <div className="mql-mon-filters">
+                <div className="mql-mon-search">
+                  <Search size={12} />
+                  <input
+                    value={profSearch}
+                    onChange={(e) => setProfSearch(e.target.value)}
+                    placeholder="Filter by ns, plan, or command…"
+                    data-testid="profiler-search"
+                  />
+                </div>
+                <label className="mql-mon-minms">
+                  ≥
+                  <input
+                    type="number"
+                    min={0}
+                    value={profMinMs}
+                    onChange={(e) => setProfMinMs(Number(e.target.value) || 0)}
+                    data-testid="profiler-min-ms"
+                  />
+                  ms
+                </label>
+                <span className="mql-mon-count">{filteredProfile.length} / {profile.length}</span>
+              </div>
+              {filteredProfile.length === 0 ? (
+                <div className="mql-mon-empty">No entries match the filter.</div>
+              ) : (
+                <table className="mql-mon-table" data-testid="profile-table">
+                  <thead>
+                    <tr><th>millis</th><th>op</th><th>ns</th><th>plan</th><th>command</th></tr>
+                  </thead>
+                  <tbody>
+                    {filteredProfile.map((p, i) => (
+                      <tr key={i}>
+                        <td className={p.millis >= 100 ? 'mql-mon-slow' : ''}>{p.millis}</td>
+                        <td><OpBadge op={p.op} /></td>
+                        <td className="mql-mon-ns">{p.ns}</td>
+                        <td>{p.planSummary}</td>
+                        <td className="mql-mon-cmd" title={p.command}>{p.command}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </>
           )}
         </div>
       )}

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { LineChart, Line, ResponsiveContainer, YAxis } from 'recharts';
-import { Activity, RefreshCw, Skull, Lock, Network, Gauge, MemoryStick, Database, ArrowDownUp, Search } from 'lucide-react';
+import { Activity, RefreshCw, Skull, Lock, Network, Gauge, MemoryStick, Database, ArrowDownUp, Search, X } from 'lucide-react';
 import { formatBytes } from '../lib/format';
 import {
   serverStatus,
@@ -140,6 +140,56 @@ const HighlightedCommand: React.FC<{ text: string }> = ({ text }) => {
   return <>{nodes}</>;
 };
 
+const fmtTs = (ms: number): string => {
+  if (!ms) return '—';
+  try { return new Date(ms).toLocaleString(); } catch { return String(ms); }
+};
+
+const DetailRow: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+  <div className="mql-mon-detail-row">
+    <span className="mql-mon-detail-label">{label}</span>
+    <span className="mql-mon-detail-val">{children}</span>
+  </div>
+);
+
+const MonitoringDetail: React.FC<{
+  detail: { kind: 'op'; data: CurrentOp } | { kind: 'profile'; data: ProfileEntry };
+  onClose: () => void;
+}> = ({ detail, onClose }) => (
+  <div className="nested-modal-overlay" data-testid="monitoring-detail" onClick={onClose}>
+    <div className="index-modal-container index-modal-container--wide" onClick={(e) => e.stopPropagation()}>
+      <div className="mql-mon-detail-head">
+        <h2>{detail.kind === 'op' ? 'Operation details' : 'Profiled operation'}</h2>
+        <button type="button" onClick={onClose} aria-label="Close" className="mql-mon-detail-close">
+          <X size={14} />
+        </button>
+      </div>
+      <div className="mql-mon-detail-fields">
+        {detail.kind === 'op' ? (
+          <>
+            <DetailRow label="opid">{detail.data.opid}</DetailRow>
+            <DetailRow label="op"><OpBadge op={detail.data.op} /></DetailRow>
+            <DetailRow label="ns">{detail.data.ns}</DetailRow>
+            <DetailRow label="running">{detail.data.secsRunning}s</DetailRow>
+            <DetailRow label="client">{detail.data.client}</DetailRow>
+            <DetailRow label="desc">{detail.data.desc || '—'}</DetailRow>
+          </>
+        ) : (
+          <>
+            <DetailRow label="op"><OpBadge op={detail.data.op} /></DetailRow>
+            <DetailRow label="ns">{detail.data.ns}</DetailRow>
+            <DetailRow label="duration">{detail.data.millis} ms</DetailRow>
+            <DetailRow label="plan">{detail.data.planSummary || '—'}</DetailRow>
+            <DetailRow label="time">{fmtTs(detail.data.tsMs)}</DetailRow>
+          </>
+        )}
+      </div>
+      <div className="mql-mon-detail-cmd-label">Command</div>
+      <pre className="mql-mon-detail-cmd"><HighlightedCommand text={detail.data.command} /></pre>
+    </div>
+  </div>
+);
+
 // MongoDB error 13 / "not authorized" → the user lacks the privilege.
 const isAuthError = (msg: string): boolean =>
   /not authorized|unauthorized|requires authentication|\(13\)|code 13/i.test(msg);
@@ -170,6 +220,9 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
   const [opsErr, setOpsErr] = useState<string | null>(null);
   const [profilerErr, setProfilerErr] = useState<string | null>(null);
   const [section, setSection] = useState<'ops' | 'profiler'>('ops');
+  const [detail, setDetail] = useState<
+    { kind: 'op'; data: CurrentOp } | { kind: 'profile'; data: ProfileEntry } | null
+  >(null);
 
   // Filters
   const [opsSearch, setOpsSearch] = useState('');
@@ -433,7 +486,12 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                   </thead>
                   <tbody>
                     {filteredOps.map((op) => (
-                      <tr key={op.opid}>
+                      <tr
+                        key={op.opid}
+                        className="mql-mon-clickable"
+                        data-testid={`op-row-${op.opid}`}
+                        onClick={() => setDetail({ kind: 'op', data: op })}
+                      >
                         <td>{op.opid}</td>
                         <td><OpBadge op={op.op} /></td>
                         <td className="mql-mon-ns">{op.ns}</td>
@@ -446,7 +504,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                             className="mql-mon-kill"
                             title="Kill operation"
                             data-testid={`kill-op-${op.opid}`}
-                            onClick={() => handleKill(op)}
+                            onClick={(e) => { e.stopPropagation(); handleKill(op); }}
                           >
                             <Skull size={12} />
                           </button>
@@ -533,7 +591,12 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                   </thead>
                   <tbody>
                     {filteredProfile.map((p, i) => (
-                      <tr key={i}>
+                      <tr
+                        key={i}
+                        className="mql-mon-clickable"
+                        data-testid={`profile-row-${i}`}
+                        onClick={() => setDetail({ kind: 'profile', data: p })}
+                      >
                         <td className={p.millis >= 100 ? 'mql-mon-slow' : ''}>{p.millis}</td>
                         <td><OpBadge op={p.op} /></td>
                         <td className="mql-mon-ns">{p.ns}</td>
@@ -548,6 +611,8 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
           )}
         </div>
       )}
+
+      {detail && <MonitoringDetail detail={detail} onClose={() => setDetail(null)} />}
     </div>
   );
 };

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { LineChart, Line, ResponsiveContainer, YAxis } from 'recharts';
-import { Activity, RefreshCw, Skull } from 'lucide-react';
+import { Activity, RefreshCw, Skull, Lock } from 'lucide-react';
 import { formatBytes } from '../lib/format';
 import {
   serverStatus,
@@ -62,11 +62,35 @@ const MetricCard: React.FC<{ label: string; value: string; sub?: string; series:
   </div>
 );
 
+// MongoDB error 13 / "not authorized" → the user lacks the privilege.
+const isAuthError = (msg: string): boolean =>
+  /not authorized|unauthorized|requires authentication|\(13\)|code 13/i.test(msg);
+
+const AccessNote: React.FC<{ what: string; role?: string }> = ({ what, role = 'clusterMonitor' }) => (
+  <div className="mql-mon-denied" data-testid="access-required">
+    <Lock size={15} />
+    <div>
+      <strong>Access required</strong>
+      <p>
+        This connection&apos;s user isn&apos;t authorized to {what}. Grant the <code>{role}</code> role
+        (or equivalent privilege) to enable it.
+      </p>
+    </div>
+  </div>
+);
+
+const errLine = (msg: string): string => {
+  const first = msg.split('\n')[0];
+  return first.length > 200 ? `${first.slice(0, 200)}…` : first;
+};
+
 export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) => {
   const [status, setStatus] = useState<ServerStatus | null>(null);
   const [ops, setOps] = useState<CurrentOp[]>([]);
   const [samples, setSamples] = useState<Sample[]>([]);
-  const [error, setError] = useState<string | null>(null);
+  const [metricsErr, setMetricsErr] = useState<string | null>(null);
+  const [opsErr, setOpsErr] = useState<string | null>(null);
+  const [profilerErr, setProfilerErr] = useState<string | null>(null);
   const [section, setSection] = useState<'ops' | 'profiler'>('ops');
 
   // Profiler state
@@ -83,15 +107,21 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
     setStatus(null);
     const tick = async () => {
       if (typeof document !== 'undefined' && document.hidden) return;
-      try {
-        const [s, o] = await Promise.all([serverStatus(connectionId), currentOps(connectionId)]);
-        if (!alive) return;
-        setStatus(s);
-        setOps(o);
-        setError(null);
-        setSamples((prev) => [...prev, { t: Date.now(), status: s }].slice(-MAX_SAMPLES));
-      } catch (e: any) {
-        if (alive) setError(String(e?.message || e));
+      // Independent: a user may have currentOp but not serverStatus (or vice versa).
+      const [sRes, oRes] = await Promise.allSettled([serverStatus(connectionId), currentOps(connectionId)]);
+      if (!alive) return;
+      if (sRes.status === 'fulfilled') {
+        setStatus(sRes.value);
+        setMetricsErr(null);
+        setSamples((prev) => [...prev, { t: Date.now(), status: sRes.value }].slice(-MAX_SAMPLES));
+      } else {
+        setMetricsErr(String((sRes.reason as any)?.message || sRes.reason));
+      }
+      if (oRes.status === 'fulfilled') {
+        setOps(oRes.value);
+        setOpsErr(null);
+      } else {
+        setOpsErr(String((oRes.reason as any)?.message || oRes.reason));
       }
     };
     tick();
@@ -127,8 +157,9 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
       ]);
       setProfiling(st);
       setProfile(entries);
+      setProfilerErr(null);
     } catch (e: any) {
-      setError(String(e?.message || e));
+      setProfilerErr(String(e?.message || e));
     } finally {
       setProfileLoading(false);
     }
@@ -144,7 +175,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
       await killOp(connectionId, op.opid);
       setOps(await currentOps(connectionId));
     } catch (e: any) {
-      setError(String(e?.message || e));
+      setOpsErr(String(e?.message || e));
     }
   };
 
@@ -154,7 +185,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
       setProfiling(st);
       void refreshProfiler();
     } catch (e: any) {
-      setError(String(e?.message || e));
+      setProfilerErr(String(e?.message || e));
     }
   };
 
@@ -194,46 +225,51 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
         )}
       </div>
 
-      {error && <div className="mql-mon-error" data-testid="monitoring-error">{error}</div>}
-
-      {/* Metric cards */}
-      <div className="mql-mon-cards">
-        <MetricCard
-          label="Connections"
-          value={status ? String(status.connections.current) : '—'}
-          sub={status ? `${status.connections.available.toLocaleString()} available` : undefined}
-          series={series.conns}
-          color="var(--accent-blue)"
-        />
-        <MetricCard
-          label="Ops / sec"
-          value={status ? Math.round(latestOpsPerSec).toLocaleString() : '—'}
-          sub="all opcounters"
-          series={series.opsPerSec}
-          color="#34d399"
-        />
-        <MetricCard
-          label="Resident memory"
-          value={status ? `${status.memory.residentMb.toLocaleString()} MB` : '—'}
-          sub={status ? `${status.memory.virtualMb.toLocaleString()} MB virtual` : undefined}
-          series={series.resident}
-          color="#f59e0b"
-        />
-        <MetricCard
-          label="Cache used"
-          value={cachePctNow != null ? `${cachePctNow.toFixed(0)}%` : 'n/a'}
-          sub={status?.cache ? `${formatBytes(status.cache.bytesInCache)} / ${formatBytes(status.cache.maxBytes)}` : undefined}
-          series={series.cachePct}
-          color="#a78bfa"
-        />
-        <MetricCard
-          label="Network"
-          value={status ? `${formatBytes(latestNetPerSec)}/s` : '—'}
-          sub={status ? `${formatBytes(status.network.bytesIn + status.network.bytesOut)} total` : undefined}
-          series={series.netPerSec}
-          color="#22d3ee"
-        />
-      </div>
+      {/* Metric cards (or an access-required panel when serverStatus is denied) */}
+      {metricsErr && isAuthError(metricsErr) ? (
+        <AccessNote what="read server metrics (serverStatus)" />
+      ) : (
+        <>
+          {metricsErr && <div className="mql-mon-error" data-testid="monitoring-error">{errLine(metricsErr)}</div>}
+          <div className="mql-mon-cards">
+            <MetricCard
+              label="Connections"
+              value={status ? String(status.connections.current) : '—'}
+              sub={status ? `${status.connections.available.toLocaleString()} available` : undefined}
+              series={series.conns}
+              color="var(--accent-blue)"
+            />
+            <MetricCard
+              label="Ops / sec"
+              value={status ? Math.round(latestOpsPerSec).toLocaleString() : '—'}
+              sub="all opcounters"
+              series={series.opsPerSec}
+              color="#34d399"
+            />
+            <MetricCard
+              label="Resident memory"
+              value={status ? `${status.memory.residentMb.toLocaleString()} MB` : '—'}
+              sub={status ? `${status.memory.virtualMb.toLocaleString()} MB virtual` : undefined}
+              series={series.resident}
+              color="#f59e0b"
+            />
+            <MetricCard
+              label="Cache used"
+              value={cachePctNow != null ? `${cachePctNow.toFixed(0)}%` : 'n/a'}
+              sub={status?.cache ? `${formatBytes(status.cache.bytesInCache)} / ${formatBytes(status.cache.maxBytes)}` : undefined}
+              series={series.cachePct}
+              color="#a78bfa"
+            />
+            <MetricCard
+              label="Network"
+              value={status ? `${formatBytes(latestNetPerSec)}/s` : '—'}
+              sub={status ? `${formatBytes(status.network.bytesIn + status.network.bytesOut)} total` : undefined}
+              series={series.netPerSec}
+              color="#22d3ee"
+            />
+          </div>
+        </>
+      )}
 
       {/* Tabs: Current operations | Profiler */}
       <div className="mql-mon-tabs">
@@ -257,7 +293,11 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
 
       {section === 'ops' ? (
         <div className="mql-mon-section" data-testid="mon-panel-ops">
-          {ops.length === 0 ? (
+          {opsErr && isAuthError(opsErr) ? (
+            <AccessNote what="inspect current operations ($currentOp)" role="inprog / clusterMonitor" />
+          ) : opsErr ? (
+            <div className="mql-mon-error">{errLine(opsErr)}</div>
+          ) : ops.length === 0 ? (
             <div className="mql-mon-empty">No active operations.</div>
           ) : (
             <table className="mql-mon-table" data-testid="current-ops-table">
@@ -322,7 +362,11 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
               <RefreshCw size={12} className={profileLoading ? 'animate-spin' : ''} />
             </button>
           </div>
-          {profile.length === 0 ? (
+          {profilerErr && isAuthError(profilerErr) ? (
+            <AccessNote what="read the profiler for this database (system.profile)" role="dbAdmin / read" />
+          ) : profilerErr ? (
+            <div className="mql-mon-error">{errLine(profilerErr)}</div>
+          ) : profile.length === 0 ? (
             <div className="mql-mon-empty">
               {profiling?.level === 0
                 ? 'Profiling is off for this database. Set level 1 (slow ops) or 2 (all ops) to collect entries.'

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,7 +22,8 @@ import {
   Archive,
   Cog,
   Pencil,
-  Table2
+  Table2,
+  Activity
 } from 'lucide-react';
 
 // Mirrors the backend CollectionInfo struct returned by `list_collections`.
@@ -57,6 +58,7 @@ interface SidebarProps {
   onCreateIndex?: (connectionId: string, dbName: string, collName: string) => void;
   onDeleteIndex?: (connectionId: string, dbName: string, collName: string, indexName: string) => void;
   onOpenShell?: (connectionId: string, dbName: string, collName?: string, initialCommand?: string) => void;
+  onOpenMonitoring?: (connectionId: string) => void;
   onAnalyzeSchema?: (connectionId: string, dbName: string, collName: string) => void;
   onCreateView?: (connectionId: string, dbName: string) => void;
   onOpenGridfs?: (connectionId: string, dbName: string, bucket: string) => void;
@@ -133,6 +135,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onCreateIndex,
   onDeleteIndex,
   onOpenShell,
+  onOpenMonitoring,
   onAnalyzeSchema,
   onCreateView,
   onOpenGridfs,
@@ -1237,6 +1240,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
               >
                 <Server size={12} />
                 <span>Manage Connections</span>
+              </div>
+              <div
+                className="mql-ctx-item"
+                data-testid="ctx-monitor"
+                onClick={() => {
+                  onOpenMonitoring?.(contextMenu.connectionId!);
+                  setContextMenu(null);
+                }}
+              >
+                <Activity size={12} />
+                <span>Monitor cluster</span>
               </div>
               <div className="mql-ctx-sep" />
               <div 

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -81,6 +81,26 @@ describe('MonitoringView', () => {
     expect(await screen.findByTestId('current-ops-table')).toBeInTheDocument();
   });
 
+  it('filters the current-operations list by search text', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'server_status') return Promise.resolve(STATUS);
+      if (cmd === 'current_ops') return Promise.resolve([
+        { opid: 1, op: 'query', ns: 'sales_db.orders', secsRunning: 1, client: 'a', desc: '', command: '{}' },
+        { opid: 2, op: 'command', ns: 'admin.$cmd', secsRunning: 0, client: 'b', desc: '', command: '{}' },
+      ]);
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'get_profiling_status') return Promise.resolve({ level: 0, slowMs: 100 });
+      if (cmd === 'read_profile') return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    render(<MonitoringView connectionId="conn-1" />);
+    expect(await screen.findByText('sales_db.orders')).toBeInTheDocument();
+    expect(screen.getByText('admin.$cmd')).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('ops-search'), { target: { value: 'orders' } });
+    expect(screen.getByText('sales_db.orders')).toBeInTheDocument();
+    expect(screen.queryByText('admin.$cmd')).toBeNull();
+  });
+
   it('switches between the Current operations and Profiler tabs', async () => {
     render(<MonitoringView connectionId="conn-1" />);
     // Current operations is the default tab.

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -62,10 +62,21 @@ describe('MonitoringView', () => {
     });
   });
 
-  it('sets the profiling level via the controls', async () => {
+  it('switches between the Current operations and Profiler tabs', async () => {
     render(<MonitoringView connectionId="conn-1" />);
-    const lvl1 = await screen.findByTestId('profiler-level-1');
-    fireEvent.click(lvl1);
+    // Current operations is the default tab.
+    expect(await screen.findByTestId('current-ops-table')).toBeInTheDocument();
+    expect(screen.queryByTestId('mon-panel-profiler')).toBeNull();
+    // Switch to the Profiler tab.
+    fireEvent.click(screen.getByTestId('mon-tab-profiler'));
+    expect(await screen.findByTestId('mon-panel-profiler')).toBeInTheDocument();
+    expect(screen.queryByTestId('current-ops-table')).toBeNull();
+  });
+
+  it('sets the profiling level via the controls (on the Profiler tab)', async () => {
+    render(<MonitoringView connectionId="conn-1" />);
+    fireEvent.click(await screen.findByTestId('mon-tab-profiler'));
+    fireEvent.click(await screen.findByTestId('profiler-level-1'));
     await waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith('set_profiling_level', expect.objectContaining({ id: 'conn-1', level: 1 }));
     });

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -62,6 +62,25 @@ describe('MonitoringView', () => {
     });
   });
 
+  it('shows "Access required" when serverStatus is unauthorized, but still lists ops', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'server_status') return Promise.reject('serverStatus failed: not authorized on admin (Unauthorized)');
+      if (cmd === 'current_ops') return Promise.resolve([
+        { opid: 1, op: 'command', ns: 'admin.$cmd', secsRunning: 0, client: 'x', desc: '', command: '{}' },
+      ]);
+      if (cmd === 'list_databases') return Promise.resolve(['admin']);
+      if (cmd === 'get_profiling_status') return Promise.resolve({ level: 0, slowMs: 100 });
+      if (cmd === 'read_profile') return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    render(<MonitoringView connectionId="conn-1" />);
+    expect(await screen.findByTestId('access-required')).toBeInTheDocument();
+    // Metric cards are hidden behind the access notice.
+    expect(screen.queryByText('Connections')).toBeNull();
+    // Current operations still work (independent privilege).
+    expect(await screen.findByTestId('current-ops-table')).toBeInTheDocument();
+  });
+
   it('switches between the Current operations and Profiler tabs', async () => {
     render(<MonitoringView connectionId="conn-1" />);
     // Current operations is the default tab.

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -101,6 +101,16 @@ describe('MonitoringView', () => {
     expect(screen.queryByText('admin.$cmd')).toBeNull();
   });
 
+  it('opens a detail modal when an operation row is clicked', async () => {
+    render(<MonitoringView connectionId="conn-1" />);
+    fireEvent.click(await screen.findByTestId('op-row-42'));
+    const modal = await screen.findByTestId('monitoring-detail');
+    expect(modal).toBeInTheDocument();
+    expect(screen.getByText('Operation details')).toBeInTheDocument();
+    // The detail modal shows the full command in its own code block.
+    expect(modal.querySelector('.mql-mon-detail-cmd')).toBeTruthy();
+  });
+
   it('switches between the Current operations and Profiler tabs', async () => {
     render(<MonitoringView connectionId="conn-1" />);
     // Current operations is the default tab.

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -101,6 +101,15 @@ describe('MonitoringView', () => {
     expect(screen.queryByText('admin.$cmd')).toBeNull();
   });
 
+  it('filters current ops by minimum duration (secs)', async () => {
+    render(<MonitoringView connectionId="conn-1" />);
+    expect(await screen.findByTestId('current-ops-table')).toBeInTheDocument();
+    // The seeded op runs for 3s; require ≥ 5s and it drops out.
+    fireEvent.change(screen.getByTestId('ops-min-secs'), { target: { value: '5' } });
+    expect(screen.queryByTestId('current-ops-table')).toBeNull();
+    expect(screen.getByText('No operations match the filter.')).toBeInTheDocument();
+  });
+
   it('opens a detail modal when an operation row is clicked', async () => {
     render(<MonitoringView connectionId="conn-1" />);
     fireEvent.click(await screen.findByTestId('op-row-42'));

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => mockInvoke(...a) }));
+
+// recharts needs layout; stub it to plain divs for jsdom.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  LineChart: ({ children }: any) => <div>{children}</div>,
+  Line: () => null,
+  YAxis: () => null,
+}));
+
+import { MonitoringView } from '../MonitoringView';
+
+const STATUS = {
+  host: 'h:27017', version: '7.0.0', uptimeSeconds: 3600,
+  connections: { current: 5, available: 100, totalCreated: 1 },
+  opcounters: { insert: 1, query: 2, update: 0, delete: 0, getmore: 0, command: 3 },
+  memory: { residentMb: 200, virtualMb: 2000 },
+  network: { bytesIn: 10, bytesOut: 20, numRequests: 5 },
+  cache: { bytesInCache: 1024, maxBytes: 4096, dirtyBytes: 0 },
+};
+
+beforeEach(() => {
+  mockInvoke.mockReset();
+  mockInvoke.mockImplementation((cmd: string) => {
+    switch (cmd) {
+      case 'server_status': return Promise.resolve(STATUS);
+      case 'current_ops': return Promise.resolve([
+        { opid: 42, op: 'query', ns: 'sales_db.orders', secsRunning: 3, client: '1.2.3.4', desc: 'conn1', command: '{ find: "orders" }' },
+      ]);
+      case 'list_databases': return Promise.resolve(['admin', 'sales_db']);
+      case 'get_profiling_status': return Promise.resolve({ level: 0, slowMs: 100 });
+      case 'read_profile': return Promise.resolve([]);
+      case 'kill_op': return Promise.resolve();
+      default: return Promise.resolve(null);
+    }
+  });
+});
+
+describe('MonitoringView', () => {
+  it('renders server metrics and current operations', async () => {
+    render(<MonitoringView connectionId="conn-1" />);
+    expect(await screen.findByTestId('monitoring-view')).toBeInTheDocument();
+    expect(await screen.findByText('Connections')).toBeInTheDocument();
+    // Connection count from server_status.
+    expect(await screen.findByText('5')).toBeInTheDocument();
+    // Current ops table with the running op.
+    expect(await screen.findByTestId('current-ops-table')).toBeInTheDocument();
+    expect(screen.getByText('sales_db.orders')).toBeInTheDocument();
+  });
+
+  it('kills an operation after confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<MonitoringView connectionId="conn-1" />);
+    const killBtn = await screen.findByTestId('kill-op-42');
+    fireEvent.click(killBtn);
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('kill_op', { id: 'conn-1', opid: 42 });
+    });
+  });
+
+  it('sets the profiling level via the controls', async () => {
+    render(<MonitoringView connectionId="conn-1" />);
+    const lvl1 = await screen.findByTestId('profiler-level-1');
+    fireEvent.click(lvl1);
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('set_profiling_level', expect.objectContaining({ id: 'conn-1', level: 1 }));
+    });
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -5368,3 +5368,36 @@ button, input, select, textarea {
 .mql-mon-denied p { margin: 0; line-height: 1.55; }
 .mql-mon-denied code { background: var(--bg-item-hover); padding: 1px 5px; border-radius: 4px; font-family: var(--font-mono); font-size: 11.5px; }
 
+/* Colorful metric cards */
+.mql-mon-card { border-top: 2px solid var(--card-color, var(--accent-blue)); }
+.mql-mon-card-top { display: flex; align-items: center; gap: 7px; margin-bottom: 2px; }
+.mql-mon-card-icon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px; border-radius: 6px; flex: none;
+  color: var(--card-color);
+  background: color-mix(in srgb, var(--card-color) 16%, transparent);
+}
+
+/* Operation-type badge */
+.mql-mon-op {
+  display: inline-block; padding: 1px 8px; border-radius: 999px;
+  font-size: 10.5px; font-weight: 700; text-transform: lowercase;
+  color: var(--op-color);
+  background: color-mix(in srgb, var(--op-color) 16%, transparent);
+}
+
+/* Filter bar */
+.mql-mon-filters { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+.mql-mon-search {
+  display: flex; align-items: center; gap: 6px; flex: 1; max-width: 360px;
+  border: 1px solid var(--border-color); border-radius: 6px; padding: 3px 8px;
+  background: var(--bg-base); color: var(--text-dim);
+}
+.mql-mon-search input { flex: 1; background: transparent; border: none; outline: none; color: var(--text-main); font-size: 12px; }
+.mql-mon-minms { display: inline-flex; align-items: center; gap: 4px; font-size: 11.5px; color: var(--text-muted); }
+.mql-mon-minms input {
+  width: 64px; background: var(--bg-base); border: 1px solid var(--border-color);
+  border-radius: 5px; padding: 2px 6px; color: var(--text-main); font-size: 11.5px;
+}
+.mql-mon-count { font-size: 11px; color: var(--text-dim); margin-left: auto; }
+

--- a/src/index.css
+++ b/src/index.css
@@ -5337,7 +5337,14 @@ button, input, select, textarea {
   border-radius: 4px; color: var(--text-dim); cursor: pointer;
 }
 .mql-mon-kill:hover { color: var(--accent-red); background: hsla(0, 70%, 50%, 0.12); }
-.mql-mon-profiler-controls { display: flex; align-items: center; gap: 10px; font-weight: 400; font-size: 11.5px; color: var(--text-muted); }
+.mql-mon-tabs { display: flex; gap: 2px; border-bottom: 1px solid var(--border-color); margin-bottom: 10px; }
+.mql-mon-tab {
+  padding: 6px 12px; font-size: 12px; font-weight: 600; color: var(--text-muted);
+  border-bottom: 2px solid transparent; cursor: pointer; background: none;
+}
+.mql-mon-tab:hover { color: var(--text-main); }
+.mql-mon-tab.is-active { color: var(--text-main); border-bottom-color: var(--accent-blue); }
+.mql-mon-profiler-controls { display: flex; align-items: center; justify-content: flex-end; gap: 10px; margin-bottom: 8px; font-weight: 400; font-size: 11.5px; color: var(--text-muted); }
 .mql-mon-select {
   background: var(--bg-dropdown-solid); color: var(--text-main);
   border: 1px solid var(--border-color); border-radius: 5px; padding: 2px 6px; font-size: 11.5px;

--- a/src/index.css
+++ b/src/index.css
@@ -5293,3 +5293,62 @@ button, input, select, textarea {
 .mql-context-item.is-danger .mql-context-icon { color: var(--accent-red); }
 .mql-context-sep { height: 1px; margin: 4px 6px; background: var(--border-color); }
 
+/* ── Cluster monitoring view ─────────────────────────────────────────────── */
+.mql-mon { flex: 1; min-height: 0; overflow: auto; background: var(--bg-base); padding: 16px; }
+.mql-mon-header { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; }
+.mql-mon-title { font-size: 13px; font-weight: 600; color: var(--text-main); }
+.mql-mon-meta { font-size: 11px; color: var(--text-dim); }
+.mql-mon-error {
+  margin-bottom: 12px; padding: 8px 10px; border-radius: 6px;
+  background: hsla(0, 70%, 50%, 0.12); color: var(--accent-red); font-size: 12px;
+}
+.mql-mon-cards {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px; margin-bottom: 18px;
+}
+.mql-mon-card {
+  border: 1px solid var(--border-color); border-radius: 8px;
+  background: var(--bg-panel); padding: 12px 14px;
+}
+.mql-mon-card-label { font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-dim); }
+.mql-mon-card-value { font-size: 22px; font-weight: 700; color: var(--text-main); margin-top: 2px; }
+.mql-mon-card-sub { font-size: 11px; color: var(--text-muted); }
+.mql-mon-spark { height: 34px; margin-top: 6px; }
+.mql-mon-spark-empty { height: 34px; }
+
+.mql-mon-section { margin-bottom: 18px; }
+.mql-mon-section-head {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 12px; font-weight: 600; color: var(--text-main);
+  padding: 6px 2px; border-bottom: 1px solid var(--border-color); margin-bottom: 6px;
+}
+.mql-mon-empty { font-size: 12px; color: var(--text-dim); font-style: italic; padding: 8px 2px; }
+.mql-mon-table { width: 100%; border-collapse: collapse; font-size: 11.5px; font-family: var(--font-mono); }
+.mql-mon-table th {
+  text-align: left; font-weight: 600; color: var(--text-dim); text-transform: uppercase;
+  font-size: 10px; letter-spacing: 0.05em; padding: 4px 8px; border-bottom: 1px solid var(--border-color);
+}
+.mql-mon-table td { padding: 4px 8px; border-bottom: 1px solid var(--border-color); color: var(--text-main); vertical-align: top; }
+.mql-mon-ns { color: var(--accent-blue); }
+.mql-mon-cmd { max-width: 360px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-muted); }
+.mql-mon-slow { color: var(--accent-red); font-weight: 700; }
+.mql-mon-kill {
+  display: inline-flex; align-items: center; justify-content: center; padding: 3px;
+  border-radius: 4px; color: var(--text-dim); cursor: pointer;
+}
+.mql-mon-kill:hover { color: var(--accent-red); background: hsla(0, 70%, 50%, 0.12); }
+.mql-mon-profiler-controls { display: flex; align-items: center; gap: 10px; font-weight: 400; font-size: 11.5px; color: var(--text-muted); }
+.mql-mon-select {
+  background: var(--bg-dropdown-solid); color: var(--text-main);
+  border: 1px solid var(--border-color); border-radius: 5px; padding: 2px 6px; font-size: 11.5px;
+}
+.mql-mon-level { display: inline-flex; align-items: center; gap: 4px; }
+.mql-mon-level-btn {
+  width: 22px; height: 20px; border: 1px solid var(--border-color); border-radius: 4px;
+  color: var(--text-muted); cursor: pointer; font-size: 11px;
+}
+.mql-mon-level-btn.is-active { background: var(--accent-blue); color: #fff; border-color: var(--accent-blue); }
+.mql-mon-slowms { color: var(--text-dim); }
+.mql-mon-refresh { display: inline-flex; padding: 3px; border-radius: 4px; color: var(--text-dim); cursor: pointer; }
+.mql-mon-refresh:hover { color: var(--text-main); background: var(--bg-item-hover); }
+

--- a/src/index.css
+++ b/src/index.css
@@ -5401,3 +5401,22 @@ button, input, select, textarea {
 }
 .mql-mon-count { font-size: 11px; color: var(--text-dim); margin-left: auto; }
 
+/* Clickable rows + detail modal */
+.mql-mon-clickable { cursor: pointer; }
+.mql-mon-clickable:hover { background: var(--bg-item-hover); }
+.mql-mon-detail-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; }
+.mql-mon-detail-head h2 { font-size: 14px; font-weight: 600; color: var(--text-main); margin: 0; }
+.mql-mon-detail-close { display: inline-flex; padding: 4px; border-radius: 5px; color: var(--text-muted); cursor: pointer; }
+.mql-mon-detail-close:hover { color: var(--text-main); background: var(--bg-item-hover); }
+.mql-mon-detail-fields { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px 18px; margin-bottom: 14px; }
+.mql-mon-detail-row { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.mql-mon-detail-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); }
+.mql-mon-detail-val { font-size: 12.5px; color: var(--text-main); font-family: var(--font-mono); overflow-wrap: anywhere; }
+.mql-mon-detail-cmd-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); margin-bottom: 4px; }
+.mql-mon-detail-cmd {
+  max-height: 360px; overflow: auto; margin: 0;
+  background: var(--bg-base); border: 1px solid var(--border-color); border-radius: 6px;
+  padding: 10px 12px; font-family: var(--font-mono); font-size: 12px; line-height: 1.55;
+  white-space: pre-wrap; word-break: break-word; color: var(--text-main);
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -5358,4 +5358,13 @@ button, input, select, textarea {
 .mql-mon-slowms { color: var(--text-dim); }
 .mql-mon-refresh { display: inline-flex; padding: 3px; border-radius: 4px; color: var(--text-dim); cursor: pointer; }
 .mql-mon-refresh:hover { color: var(--text-main); background: var(--bg-item-hover); }
+.mql-mon-denied {
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 16px 18px; border: 1px solid var(--border-color); border-radius: 8px;
+  background: var(--bg-panel); color: var(--text-muted); font-size: 12.5px;
+}
+.mql-mon-denied > svg { color: #f59e0b; flex: none; margin-top: 1px; }
+.mql-mon-denied strong { color: var(--text-main); display: block; margin-bottom: 3px; }
+.mql-mon-denied p { margin: 0; line-height: 1.55; }
+.mql-mon-denied code { background: var(--bg-item-hover); padding: 1px 5px; border-radius: 4px; font-family: var(--font-mono); font-size: 11.5px; }
 

--- a/src/lib/monitoringApi.ts
+++ b/src/lib/monitoringApi.ts
@@ -1,0 +1,47 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface ServerStatus {
+  host: string;
+  version: string;
+  uptimeSeconds: number;
+  connections: { current: number; available: number; totalCreated: number };
+  opcounters: { insert: number; query: number; update: number; delete: number; getmore: number; command: number };
+  memory: { residentMb: number; virtualMb: number };
+  network: { bytesIn: number; bytesOut: number; numRequests: number };
+  cache?: { bytesInCache: number; maxBytes: number; dirtyBytes: number };
+  replSet?: string;
+}
+
+export interface CurrentOp {
+  opid: number;
+  op: string;
+  ns: string;
+  secsRunning: number;
+  client: string;
+  desc: string;
+  command: string;
+}
+
+export interface ProfilingStatus {
+  level: number;
+  slowMs: number;
+}
+
+export interface ProfileEntry {
+  op: string;
+  ns: string;
+  millis: number;
+  tsMs: number;
+  planSummary: string;
+  command: string;
+}
+
+export const serverStatus = (id: string) => invoke<ServerStatus>('server_status', { id });
+export const currentOps = (id: string) => invoke<CurrentOp[]>('current_ops', { id });
+export const killOp = (id: string, opid: number) => invoke<void>('kill_op', { id, opid });
+export const getProfilingStatus = (id: string, database: string) =>
+  invoke<ProfilingStatus>('get_profiling_status', { id, database });
+export const setProfilingLevel = (id: string, database: string, level: number, slowMs: number) =>
+  invoke<ProfilingStatus>('set_profiling_level', { id, database, level, slowMs });
+export const readProfile = (id: string, database: string, limit: number) =>
+  invoke<ProfileEntry[]>('read_profile', { id, database, limit });


### PR DESCRIPTION
Closes #50. Implements all three phases of the cluster monitoring tab.

## Backend (`monitoring.rs`, 6 commands)
- `server_status` — curated `serverStatus` (connections, opcounters, mem, network, WiredTiger cache, replSet)
- `current_ops` / `kill_op` — `$currentOp` (active, sorted by runtime) + `killOp`
- `get_profiling_status` / `set_profiling_level` / `read_profile` — DB profiler (level/slowms + `system.profile`)
- Pure curation functions are unit-tested (4 Rust tests); **mock connections return synthetic data** so the dashboard works in demo mode.

## Frontend
- `monitoringApi.ts` typed wrappers.
- `MonitoringView`:
  - **Metric cards + sparklines** (recharts): connections, ops/sec (from opcounter deltas), resident memory, cache used %, network/s — polled every 3s, **paused when the window is hidden**.
  - **Current operations** table with a **kill** action (confirm).
  - **Profiler**: per-database level controls (0/1/2 + slow-ms), and a slow-query list from `system.profile` with refresh.
- New `monitoring` tab type (icon/label/render) + **"Monitor cluster"** in the connection context menu.

## Verified
- 270 frontend tests (3 new MonitoringView), 98 Rust tests, `tsc` + `npm run build` clean.

## Notes
The metric structs are a curated subset (not the full serverStatus dump). Profiler is per-db via an in-view DB selector since metrics/ops are connection-level.