### PR TITLE
fix(monitoring): prevent hang on large clusters + refresh-interval control

### DIFF
--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -151,8 +151,26 @@ pub struct CurrentOp {
     pub command: String,
 }
 
-/// Curate one `inprog` entry into a CurrentOp row. The full command is kept (the
-/// UI ellipsizes it in the table and shows it in full in the detail view).
+/// Keep the current-op payload bounded so a busy/large cluster can't flood the
+/// IPC boundary and hang the UI: retain at most `MAX_OPS` ops (the caller sorts
+/// longest-running first) and truncate each command string to `MAX_CMD_CHARS`.
+const MAX_OPS: usize = 200;
+const MAX_CMD_CHARS: usize = 2000;
+
+pub fn cap_current_ops(mut ops: Vec<CurrentOp>) -> Vec<CurrentOp> {
+    ops.truncate(MAX_OPS);
+    for o in &mut ops {
+        if o.command.chars().count() > MAX_CMD_CHARS {
+            // char-boundary safe (commands can contain multibyte UTF-8).
+            let truncated: String = o.command.chars().take(MAX_CMD_CHARS).collect();
+            o.command = format!("{truncated}…");
+        }
+    }
+    ops
+}
+
+/// Curate one `inprog` entry into a CurrentOp row. The full command is kept here;
+/// `cap_current_ops` bounds it for transport. The UI ellipsizes it in the table.
 pub fn curate_current_op(d: &Document) -> CurrentOp {
     let command = d.get("command").map(|c| c.to_string()).unwrap_or_default();
     CurrentOp {
@@ -259,7 +277,7 @@ pub async fn current_ops_impl(state: &AppState, id: &str) -> Result<Vec<CurrentO
         .map(curate_current_op)
         .collect();
     ops.sort_by(|a, b| b.secs_running.cmp(&a.secs_running));
-    Ok(ops)
+    Ok(cap_current_ops(ops))
 }
 
 pub async fn kill_op_impl(state: &AppState, id: &str, opid: i64) -> Result<(), String> {
@@ -389,6 +407,41 @@ mod tests {
         assert_eq!(op.ns, "db.c");
         assert_eq!(op.secs_running, 4);
         assert!(op.command.contains(&long), "full command is preserved");
+    }
+
+    #[test]
+    fn cap_current_ops_limits_count_and_command_length() {
+        let big = "x".repeat(5000);
+        let ops: Vec<CurrentOp> = (0..300)
+            .map(|i| CurrentOp {
+                opid: i,
+                op: "query".into(),
+                ns: "db.c".into(),
+                secs_running: 0,
+                client: String::new(),
+                desc: String::new(),
+                command: big.clone(),
+            })
+            .collect();
+        let capped = cap_current_ops(ops);
+        assert_eq!(capped.len(), 200, "op count is capped");
+        assert_eq!(capped[0].command.chars().count(), 2001, "command truncated to MAX + ellipsis");
+        assert!(capped[0].command.ends_with('…'));
+    }
+
+    #[test]
+    fn cap_current_ops_leaves_short_commands_intact() {
+        let ops = vec![CurrentOp {
+            opid: 1,
+            op: "query".into(),
+            ns: "db.c".into(),
+            secs_running: 0,
+            client: String::new(),
+            desc: String::new(),
+            command: "{ find: \"c\" }".into(),
+        }];
+        let capped = cap_current_ops(ops);
+        assert_eq!(capped[0].command, "{ find: \"c\" }");
     }
 
     #[test]

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { LineChart, Line, ResponsiveContainer, YAxis } from 'recharts';
 import { Activity, RefreshCw, Skull, Lock, Network, Gauge, MemoryStick, Database, ArrowDownUp, Search, X } from 'lucide-react';
@@ -20,7 +20,17 @@ interface MonitoringViewProps {
   connectionId: string;
 }
 
-const POLL_MS = 3000;
+// Refresh-interval choices. "Off" (0) pauses auto-refresh — important on large/
+// busy clusters where each poll pulls server status + the current-op list.
+const REFRESH_OPTIONS: { label: string; ms: number }[] = [
+  { label: '2s', ms: 2000 },
+  { label: '5s', ms: 5000 },
+  { label: '10s', ms: 10000 },
+  { label: '30s', ms: 30000 },
+  { label: '1m', ms: 60000 },
+  { label: 'Off', ms: 0 },
+];
+const DEFAULT_POLL_MS = 5000;
 const MAX_SAMPLES = 40;
 
 interface Sample {
@@ -240,37 +250,48 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
   const [profile, setProfile] = useState<ProfileEntry[]>([]);
   const [profileLoading, setProfileLoading] = useState(false);
 
-  // ── Metrics + current-ops polling (paused when the window is hidden) ──────────
+  // ── Metrics + current-ops polling ────────────────────────────────────────────
+  // Auto-refresh cadence is user-selectable (and pausable) so a large/busy cluster
+  // can't be polled faster than it can answer.
+  const [pollMs, setPollMs] = useState(DEFAULT_POLL_MS);
+  const aliveRef = useRef(true);
+
+  const pollOnce = useCallback(async () => {
+    if (typeof document !== 'undefined' && document.hidden) return;
+    // Independent: a user may have currentOp but not serverStatus (or vice versa).
+    const [sRes, oRes] = await Promise.allSettled([serverStatus(connectionId), currentOps(connectionId)]);
+    if (!aliveRef.current) return;
+    if (sRes.status === 'fulfilled') {
+      setStatus(sRes.value);
+      setMetricsErr(null);
+      setSamples((prev) => [...prev, { t: Date.now(), status: sRes.value }].slice(-MAX_SAMPLES));
+    } else {
+      setMetricsErr(String((sRes.reason as any)?.message || sRes.reason));
+    }
+    if (oRes.status === 'fulfilled') {
+      setOps(oRes.value);
+      setOpsErr(null);
+    } else {
+      setOpsErr(String((oRes.reason as any)?.message || oRes.reason));
+    }
+  }, [connectionId]);
+
   useEffect(() => {
-    let alive = true;
+    aliveRef.current = true;
     setSamples([]);
     setStatus(null);
-    const tick = async () => {
-      if (typeof document !== 'undefined' && document.hidden) return;
-      // Independent: a user may have currentOp but not serverStatus (or vice versa).
-      const [sRes, oRes] = await Promise.allSettled([serverStatus(connectionId), currentOps(connectionId)]);
-      if (!alive) return;
-      if (sRes.status === 'fulfilled') {
-        setStatus(sRes.value);
-        setMetricsErr(null);
-        setSamples((prev) => [...prev, { t: Date.now(), status: sRes.value }].slice(-MAX_SAMPLES));
-      } else {
-        setMetricsErr(String((sRes.reason as any)?.message || sRes.reason));
-      }
-      if (oRes.status === 'fulfilled') {
-        setOps(oRes.value);
-        setOpsErr(null);
-      } else {
-        setOpsErr(String((oRes.reason as any)?.message || oRes.reason));
-      }
-    };
-    tick();
-    const iv = setInterval(tick, POLL_MS);
+    void pollOnce();
+    if (pollMs <= 0) {
+      return () => {
+        aliveRef.current = false;
+      };
+    }
+    const iv = setInterval(() => void pollOnce(), pollMs);
     return () => {
-      alive = false;
+      aliveRef.current = false;
       clearInterval(iv);
     };
-  }, [connectionId]);
+  }, [pollOnce, pollMs]);
 
   // ── Profiler: load db list once, then status + slow queries for the chosen db ─
   useEffect(() => {
@@ -387,6 +408,31 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
             {status.replSet ? ` · ${status.replSet}` : ''} · up {Math.floor(status.uptimeSeconds / 3600)}h
           </span>
         )}
+        <div className="mql-mon-refresh-ctl">
+          <button
+            type="button"
+            className="mql-mon-refresh"
+            onClick={() => void pollOnce()}
+            title="Refresh now"
+            aria-label="Refresh now"
+            data-testid="monitoring-refresh-now"
+          >
+            <RefreshCw size={13} />
+          </button>
+          <label className="mql-mon-minms" title="Auto-refresh interval">
+            Refresh
+            <select
+              className="mql-mon-select"
+              value={pollMs}
+              onChange={(e) => setPollMs(Number(e.target.value))}
+              data-testid="monitoring-refresh-interval"
+            >
+              {REFRESH_OPTIONS.map((o) => (
+                <option key={o.label} value={o.ms}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+        </div>
       </div>
 
       {/* Metric cards (or an access-required panel when serverStatus is denied) */}

--- a/src/index.css
+++ b/src/index.css
@@ -5296,6 +5296,7 @@ button, input, select, textarea {
 /* ── Cluster monitoring view ─────────────────────────────────────────────── */
 .mql-mon { flex: 1; min-height: 0; overflow: auto; background: var(--bg-base); padding: 16px; }
 .mql-mon-header { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; }
+.mql-mon-refresh-ctl { display: flex; align-items: center; gap: 8px; margin-left: auto; }
 .mql-mon-title { font-size: 13px; font-weight: 600; color: var(--text-main); }
 .mql-mon-meta { font-size: 11px; color: var(--text-dim); }
 .mql-mon-error {


### PR DESCRIPTION
On large/busy clusters the Monitoring tab could hang the whole app: `current_ops` returned **every active operation with its full command document**, producing a massive IPC payload that was then rendered + syntax-tokenized on a fixed 3s timer.

## Fix
- **Bound the payload (backend):** `current_ops_impl` now keeps the **200 longest-running** ops and truncates each command to **2000 chars** (`cap_current_ops`, char-boundary safe). Unit-tested.
- **Selectable refresh interval (frontend):** a dropdown — **2s / 5s / 10s / 30s / 1m / Off** — plus a manual **Refresh now** button. Default is now **5s** (was a fixed 3s); **Off** pauses auto-polling entirely.

## Verified
`cargo test` (incl. 2 new cap tests), `tsc`, `npm run build`, 280 frontend tests pass.