### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqlens",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A native desktop GUI for MongoDB, built with Tauri and React.",
   "homepage": "https://mqlens.com",
   "author": "Devesh Kumar <vrshu112@gmail.com>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "0.1.0"
+version = "0.2.0"
 description = "MQLens — a native desktop GUI for MongoDB."
 authors = ["Devesh Kumar <vrshu112@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MQLens",
   "mainBinaryName": "MQLens",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.mqlens.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.2.0 ahead of the dev→main release (tags mqlens-v0.2.0). Bumps package.json, tauri.conf.json, and Cargo.toml/lock.