### PR TITLE
fix/feat(connections): connection editor overhaul (errors, import, topology, TLS)

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1475,9 +1475,23 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                 error scrolls inside it instead of growing the dialog. */}
             {(testing || testResult) && (
               <div style={{ flexShrink: 0, margin: '0 12px', padding: '10px', maxHeight: 200, overflowY: 'auto', background: 'var(--bg-panel)', border: '1px solid var(--border-color)', borderRadius: '6px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
                   <span className="mql-label" style={{ fontSize: 9 }}>Connection Test Progress</span>
-                  <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--accent-blue)', fontWeight: 600 }}>{testProgress}%</span>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--accent-blue)', fontWeight: 600 }}>{testProgress}%</span>
+                    {testResult && !testing && (
+                      <button
+                        type="button"
+                        data-testid="test-dismiss"
+                        aria-label="Dismiss test result"
+                        title="Dismiss"
+                        onClick={() => { setTestResult(null); setShowErrDetail(false); setTestProgress(0); }}
+                        style={{ display: 'inline-flex', background: 'none', border: 'none', padding: 2, cursor: 'pointer', color: 'var(--text-muted)' }}
+                      >
+                        <X size={13} />
+                      </button>
+                    )}
+                  </div>
                 </div>
                 
                 {/* Progress bar fill */}

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -107,6 +107,33 @@ const TABS = [
 export const maskUriPassword = (uri: string): string =>
   uri.replace(/(\/\/[^/:@\s]+:)([^@/\s]+)(@)/, (_m, a, _p, c) => `${a}••••••${c}`);
 
+// Turn a raw mongodb driver error (often a huge "server selection timeout" with
+// the full topology dump) into a concise root-cause headline + actionable hint.
+// TLS/auth/refused/DNS are checked first because those causes are usually buried
+// inside the topology of a wrapping "server selection timeout".
+export const summarizeConnectionError = (raw: string): { summary: string; hint?: string } => {
+  const e = (raw || '').toLowerCase();
+  if (/invalid peer certificate|unknownissuer|certnotvalidfor|certificate verify failed|self.?signed/.test(e))
+    return {
+      summary: 'TLS certificate not trusted.',
+      hint: 'Provide the cluster’s CA file under TLS, or enable “Allow invalid certificates” for self-signed / dev clusters.',
+    };
+  if (/authentication failed|\(18\)|bad auth|authenticationfailed/.test(e))
+    return { summary: 'Authentication failed.', hint: 'Check the username, password, and authentication database.' };
+  if (/connection refused|os error 61|os error 111|actively refused/.test(e))
+    return { summary: 'Connection refused.', hint: 'Is the server running and the host/port reachable from this machine?' };
+  if (/failed to lookup|name or service not known|no such host|nodename nor servname|dns error/.test(e))
+    return { summary: 'Host not found (DNS lookup failed).', hint: 'Check the hostname; for private hosts you may need an SSH tunnel.' };
+  if (/server selection timeout|no available servers|no suitable servers/.test(e))
+    return {
+      summary: 'Couldn’t reach any server (selection timed out).',
+      hint: 'Check the host/port and TLS settings, and that this machine can reach the cluster.',
+    };
+  if (/timed out|timeout/.test(e)) return { summary: 'Connection timed out.' };
+  const firstLine = (raw || 'Connection failed').replace(/^kind:\s*/i, '').split(/\n|\. /)[0].trim();
+  return { summary: firstLine.length > 160 ? `${firstLine.slice(0, 160)}…` : firstLine };
+};
+
 // Parse a mongodb URI into structured editor fields so the form (hosts / auth /
 // TLS) can be edited interactively. Used both when editing a saved profile and
 // when "Parse into form" is clicked on a pasted URI.
@@ -256,6 +283,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
     { name: 'Verify Connection (Ping)', status: 'pending' },
   ]);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [showErrDetail, setShowErrDetail] = useState(false);
 
   // Initialize folders and load connection profiles
   useEffect(() => {
@@ -523,6 +551,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
   const runTestStepSequence = async () => {
     setTesting(true);
     setTestResult(null);
+    setShowErrDetail(false);
     setTestProgress(0);
 
     const steps: TestStep[] = [
@@ -1470,17 +1499,44 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                   ))}
                 </div>
 
-                {/* Final status feedback pill */}
-                {testResult && (
-                  <div style={{ padding: '6px 8px', borderRadius: '4px', fontSize: '11px', display: 'flex', alignItems: 'center', gap: 6, border: '1px solid transparent', 
-                    background: testResult.success ? 'var(--soft-green-bg)' : 'var(--soft-red-bg)', 
-                    borderColor: testResult.success ? 'var(--soft-green-bd)' : 'var(--soft-red-bd)',
-                    color: testResult.success ? 'var(--accent-green)' : 'var(--accent-red)'
-                  }}>
-                    {testResult.success ? <Check size={12} /> : <AlertCircle size={12} />}
-                    <span style={{ fontWeight: 500 }}>{testResult.message}</span>
-                  </div>
-                )}
+                {/* Final status feedback */}
+                {testResult && (() => {
+                  const info = testResult.success
+                    ? { summary: testResult.message, hint: undefined as string | undefined }
+                    : summarizeConnectionError(testResult.message);
+                  return (
+                    <div style={{ padding: '8px 10px', borderRadius: '4px', fontSize: '11px', border: '1px solid transparent',
+                      background: testResult.success ? 'var(--soft-green-bg)' : 'var(--soft-red-bg)',
+                      borderColor: testResult.success ? 'var(--soft-green-bd)' : 'var(--soft-red-bd)',
+                      color: testResult.success ? 'var(--accent-green)' : 'var(--accent-red)'
+                    }}>
+                      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
+                        {testResult.success ? <Check size={12} style={{ flex: 'none', marginTop: 1 }} /> : <AlertCircle size={12} style={{ flex: 'none', marginTop: 1 }} />}
+                        <span style={{ fontWeight: 600 }} data-testid="test-result-summary">{info.summary}</span>
+                      </div>
+                      {info.hint && (
+                        <div style={{ marginTop: 4, marginLeft: 18, color: 'var(--text-muted)', fontWeight: 400 }}>{info.hint}</div>
+                      )}
+                      {!testResult.success && (
+                        <>
+                          <button
+                            type="button"
+                            data-testid="test-error-details-toggle"
+                            onClick={() => setShowErrDetail(v => !v)}
+                            style={{ marginTop: 6, marginLeft: 18, background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--text-muted)', fontSize: 10, textDecoration: 'underline' }}
+                          >
+                            {showErrDetail ? 'Hide details' : 'Show details'}
+                          </button>
+                          {showErrDetail && (
+                            <pre data-testid="test-error-detail" style={{ marginTop: 6, marginBottom: 0, maxHeight: 160, overflow: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 10, lineHeight: 1.5, color: 'var(--text-dim)', fontFamily: 'var(--font-mono)' }}>
+                              {testResult.message}
+                            </pre>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  );
+                })()}
               </div>
             )}
 

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -996,7 +996,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
             </nav>
 
             {/* Editor dialog body views */}
-            <div className="mql-ncd-body" style={{ flex: 1, padding: 12, overflowY: 'auto' }}>
+            <div className="mql-ncd-body" style={{ flex: 1, minHeight: 0, padding: 12, overflowY: 'auto' }}>
               {activeEditorTab === 'server' && (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
@@ -1471,9 +1471,10 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
               )}
             </div>
 
-            {/* Test progress strip */}
+            {/* Test progress strip — pinned above the footer, capped so a long
+                error scrolls inside it instead of growing the dialog. */}
             {(testing || testResult) && (
-              <div style={{ margin: '0 12px', padding: '10px', background: 'var(--bg-panel)', border: '1px solid var(--border-color)', borderRadius: '6px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <div style={{ flexShrink: 0, margin: '0 12px', padding: '10px', maxHeight: 200, overflowY: 'auto', background: 'var(--bg-panel)', border: '1px solid var(--border-color)', borderRadius: '6px', display: 'flex', flexDirection: 'column', gap: 8 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                   <span className="mql-label" style={{ fontSize: 9 }}>Connection Test Progress</span>
                   <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--accent-blue)', fontWeight: 600 }}>{testProgress}%</span>
@@ -1528,7 +1529,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                             {showErrDetail ? 'Hide details' : 'Show details'}
                           </button>
                           {showErrDetail && (
-                            <pre data-testid="test-error-detail" style={{ marginTop: 6, marginBottom: 0, maxHeight: 160, overflow: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 10, lineHeight: 1.5, color: 'var(--text-dim)', fontFamily: 'var(--font-mono)' }}>
+                            <pre data-testid="test-error-detail" style={{ marginTop: 6, marginBottom: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 10, lineHeight: 1.5, color: 'var(--text-dim)', fontFamily: 'var(--font-mono)' }}>
                               {testResult.message}
                             </pre>
                           )}

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { invoke, Channel } from '@tauri-apps/api/core';
+import { open } from '@tauri-apps/plugin-dialog';
 import { useDialogs } from './dialogs/DialogProvider';
 import { PasswordInput } from './PasswordInput';
 import {
   Plus, X, Server, Play, Edit3, Trash2, Check, AlertCircle, RefreshCw,
   Folder, FolderPlus, FolderOpen, Search, ChevronDown, ChevronRight,
-  Copy, ExternalLink, ShieldAlert, Eye, EyeOff, LayoutGrid
+  Copy, ExternalLink, ShieldAlert, Eye, EyeOff, LayoutGrid, ClipboardPaste
 } from 'lucide-react';
 
 // Mirrors the backend ssh_tunnel::SshConfig (auth is internally tagged).
@@ -54,6 +55,7 @@ const generateUUID = () => {
 
 const BLANK_CONN = {
   topology: 'standalone',
+  protocol: 'mongodb',
   hosts: [{ host: 'localhost', port: '27017' }],
   replicaSetName: '',
   directConnection: true,
@@ -134,44 +136,102 @@ export const summarizeConnectionError = (raw: string): { summary: string; hint?:
   return { summary: firstLine.length > 160 ? `${firstLine.slice(0, 160)}…` : firstLine };
 };
 
-// Parse a mongodb URI into structured editor fields so the form (hosts / auth /
-// TLS) can be edited interactively. Used both when editing a saved profile and
-// when "Parse into form" is clicked on a pasted URI.
+// Parse a mongodb URI into structured editor fields so the form (protocol / hosts
+// / auth / TLS) can be edited interactively, auto-detecting the deployment type.
+// Used both when editing a saved profile and when importing a pasted URI.
 export const parseUriIntoFields = (uri: string) => {
-  const m = uri.match(/mongodb(?:\+srv)?:\/\/(?:([^:@]+):([^@]*)@)?([^/?]+)(?:\/([^?]+))?(?:\?(.*))?/);
+  const isSrv = /^mongodb\+srv:\/\//i.test(uri);
+  const m = uri.match(/mongodb(?:\+srv)?:\/\/(?:([^:@]+):([^@]*)@)?([^/?]+)(?:\/([^?]*))?(?:\?(.*))?/i);
   let authUser = '';
   let authPass = '';
-  let hostStr = 'localhost:27017';
+  let hostStr = isSrv ? 'localhost' : 'localhost:27017';
   let defaultDb = '';
   let tlsMode = 'off';
+  let tlsCa = '';
+  let tlsClientCert = '';
+  let tlsAllowInvalidCerts = false;
+  let tlsAllowInvalidHosts = false;
   let authMethod = 'none';
+  let query = '';
   if (m) {
     authUser = m[1] ? decodeURIComponent(m[1]) : '';
     authPass = m[2] ? decodeURIComponent(m[2]) : '';
-    hostStr = m[3] || 'localhost:27017';
+    hostStr = m[3] || hostStr;
     defaultDb = m[4] || '';
-    const q = m[5] || '';
-    if (q.includes('tls=true') || q.includes('ssl=true')) tlsMode = 'system';
+    query = m[5] || '';
+    const param = (name: string): string | null => {
+      const mm = query.match(new RegExp(`(?:^|&)${name}=([^&]*)`, 'i'));
+      return mm ? decodeURIComponent(mm[1]) : null;
+    };
+    const caFile = param('tlsCAFile') || param('sslCertificateAuthorityFile');
+    if (caFile) {
+      tlsMode = 'file';
+      tlsCa = caFile;
+    } else if (/(?:^|&)(?:tls|ssl)=true/i.test(query)) {
+      tlsMode = 'system';
+    }
+    tlsClientCert = param('tlsCertificateKeyFile') || param('sslClientCertificateKeyFile') || '';
+    // tlsInsecure implies both allow-invalid relaxations.
+    const insecure = /(?:^|&)tlsInsecure=true/i.test(query);
+    tlsAllowInvalidCerts = insecure || /(?:^|&)tlsAllowInvalidCertificates=true/i.test(query);
+    tlsAllowInvalidHosts = insecure || /(?:^|&)tlsAllowInvalidHostnames=true/i.test(query);
     if (authUser) authMethod = 'scram-256';
   }
   const hosts = hostStr.split(',').map((h) => {
     const [host, port] = h.split(':');
-    return { host: host || 'localhost', port: port || '27017' };
+    return { host: host || 'localhost', port: port || (isSrv ? '' : '27017') };
   });
+  const rsMatch = query.match(/(?:^|&)replicaSet=([^&]+)/i);
+  const directConnection = /directConnection=true/i.test(query);
+  // Auto-detect the deployment type from the URI shape:
+  //  replicaSet= → replica set · directConnection=true → single direct node ·
+  //  +srv or multiple hosts → cluster (sharded/mongos) · otherwise standalone.
+  let topology: string;
+  if (rsMatch) topology = 'replicaSet';
+  else if (directConnection) topology = 'standalone';
+  else if (isSrv || hosts.length > 1) topology = 'sharded';
+  else topology = 'standalone';
   return {
+    protocol: isSrv ? 'mongodb+srv' : 'mongodb',
     authUser,
     authPass,
     authMethod,
     tlsMode,
+    tlsCa,
+    tlsClientCert,
+    tlsAllowInvalidCerts,
+    tlsAllowInvalidHosts,
     defaultDb,
-    hosts: hosts.length > 0 ? hosts : [{ host: 'localhost', port: '27017' }],
-    topology: uri.includes('replicaSet=') ? 'replicaSet' : 'standalone',
+    hosts: hosts.length > 0 ? hosts : [{ host: 'localhost', port: isSrv ? '' : '27017' }],
+    topology,
+    replicaSetName: rsMatch ? decodeURIComponent(rsMatch[1]) : '',
+    directConnection,
   };
+};
+
+// Host list <-> "host:port, host:port" text for the editable Host List field.
+export const hostsToText = (hosts: { host: string; port: string }[], isSrv: boolean): string =>
+  hosts.filter((h) => h.host).map((h) => (isSrv || !h.port ? h.host : `${h.host}:${h.port}`)).join(', ');
+
+export const textToHosts = (text: string): { host: string; port: string }[] => {
+  const list = text
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((h) => {
+      const [host, port] = h.split(':');
+      return { host: host || '', port: port || '' };
+    });
+  return list.length ? list : [{ host: '', port: '' }];
 };
 
 export const buildUri = (s: typeof BLANK_CONN) => {
   if (s.topology === 'uri') return s.uri;
-  const hosts = s.hosts.filter(h => h.host).map(h => `${h.host}:${h.port || 27017}`).join(',');
+  const isSrv = s.protocol === 'mongodb+srv';
+  // SRV records resolve the port set, so a +srv URI carries hostnames only.
+  const hosts = isSrv
+    ? s.hosts.filter(h => h.host).map(h => h.host).join(',')
+    : s.hosts.filter(h => h.host).map(h => `${h.host}:${h.port || 27017}`).join(',');
   let creds = '';
   if (s.authMethod !== 'none' && s.authUser) {
     const u = encodeURIComponent(s.authUser);
@@ -182,7 +242,9 @@ export const buildUri = (s: typeof BLANK_CONN) => {
   }
   const params = [];
   if (s.topology === 'replicaSet' && s.replicaSetName) params.push(`replicaSet=${s.replicaSetName}`);
-  if (s.topology === 'standalone' && s.directConnection) params.push('directConnection=true');
+  // directConnection only makes sense for a single-host, non-SRV standalone.
+  if (s.topology === 'standalone' && s.directConnection && !isSrv && s.hosts.filter(h => h.host).length <= 1)
+    params.push('directConnection=true');
   if (s.tlsMode !== 'off') params.push('tls=true');
   // Custom CA file (and optional client cert/key file) must be passed to the driver.
   if (s.tlsMode === 'file' && s.tlsCa) params.push(`tlsCAFile=${encodeURIComponent(s.tlsCa)}`);
@@ -223,7 +285,8 @@ export const buildUri = (s: typeof BLANK_CONN) => {
     if (s.proxyPass) params.push(`proxyPassword=${encodeURIComponent(s.proxyPass)}`);
   }
   const dbPath = s.defaultDb ? `/${s.defaultDb}` : '';
-  return `mongodb://${creds}${hosts}${dbPath}${params.length ? '?' + params.join('&') : ''}`;
+  const scheme = isSrv ? 'mongodb+srv' : 'mongodb';
+  return `${scheme}://${creds}${hosts}${dbPath}${params.length ? '?' + params.join('&') : ''}`;
 };
 
 // Build the structured SSH tunnel config the backend expects, or null when disabled.
@@ -248,7 +311,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
   onConnect,
   activeConnections = [],
 }) => {
-  const { confirm } = useDialogs();
+  const { confirm, prompt } = useDialogs();
   const [profiles, setProfiles] = useState<ConnectionProfile[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -546,6 +609,40 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
     } finally {
       setLoading(false);
     }
+  };
+
+  // Native file picker for TLS certificate paths.
+  const pickTlsFile = async (field: 'tlsCa' | 'tlsClientCert') => {
+    try {
+      const path = await open({
+        multiple: false,
+        directory: false,
+        title: 'Select certificate file',
+        filters: [
+          { name: 'Certificates', extensions: ['pem', 'crt', 'cer', 'key', 'p12', 'pfx'] },
+          { name: 'All files', extensions: ['*'] },
+        ],
+      });
+      if (typeof path === 'string') setEditorState(prev => ({ ...prev, [field]: path }));
+    } catch {
+      /* user cancelled */
+    }
+  };
+
+  // Paste a connection string → auto-detect protocol, hosts, auth, and topology.
+  const handleImportUri = async () => {
+    const uri = await prompt({
+      title: 'Import Connection URI',
+      message: 'Paste a mongodb:// or mongodb+srv:// connection string. Protocol, hosts, auth, TLS, and topology are detected automatically. (⌘/Ctrl+Enter to import)',
+      placeholder: 'mongodb://user:pass@host1:27017,host2:27017/?replicaSet=rs0&tls=true',
+      confirmLabel: 'Import',
+      multiline: true,
+      validate: (v) => (/^mongodb(\+srv)?:\/\//i.test(v.trim()) ? null : 'Enter a mongodb:// or mongodb+srv:// URI'),
+    });
+    if (!uri || !uri.trim()) return;
+    const clean = uri.trim();
+    setEditorState(prev => ({ ...prev, uri: clean, ...parseUriIntoFields(clean) }));
+    setActiveEditorTab('server');
   };
 
   const runTestStepSequence = async () => {
@@ -970,7 +1067,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
 
               <div className="mql-ncd-uri-row">
                 <span className="mql-ncd-uri-badge">URI</span>
-                <code className="mql-ncd-uri">{buildUri(editorState)}</code>
+                <code className="mql-ncd-uri">{maskUriPassword(buildUri(editorState))}</code>
                 <button className="mql-ncd-copy" onClick={() => navigator.clipboard?.writeText(buildUri(editorState))}>
                   <Copy size={11} />
                   <span>Copy</span>
@@ -999,6 +1096,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
             <div className="mql-ncd-body" style={{ flex: 1, minHeight: 0, padding: 12, overflowY: 'auto' }}>
               {activeEditorTab === 'server' && (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  {editorState.topology === 'uri' && (
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                     <label htmlFor="connection-uri" className="mql-label">Connection URI</label>
                     {(() => {
@@ -1046,18 +1144,54 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                       <LayoutGrid size={12} /> Parse into form fields
                     </button>
                   </div>
+                  )}
+
+                  {editorState.topology !== 'uri' && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                      <span className="mql-label">
+                        Host List {editorState.protocol === 'mongodb+srv' ? '(hostname only)' : '(host:port, comma-separated)'}
+                      </span>
+                      <input
+                        type="text"
+                        data-testid="host-list"
+                        value={hostsToText(editorState.hosts, editorState.protocol === 'mongodb+srv')}
+                        onChange={e => setEditorState(prev => ({ ...prev, hosts: textToHosts(e.target.value) }))}
+                        placeholder={editorState.protocol === 'mongodb+srv' ? 'cluster0.abcd.mongodb.net' : '172.18.19.60:27017, 172.18.19.61:27017'}
+                        className="mql-ncd-input font-mono"
+                      />
+                    </div>
+                  )}
 
                   <div style={{ borderTop: '1px solid var(--border-color)', paddingTop: 10, display: 'flex', gap: 12 }}>
+                    {editorState.topology !== 'uri' && (
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1 }}>
+                        <span className="mql-label">Protocol</span>
+                        <div className="mql-ncd-select-wrap">
+                          <select
+                            className="mql-ncd-select"
+                            data-testid="protocol-select"
+                            value={editorState.protocol}
+                            onChange={e => setEditorState(prev => ({ ...prev, protocol: e.target.value }))}
+                          >
+                            <option value="mongodb">mongodb://</option>
+                            <option value="mongodb+srv">mongodb+srv://</option>
+                          </select>
+                          <ChevronDown size={10} color="var(--text-dim)" />
+                        </div>
+                      </div>
+                    )}
                     <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1 }}>
                       <span className="mql-label">Topology</span>
                       <div className="mql-ncd-select-wrap">
-                        <select 
-                          className="mql-ncd-select" 
-                          value={editorState.topology} 
+                        <select
+                          className="mql-ncd-select"
+                          data-testid="topology-select"
+                          value={editorState.topology}
                           onChange={e => setEditorState(prev => ({ ...prev, topology: e.target.value }))}
                         >
-                          <option value="standalone">Standalone Connection</option>
-                          <option value="replicaSet">Replica Set Cluster</option>
+                          <option value="standalone">Standalone / Direct</option>
+                          <option value="replicaSet">Replica Set</option>
+                          <option value="sharded">Sharded Cluster (mongos)</option>
                           <option value="uri">Full URI String Only</option>
                         </select>
                         <ChevronDown size={10} color="var(--text-dim)" />
@@ -1226,13 +1360,24 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                   {editorState.tlsMode === 'file' && (
                     <div style={{ display: 'flex', flexDirection: 'column', gap: 4, borderTop: '1px solid var(--border-color)', paddingTop: 10 }}>
                       <span className="mql-label">CA File Path</span>
-                      <input
-                        type="text"
-                        value={editorState.tlsCa}
-                        onChange={e => setEditorState(prev => ({ ...prev, tlsCa: e.target.value }))}
-                        placeholder="/path/to/ca.pem"
-                        className="mql-ncd-input font-mono"
-                      />
+                      <div style={{ display: 'flex', gap: 6 }}>
+                        <input
+                          type="text"
+                          value={editorState.tlsCa}
+                          onChange={e => setEditorState(prev => ({ ...prev, tlsCa: e.target.value }))}
+                          placeholder="/path/to/ca.pem"
+                          className="mql-ncd-input font-mono"
+                          style={{ flex: 1 }}
+                        />
+                        <button
+                          type="button"
+                          className="mql-btn mql-btn-ghost mql-btn-outlined"
+                          data-testid="ca-file-browse"
+                          onClick={() => pickTlsFile('tlsCa')}
+                        >
+                          Browse…
+                        </button>
+                      </div>
                     </div>
                   )}
 
@@ -1557,10 +1702,16 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
 
             {/* Dialog Footer */}
             <footer className="mql-ncd-foot">
-              <button className="mql-btn mql-btn-ghost mql-btn-outlined" onClick={runTestStepSequence} disabled={testing}>
-                <RefreshCw size={11} className={`mr-1 ${testing ? 'animate-spin' : ''}`} />
-                <span>Test Connection</span>
-              </button>
+              <div className="mql-row" style={{ gap: 8 }}>
+                <button className="mql-btn mql-btn-ghost mql-btn-outlined" onClick={runTestStepSequence} disabled={testing}>
+                  <RefreshCw size={11} className={`mr-1 ${testing ? 'animate-spin' : ''}`} />
+                  <span>Test Connection</span>
+                </button>
+                <button className="mql-btn mql-btn-ghost mql-btn-outlined" onClick={handleImportUri} data-testid="import-uri-btn">
+                  <ClipboardPaste size={11} className="mr-1" />
+                  <span>Import URI</span>
+                </button>
+              </div>
               <div className="mql-row" style={{ gap: 8 }}>
                 <button className="mql-btn mql-btn-ghost mql-btn-outlined" onClick={() => setShowEditDialog(false)}>Cancel</button>
                 <button className="mql-btn mql-btn-primary" onClick={handleSave} disabled={loading || testing}>

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -81,7 +81,7 @@ describe('parseUriIntoFields (import → form)', () => {
     expect(f.topology).toBe('standalone');
   });
 
-  it('splits multiple hosts and detects a replica set', () => {
+  it('splits multiple hosts and detects a replica set (with its name)', () => {
     const f = parseUriIntoFields('mongodb://h1:27017,h2:27017,h3:27017/?replicaSet=rs0');
     expect(f.hosts).toEqual([
       { host: 'h1', port: '27017' },
@@ -89,6 +89,42 @@ describe('parseUriIntoFields (import → form)', () => {
       { host: 'h3', port: '27017' },
     ]);
     expect(f.topology).toBe('replicaSet');
+    expect(f.replicaSetName).toBe('rs0');
+    expect(f.protocol).toBe('mongodb');
+  });
+
+  it('detects a sharded cluster from multiple hosts without a replicaSet', () => {
+    const f = parseUriIntoFields('mongodb://m1:27017,m2:27017/admin');
+    expect(f.topology).toBe('sharded');
+  });
+
+  it('detects a direct/standalone connection from directConnection=true', () => {
+    const f = parseUriIntoFields('mongodb://h1:27017,h2:27017/?directConnection=true');
+    expect(f.topology).toBe('standalone');
+    expect(f.directConnection).toBe(true);
+  });
+
+  it('maps TLS options (CA file, tlsInsecure) into the form', () => {
+    const f = parseUriIntoFields('mongodb://h:27017/?tls=true&tlsCAFile=%2Fetc%2Fca.pem&tlsInsecure=true');
+    expect(f.tlsMode).toBe('file');
+    expect(f.tlsCa).toBe('/etc/ca.pem');
+    expect(f.tlsAllowInvalidCerts).toBe(true);
+    expect(f.tlsAllowInvalidHosts).toBe(true);
+  });
+
+  it('maps individual allow-invalid TLS flags', () => {
+    const f = parseUriIntoFields('mongodb://h:27017/?tls=true&tlsAllowInvalidCertificates=true');
+    expect(f.tlsMode).toBe('system');
+    expect(f.tlsAllowInvalidCerts).toBe(true);
+    expect(f.tlsAllowInvalidHosts).toBe(false);
+  });
+
+  it('detects mongodb+srv: protocol, port-less host, sharded topology', () => {
+    const f = parseUriIntoFields('mongodb+srv://user:pw@cluster0.abcd.mongodb.net/app');
+    expect(f.protocol).toBe('mongodb+srv');
+    expect(f.hosts).toEqual([{ host: 'cluster0.abcd.mongodb.net', port: '' }]);
+    expect(f.topology).toBe('sharded');
+    expect(f.defaultDb).toBe('app');
   });
 
   it('handles a bare host with no credentials', () => {
@@ -109,6 +145,30 @@ describe('parseUriIntoFields (import → form)', () => {
     const uri = buildUri({ ...baseConn, ...f, authPass: f.authPass });
     expect(uri).toContain('db.example.com:27018');
     expect(uri).toContain('alice');
+  });
+});
+
+describe('buildUri protocol + topology', () => {
+  it('emits a mongodb+srv:// scheme with port-less hosts', () => {
+    const uri = buildUri({ ...baseConn, protocol: 'mongodb+srv', topology: 'sharded', hosts: [{ host: 'cluster0.abcd.mongodb.net', port: '' }] });
+    expect(uri.startsWith('mongodb+srv://')).toBe(true);
+    expect(uri).toContain('cluster0.abcd.mongodb.net');
+    expect(uri).not.toContain(':27017');
+    expect(uri).not.toContain('directConnection');
+  });
+
+  it('sharded topology joins the host list without a replicaSet param', () => {
+    const uri = buildUri({ ...baseConn, topology: 'sharded', hosts: [{ host: 'm1', port: '27017' }, { host: 'm2', port: '27017' }] });
+    expect(uri).toContain('m1:27017,m2:27017');
+    expect(uri).not.toContain('replicaSet');
+    expect(uri).not.toContain('directConnection');
+  });
+
+  it('only emits directConnection for a single-host standalone', () => {
+    const single = buildUri({ ...baseConn, topology: 'standalone', directConnection: true, hosts: [{ host: 'h1', port: '27017' }] });
+    expect(single).toContain('directConnection=true');
+    const multi = buildUri({ ...baseConn, topology: 'standalone', directConnection: true, hosts: [{ host: 'h1', port: '27017' }, { host: 'h2', port: '27017' }] });
+    expect(multi).not.toContain('directConnection');
   });
 });
 
@@ -363,6 +423,7 @@ describe('ConnectionManager Component', () => {
     expect(screen.getByText('New Connection')).toBeInTheDocument();
 
     const nameInput = screen.getByLabelText(/display name/i);
+    fireEvent.change(screen.getByTestId('topology-select'), { target: { value: 'uri' } });
     const uriInput = screen.getByLabelText(/connection uri/i);
 
     fireEvent.change(nameInput, { target: { value: 'Staging DB' } });
@@ -452,6 +513,7 @@ describe('ConnectionManager Component', () => {
     const newBtn = await screen.findByRole('button', { name: /new\.\.\./i });
     fireEvent.click(newBtn);
 
+    fireEvent.change(screen.getByTestId('topology-select'), { target: { value: 'uri' } });
     const uriInput = screen.getByLabelText(/connection uri/i);
     fireEvent.change(uriInput, { target: { value: 'mongodb://mock' } });
 
@@ -505,6 +567,7 @@ describe('ConnectionManager Component', () => {
     const newBtn = await screen.findByRole('button', { name: /new\.\.\./i });
     fireEvent.click(newBtn);
 
+    fireEvent.change(screen.getByTestId('topology-select'), { target: { value: 'uri' } });
     const uriInput = screen.getByLabelText(/connection uri/i);
     fireEvent.change(uriInput, { target: { value: 'mongodb://invalid' } });
 

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -518,6 +518,10 @@ describe('ConnectionManager Component', () => {
     }, { timeout: 4000 });
     fireEvent.click(screen.getByTestId('test-error-details-toggle'));
     expect(screen.getByTestId('test-error-detail')).toHaveTextContent('Connection timed out');
+
+    // The result can be dismissed.
+    fireEvent.click(screen.getByTestId('test-dismiss'));
+    expect(screen.queryByTestId('test-result-summary')).toBeNull();
   });
 
   it('calls connect_db and triggers onConnect callback when Connect is clicked', async () => {

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ReactElement } from 'react';
 import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react';
-import { ConnectionManager, buildUri, buildSshConfig, parseUriIntoFields } from '../ConnectionManager';
+import { ConnectionManager, buildUri, buildSshConfig, parseUriIntoFields, summarizeConnectionError } from '../ConnectionManager';
 import { DialogProvider } from '../dialogs/DialogProvider';
 
 // ConnectionManager now uses the in-app dialog system, so it must render inside a provider.
@@ -41,6 +41,33 @@ const baseConn = {
   appName: '',
   defaultDb: '',
 } as any;
+
+describe('summarizeConnectionError', () => {
+  it('reports a TLS trust problem buried inside a server-selection timeout', () => {
+    const raw = 'Kind: Server selection timeout: No available servers. Topology: { Servers: [ { Address: 1.2.3.4:27017, Type: Unknown, Error: Kind: I/O error: invalid peer certificate: UnknownIssuer } ] }';
+    const { summary, hint } = summarizeConnectionError(raw);
+    expect(summary).toMatch(/certificate not trusted/i);
+    expect(hint).toMatch(/CA file|invalid certificates/i);
+  });
+
+  it('detects authentication failures', () => {
+    expect(summarizeConnectionError('Authentication failed. (18)').summary).toMatch(/authentication failed/i);
+  });
+
+  it('detects connection refused', () => {
+    expect(summarizeConnectionError('Kind: I/O error: Connection refused (os error 61)').summary).toMatch(/refused/i);
+  });
+
+  it('falls back to a trimmed first line for unknown errors', () => {
+    const { summary, hint } = summarizeConnectionError('Kind: some weird failure\nwith more lines');
+    expect(summary).toBe('some weird failure');
+    expect(hint).toBeUndefined();
+  });
+
+  it('summarizes a bare server-selection timeout when no deeper cause is present', () => {
+    expect(summarizeConnectionError('Server selection timeout: No available servers').summary).toMatch(/selection timed out/i);
+  });
+});
 
 describe('parseUriIntoFields (import → form)', () => {
   it('extracts credentials, host/port, and default db into editable fields', () => {
@@ -485,10 +512,12 @@ describe('ConnectionManager Component', () => {
     const testBtn = screen.getByRole('button', { name: /test connection/i });
     fireEvent.click(testBtn);
 
-    // Verify error feedback is displayed
+    // Verify summarized error feedback is displayed (raw error lives behind "Show details").
     await waitFor(() => {
-      expect(screen.getByText('Connection timed out')).toBeInTheDocument();
+      expect(screen.getByTestId('test-result-summary')).toHaveTextContent(/timed out/i);
     }, { timeout: 4000 });
+    fireEvent.click(screen.getByTestId('test-error-details-toggle'));
+    expect(screen.getByTestId('test-error-detail')).toHaveTextContent('Connection timed out');
   });
 
   it('calls connect_db and triggers onConnect callback when Connect is clicked', async () => {

--- a/src/components/dialogs/DialogModal.tsx
+++ b/src/components/dialogs/DialogModal.tsx
@@ -18,6 +18,8 @@ export interface PromptRequest {
   confirmLabel?: string;
   cancelLabel?: string;
   validate?: (value: string) => string | null;
+  /** Render a multi-line textarea instead of a single-line input. */
+  multiline?: boolean;
 }
 
 export interface ChooseRequest {
@@ -38,7 +40,7 @@ interface DialogModalProps {
 export const DialogModal: React.FC<DialogModalProps> = ({ request, onResolve }) => {
   const [value, setValue] = useState(request.type === 'prompt' ? request.defaultValue ?? '' : '');
   const [error, setError] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   const confirmRef = useRef<HTMLButtonElement>(null);
 
   // Cancelling means: confirm → false, prompt/choose → null.
@@ -93,23 +95,45 @@ export const DialogModal: React.FC<DialogModalProps> = ({ request, onResolve }) 
 
         {request.type === 'prompt' && (
           <>
-            <input
-              ref={inputRef}
-              className="dialog-input"
-              data-testid="dialog-input"
-              value={value}
-              placeholder={request.placeholder}
-              onChange={(e) => {
-                setValue(e.target.value);
-                if (error) setError(null);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  submitPrompt();
-                }
-              }}
-            />
+            {request.multiline ? (
+              <textarea
+                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                className="dialog-input dialog-input--multiline"
+                data-testid="dialog-input"
+                value={value}
+                rows={5}
+                placeholder={request.placeholder}
+                onChange={(e) => {
+                  setValue(e.target.value);
+                  if (error) setError(null);
+                }}
+                onKeyDown={(e) => {
+                  // Cmd/Ctrl+Enter submits; plain Enter inserts a newline.
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                    e.preventDefault();
+                    submitPrompt();
+                  }
+                }}
+              />
+            ) : (
+              <input
+                ref={inputRef as React.RefObject<HTMLInputElement>}
+                className="dialog-input"
+                data-testid="dialog-input"
+                value={value}
+                placeholder={request.placeholder}
+                onChange={(e) => {
+                  setValue(e.target.value);
+                  if (error) setError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    submitPrompt();
+                  }
+                }}
+              />
+            )}
             {error && (
               <div className="dialog-error" data-testid="dialog-error">
                 {error}

--- a/src/components/dialogs/DialogProvider.tsx
+++ b/src/components/dialogs/DialogProvider.tsx
@@ -19,6 +19,8 @@ export interface PromptOptions {
   cancelLabel?: string;
   /** Return an error string to block submit, or null to allow it. */
   validate?: (value: string) => string | null;
+  /** Render a multi-line textarea instead of a single-line input. */
+  multiline?: boolean;
 }
 
 export interface ChooseOptions {

--- a/src/index.css
+++ b/src/index.css
@@ -5250,6 +5250,11 @@ button, input, select, textarea {
   font-size: 12px;
 }
 .dialog-input:focus { outline: none; border-color: var(--accent-blue); }
+.dialog-input--multiline {
+  height: auto; min-height: 110px; padding: 8px 10px; resize: vertical;
+  font-family: var(--font-mono); line-height: 1.5;
+  white-space: pre-wrap; word-break: break-all;
+}
 .dialog-error { font-size: 11px; color: var(--accent-red); }
 .dialog-choices { display: flex; flex-direction: column; gap: 6px; }
 .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }


### PR DESCRIPTION
A batch of connection-editor fixes + improvements reported during testing.

## Test panel (errors)
- `summarizeConnectionError` → readable root cause (TLS not trusted / auth / refused / DNS / timeout) + hint; raw error behind **Show details** in a scrollable box.
- Panel stays inside the dialog (body `min-height:0`, capped scroll) — no more overflow.
- **Dismiss (✕)** to clear a finished result.

## Import + structured editor
- **Auto-detect deployment type** on import: standalone/direct, replica set (with name), sharded (mongos / multi-host), and **mongodb+srv**. Protocol + replicaSet name now parsed.
- Server tab shows **Protocol + editable Host List** in structured modes; the raw **Connection URI** field only appears in "Full URI" mode. Top preview masks the password.
- **Import URI** button in the footer with a **large multi-line paste box** (new prompt `multiline` option; ⌘/Ctrl+Enter submits).

## TLS
- Map `tlsCAFile` / `tlsCertificateKeyFile` / `tlsInsecure` / `tlsAllowInvalid*` from an imported URI into the form.
- Native **Browse…** file picker for the CA file path.

## Verified
`tsc`, `npm run build`, **298** tests pass (new cases for topology/protocol/TLS detection, SRV/sharded URI building, summarizer, dismiss).