### PR TITLE
Settings: tabbed two-pane layout

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -43,6 +43,15 @@ const PROVIDER_LABELS: Record<string, string> = {
   antigravity: 'Antigravity (local)',
 };
 
+type SettingsTab = 'appearance' | 'ai' | 'mongosh' | 'updates' | 'security';
+const SETTINGS_TABS: { id: SettingsTab; label: string; Icon: typeof LayoutGrid }[] = [
+  { id: 'appearance', label: 'Appearance', Icon: LayoutGrid },
+  { id: 'ai', label: 'AI Assistant', Icon: Sparkles },
+  { id: 'mongosh', label: 'Mongosh', Icon: Terminal },
+  { id: 'updates', label: 'Updates', Icon: ArrowUpCircle },
+  { id: 'security', label: 'Security', Icon: ShieldCheck },
+];
+
 interface SettingsViewProps {
   density: 'roomy' | 'cozy' | 'compact';
   onChangeDensity: (density: 'roomy' | 'cozy' | 'compact') => void;
@@ -63,6 +72,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
   const [localCommands, setLocalCommands] = useState<Record<string, string>>({});
   const [customInstructions, setCustomInstructions] = useState('');
   const [updateChannel, setUpdateChannel] = useState<'stable' | 'dev'>('stable');
+  const [tab, setTab] = useState<SettingsTab>('appearance');
   const [agents, setAgents] = useState<AgentDetection[]>([]);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -201,7 +211,25 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
         </div>
       </header>
 
-      <div className="mql-settings-body">
+      <div className="mql-settings-layout">
+        <nav className="mql-settings-tabs" role="tablist" aria-label="Settings sections">
+          {SETTINGS_TABS.map(({ id, label, Icon }) => (
+            <button
+              key={id}
+              type="button"
+              role="tab"
+              aria-selected={tab === id}
+              data-testid={`settings-tab-${id}`}
+              className={`mql-settings-tab ${tab === id ? 'is-active' : ''}`}
+              onClick={() => setTab(id)}
+            >
+              <Icon size={14} /> <span>{label}</span>
+            </button>
+          ))}
+        </nav>
+
+        <div className="mql-settings-panel">
+        {tab === 'appearance' && (
         <section className="mql-settings-section">
           <div className="mql-settings-section-h">
             <LayoutGrid size={13} color="var(--accent-blue)" />
@@ -234,7 +262,9 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
             })}
           </div>
         </section>
+        )}
 
+        {tab === 'updates' && (
         <section className="mql-settings-section">
           <div className="mql-settings-section-h">
             <ArrowUpCircle size={13} color="var(--accent-blue)" />
@@ -271,7 +301,9 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
             <ArrowUpCircle size={13} /> Check for updates
           </button>
         </section>
+        )}
 
+        {tab === 'mongosh' && (
         <section className="mql-settings-section">
           <div className="mql-settings-section-h">
             <Terminal size={13} color="var(--accent-green)" />
@@ -292,15 +324,11 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
               <Terminal size={11} />
               {testing ? 'Testing...' : 'Test Path'}
             </button>
-            <button className="mql-btn mql-btn-primary" onClick={saveSettings} disabled={saving} type="button">
-              <Save size={11} />
-              {saving ? 'Saving...' : 'Save'}
-            </button>
           </div>
-          {status && <div className="mql-settings-status">{status}</div>}
-          {error && <div className="mql-settings-error">{error}</div>}
         </section>
+        )}
 
+        {tab === 'ai' && (
         <section className="mql-settings-section">
           <div className="mql-settings-section-h">
             <Sparkles size={13} color="var(--accent-blue)" />
@@ -405,14 +433,10 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
               data-testid="ai-instructions-input" />
           </label>
 
-          <div className="mql-settings-actions">
-            <button className="mql-btn mql-btn-primary" onClick={saveSettings} disabled={saving} type="button">
-              <Save size={11} />
-              {saving ? 'Saving...' : 'Save'}
-            </button>
-          </div>
         </section>
+        )}
 
