### PR TITLE
Release v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqlens",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A native desktop GUI for MongoDB, built with Tauri and React.",
   "homepage": "https://mqlens.com",
   "author": "Devesh Kumar <vrshu112@gmail.com>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6209,7 +6209,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "0.3.0"
+version = "0.3.1"
 description = "MQLens — a native desktop GUI for MongoDB."
 authors = ["Devesh Kumar <vrshu112@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MQLens",
   "mainBinaryName": "MQLens",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.mqlens.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { save, open } from '@tauri-apps/plugin-dialog';
 import { writeTextFile, readTextFile } from '@tauri-apps/plugin-fs';
 import { toJson, toCsv, parseJson, parseCsv } from './lib/dataTransfer';
 import { invoke } from '@tauri-apps/api/core';
+import { getVersion } from '@tauri-apps/api/app';
 import { FolderCode, X, KeyRound, Play, Settings, Terminal, Rocket, Download, Table2, Eye, HardDrive, Activity } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
@@ -183,6 +184,13 @@ function Workspace() {
     };
   }, []);
 
+  // App + connected MongoDB versions for the status bar.
+  const [appVersion, setAppVersion] = useState('');
+  const [mongoVersion, setMongoVersion] = useState<string | null>(null);
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(() => undefined);
+  }, []);
+
   const [exportTasks, setExportTasks] = useState<ExportTaskInfo[]>([]);
   const loadExportTasks = React.useCallback(async () => {
     try {
@@ -241,6 +249,20 @@ function Workspace() {
   }, [isResizing]);
 
   const activeTab = tabs.find(t => t.id === activeTabId) || null;
+
+  // MongoDB server version of the active connection, for the status bar.
+  const activeConnId = activeTab && activeConnections.some(c => c.id === activeTab.connectionId) ? activeTab.connectionId : null;
+  useEffect(() => {
+    if (!activeConnId) {
+      setMongoVersion(null);
+      return;
+    }
+    let alive = true;
+    invoke<string>('get_mongodb_version', { id: activeConnId })
+      .then((v) => { if (alive) setMongoVersion(v || null); })
+      .catch(() => { if (alive) setMongoVersion(null); });
+    return () => { alive = false; };
+  }, [activeConnId]);
 
   const connectionNameFor = (connectionId: string): string =>
     activeConnections.find((c) => c.id === connectionId)?.name || connectionId;
@@ -1502,8 +1524,16 @@ function Workspace() {
           <span data-testid="status-mem" title="App memory (resident set size)">
             RAM {resUsage ? formatBytes(resUsage.memory_bytes) : '—'}
           </span>
-          <span>Tauri v2.0.0</span>
-          <span>v0.1.0</span>
+          {mongoVersion && (
+            <span data-testid="status-mongodb" title="Connected MongoDB server version">
+              MongoDB {mongoVersion}
+            </span>
+          )}
+          {appVersion && (
+            <span data-testid="status-app-version" title="MQLens version">
+              MQLens v{appVersion}
+            </span>
+          )}
         </div>
       </footer>
     </div>

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -34,6 +34,10 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: any[]) => mockInvoke(...args),
 }));
 
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: () => Promise.resolve('0.3.1'),
+}));
+
 const saveMock = vi.fn();
 const openMock = vi.fn();
 const writeTextFileMock = vi.fn();
@@ -87,8 +91,9 @@ describe('App Component', () => {
     const bottomBar = screen.getByTestId('bottom-bar');
     expect(bottomBar).toBeInTheDocument();
     expect(screen.getByText('MQLens Engine Online')).toBeInTheDocument();
-    expect(screen.getByText('Tauri v2.0.0')).toBeInTheDocument();
-    expect(screen.getByText('v0.1.0')).toBeInTheDocument();
+    // App version comes from getVersion() (no longer hardcoded); Tauri version removed.
+    expect(await screen.findByText('MQLens v0.3.1')).toBeInTheDocument();
+    expect(screen.queryByText(/Tauri v/)).toBeNull();
   });
 
   it('opens collection tab and index tab, and shows REAL index details (not fabricated)', async () => {


### PR DESCRIPTION
Promotes `dev` → `main` for **v0.3.1**.

## Changes
- **Status bar fix**: show the real app version (`getVersion()`) and the connected MongoDB server version; remove the hardcoded `Tauri v2.0.0` / `v0.1.0`.

## Auto-update test
v0.3.0 (published) is the updater baseline. v0.3.1 is the first update *after* it — installing v0.3.0 should now prompt to update to v0.3.1 (with approval).