### PR TITLE
fix(statusbar): report whole-app memory + CPU (process tree)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,8 +62,10 @@ pub fn apply_main_timeouts(opts: &mut mongodb::options::ClientOptions) {
     }
 }
 
-/// Sample this process's CPU% and resident memory. CPU is a delta since the
-/// previous sample, so the first call after startup typically reports 0.
+/// Sample the whole app's CPU% and resident memory — the main process plus all
+/// descendant processes (the WebView/renderer helpers), so the total matches
+/// what Activity Monitor / Task Manager shows rather than the backend alone.
+/// CPU is a delta since the previous sample, so the first call reports ~0.
 pub fn resource_usage_impl(state: &AppState) -> ResourceUsage {
     let pid = match sysinfo::get_current_pid() {
         Ok(pid) => pid,
@@ -75,16 +77,41 @@ pub fn resource_usage_impl(state: &AppState) -> ResourceUsage {
         }
     };
     let mut sys = state.sys.lock().unwrap_or_else(|p| p.into_inner());
-    sys.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
-    match sys.process(pid) {
-        Some(proc_) => ResourceUsage {
-            cpu_percent: proc_.cpu_usage(),
-            memory_bytes: proc_.memory(),
-        },
-        None => ResourceUsage {
-            cpu_percent: 0.0,
-            memory_bytes: 0,
-        },
+    // Refresh every process so we can discover our descendants by parent PID.
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+
+    // Collect our process tree: start at our PID and keep absorbing any process
+    // whose parent is already in the set until it stops growing.
+    let mut tree: std::collections::HashSet<sysinfo::Pid> = std::collections::HashSet::new();
+    tree.insert(pid);
+    loop {
+        let mut added = false;
+        for (cpid, proc_) in sys.processes() {
+            if !tree.contains(cpid) {
+                if let Some(parent) = proc_.parent() {
+                    if tree.contains(&parent) {
+                        tree.insert(*cpid);
+                        added = true;
+                    }
+                }
+            }
+        }
+        if !added {
+            break;
+        }
+    }
+
+    let mut memory_bytes: u64 = 0;
+    let mut cpu_percent: f32 = 0.0;
+    for p in &tree {
+        if let Some(proc_) = sys.process(*p) {
+            memory_bytes += proc_.memory();
+            cpu_percent += proc_.cpu_usage();
+        }
+    }
+    ResourceUsage {
+        cpu_percent,
+        memory_bytes,
     }
 }
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -10,6 +10,16 @@ mod tests {
         rename_database_impl, start_collection_export_impl, update_document_impl,
     };
 
+    #[test]
+    fn test_resource_usage_sums_process_tree() {
+        // The current (test) process always exists, so the summed tree memory
+        // must be non-zero. Guards against the walk returning an empty set.
+        let state = AppState::new();
+        let usage = crate::resource_usage_impl(&state);
+        assert!(usage.memory_bytes > 0, "process-tree memory should be > 0");
+        assert!(usage.cpu_percent >= 0.0);
+    }
+
     #[tokio::test]
     async fn test_mock_connection_lifecycle() {
         let state = AppState::new();


### PR DESCRIPTION
The status-bar RAM/CPU only measured the **main backend process**, so it under-reported vs Activity Monitor — the **WebView/renderer** helper processes (the bulk of memory) were excluded.

## Fix
`resource_usage_impl` now refreshes all processes, walks the **process tree** from our PID (absorbing any process whose parent is already in the set), and **sums memory + CPU** across the main process and all descendants. The status bar now reflects the app's true footprint.

(Note: dev builds are inflated by Vite/HMR/DevTools in the webview; production builds are much leaner.)

## Verified
`cargo test` (101 pass, incl. a new smoke test asserting the summed tree memory is non-zero).