+        {tab === 'security' && (
         <section className="mql-settings-section">
           <div className="mql-settings-section-h">
             <ShieldCheck size={13} color="var(--accent-amber)" />
@@ -488,6 +512,21 @@ export const SettingsView: React.FC<SettingsViewProps> = ({
             </label>
           )}
         </section>
+        )}
+
+          {(tab === 'updates' || tab === 'mongosh' || tab === 'ai') && (
+            <div className="mql-settings-footer">
+              <div className="mql-settings-footer-msg">
+                {status && <span className="mql-settings-status">{status}</span>}
+                {error && <span className="mql-settings-error">{error}</span>}
+              </div>
+              <button className="mql-btn mql-btn-primary" onClick={saveSettings} disabled={saving} type="button" data-testid="settings-save-btn">
+                <Save size={11} />
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -444,7 +444,8 @@ describe('App Component', () => {
 
     expect(await screen.findByTestId('settings-view')).toBeInTheDocument();
     expect(screen.getAllByText('Settings').length).toBeGreaterThan(0);
-    expect(screen.getByTestId('mongosh-path-input')).toHaveValue('/usr/local/bin/mongosh');
+    fireEvent.click(screen.getByTestId('settings-tab-mongosh'));
+    expect(await screen.findByTestId('mongosh-path-input')).toHaveValue('/usr/local/bin/mongosh');
   });
 
   it('runs an aggregation pipeline via execute_aggregate, not a collapsed find (C4)', async () => {

--- a/src/components/__tests__/SettingsModal.test.tsx
+++ b/src/components/__tests__/SettingsModal.test.tsx
@@ -57,6 +57,7 @@ describe('SettingsView Component', () => {
     expect(screen.getByText('Balanced padding and standard grid heights (recommended).')).toBeInTheDocument();
     expect(screen.getByTestId('density-check-cozy')).toBeInTheDocument();
 
+    fireEvent.click(screen.getByTestId('settings-tab-mongosh'));
     const pathInput = await screen.findByTestId('mongosh-path-input') as HTMLInputElement;
     expect(pathInput.value).toBe('/usr/local/bin/mongosh');
   });
@@ -85,6 +86,7 @@ describe('SettingsView Component', () => {
       />
     );
 
+    fireEvent.click(screen.getByTestId('settings-tab-mongosh'));
     const pathInput = await screen.findByTestId('mongosh-path-input') as HTMLInputElement;
     fireEvent.change(pathInput, { target: { value: '/opt/homebrew/bin/mongosh' } });
 
@@ -93,8 +95,8 @@ describe('SettingsView Component', () => {
       expect(mockInvoke).toHaveBeenCalledWith('test_mongosh_path', { path: '/opt/homebrew/bin/mongosh' });
     });
 
-    // Two "Save" buttons (mongosh + AI sections) both persist all settings.
-    fireEvent.click(screen.getAllByRole('button', { name: /^save$/i })[0]);
+    // One shared Save button in the panel footer persists all settings.
+    fireEvent.click(screen.getByTestId('settings-save-btn'));
     await waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith('save_app_settings', {
         settings: expect.objectContaining({
@@ -116,6 +118,7 @@ describe('SettingsView Component', () => {
     mockChangeVaultPassword.mockResolvedValue(undefined);
     render(<SettingsView density="cozy" onChangeDensity={() => {}} />);
 
+    fireEvent.click(screen.getByTestId('settings-tab-security'));
     fireEvent.change(await screen.findByTestId('sec-old-pw'), { target: { value: 'oldpass' } });
     fireEvent.change(screen.getByTestId('sec-new-pw'), { target: { value: 'newpass' } });
     fireEvent.change(screen.getByTestId('sec-new-pw2'), { target: { value: 'newpass' } });
@@ -130,6 +133,7 @@ describe('SettingsView Component', () => {
   it('shows error when new passwords do not match (H7)', async () => {
     render(<SettingsView density="cozy" onChangeDensity={() => {}} />);
 
+    fireEvent.click(screen.getByTestId('settings-tab-security'));
     fireEvent.change(await screen.findByTestId('sec-old-pw'), { target: { value: 'oldpass' } });
     fireEvent.change(screen.getByTestId('sec-new-pw'), { target: { value: 'newpass' } });
     fireEvent.change(screen.getByTestId('sec-new-pw2'), { target: { value: 'different' } });
@@ -143,6 +147,7 @@ describe('SettingsView Component', () => {
     mockBiometricStatus.mockResolvedValue({ available: true, biometryType: 2, enrolled: false });
     mockBiometricEnable.mockResolvedValue(undefined);
     render(<SettingsView density="cozy" onChangeDensity={() => {}} />);
+    fireEvent.click(screen.getByTestId('settings-tab-security'));
     const toggle = await screen.findByTestId('sec-biometric-toggle');
     fireEvent.click(toggle);
     await waitFor(() => expect(mockBiometricEnable).toHaveBeenCalledTimes(1));
@@ -151,6 +156,7 @@ describe('SettingsView Component', () => {
   it('hides the biometric toggle when unavailable', async () => {
     mockBiometricStatus.mockResolvedValue({ available: false, biometryType: 0, enrolled: false });
     render(<SettingsView density="cozy" onChangeDensity={() => {}} />);
+    fireEvent.click(screen.getByTestId('settings-tab-security'));
     await screen.findByTestId('sec-change-pw-btn');
     expect(screen.queryByTestId('sec-biometric-toggle')).not.toBeInTheDocument();
   });
@@ -171,6 +177,7 @@ describe('SettingsView Component', () => {
 
     render(<SettingsView density="cozy" onChangeDensity={() => {}} />);
 
+    fireEvent.click(screen.getByTestId('settings-tab-ai'));
     const select = await screen.findByTestId('ai-provider-select');
 
     // Cloud provider shows key + model.

--- a/src/index.css
+++ b/src/index.css
@@ -5586,3 +5586,18 @@ button, input, select, textarea {
   .mql-qs-page { grid-template-columns: 1fr; }
   .mql-quickstart { padding: 28px 20px 44px; }
 }
+
+/* ===== Settings (tabbed two-pane) ===== */
+.mql-settings-layout { flex: 1; min-height: 0; display: flex; gap: 20px; padding: 18px; overflow: hidden; }
+.mql-settings-tabs { flex: 0 0 196px; display: flex; flex-direction: column; gap: 2px; }
+.mql-settings-tab { display: flex; align-items: center; gap: 10px; width: 100%; text-align: left;
+  background: none; border: none; padding: 9px 12px; border-radius: 9px; cursor: pointer;
+  color: var(--text-muted); font-size: 13px; font-weight: 500; }
+.mql-settings-tab:hover { background: var(--bg-item-hover); color: var(--text-main); }
+.mql-settings-tab.is-active { background: var(--bg-item-active); color: var(--text-main); font-weight: 600; }
+.mql-settings-tab svg { color: var(--text-dim); flex: 0 0 auto; }
+.mql-settings-tab.is-active svg { color: var(--accent-blue); }
+.mql-settings-panel { flex: 1; min-width: 0; max-width: 720px; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 16px; }
+.mql-settings-footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding-top: 6px; }
+.mql-settings-footer-msg { display: flex; align-items: center; gap: 12px; min-width: 0; }


### PR DESCRIPTION
Redesigns the Settings page from one long scrolling list into a tabbed two-pane layout.

## Changes
- **Left vertical nav** with 5 tabs (icon + label, active state): Appearance, AI Assistant, Mongosh, Updates, Security. Content shows in the right panel.
- **One shared Save** in a panel footer (shown on Updates/Mongosh/AI), **right-aligned**, with status/errors on the left. Saves all settings at once, as before. Density applies instantly; Security keeps its own actions.
- All existing settings logic/state unchanged — just reorganized under tabs (conditional rendering, clean DOM).
- Tests updated to switch tabs before asserting per-section content (SettingsModal + the App "opens settings" test).

## Verified
- tsc clean, `npx vitest run` (322 passing), `npm run build` ok.
- Headless screenshot of the real CSS confirms the two-pane layout and right-aligned Save.