### PR TITLE
feat(security): mask passwords with show/hide toggles

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -207,6 +207,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
   const [activeEditorTab, setActiveEditorTab] = useState('server');
   const [showPassword, setShowPassword] = useState(false);
   const [revealUri, setRevealUri] = useState(false);
+  const [revealDetailUri, setRevealDetailUri] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -284,6 +285,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
 
   const handleSelect = (id: string) => {
     setSelectedId(id);
+    setRevealDetailUri(false);
     setError(null);
     setTestResult(null);
   };
@@ -759,9 +761,22 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                   </div>
 
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 16 }}>
-                    <span className="mql-label" style={{ fontSize: 9 }}>Connection URI</span>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                      <span className="mql-label" style={{ fontSize: 9 }}>Connection URI</span>
+                      {maskUriPassword(selectedProfile.uri) !== selectedProfile.uri && (
+                        <button
+                          type="button"
+                          onClick={() => setRevealDetailUri(v => !v)}
+                          title={revealDetailUri ? 'Hide password' : 'Show password'}
+                          aria-label={revealDetailUri ? 'Hide password' : 'Show password'}
+                          style={{ display: 'inline-flex', background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', padding: 2 }}
+                        >
+                          {revealDetailUri ? <EyeOff size={13} /> : <Eye size={13} />}
+                        </button>
+                      )}
+                    </div>
                     <div style={{ padding: 10, background: 'var(--bg-panel)', border: '1px solid var(--border-color)', borderRadius: 4, fontFamily: 'var(--font-mono)', fontSize: 11, wordBreak: 'break-all', userSelect: 'text' }}>
-                      {selectedProfile.uri}
+                      {revealDetailUri ? selectedProfile.uri : maskUriPassword(selectedProfile.uri)}
                     </div>
                   </div>
 

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { invoke, Channel } from '@tauri-apps/api/core';
 import { useDialogs } from './dialogs/DialogProvider';
-import { 
+import { PasswordInput } from './PasswordInput';
+import {
   Plus, X, Server, Play, Edit3, Trash2, Check, AlertCircle, RefreshCw,
   Folder, FolderPlus, FolderOpen, Search, ChevronDown, ChevronRight,
   Copy, ExternalLink, ShieldAlert, Eye, EyeOff, LayoutGrid
@@ -100,6 +101,11 @@ const TABS = [
   { id: 'proxy', label: 'Proxy', icon: RefreshCw },
   { id: 'adv', label: 'Advanced', icon: LayoutGrid },
 ];
+
+// Replace the password in a mongodb URI (//user:PASSWORD@host) with dots, so the
+// connection string can be shown without exposing the credential.
+export const maskUriPassword = (uri: string): string =>
+  uri.replace(/(\/\/[^/:@\s]+:)([^@/\s]+)(@)/, (_m, a, _p, c) => `${a}••••••${c}`);
 
 export const buildUri = (s: typeof BLANK_CONN) => {
   if (s.topology === 'uri') return s.uri;
@@ -200,6 +206,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
   const [editorState, setEditorState] = useState<typeof BLANK_CONN>(BLANK_CONN);
   const [activeEditorTab, setActiveEditorTab] = useState('server');
   const [showPassword, setShowPassword] = useState(false);
+  const [revealUri, setRevealUri] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -947,15 +954,35 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                     <label htmlFor="connection-uri" className="mql-label">Connection URI</label>
-                    <input 
-                      id="connection-uri"
-                      type="text" 
-                      value={editorState.uri}
-                      onChange={e => setEditorState(prev => ({ ...prev, uri: e.target.value, topology: 'uri' }))}
-                      placeholder="mongodb://localhost:27017"
-                      className="mql-ncd-input font-mono"
-                      style={{ width: '100%' }}
-                    />
+                    {(() => {
+                      const masked = maskUriPassword(editorState.uri);
+                      const hasSecret = masked !== editorState.uri;
+                      return (
+                        <div className="mql-password-field">
+                          <input
+                            id="connection-uri"
+                            type="text"
+                            value={revealUri || !hasSecret ? editorState.uri : masked}
+                            readOnly={hasSecret && !revealUri}
+                            onChange={e => setEditorState(prev => ({ ...prev, uri: e.target.value, topology: 'uri' }))}
+                            placeholder="mongodb://localhost:27017"
+                            className="mql-ncd-input font-mono"
+                          />
+                          {hasSecret && (
+                            <button
+                              type="button"
+                              className="mql-password-toggle"
+                              aria-label={revealUri ? 'Hide password' : 'Show password'}
+                              title={revealUri ? 'Hide password' : 'Show password to edit'}
+                              onClick={() => setRevealUri(v => !v)}
+                              tabIndex={-1}
+                            >
+                              {revealUri ? <EyeOff size={13} /> : <Eye size={13} />}
+                            </button>
+                          )}
+                        </div>
+                      );
+                    })()}
                   </div>
 
                   <div style={{ borderTop: '1px solid var(--border-color)', paddingTop: 10, display: 'flex', gap: 12 }}>
@@ -1253,8 +1280,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                           </div>
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                             <span className="mql-label">Key Passphrase (optional)</span>
-                            <input
-                              type="password"
+                            <PasswordInput
                               value={editorState.sshPass}
                               onChange={e => setEditorState(prev => ({ ...prev, sshPass: e.target.value }))}
                               placeholder="Leave blank if the key is unencrypted"
@@ -1265,8 +1291,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                       ) : (
                         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                           <span className="mql-label">SSH Password</span>
-                          <input
-                            type="password"
+                          <PasswordInput
                             value={editorState.sshPass}
                             onChange={e => setEditorState(prev => ({ ...prev, sshPass: e.target.value }))}
                             placeholder="••••••••"

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+
+// A masked text input with a show/hide toggle. Forwards all standard input props
+// (value, onChange, placeholder, className, data-testid, …) to the inner input.
+export const PasswordInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({ className, ...rest }) => {
+  const [show, setShow] = useState(false);
+  return (
+    <div className="mql-password-field">
+      <input {...rest} type={show ? 'text' : 'password'} className={className} />
+      <button
+        type="button"
+        className="mql-password-toggle"
+        aria-label={show ? 'Hide password' : 'Show password'}
+        title={show ? 'Hide' : 'Show'}
+        onClick={() => setShow((s) => !s)}
+        tabIndex={-1}
+      >
+        {show ? <EyeOff size={13} /> : <Eye size={13} />}
+      </button>
+    </div>
+  );
+};

--- a/src/components/VaultGate.tsx
+++ b/src/components/VaultGate.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { PasswordInput } from './PasswordInput';
 import {
   getVaultStatus,
   initializeVault,
@@ -127,8 +128,7 @@ export const VaultGate: React.FC<VaultGateProps> = ({ children }) => {
             ? 'Your saved connections and API keys are encrypted with this password. There is no recovery if you forget it.'
             : 'Enter your master password to decrypt your saved credentials.'}
         </p>
-        <input
-          type="password"
+        <PasswordInput
           data-testid="vault-password"
           placeholder="Master password"
           value={password}
@@ -136,8 +136,7 @@ export const VaultGate: React.FC<VaultGateProps> = ({ children }) => {
           onKeyDown={(e) => e.key === 'Enter' && !isSetup && submit()}
         />
         {isSetup && (
-          <input
-            type="password"
+          <PasswordInput
             data-testid="vault-confirm"
             placeholder="Confirm password"
             value={confirm}

--- a/src/components/__tests__/PasswordInput.test.tsx
+++ b/src/components/__tests__/PasswordInput.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PasswordInput } from '../PasswordInput';
+
+describe('PasswordInput', () => {
+  it('masks by default and toggles visibility', () => {
+    render(<PasswordInput data-testid="pw" value="secret" onChange={() => {}} />);
+    const input = screen.getByTestId('pw') as HTMLInputElement;
+    expect(input.type).toBe('password');
+    fireEvent.click(screen.getByRole('button', { name: /show password/i }));
+    expect(input.type).toBe('text');
+    fireEvent.click(screen.getByRole('button', { name: /hide password/i }));
+    expect(input.type).toBe('password');
+  });
+
+  it('forwards value and onChange', () => {
+    const onChange = vi.fn();
+    render(<PasswordInput data-testid="pw" value="" onChange={onChange} />);
+    fireEvent.change(screen.getByTestId('pw'), { target: { value: 'abc' } });
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -5293,3 +5293,12 @@ button, input, select, textarea {
 .mql-context-item.is-danger .mql-context-icon { color: var(--accent-red); }
 .mql-context-sep { height: 1px; margin: 4px 6px; background: var(--border-color); }
 
+/* Masked password input with show/hide toggle */
+.mql-password-field { position: relative; display: flex; align-items: center; width: 100%; }
+.mql-password-field input { width: 100%; padding-right: 30px; }
+.mql-password-toggle {
+  position: absolute; right: 8px; display: inline-flex; align-items: center; justify-content: center;
+  background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 2px;
+}
+.mql-password-toggle:hover { color: var(--text-main); }
+


### PR DESCRIPTION
Passwords were shown in plain text. Now masked by default with a reveal toggle.

## What
- New reusable **`PasswordInput`** (masked input + eye show/hide button).
- **Connection Manager:**
  - The **Connection URI** field masked the embedded credential (`//user:••••••@host`) by default, with an eye toggle to reveal/edit. (Host/port stay visible; revealing makes it editable.)
  - **SSH password** and **SSH key passphrase** use `PasswordInput`.
  - (The SCRAM auth password already had a toggle.)
- **VaultGate** (first-run "Create master password" / "Unlock"): the master password + confirm fields now have show/hide toggles.

## Verified
- 269 tests pass (2 new PasswordInput tests; VaultGate tests unaffected — `PasswordInput` forwards `data-testid`/`value`/`onChange`), `tsc` + `npm run build` clean.