### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,13 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Updater signing — produces signed update artifacts + latest.json so
+          # the in-app updater can verify downloads. Generate a keypair with
+          #   npm run tauri signer generate -- -w ~/.tauri/mqlens.key
+          # then set these repo secrets and paste the PUBLIC key into
+          # src-tauri/tauri.conf.json (plugins.updater.pubkey).
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           # macOS code signing + notarization (App Store Connect API key).
           # All inactive until the matching repo secrets are set, so non-mac
           # builds and unsigned macOS builds are unaffected.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mqlens",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mqlens",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
@@ -14,6 +14,8 @@
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-fs": "^2.5.1",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "bson": "^7.2.0",
         "lucide-react": "^1.16.0",
         "react": "^19.1.0",
@@ -1739,6 +1741,24 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "bson": "^7.2.0",
     "lucide-react": "^1.16.0",
     "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqlens",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A native desktop GUI for MongoDB, built with Tauri and React.",
   "homepage": "https://mqlens.com",
   "author": "Devesh Kumar <vrshu112@gmail.com>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6209,7 +6209,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -133,6 +133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1604,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2008,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -3497,6 +3527,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3950,6 +3986,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,6 +4115,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4909,15 +4971,20 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5195,6 +5262,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6046,6 +6140,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6123,6 +6228,8 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
  "uuid",
@@ -6290,6 +6397,49 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http 1.4.0",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.3",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -7282,6 +7432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8037,6 +8196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8204,6 +8373,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,8 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-biometry = "0.2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 mongodb = { version = "3.0.0", features = ["aws-auth", "gssapi-auth"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "0.2.0"
+version = "0.3.0"
 description = "MQLens — a native desktop GUI for MongoDB."
 authors = ["Devesh Kumar <vrshu112@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,8 @@
     "dialog:default",
     "fs:default",
     "fs:allow-read-text-file",
-    "fs:allow-write-text-file"
+    "fs:allow-write-text-file",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1239,6 +1239,8 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_biometry::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .setup(|app| {
             use tauri::Manager;
             if let Some(win) = app.get_webview_window("main") {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MQLens",
   "mainBinaryName": "MQLens",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "com.mqlens.app",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -35,7 +35,7 @@
       "endpoints": [
         "https://github.com/mqlens/mqlens-mongodb/releases/latest/download/latest.json"
       ],
-      "pubkey": "REPLACE_WITH_TAURI_UPDATER_PUBLIC_KEY"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEFBODc1NkQzNEI1NDY3NzUKUldSMVoxUkwwMWFIcW9ZWFdFc3pRdmJVT2RPeWJXSHIvZGxLWndCQ3dUMk9IT1ZMM0ZwSlRialIK"
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,8 +30,17 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/mqlens/mqlens-mongodb/releases/latest/download/latest.json"
+      ],
+      "pubkey": "REPLACE_WITH_TAURI_UPDATER_PUBLIC_KEY"
+    }
+  },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { GridFsView } from './components/GridFsView';
 import { MonitoringView } from './components/MonitoringView';
 import { type ExportTaskInfo } from './components/TaskManager';
 import { VaultGate } from './components/VaultGate';
+import { UpdatePrompt } from './components/UpdatePrompt';
 import { DialogProvider, useDialogs } from './components/dialogs/DialogProvider';
 import { formatBytes } from './lib/format';
 import { buildRunnableCommand } from './lib/mongoCommand';
@@ -1227,6 +1228,8 @@ function Workspace() {
           onClose={() => setDocumentModal(null)}
           onSave={handleSaveDocument}
         />
+
+        <UpdatePrompt />
 
         {/* Main Work Area */}
         <div className="mql-content">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Check, LayoutGrid, Save, Terminal, Sparkles, ShieldCheck } from 'lucide-react';
+import { Check, LayoutGrid, Save, Terminal, Sparkles, ShieldCheck, ArrowUpCircle } from 'lucide-react';
 import { changeVaultPassword, resetVault, biometricStatus, biometricEnable, biometricDisable, type BiometricStatus } from '../lib/vault';
+import { CHECK_UPDATE_EVENT } from './UpdatePrompt';
 
 interface AppSettings {
   mongosh_path: string;
@@ -228,6 +229,24 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
               );
             })}
           </div>
