### PR TITLE
Dual-channel auto-update (stable/dev) + fix release latest.json race

### DIFF
--- a/.github/scripts/compose-latest.cjs
+++ b/.github/scripts/compose-latest.cjs
@@ -1,0 +1,52 @@
+// Assemble a Tauri updater `latest.json` from the per-platform updater
+// signatures attached to a release. Run after all matrix builds have uploaded
+// their bundles + `.sig` files (the matrix uses uploadUpdaterJson:false so it
+// never races on this single asset).
+//
+// Inputs (env): REPO (owner/name), REL_TAG (release the bundles live on),
+// VERSION, NOTES. Reads `*.sig` files from ./sigs (downloaded by the caller).
+// Writes ./latest.json.
+//
+// Each `<artifact>.sig` file's contents is the updater signature for `<artifact>`;
+// the artifact's download URL is on the REL_TAG release. We ignore any duplicate
+// non-canonical bundles (only files starting with the productName "MQLens").
+const fs = require('fs');
+const path = require('path');
+
+const REPO = process.env.REPO;
+const TAG = process.env.REL_TAG;
+const VERSION = process.env.VERSION;
+const NOTES = process.env.NOTES || '';
+const PUB_DATE = process.env.PUB_DATE || new Date().toISOString();
+const DIR = 'sigs';
+
+const urlFor = (artifact) =>
+  `https://github.com/${REPO}/releases/download/${TAG}/${encodeURIComponent(artifact)}`;
+
+const platforms = {};
+const add = (key, artifact) => {
+  if (platforms[key]) return; // first match wins
+  const sig = fs.readFileSync(path.join(DIR, `${artifact}.sig`), 'utf8').trim();
+  platforms[key] = { signature: sig, url: urlFor(artifact) };
+};
+
+const sigFiles = fs.existsSync(DIR) ? fs.readdirSync(DIR).filter((f) => f.endsWith('.sig')) : [];
+for (const f of sigFiles) {
+  const artifact = f.slice(0, -4); // strip ".sig"
+  if (!artifact.startsWith('MQLens')) continue; // skip duplicate mq-lens_ bundles
+  if (/aarch64\.app\.tar\.gz$/.test(artifact)) add('darwin-aarch64', artifact);
+  else if (/(x64|x86_64)\.app\.tar\.gz$/.test(artifact)) add('darwin-x86_64', artifact);
+  else if (/\.app\.tar\.gz$/.test(artifact)) add('darwin-x86_64', artifact); // mac, no arch suffix
+  else if (/\.AppImage(\.tar\.gz)?$/.test(artifact)) add('linux-x86_64', artifact);
+  else if (/(-setup\.exe|\.nsis\.zip)$/.test(artifact)) add('windows-x86_64', artifact);
+  else if (/\.msi(\.zip)?$/.test(artifact)) add('windows-x86_64', artifact); // MSI fallback
+}
+
+if (Object.keys(platforms).length === 0) {
+  console.error('No updater signatures found in ./sigs — refusing to write an empty manifest.');
+  process.exit(1);
+}
+
+const manifest = { version: VERSION, notes: NOTES, pub_date: PUB_DATE, platforms };
+fs.writeFileSync('latest.json', JSON.stringify(manifest, null, 2));
+console.log('Composed latest.json for', VERSION, '— platforms:', Object.keys(platforms).join(', '));

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
   # Commits, bump the version files, and commit the bump back to main ([skip ci]
   # so it doesn't re-trigger). Outputs the new version + whether to release.
   version:
-    if: github.ref_name == 'main'
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.compute.outputs.version }}
@@ -42,6 +41,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Dev branch: derive a monotonic pre-release version that sorts ABOVE the
+          # current stable (semver prereleases sort below their release, so we bump
+          # the patch first): 0.4.0 -> 0.4.1-dev.<run>. Not committed; the build
+          # job writes it into the version files locally before building.
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            CUR=$(node -p "require('./package.json').version")
+            BASE=${CUR%%-*}
+            NEXT=$(node -e 'const p=process.argv[1].split(".").map(Number);p[2]++;process.stdout.write(p.join("."))' "$BASE")
+            DEVV="${NEXT}-dev.${GITHUB_RUN_NUMBER}"
+            echo "version=$DEVV" >> "$GITHUB_OUTPUT"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "Dev build version: $DEVV"
+            exit 0
+          fi
           LAST_TAG=$(git tag --list 'mqlens-v*' | grep -v -- '-dev\.' | sort -V | tail -1 || true)
           RANGE=""
           [ -n "$LAST_TAG" ] && RANGE="${LAST_TAG}..HEAD"
