### PR TITLE
In-app Help & feedback menu + GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug / workflow issue
+description: Something didn't work the way you expected
+labels: [bug]
+body:
+  - type: textarea
+    id: trying
+    attributes:
+      label: What were you trying to do?
+      placeholder: e.g. Connect to a replica set over an SSH tunnel and browse a collection
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: MongoDB deployment
+      options:
+        - Local
+        - Atlas
+        - Self-hosted
+        - DocumentDB
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: auth
+    attributes:
+      label: Auth mode (if relevant)
+      placeholder: SCRAM / X.509 / MONGODB-AWS / Kerberos / LDAP / none
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: MQLens version
+      placeholder: e.g. 0.4.0
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://mqlens.com/docs/
+    about: Guides and feature documentation.
+  - name: Website & downloads
+    url: https://mqlens.com
+    about: Installers, comparisons, and changelog.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature / workflow request
+description: Suggest an improvement or a workflow MQLens should support
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What workflow is painful today?
+      placeholder: Describe the task and where MQLens (or another tool) gets in your way.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like MQLens to do?
+    validations:
+      required: true
+  - type: input
+    id: deployment
+    attributes:
+      label: MongoDB deployment (if relevant)
+      placeholder: Local / Atlas / Self-hosted / DocumentDB

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,15 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { invoke } from '@tauri-apps/api/core';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { useDialogs } from './dialogs/DialogProvider';
 import {
   Database,
-  Folder, 
-  FolderOpen, 
-  Server, 
-  RefreshCw, 
-  Trash2, 
-  Plus, 
+  Folder,
+  FolderOpen,
+  Server,
+  RefreshCw,
+  Trash2,
+  Plus,
   LogOut,
   Layers,
   KeyRound,
@@ -25,8 +26,21 @@ import {
   Table2,
   Activity,
   Search,
+  HelpCircle,
+  Bug,
+  Lightbulb,
+  Star,
+  BookOpen,
   X
 } from 'lucide-react';
+
+const REPO_URL = 'https://github.com/mqlens/mqlens-mongodb';
+const HELP_LINKS = [
+  { Icon: Bug, label: 'Report a bug', url: `${REPO_URL}/issues/new?template=bug_report.yml` },
+  { Icon: Lightbulb, label: 'Request a feature', url: `${REPO_URL}/issues/new?template=feature_request.yml` },
+  { Icon: BookOpen, label: 'Documentation', url: 'https://mqlens.com/docs/' },
+  { Icon: Star, label: 'Star on GitHub', url: `${REPO_URL}/stargazers` },
+];
 
 // Mirrors the backend CollectionInfo struct returned by `list_collections`.
 export interface CollectionInfo {
@@ -150,6 +164,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const { toast, confirm, prompt } = useDialogs();
   // Tree filter: matches connection / database / (loaded) collection names.
   const [filterQuery, setFilterQuery] = useState('');
+  const [helpOpen, setHelpOpen] = useState(false);
   // key: connectionId, value: database names list
   const [databases, setDatabases] = useState<{ [connectionId: string]: string[] }>({});
   
@@ -836,6 +851,40 @@ export const Sidebar: React.FC<SidebarProps> = ({
           >
             <Settings size={13} />
           </button>
+          <span style={{ position: 'relative', display: 'inline-flex' }}>
+            <button
+              onClick={() => setHelpOpen((o) => !o)}
+              className="mql-icon-btn"
+              title="Help & feedback"
+              aria-label="Help and feedback"
+              aria-haspopup="menu"
+              aria-expanded={helpOpen}
+              data-testid="help-menu-btn"
+            >
+              <HelpCircle size={13} />
+            </button>
+            {helpOpen && (
+              <>
+                <div
+                  onClick={() => setHelpOpen(false)}
+                  style={{ position: 'fixed', inset: 0, zIndex: 60 }}
+                  aria-hidden="true"
+                />
+                <div className="mql-help-menu" role="menu">
+                  {HELP_LINKS.map(({ Icon, label, url }) => (
+                    <button
+                      key={label}
+                      type="button"
+                      role="menuitem"
+                      onClick={() => { setHelpOpen(false); void openUrl(url); }}
+                    >
+                      <Icon size={13} /> <span>{label}</span>
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
+          </span>
           <button
             onClick={onOpenConnectionManager}
             className="mql-icon-btn"

--- a/src/index.css
+++ b/src/index.css
@@ -5601,3 +5601,13 @@ button, input, select, textarea {
   display: flex; flex-direction: column; gap: 16px; }
 .mql-settings-footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding-top: 6px; }
 .mql-settings-footer-msg { display: flex; align-items: center; gap: 12px; min-width: 0; }
+
+/* ===== Sidebar help & feedback menu ===== */
+.mql-help-menu { position: absolute; right: 0; top: calc(100% + 6px); z-index: 70; min-width: 196px;
+  background: var(--bg-dropdown-solid); border: 1px solid var(--border-color); border-radius: 10px;
+  padding: 5px; box-shadow: var(--shadow-panel); display: flex; flex-direction: column; }
+.mql-help-menu button { display: flex; align-items: center; gap: 9px; width: 100%; text-align: left;
+  background: none; border: none; padding: 8px 10px; border-radius: 7px; color: var(--text-main);
+  font-size: 12.5px; cursor: pointer; }
+.mql-help-menu button:hover { background: var(--bg-item-hover); }
+.mql-help-menu button svg { color: var(--accent-blue); flex: 0 0 auto; }


### PR DESCRIPTION
Adds an in-app feedback loop to generate real product feedback and visible repo activity (from the growth plan).

## Changes
- **Sidebar Help menu** — a `Help & feedback` dropdown in the sidebar header with: Report a bug, Request a feature, Documentation, Star on GitHub. Links open in the system browser via `@tauri-apps/plugin-opener`. Bug/feature links go straight to the prefilled GitHub issue forms.
- **GitHub issue templates** — `bug_report.yml` (what were you trying to do / expected / actual / MongoDB deployment / auth mode / OS / MQLens version), `feature_request.yml` (painful workflow / proposal), and `config.yml` (links to docs + website).

## Verified
- tsc clean, full `vitest` suite passing, `npm run build` OK.