### PR TITLE
Website: count installer downloads only + auto-refresh the counter

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - 'website/**'
       - '.github/workflows/website.yml'
+  # The download counter is computed at build time, so rebuild periodically to
+  # keep it fresh (every 6 hours). Scheduled runs use this file on the default
+  # branch (dev).
+  schedule:
+    - cron: '17 */6 * * *'
   workflow_dispatch:
 
 # Allow only one concurrent deployment; let an in-progress run finish.
@@ -38,6 +43,10 @@ jobs:
 
       - name: Build
         run: npm run build
+        # Authenticate the build-time GitHub API call (download counts) to avoid
+        # the unauthenticated 60-req/hour rate limit.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/website/src/components/Download.astro
+++ b/website/src/components/Download.astro
@@ -23,7 +23,11 @@ async function fetchRelease(): Promise<{ totalDownloads: number | null; assets: 
     if (!Array.isArray(releases) || releases.length === 0) return { totalDownloads: null, assets: [] };
     const total = releases
       .flatMap((r) => (Array.isArray(r.assets) ? r.assets : []))
-      .filter((a) => a && typeof a.name === 'string' && !a.name.endsWith('.asc'))
+      // Count real installer downloads only — not signatures (.sig), checksums
+      // (.asc), the updater manifest (latest.json), or .app.tar.gz updater bundles.
+      .filter(
+        (a) => a && typeof a.name === 'string' && /\.(dmg|msi|exe|deb|rpm|AppImage)$/i.test(a.name),
+      )
       .reduce((sum, a) => sum + (Number(a.download_count) || 0), 0);
     const latest = releases.find((r) => !r.draft && !r.prerelease) ?? releases[0];
     const assets: Asset[] = Array.isArray(latest?.assets) ? latest.assets : [];


### PR DESCRIPTION
## Why
The homepage "downloads" stat showed **129** while the live number was much higher. Two causes:
1. **Stale** — it's computed at build time (Astro SSG), so it only reflects the last deploy. It never refreshes on its own.
2. **Inflated metric** — `Download.astro` counted every asset except `.asc`, i.e. it also counted `.sig` signatures and `latest.json` (fetched automatically by the updater/CI), not real downloads.

## Changes
- **Count installers only** — filter to `.dmg`/`.msi`/`.exe`/`.deb`/`.rpm`/`.AppImage` (excludes `.sig`, `.asc`, `latest.json`, and `.app.tar.gz` updater bundles). Honest number ≈ **131**.
- **Auto-refresh** — add a 6-hourly `schedule` cron to the website deploy so the build-time count stays current without a manual deploy (cron fires from `dev`, the default branch).
- Pass `GITHUB_TOKEN` to the build so the download-count API call is authenticated (avoids the 60-req/hr unauthenticated limit).

## Verified
- `npm run build` succeeds; the built `index.html` now renders **131 downloads** (live fetch).
- `website.yml` parses.