@@ -160,6 +173,23 @@ jobs:
 
       - run: npm ci
 
+      # Write the resolved version into the bundle version files so the built app
+      # and its updater manifest carry it. On main the version job already
+      # committed this value (idempotent here); on dev it's <next>-dev.<run>.
+      - name: Set build version
+        shell: bash
+        run: |
+          V="${{ needs.version.outputs.version }}"
+          node -e '
+            const fs=require("fs");const v=process.argv[1];
+            const sub=(p,re,to)=>{const s=fs.readFileSync(p,"utf8");if(!re.test(s))throw new Error("no version field in "+p);fs.writeFileSync(p,s.replace(re,to))};
+            sub("package.json",/("version":\s*)"[^"]+"/,`$1"${v}"`);
+            sub("src-tauri/tauri.conf.json",/("version":\s*)"[^"]+"/,`$1"${v}"`);
+            sub("src-tauri/Cargo.toml",/^version = "[^"]+"/m,`version = "${v}"`);
+            sub("src-tauri/Cargo.lock",/(name = "tauri-app"\nversion = ")[^"]+(")/,`$1${v}$2`);
+          ' "$V"
+          echo "Built version: $V"
+
       # Notarization uses an App Store Connect API key (.p8). Materialize it to
       # a file on the runner; tauri-action reads APPLE_API_KEY_PATH from there.
       - name: Prepare Apple API key (macOS signing)
@@ -190,18 +220,13 @@ jobs:
       # Stable -> mqlens-v<version>. Dev -> a unique semver pre-release carrying
       # the build's short SHA (e.g. mqlens-v0.1.0-dev.a1b2c3d) so every dev build
       # gets its own tag and nothing collides with the `dev` branch name.
+      # Unified tag: the version (dev already carries -dev.<run>) drives the tag
+      # for every job, so build, notes, signing and the manifest agree.
       - name: Compute release tag
         shell: bash
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            echo "REL_TAG=mqlens-v${VERSION}" >> "$GITHUB_ENV"
-            echo "REL_NAME=MQLens v${VERSION}" >> "$GITHUB_ENV"
-          else
-            SHA="${GITHUB_SHA:0:7}"
-            echo "REL_TAG=mqlens-v${VERSION}-dev.${SHA}" >> "$GITHUB_ENV"
-            echo "REL_NAME=MQLens v${VERSION}-dev.${SHA}" >> "$GITHUB_ENV"
-          fi
+          echo "REL_TAG=mqlens-v${{ needs.version.outputs.version }}" >> "$GITHUB_ENV"
+          echo "REL_NAME=MQLens v${{ needs.version.outputs.version }}" >> "$GITHUB_ENV"
 
       - name: Build app & publish release
         uses: tauri-apps/tauri-action@v0
@@ -231,6 +256,11 @@ jobs:
           releaseBody: ${{ needs.version.outputs.notes || 'Generating release notes…' }}
           prerelease: ${{ github.ref_name != 'main' }}
           args: ${{ matrix.args }}
+          # Each matrix job uploads its own binaries + signatures, but NOT
+          # latest.json — the parallel jobs would race on that single asset
+          # (causing "Not Found - update-a-release-asset"). The updater-manifest
+          # job below assembles and uploads latest.json once, after all builds.
+          uploadUpdaterJson: false
 
   # Replace the placeholder body with real notes once the bundles are uploaded:
   # an auto-generated changelog for stable (main) releases, or a recent-commit
@@ -238,7 +268,7 @@ jobs:
   # Dev only: stable (main) notes are written by the version job and already in
   # latest.json. This fills the dev pre-release body + prunes old dev releases.
   release-notes:
-    needs: build
+    needs: [version, build]
     if: github.ref_name != 'main'
     runs-on: ubuntu-22.04
     permissions:
@@ -253,13 +283,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION="${{ needs.version.outputs.version }}"
+          TAG="mqlens-v${VERSION}"
           if [ "${{ github.ref_name }}" = "main" ]; then
-            TAG="mqlens-v${VERSION}"
             gh api --method POST "repos/${{ github.repository }}/releases/generate-notes" \
               -f tag_name="$TAG" --jq '.body' > notes.md
           else
-            TAG="mqlens-v${VERSION}-dev.${GITHUB_SHA:0:7}"
             {
               echo "Development pre-release — unstable, not for production."
               echo ""
@@ -290,7 +319,7 @@ jobs:
   # verify authenticity (`gpg --verify file.asc file`). Activates automatically
   # once the GPG_PRIVATE_KEY secret is set; otherwise it's a no-op.
   sign-artifacts:
-    needs: build
+    needs: [version, build]
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -310,12 +339,8 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         shell: bash
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            TAG="mqlens-v${VERSION}"
-          else
-            TAG="mqlens-v${VERSION}-dev.${GITHUB_SHA:0:7}"
-          fi
+          VERSION="${{ needs.version.outputs.version }}"
+          TAG="mqlens-v${VERSION}"
           KEYID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
           mkdir -p _assets && cd _assets
           gh release download "$TAG" --repo "${{ github.repository }}" --clobber
@@ -333,7 +358,7 @@ jobs:
   # replace the unsigned assets on the release. Activates once the AZURE_*
   # secrets are set; otherwise a no-op.
   sign-windows:
-    needs: build
+    needs: [version, build]
     runs-on: windows-latest
     permissions:
       contents: write
@@ -351,12 +376,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            TAG="mqlens-v${VERSION}"
-          else
-            TAG="mqlens-v${VERSION}-dev.${GITHUB_SHA:0:7}"
-          fi
+          VERSION="${{ needs.version.outputs.version }}"
+          TAG="mqlens-v${VERSION}"
           echo "REL_TAG=$TAG" >> "$GITHUB_ENV"
           mkdir -p win-assets
           gh release download "$TAG" --repo "${{ github.repository }}" \
@@ -384,3 +405,43 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: gh release upload "$REL_TAG" win-assets/*.exe win-assets/*.msi --repo "${{ github.repository }}" --clobber
+
+  # Assemble latest.json ONCE from the per-platform signatures the matrix uploaded
+  # (the matrix set uploadUpdaterJson:false so the parallel jobs never race on it),
+  # then publish it per channel:
+  #   stable (main) -> the release itself, served at releases/latest/download/latest.json
+  #   dev           -> the permanent `dev-channel` pre-release, giving the in-app
+  #                    dev channel a stable URL that points at this build's assets.
+  updater-manifest:
+    needs: [version, build]
+    if: ${{ always() && needs.build.result == 'success' && (github.ref_name != 'main' || needs.version.outputs.release == 'true') }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name == 'main' && 'main' || github.sha }}
+      - name: Compose and publish updater manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ needs.version.outputs.version }}
+          NOTES: ${{ needs.version.outputs.notes }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          export REL_TAG="mqlens-v${VERSION}"
+          mkdir -p sigs
+          gh release download "$REL_TAG" --repo "$REPO" --pattern '*.sig' --dir sigs --clobber
+          node .github/scripts/compose-latest.cjs
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            gh release upload "$REL_TAG" latest.json --repo "$REPO" --clobber
+          else
+            gh release view dev-channel --repo "$REPO" >/dev/null 2>&1 || \
+              gh release create dev-channel --repo "$REPO" --prerelease \
+                --title "Dev channel" \
+                --notes "Rolling dev-channel updater manifest. Do not delete." \
+                --target "$GITHUB_SHA"
+            gh release upload dev-channel latest.json --repo "$REPO" --clobber
+          fi

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -28,6 +28,9 @@ fn default_openai_model() -> String {
 fn default_gemini_model() -> String {
     "gemini-1.5-flash".to_string()
 }
+fn default_update_channel() -> String {
+    "stable".to_string()
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct AppSettings {
@@ -55,6 +58,9 @@ pub struct AppSettings {
     // Extra instructions appended to the generated system prompt for any provider.
     #[serde(default)]
     pub ai_custom_instructions: String,
+    // Auto-update channel: "stable" (default) or "dev".
+    #[serde(default = "default_update_channel")]
+    pub update_channel: String,
 }
 
 impl Default for AppSettings {
@@ -70,6 +76,7 @@ impl Default for AppSettings {
             gemini_model: default_gemini_model(),
             local_commands: std::collections::HashMap::new(),
             ai_custom_instructions: String::new(),
+            update_channel: default_update_channel(),
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub mod path_env;
 pub mod queries;
 pub mod ssh_tunnel;
 mod state;
+pub mod updater;
 mod vault;
 mod window;
 pub mod biometric;
@@ -1364,7 +1365,9 @@ pub fn run() {
             kill_op,
             get_profiling_status,
             set_profiling_level,
-            read_profile
+            read_profile,
+            updater::update_check,
+            updater::update_install
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,0 +1,95 @@
+//! Channel-aware auto-update.
+//!
+//! Tauri's updater endpoints are static config, so they can't be switched at
+//! runtime. To support a user-selectable channel ("stable" / "dev") we build the
+//! updater per check with the endpoint for the chosen channel via
+//! `app.updater_builder().endpoints(...)`.
+//!
+//! - stable → the latest non-prerelease `latest.json`
+//! - dev    → `latest.json` attached to the permanent `dev-channel` pre-release
+//!
+//! Both manifests are signed with the same updater key (configured in
+//! tauri.conf.json `plugins.updater.pubkey`), so switching channels is safe.
+//! Tauri only updates to a *higher* version, so stable→dev pulls newer dev
+//! builds; dev→stable does not auto-downgrade.
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use tauri_plugin_updater::UpdaterExt;
+
+const STABLE_ENDPOINT: &str =
+    "https://github.com/mqlens/mqlens-mongodb/releases/latest/download/latest.json";
+const DEV_ENDPOINT: &str =
+    "https://github.com/mqlens/mqlens-mongodb/releases/download/dev-channel/latest.json";
+
+fn endpoint_for(channel: &str) -> &'static str {
+    if channel == "dev" {
+        DEV_ENDPOINT
+    } else {
+        STABLE_ENDPOINT
+    }
+}
+
+#[derive(Serialize, Clone)]
+pub struct UpdateMeta {
+    pub version: String,
+    pub current_version: String,
+    pub notes: Option<String>,
+    pub date: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+struct DownloadProgress {
+    downloaded: usize,
+    total: Option<u64>,
+}
+
+async fn fetch_update(
+    app: &AppHandle,
+    channel: &str,
+) -> Result<Option<tauri_plugin_updater::Update>, String> {
+    let url = endpoint_for(channel)
+        .parse()
+        .map_err(|e| format!("invalid update endpoint: {e}"))?;
+    let updater = app
+        .updater_builder()
+        .endpoints(vec![url])
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?;
+    updater.check().await.map_err(|e| e.to_string())
+}
+
+/// Check the given channel's manifest for an available update.
+#[tauri::command]
+pub async fn update_check(app: AppHandle, channel: String) -> Result<Option<UpdateMeta>, String> {
+    let update = fetch_update(&app, &channel).await?;
+    Ok(update.map(|u| UpdateMeta {
+        version: u.version.clone(),
+        current_version: u.current_version.clone(),
+        notes: u.body.clone(),
+        date: u.date.map(|d| d.to_string()),
+    }))
+}
+
+/// Download + install the available update on the given channel, emitting
+/// `update://progress` events. The caller relaunches the app afterward.
+#[tauri::command]
+pub async fn update_install(app: AppHandle, channel: String) -> Result<(), String> {
+    let update = fetch_update(&app, &channel)
+        .await?
+        .ok_or_else(|| "No update available".to_string())?;
+    let mut downloaded: usize = 0;
+    let app2 = app.clone();
+    update
+        .download_and_install(
+            move |chunk, total| {
+                downloaded += chunk;
+                let _ = app2.emit("update://progress", DownloadProgress { downloaded, total });
+            },
+            || {},
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -15,6 +15,7 @@ interface AppSettings {
   gemini_model?: string;
   local_commands?: Record<string, string>;
   ai_custom_instructions?: string;
+  update_channel?: string;
 }
 
 interface AgentDetection {
@@ -61,6 +62,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
   const [geminiModel, setGeminiModel] = useState('gemini-1.5-flash');
   const [localCommands, setLocalCommands] = useState<Record<string, string>>({});
   const [customInstructions, setCustomInstructions] = useState('');
+  const [updateChannel, setUpdateChannel] = useState<'stable' | 'dev'>('stable');
   const [agents, setAgents] = useState<AgentDetection[]>([]);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -90,6 +92,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
         setGeminiModel(s.gemini_model || 'gemini-1.5-flash');
         setLocalCommands(s.local_commands || {});
         setCustomInstructions(s.ai_custom_instructions || '');
+        setUpdateChannel(s.update_channel === 'dev' ? 'dev' : 'stable');
       })
       .catch((err) => { if (!cancelled) setError(String(err)); });
     invoke<AgentDetection[]>('detect_local_agents')
@@ -122,6 +125,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
           gemini_model: geminiModel.trim() || 'gemini-1.5-flash',
           local_commands: localCommands,
           ai_custom_instructions: customInstructions,
+          update_channel: updateChannel,
         },
       });
       setStatus('Settings saved');
@@ -239,6 +243,25 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
           <div className="mql-settings-option-copy" style={{ marginBottom: 8 }}>
             MQLens checks for updates on launch and installs only after you approve. You can also check now.
           </div>
+
+          <div className="mql-label" style={{ marginBottom: 6 }}>Channel</div>
+          <div role="group" aria-label="Update channel" style={{ display: 'inline-flex', gap: 4, marginBottom: 6 }}>
+            {(['stable', 'dev'] as const).map((ch) => (
+              <button
+                key={ch}
+                type="button"
+                data-testid={`update-channel-${ch}`}
+                className={`mql-btn ${updateChannel === ch ? 'mql-btn-primary' : 'mql-btn-secondary'}`}
+                onClick={() => setUpdateChannel(ch)}
+              >
+                {ch === 'stable' ? 'Stable' : 'Dev (pre-release)'}
+              </button>
+            ))}
+          </div>
+          <div className="mql-settings-option-copy" style={{ marginBottom: 10, fontSize: 11 }}>
+            Dev receives pre-release builds. Switching to Dev pulls newer dev builds; switching back to Stable won’t downgrade automatically. Click Save to apply.
+          </div>
+
           <button
             type="button"
             className="mql-btn mql-btn-secondary"

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,18 +1,39 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { check, type Update } from '@tauri-apps/plugin-updater';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { Download, X, RefreshCw, CheckCircle2, AlertTriangle, ArrowUpCircle } from 'lucide-react';
 
 // Event other components (e.g. Settings) dispatch to trigger a manual check.
 export const CHECK_UPDATE_EVENT = 'mqlens:check-update';
 
+// Mirrors the Rust updater::UpdateMeta returned by the `update_check` command.
+interface UpdateMeta {
+  version: string;
+  current_version: string;
+  notes: string | null;
+  date: string | null;
+}
+
 type Phase = 'idle' | 'checking' | 'available' | 'downloading' | 'uptodate' | 'error';
 
+/** The user's selected update channel, read from app settings. */
+async function currentChannel(): Promise<string> {
+  try {
+    const s = await invoke<{ update_channel?: string }>('load_app_settings');
+    return s.update_channel === 'dev' ? 'dev' : 'stable';
+  } catch {
+    return 'stable';
+  }
+}
+
 // Auto-checks for an update a few seconds after launch (silent), and on demand
-// via the CHECK_UPDATE_EVENT. An available update is only ever downloaded and
-// installed after the user clicks "Update now" — human approval is required.
+// via the CHECK_UPDATE_EVENT. The check + install run against the channel the
+// user picked in Settings (stable | dev) via the Rust updater commands — Tauri's
+// static endpoints can't be switched at runtime. An available update is only ever
+// downloaded and installed after the user clicks "Update now".
 export const UpdatePrompt: React.FC = () => {
-  const [update, setUpdate] = useState<Update | null>(null);
+  const [update, setUpdate] = useState<UpdateMeta | null>(null);
   const [phase, setPhase] = useState<Phase>('idle');
   const [error, setError] = useState<string | null>(null);
   const [pct, setPct] = useState(0);
@@ -23,9 +44,10 @@ export const UpdatePrompt: React.FC = () => {
     setError(null);
     setPhase('checking');
     try {
-      const u = await check();
-      if (u) {
-        setUpdate(u);
+      const channel = await currentChannel();
+      const meta = await invoke<UpdateMeta | null>('update_check', { channel });
+      if (meta) {
+        setUpdate(meta);
         setPhase('available');
       } else {
         setPhase(isManual ? 'uptodate' : 'idle');
@@ -51,20 +73,23 @@ export const UpdatePrompt: React.FC = () => {
     if (!update) return;
     setPhase('downloading');
     setPct(0);
-    let total = 0;
-    let got = 0;
+    let unlisten: (() => void) | undefined;
     try {
-      await update.downloadAndInstall((ev: any) => {
-        if (ev.event === 'Started') total = ev.data?.contentLength ?? 0;
-        else if (ev.event === 'Progress') {
-          got += ev.data?.chunkLength ?? 0;
-          if (total > 0) setPct(Math.min(100, Math.round((got / total) * 100)));
+      unlisten = await listen<{ downloaded: number; total: number | null }>(
+        'update://progress',
+        (ev) => {
+          const { downloaded, total } = ev.payload;
+          if (total && total > 0) setPct(Math.min(100, Math.round((downloaded / total) * 100)));
         }
-      });
+      );
+      const channel = await currentChannel();
+      await invoke('update_install', { channel });
       await relaunch();
     } catch (e: any) {
       setError(String(e?.message || e));
       setPhase('error');
+    } finally {
+      unlisten?.();
     }
   };
 
@@ -119,10 +144,10 @@ export const UpdatePrompt: React.FC = () => {
 
         <p className="text-[13px] text-[var(--text-main)]" data-testid="update-version">
           MQLens <strong>{update?.version}</strong> is available
-          {update?.currentVersion ? <> (you have {update.currentVersion})</> : null}.
+          {update?.current_version ? <> (you have {update.current_version})</> : null}.
         </p>
-        {update?.body && (
-          <pre className="mql-update-notes">{update.body}</pre>
+        {update?.notes && (
+          <pre className="mql-update-notes">{update.notes}</pre>
         )}
 
         {downloading ? (

--- a/src/components/__tests__/UpdatePrompt.test.tsx
+++ b/src/components/__tests__/UpdatePrompt.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-const mockCheck = vi.fn();
-vi.mock('@tauri-apps/plugin-updater', () => ({ check: () => mockCheck() }));
+const invokeMock = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => invokeMock(...a) }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: () => Promise.resolve(() => {}) }));
 const mockRelaunch = vi.fn(() => Promise.resolve());
 vi.mock('@tauri-apps/plugin-process', () => ({ relaunch: () => mockRelaunch() }));
 
@@ -10,26 +11,37 @@ import { UpdatePrompt, CHECK_UPDATE_EVENT } from '../UpdatePrompt';
 
 const triggerManualCheck = () => fireEvent(window, new Event(CHECK_UPDATE_EVENT));
 
+// Route invoke() by command name; load_app_settings always returns a stable channel.
+function routeInvoke(map: Record<string, unknown>) {
+  invokeMock.mockImplementation((cmd: string) => {
+    if (cmd === 'load_app_settings') return Promise.resolve({ update_channel: 'stable' });
+    if (cmd in map) {
+      const v = map[cmd];
+      return typeof v === 'function' ? (v as () => unknown)() : Promise.resolve(v);
+    }
+    return Promise.resolve(null);
+  });
+}
+
 beforeEach(() => {
-  mockCheck.mockReset();
+  invokeMock.mockReset();
   mockRelaunch.mockClear();
 });
 
 describe('UpdatePrompt', () => {
   it('shows "latest version" on a manual check when up to date', async () => {
-    mockCheck.mockResolvedValue(null);
+    routeInvoke({ update_check: null });
     render(<UpdatePrompt />);
     triggerManualCheck();
     expect(await screen.findByTestId('update-toast')).toHaveTextContent(/latest version/i);
   });
 
   it('prompts for approval and installs only after clicking Update now', async () => {
-    const downloadAndInstall = vi.fn(async (cb: (e: any) => void) => {
-      cb({ event: 'Started', data: { contentLength: 100 } });
-      cb({ event: 'Progress', data: { chunkLength: 100 } });
-      cb({ event: 'Finished' });
+    const installFn = vi.fn(() => Promise.resolve());
+    routeInvoke({
+      update_check: { version: '0.3.0', current_version: '0.2.0', notes: 'New stuff', date: null },
+      update_install: installFn,
     });
-    mockCheck.mockResolvedValue({ version: '0.3.0', currentVersion: '0.2.0', body: 'New stuff', downloadAndInstall });
 
     render(<UpdatePrompt />);
     triggerManualCheck();
@@ -38,20 +50,23 @@ describe('UpdatePrompt', () => {
     expect(dialog).toBeInTheDocument();
     expect(screen.getByTestId('update-version')).toHaveTextContent('0.3.0');
     // Nothing installed until approval.
-    expect(downloadAndInstall).not.toHaveBeenCalled();
+    expect(installFn).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByTestId('update-now'));
-    await waitFor(() => expect(downloadAndInstall).toHaveBeenCalled());
+    await waitFor(() => expect(installFn).toHaveBeenCalled());
     await waitFor(() => expect(mockRelaunch).toHaveBeenCalled());
   });
 
   it('dismisses with Later without installing', async () => {
-    const downloadAndInstall = vi.fn();
-    mockCheck.mockResolvedValue({ version: '0.3.0', currentVersion: '0.2.0', body: '', downloadAndInstall });
+    const installFn = vi.fn(() => Promise.resolve());
+    routeInvoke({
+      update_check: { version: '0.3.0', current_version: '0.2.0', notes: '', date: null },
+      update_install: installFn,
+    });
     render(<UpdatePrompt />);
     triggerManualCheck();
     fireEvent.click(await screen.findByTestId('update-later'));
     expect(screen.queryByTestId('update-dialog')).toBeNull();
-    expect(downloadAndInstall).not.toHaveBeenCalled();
+    expect(installFn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Adds a user-selectable update channel (Stable / Dev) and fixes the release
pipeline's `latest.json` race (the failure on the 0.4.0 release).

## App (runtime channel toggle)
- `update_channel` setting (`stable` | `dev`, default stable), persisted in app settings.
- Rust `update_check` / `update_install` commands build the updater with the chosen
  channel's manifest endpoint at runtime (Tauri's static endpoints can't be switched):
  stable → `releases/latest/download/latest.json`, dev → `releases/download/dev-channel/latest.json`.
- Settings: a Stable/Dev toggle. `UpdatePrompt` now checks/installs via these commands
  (with `update://progress` events) instead of the static-endpoint JS updater.

## CI (publish two manifests, fix the race)
- Matrix builds set `uploadUpdaterJson: false` → the parallel jobs stop racing on the
  single `latest.json` asset (the cause of `Not Found - update-a-release-asset`).
- A new `updater-manifest` job assembles `latest.json` once from the per-platform
  signatures (`compose-latest.cjs`) and publishes per channel:
  stable → the release itself; dev → a permanent `dev-channel` pre-release (stable URL).
- The `version` job now also derives a monotonic dev version `<next-patch>-dev.<run>`
  (semver prereleases sort *below* their release, so the patch is bumped) and the build
  writes it into the bundle files; a unified `mqlens-v<version>` tag is used everywhere.

## Validation (required before this helps stable)
This is release automation that can't be exercised locally. After merge to `dev`:
1. Watch the dev `Release` run succeed (no `latest.json` race).
2. Confirm a `dev-channel` pre-release exists and its `latest.json` lists all 4
   platforms with correct download URLs.
3. Install a dev build, set Settings → channel = Dev, and confirm "Check for updates"
   offers the newer dev build.

## Known caveat (pre-existing, flagged)
When Azure Windows signing is enabled, `sign-windows` re-signs the installers *after*
tauri computed the updater signature, which invalidates the Windows updater entry.
Out of scope here; worth fixing the sign-then-manifest ordering separately.

## Local checks
- [x] `cargo build` (Rust updater commands compile)
- [x] `cargo test --lib settings` (AppSettings back-compat)
- [x] `npx tsc --noEmit`, `npx vitest run` (full suite incl. updated UpdatePrompt tests)
- [x] `npm run build`
- [x] release.yml parses; `compose-latest.cjs` produces a correct 4-platform manifest (skips duplicate mq-lens_ bundles)