### PR TITLE
feat(sidebar): tree search + remove redundant titlebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1158,15 +1158,6 @@ function Workspace() {
 
   return (
     <div className="mql-app">
-      <div className="mql-titlebar" data-tauri-drag-region="true">
-        <span style={{ flex: 1 }}/>
-        <span className="mql-titlebar-brand">
-          <img src={logoMark} alt="" className="mql-titlebar-logo" />
-          MQLens — {activeConnections[0]?.name || 'No connection'}
-        </span>
-        <span style={{ flex: 1 }}/>
-      </div>
-
       <div className="mql-main">
         {/* Sidebar Explorer */}
         <div className="mql-sidebar-wrap" style={{ width: sidebarWidth }}>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,7 +23,9 @@ import {
   Cog,
   Pencil,
   Table2,
-  Activity
+  Activity,
+  Search,
+  X
 } from 'lucide-react';
 
 // Mirrors the backend CollectionInfo struct returned by `list_collections`.
@@ -146,6 +148,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
   collectionMutationTrigger,
 }) => {
   const { toast, confirm, prompt } = useDialogs();
+  // Tree filter: matches connection / database / (loaded) collection names.
+  const [filterQuery, setFilterQuery] = useState('');
   // key: connectionId, value: database names list
   const [databases, setDatabases] = useState<{ [connectionId: string]: string[] }>({});
   
@@ -843,9 +847,34 @@ export const Sidebar: React.FC<SidebarProps> = ({
         </div>
       </header>
 
+      {/* Filter / search the tree */}
+      {activeConnections.length > 0 && (
+        <div className="mql-tree-search">
+          <Search size={12} className="mql-tree-search-icon" />
+          <input
+            type="text"
+            value={filterQuery}
+            onChange={(e) => setFilterQuery(e.target.value)}
+            placeholder="Search connections, databases, collections…"
+            aria-label="Search sidebar"
+            data-testid="sidebar-search"
+          />
+          {filterQuery && (
+            <button
+              type="button"
+              className="mql-tree-search-clear"
+              onClick={() => setFilterQuery('')}
+              aria-label="Clear search"
+            >
+              <X size={12} />
+            </button>
+          )}
+        </div>
+      )}
+
       {/* Database Navigation Tree */}
-      <div 
-        className="mql-tree-scroll database-tree-container" 
+      <div
+        className="mql-tree-scroll database-tree-container"
         onContextMenu={(e) => {
           if (e.target === e.currentTarget) handleEmptySpaceContextMenu(e);
         }}
@@ -853,8 +882,20 @@ export const Sidebar: React.FC<SidebarProps> = ({
         {activeConnections.length > 0 ? (
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             {activeConnections.map((conn) => {
-              const isConnExpanded = expandedConnections[conn.id];
+              const q = filterQuery.trim().toLowerCase();
+              const filterActive = q.length > 0;
               const connDbs = databases[conn.id] || [];
+              const connNameMatch = filterActive && conn.name.toLowerCase().includes(q);
+              const visibleDbs = connDbs.filter((dbName) =>
+                !filterActive ||
+                connNameMatch ||
+                dbName.toLowerCase().includes(q) ||
+                (collections[`${conn.id}/${dbName}`] || []).some((c) => c.name.toLowerCase().includes(q))
+              );
+              // Hide a connection entirely when nothing under it matches.
+              if (filterActive && !connNameMatch && visibleDbs.length === 0) return null;
+              // While filtering, auto-reveal connections so matches are visible.
+              const isConnExpanded = expandedConnections[conn.id] || filterActive;
 
               return (
                 <div key={conn.id} className="mql-tree-node">
@@ -891,11 +932,19 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   {/* Databases List */}
                   {isConnExpanded && (
                     <div className="mql-tree-children">
-                      {connDbs.map((dbName) => {
+                      {visibleDbs.map((dbName) => {
                         const dbKey = `${conn.id}/${dbName}`;
-                        const isDbExpanded = expandedDbs[dbKey];
-                        const isFolderExpanded = expandedCollectionsFolders[`${dbKey}/collections`];
-                        const dbColls = collections[dbKey] || [];
+                        const rawColls = collections[dbKey] || [];
+                        // When filtering and neither the connection nor the db name
+                        // matches, narrow the db's collections to the matches and
+                        // auto-expand so they're visible.
+                        const dbNameMatch = filterActive && (connNameMatch || dbName.toLowerCase().includes(q));
+                        const dbColls = filterActive && !dbNameMatch
+                          ? rawColls.filter((c) => c.name.toLowerCase().includes(q))
+                          : rawColls;
+                        const autoExpandDb = filterActive && !dbNameMatch && dbColls.length > 0;
+                        const isDbExpanded = expandedDbs[dbKey] || autoExpandDb;
+                        const isFolderExpanded = expandedCollectionsFolders[`${dbKey}/collections`] || autoExpandDb;
 
                         // Separate the flat collection list into the standard MongoDB
                         // categories. Views come from the backend's collection type;

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -41,6 +41,43 @@ describe('Sidebar Component', () => {
     expect(handleOpenModal).toHaveBeenCalledTimes(1);
   });
 
+  it('filters the tree by the search box (database names)', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases') {
+        if (args.id === 'conn-1') return Promise.resolve(['sales_db', 'user_analytics']);
+      }
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB 1', uri: 'mongodb://mock1' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        theme="dark"
+        onToggleTheme={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    // Both databases visible before filtering.
+    expect(await screen.findByText('sales_db')).toBeInTheDocument();
+    expect(await screen.findByText('user_analytics')).toBeInTheDocument();
+
+    // Typing "sales" hides the non-matching database.
+    fireEvent.change(screen.getByTestId('sidebar-search'), { target: { value: 'sales' } });
+    expect(screen.getByText('sales_db')).toBeInTheDocument();
+    expect(screen.queryByText('user_analytics')).toBeNull();
+
+    // Clearing restores everything.
+    fireEvent.click(screen.getByRole('button', { name: /clear search/i }));
+    expect(screen.getByText('user_analytics')).toBeInTheDocument();
+  });
+
   it('handles rendering multiple connections, databases, collections, and indexes', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {

--- a/src/index.css
+++ b/src/index.css
@@ -572,6 +572,23 @@ button { cursor: pointer; }
   padding: 8px;
   display: flex; flex-direction: column; gap: 4px;
 }
+.mql-tree-search {
+  display: flex; align-items: center; gap: 6px;
+  margin: 6px 8px 0; padding: 4px 8px;
+  border: 1px solid var(--border-color); border-radius: 6px;
+  background: var(--bg-base);
+}
+.mql-tree-search-icon { color: var(--text-dim); flex: none; }
+.mql-tree-search input {
+  flex: 1; min-width: 0; background: transparent; border: none; outline: none;
+  color: var(--text-main); font-size: 12px;
+}
+.mql-tree-search input::placeholder { color: var(--text-dim); }
+.mql-tree-search-clear {
+  display: inline-flex; background: none; border: none; color: var(--text-dim);
+  cursor: pointer; padding: 0; flex: none;
+}
+.mql-tree-search-clear:hover { color: var(--text-main); }
 .mql-tree-node { display: flex; flex-direction: column; }
 .mql-tree-children {
   margin-left: 12px; padding-left: 4px;


### PR DESCRIPTION
Two UI changes.

## Sidebar search
- New search box at the top of the sidebar that filters **connections, databases, and loaded collections** by name.
- Matching branches auto-expand so results are visible; non-matching connections/databases are hidden; a clear (✕) button resets it.
- (Collections must be loaded — i.e. their database expanded at least once — to be matched; this avoids force-loading every collection on large clusters.)

## Remove redundant titlebar
- Removed the custom `MQLens — <connection>` bar. The window uses native decorations, so the OS title bar already provides the title, dragging, and traffic lights — the custom row was a duplicate second bar.

## Verified
`tsc`, `npm run build`, 299 tests pass (new sidebar-search filter test).