+        </section>
+
+        <section className="mql-settings-section">
+          <div className="mql-settings-section-h">
+            <ArrowUpCircle size={13} color="var(--accent-blue)" />
+            <span className="mql-label">Updates</span>
+          </div>
+          <div className="mql-settings-option-copy" style={{ marginBottom: 8 }}>
+            MQLens checks for updates on launch and installs only after you approve. You can also check now.
+          </div>
+          <button
+            type="button"
+            className="mql-btn mql-btn-secondary"
+            data-testid="check-updates-btn"
+            onClick={() => window.dispatchEvent(new Event(CHECK_UPDATE_EVENT))}
+          >
+            <ArrowUpCircle size={13} /> Check for updates
+          </button>
         </section>
 
         <section className="mql-settings-section">

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,0 +1,146 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { check, type Update } from '@tauri-apps/plugin-updater';
+import { relaunch } from '@tauri-apps/plugin-process';
+import { Download, X, RefreshCw, CheckCircle2, AlertTriangle, ArrowUpCircle } from 'lucide-react';
+
+// Event other components (e.g. Settings) dispatch to trigger a manual check.
+export const CHECK_UPDATE_EVENT = 'mqlens:check-update';
+
+type Phase = 'idle' | 'checking' | 'available' | 'downloading' | 'uptodate' | 'error';
+
+// Auto-checks for an update a few seconds after launch (silent), and on demand
+// via the CHECK_UPDATE_EVENT. An available update is only ever downloaded and
+// installed after the user clicks "Update now" — human approval is required.
+export const UpdatePrompt: React.FC = () => {
+  const [update, setUpdate] = useState<Update | null>(null);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [pct, setPct] = useState(0);
+  const [manual, setManual] = useState(false);
+
+  const runCheck = useCallback(async (isManual: boolean) => {
+    setManual(isManual);
+    setError(null);
+    setPhase('checking');
+    try {
+      const u = await check();
+      if (u) {
+        setUpdate(u);
+        setPhase('available');
+      } else {
+        setPhase(isManual ? 'uptodate' : 'idle');
+      }
+    } catch (e: any) {
+      setError(String(e?.message || e));
+      setPhase(isManual ? 'error' : 'idle');
+    }
+  }, []);
+
+  useEffect(() => {
+    // Silent check shortly after startup so it doesn't compete with launch work.
+    const t = setTimeout(() => void runCheck(false), 4000);
+    const onManual = () => void runCheck(true);
+    window.addEventListener(CHECK_UPDATE_EVENT, onManual);
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener(CHECK_UPDATE_EVENT, onManual);
+    };
+  }, [runCheck]);
+
+  const install = async () => {
+    if (!update) return;
+    setPhase('downloading');
+    setPct(0);
+    let total = 0;
+    let got = 0;
+    try {
+      await update.downloadAndInstall((ev: any) => {
+        if (ev.event === 'Started') total = ev.data?.contentLength ?? 0;
+        else if (ev.event === 'Progress') {
+          got += ev.data?.chunkLength ?? 0;
+          if (total > 0) setPct(Math.min(100, Math.round((got / total) * 100)));
+        }
+      });
+      await relaunch();
+    } catch (e: any) {
+      setError(String(e?.message || e));
+      setPhase('error');
+    }
+  };
+
+  const dismiss = () => {
+    setPhase('idle');
+    setError(null);
+  };
+
+  // Transient toasts (manual feedback) ────────────────────────────────────────
+  if (phase === 'checking' && manual) {
+    return (
+      <div className="mql-update-toast" data-testid="update-toast">
+        <RefreshCw size={14} className="animate-spin" /> Checking for updates…
+      </div>
+    );
+  }
+  if (phase === 'uptodate') {
+    return (
+      <div className="mql-update-toast" data-testid="update-toast">
+        <CheckCircle2 size={14} style={{ color: '#34d399' }} /> You’re on the latest version.
+        <button type="button" className="mql-update-toast-x" onClick={dismiss} aria-label="Dismiss"><X size={12} /></button>
+      </div>
+    );
+  }
+  if (phase === 'error') {
+    return (
+      <div className="mql-update-toast is-error" data-testid="update-toast" title={error ?? undefined}>
+        <AlertTriangle size={14} /> Update check failed.
+        <button type="button" className="mql-update-toast-x" onClick={dismiss} aria-label="Dismiss"><X size={12} /></button>
+      </div>
+    );
+  }
+
+  // Available / downloading → approval modal ───────────────────────────────────
+  if (phase !== 'available' && phase !== 'downloading') return null;
+
+  const downloading = phase === 'downloading';
+  return (
+    <div className="nested-modal-overlay" data-testid="update-dialog" onClick={downloading ? undefined : dismiss}>
+      <div className="index-modal-container" onClick={(e) => e.stopPropagation()} style={{ width: 'min(520px, 92vw)' }}>
+        <div className="flex items-center justify-between border-b border-[var(--border-color)] pb-3 mb-4">
+          <div className="flex items-center gap-2">
+            <ArrowUpCircle size={16} className="text-[var(--accent-blue)]" />
+            <h2 className="text-sm font-semibold text-[var(--text-main)]">Update available</h2>
+          </div>
+          {!downloading && (
+            <button type="button" onClick={dismiss} aria-label="Close" className="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-main)] hover:bg-[var(--bg-item-hover)]">
+              <X size={14} />
+            </button>
+          )}
+        </div>
+
+        <p className="text-[13px] text-[var(--text-main)]" data-testid="update-version">
+          MQLens <strong>{update?.version}</strong> is available
+          {update?.currentVersion ? <> (you have {update.currentVersion})</> : null}.
+        </p>
+        {update?.body && (
+          <pre className="mql-update-notes">{update.body}</pre>
+        )}
+
+        {downloading ? (
+          <div className="mql-update-progress" data-testid="update-progress">
+            <div className="mql-update-progress-bar"><span style={{ width: `${pct}%` }} /></div>
+            <span className="mql-update-progress-pct">{pct}% — downloading, the app will restart when done…</span>
+          </div>
+        ) : (
+          <div className="flex items-center justify-end gap-2 border-t border-[var(--border-color)] pt-3 mt-4">
+            <button type="button" onClick={dismiss} className="index-modal-btn-secondary" data-testid="update-later">
+              Later
+            </button>
+            <button type="button" onClick={install} className="index-modal-btn-primary" data-testid="update-now">
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}><Download size={13} /> Update now</span>
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/__tests__/UpdatePrompt.test.tsx
+++ b/src/components/__tests__/UpdatePrompt.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockCheck = vi.fn();
+vi.mock('@tauri-apps/plugin-updater', () => ({ check: () => mockCheck() }));
+const mockRelaunch = vi.fn(() => Promise.resolve());
+vi.mock('@tauri-apps/plugin-process', () => ({ relaunch: () => mockRelaunch() }));
+
+import { UpdatePrompt, CHECK_UPDATE_EVENT } from '../UpdatePrompt';
+
+const triggerManualCheck = () => fireEvent(window, new Event(CHECK_UPDATE_EVENT));
+
+beforeEach(() => {
+  mockCheck.mockReset();
+  mockRelaunch.mockClear();
+});
+
+describe('UpdatePrompt', () => {
+  it('shows "latest version" on a manual check when up to date', async () => {
+    mockCheck.mockResolvedValue(null);
+    render(<UpdatePrompt />);
+    triggerManualCheck();
+    expect(await screen.findByTestId('update-toast')).toHaveTextContent(/latest version/i);
+  });
+
+  it('prompts for approval and installs only after clicking Update now', async () => {
+    const downloadAndInstall = vi.fn(async (cb: (e: any) => void) => {
+      cb({ event: 'Started', data: { contentLength: 100 } });
+      cb({ event: 'Progress', data: { chunkLength: 100 } });
+      cb({ event: 'Finished' });
+    });
+    mockCheck.mockResolvedValue({ version: '0.3.0', currentVersion: '0.2.0', body: 'New stuff', downloadAndInstall });
+
+    render(<UpdatePrompt />);
+    triggerManualCheck();
+
+    const dialog = await screen.findByTestId('update-dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByTestId('update-version')).toHaveTextContent('0.3.0');
+    // Nothing installed until approval.
+    expect(downloadAndInstall).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('update-now'));
+    await waitFor(() => expect(downloadAndInstall).toHaveBeenCalled());
+    await waitFor(() => expect(mockRelaunch).toHaveBeenCalled());
+  });
+
+  it('dismisses with Later without installing', async () => {
+    const downloadAndInstall = vi.fn();
+    mockCheck.mockResolvedValue({ version: '0.3.0', currentVersion: '0.2.0', body: '', downloadAndInstall });
+    render(<UpdatePrompt />);
+    triggerManualCheck();
+    fireEvent.click(await screen.findByTestId('update-later'));
+    expect(screen.queryByTestId('update-dialog')).toBeNull();
+    expect(downloadAndInstall).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -5428,3 +5428,24 @@ button, input, select, textarea {
 }
 .mql-password-toggle:hover { color: var(--text-main); }
 
+/* In-app updater (toast + approval dialog) */
+.mql-update-toast {
+  position: fixed; right: 16px; bottom: 16px; z-index: 100000;
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--bg-dropdown-solid); color: var(--text-main);
+  border: 1px solid var(--border-color); border-radius: 8px;
+  padding: 8px 12px; font-size: 12.5px; box-shadow: 0 10px 30px hsla(0, 0%, 0%, 0.35);
+}
+.mql-update-toast.is-error { border-color: var(--accent-red); color: var(--accent-red); }
+.mql-update-toast-x { display: inline-flex; background: none; border: none; color: var(--text-dim); cursor: pointer; padding: 2px; }
+.mql-update-toast-x:hover { color: var(--text-main); }
+.mql-update-notes {
+  max-height: 200px; overflow: auto; margin: 10px 0 0;
+  background: var(--bg-base); border: 1px solid var(--border-color); border-radius: 6px;
+  padding: 8px 10px; font-size: 11.5px; line-height: 1.5; white-space: pre-wrap; color: var(--text-muted);
+}
+.mql-update-progress { margin-top: 14px; }
+.mql-update-progress-bar { height: 8px; background: var(--bg-base); border: 1px solid var(--border-color); border-radius: 999px; overflow: hidden; }
+.mql-update-progress-bar > span { display: block; height: 100%; background: var(--accent-blue); transition: width 0.2s ease; }
+.mql-update-progress-pct { display: block; margin-top: 6px; font-size: 11px; color: var(--text-dim); }
+

--- a/website/src/components/Download.astro
+++ b/website/src/components/Download.astro
@@ -55,8 +55,8 @@ const cards = [
     match: 'win',
     requires: 'Windows 10 or later (x64)',
     install: 'Download the installer, run it, and launch MQLens from the Start menu.',
-    primary: { label: '.exe (recommended)', ...dl((n) => n.endsWith('.exe'), '~8 MB') },
-    secondary: { label: '.msi', ...dl((n) => n.endsWith('.msi'), '~12 MB') },
+    primary: { label: '.exe (recommended)', key: 'exe', ...dl((n) => n.endsWith('.exe'), '~8 MB') },
+    secondary: { label: '.msi', key: 'msi', ...dl((n) => n.endsWith('.msi'), '~12 MB') },
   },
   {
     icon: 'apple',
@@ -64,8 +64,8 @@ const cards = [
     match: 'mac',
     requires: 'macOS 11 (Big Sur) or later',
     install: 'Download the .dmg, open it, and drag MQLens to your Applications folder.',
-    primary: { label: '.dmg (Apple Silicon)', ...dl((n) => n.endsWith('.dmg') && /(aarch64|arm64|aarch)/.test(n), '~13 MB') },
-    secondary: { label: '.dmg (Intel)', ...dl((n) => n.endsWith('.dmg') && /(x64|x86_64|intel)/.test(n), '~14 MB') },
+    primary: { label: '.dmg (Apple Silicon)', key: 'dmg-arm', ...dl((n) => n.endsWith('.dmg') && /(aarch64|arm64|aarch)/.test(n), '~13 MB') },
+    secondary: { label: '.dmg (Intel)', key: 'dmg-intel', ...dl((n) => n.endsWith('.dmg') && /(x64|x86_64|intel)/.test(n), '~14 MB') },
   },
   {
     icon: 'linux',
@@ -73,8 +73,8 @@ const cards = [
     match: 'linux',
     requires: 'Ubuntu 20.04+, Fedora 36+, or equivalent (x64)',
     install: 'Debian/Ubuntu: install the .deb. Fedora/RHEL: install the .rpm. An AppImage is also available.',
-    primary: { label: '.deb (Ubuntu/Debian)', ...dl((n) => n.endsWith('.deb'), '~15 MB') },
-    secondary: { label: '.rpm (Fedora/RHEL)', ...dl((n) => n.endsWith('.rpm'), '~15 MB') },
+    primary: { label: '.deb (Ubuntu/Debian)', key: 'deb', ...dl((n) => n.endsWith('.deb'), '~15 MB') },
+    secondary: { label: '.rpm (Fedora/RHEL)', key: 'rpm', ...dl((n) => n.endsWith('.rpm'), '~15 MB') },
   },
 ];
 ---
@@ -105,11 +105,11 @@ const cards = [
         </div>
 
         <div class="dl-actions">
-          <a class="dl-btn dl-btn-primary" href={c.primary.href} download target="_blank" rel="noopener">
+          <a class="dl-btn dl-btn-primary" href={c.primary.href} data-dl={c.primary.key} download target="_blank" rel="noopener">
             <span>{c.primary.label}</span>
             <span class="dl-size">{c.primary.size}</span>
           </a>
-          <a class="dl-btn dl-btn-secondary" href={c.secondary.href} download target="_blank" rel="noopener">
+          <a class="dl-btn dl-btn-secondary" href={c.secondary.href} data-dl={c.secondary.key} download target="_blank" rel="noopener">
             <span>{c.secondary.label}</span>
             <span class="dl-size">{c.secondary.size}</span>
           </a>
@@ -142,6 +142,40 @@ const cards = [
       }
     });
   }
+
+  // Always point the buttons at the CURRENT latest stable release, resolved at
+  // runtime so they never go stale between site deploys. Build-time hrefs remain
+  // as the fallback if this fetch fails (offline / rate-limited).
+  type Asset = { name: string; size: number; browser_download_url: string };
+  const matchers: Record<string, (n: string) => boolean> = {
+    exe: (n) => n.endsWith('.exe'),
+    msi: (n) => n.endsWith('.msi'),
+    'dmg-arm': (n) => n.endsWith('.dmg') && /(aarch64|arm64|aarch)/.test(n),
+    'dmg-intel': (n) => n.endsWith('.dmg') && /(x64|x86_64|intel)/.test(n),
+    deb: (n) => n.endsWith('.deb'),
+    rpm: (n) => n.endsWith('.rpm'),
+  };
+  const fmtSize = (b: number) =>
+    b >= 1048576 ? `${(b / 1048576).toFixed(1)} MB` : `${Math.max(1, Math.round(b / 1024))} KB`;
+
+  fetch('https://api.github.com/repos/mqlens/mqlens-mongodb/releases/latest', {
+    headers: { Accept: 'application/vnd.github+json' },
+  })
+    .then((r) => (r.ok ? r.json() : null))
+    .then((rel: any) => {
+      const assets: Asset[] = Array.isArray(rel?.assets) ? rel.assets : [];
+      if (!assets.length) return;
+      document.querySelectorAll<HTMLAnchorElement>('a.dl-btn[data-dl]').forEach((btn) => {
+        const test = matchers[btn.dataset.dl || ''];
+        if (!test) return;
+        const a = assets.find((x) => typeof x.name === 'string' && test(x.name.toLowerCase()));
+        if (!a) return;
+        btn.href = a.browser_download_url;
+        const sizeEl = btn.querySelector<HTMLElement>('.dl-size');
+        if (sizeEl) sizeEl.textContent = fmtSize(a.size);
+      });
+    })
+    .catch(() => { /* keep build-time fallback hrefs */ });
 </script>
 
 <style>


### PR DESCRIPTION
Promotes `dev` → `main` to cut **v0.3.0** (the release workflow tags `mqlens-v0.3.0`, builds + signs installers, and — new in this release — publishes signed updater artifacts + `latest.json`).

## Highlights since v0.2.0
- **In-app auto-update with human approval** — checks on launch + manual "Check for updates" in Settings; an approval dialog (version + notes + Update now/Later) that only downloads/installs/relaunches after the user approves. Built on `tauri-plugin-updater` with a signed `latest.json` manifest.
- **Website downloads always resolve the latest release** at runtime (no longer stale between deploys).

## Auto-update baseline
This is the **first release that ships the updater** (public key configured, `TAURI_SIGNING_PRIVATE_KEY`/password secrets set). v0.3.0 becomes the baseline; installed v0.3.0 apps will detect, prompt for, and (on approval) self-update to the next release onward.