### PR TITLE
Site/README: fix comparison accuracy + trust block + sharper positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![CI](https://github.com/mqlens/mqlens-mongodb/actions/workflows/ci.yml/badge.svg)](https://github.com/mqlens/mqlens-mongodb/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-enabled-brightgreen.svg)](.github/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/mqlens/mqlens-mongodb)](https://github.com/mqlens/mqlens-mongodb/releases)
+[![Downloads](https://img.shields.io/github/downloads/mqlens/mqlens-mongodb/total)](https://github.com/mqlens/mqlens-mongodb/releases)
+[![Stars](https://img.shields.io/github/stars/mqlens/mqlens-mongodb?style=flat)](https://github.com/mqlens/mqlens-mongodb/stargazers)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 **A fast, native desktop GUI for MongoDB** — built with [Tauri](https://tauri.app)
 (Rust) and React + TypeScript.
@@ -72,18 +76,28 @@ Grab the latest build for your OS from
 
 No account, no sign-up, no telemetry.
 
+## Trust & privacy
+
+- **No telemetry** — nothing is tracked or phoned home.
+- **No account required** — just download and connect.
+- **Credentials encrypted locally** with AES-256-GCM and Argon2id key derivation.
+- **Signed release assets** (detached signatures on every artifact).
+- **macOS notarized** builds and **Windows signed** installers.
+- **Apache-2.0** — fully open source.
+
 ## MQLens vs. the alternatives
 
 | | MQLens | Compass | Studio 3T |
 |---|---|---|---|
 | Price | **Free (Apache-2.0)** | Free | Paid |
 | Engine | **Native (Tauri/Rust)** | Electron | Java |
-| All auth (X.509 / AWS / Kerberos / LDAP) | ✅ | partial | ✅ |
-| SSH tunnel / SOCKS5 proxy | ✅ | ❌ | ✅ |
+| Enterprise auth (X.509 / AWS / Kerberos / LDAP) | ✅ | ✅ | ✅ |
+| SSH tunnel | ✅ | ✅ | ✅ |
+| SOCKS5 proxy | ✅ | Not clearly exposed | Varies |
 | Aggregation + explain tree | ✅ | ✅ | ✅ |
 | Embedded `mongosh` | ✅ | ✅ | ✅ |
 | AI query assistant (bring-your-own key) | ✅ | ✅ | partial |
-| Encrypted creds + biometric unlock | ✅ | ❌ | partial |
+| Biometric-unlocked encrypted vault | ✅ | ❌ | partial |
 | Telemetry | **None** | yes | yes |
 
 *Comparison reflects publicly documented behavior at time of writing; tools change — corrections welcome via an issue.*

--- a/website/src/consts.ts
+++ b/website/src/consts.ts
@@ -1,7 +1,7 @@
 // Single source of truth for site-wide constants.
 export const SITE = {
   name: 'MQLens',
-  tagline: 'The MongoDB GUI that does it all — free, native, and private',
+  tagline: 'Free native MongoDB GUI for SSH, TLS, enterprise auth, explain plans, and private local workflows',
   description:
     'MQLens is a free, native, cross-platform MongoDB GUI with the power of paid tools: every auth mode (SCRAM, X.509, AWS, Kerberos, LDAP), TLS/SSH/proxy, aggregation pipelines with explain plans, bulk edit, index/view management, schema analysis, GridFS, an embedded mongosh, and an AI query assistant. Credentials are encrypted locally with zero telemetry. Apache-2.0.',
   url: 'https://mqlens.com',

--- a/website/src/pages/compare/mongodb-compass-alternative.astro
+++ b/website/src/pages/compare/mongodb-compass-alternative.astro
@@ -62,7 +62,7 @@ import { SITE } from '../../consts';
             <tr>
               <td>Credential storage</td>
               <td class="col-us">AES-256-GCM encrypted + biometric unlock</td>
-              <td>Stored per OS keychain or plaintext</td>
+              <td>Platform-specific storage (OS keychain)</td>
             </tr>
             <tr>
               <td>SSH tunnel</td>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -111,7 +111,7 @@ const screenshots = [
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Tiny native app · macOS · Windows · Linux
         </span>
-        <h1>The MongoDB GUI that does it all.<span class="grad">Free, native, and private.</span></h1>
+        <h1>A free, native MongoDB GUI for real developer workflows. <span class="grad">Private, open source, built for SSH/TLS/auth-heavy deployments.</span></h1>
         <p class="lede">
           Every auth mode, TLS/SSH/proxy, aggregation pipelines with explain plans,
           bulk edit, schema analysis, GridFS, an embedded <code>mongosh</code>, and an


### PR DESCRIPTION
Addresses the trust/accuracy items (the #1 priority): some comparison claims about Compass were inaccurate and could hurt credibility with MongoDB users.

## Accuracy fixes
- **README comparison**: Compass **SSH tunnel ✅** (was ❌ — Compass does support SSH); **enterprise auth ✅** for all (was 'partial' — Compass supports X.509/Kerberos/LDAP/AWS IAM); split **SOCKS5** into its own row ('not clearly exposed' for Compass); reframed the credentials row to **'Biometric-unlocked encrypted vault'** so the ❌ is accurate (Compass uses the OS keychain).
- **Compare page**: removed the unprovable **'plaintext'** Compass credential claim → 'Platform-specific storage (OS keychain)'.

## Trust & positioning
- **README**: added a visible **Trust & privacy** block (no telemetry, no account, local AES-256-GCM+Argon2id, signed/notarized/signed installers, Apache-2.0) + release/downloads/stars/license badges.
- **Hero**: fixed the `all.Free` spacing typo and sharpened the tagline toward real-world workflows (SSH/TLS/enterprise auth/explain plans/local-first); updated the site meta tagline too.

Website builds clean. Honest differentiator stays: native/lightweight, no telemetry, no account, Apache-2.0, biometric-unlocked encrypted vault.