### PR TITLE
Website: workflow & platform SEO landing pages

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -31,7 +31,21 @@ const year = 2026;
         <a href="/compare/studio-3t-alternative/">vs Studio 3T</a>
         <a href="/compare/robo-3t-alternative/">vs Robo 3T</a>
         <a href="/compare/nosqlbooster-alternative/">vs NoSQLBooster</a>
+      </div>
+      <div>
+        <h4>Platforms</h4>
+        <a href="/mongodb-client-for-mac/">MongoDB client for Mac</a>
+        <a href="/mongodb-client-for-windows/">MongoDB client for Windows</a>
         <a href="/mongodb-gui-for-linux/">MongoDB GUI for Linux</a>
+      </div>
+      <div>
+        <h4>Workflows</h4>
+        <a href="/mongodb-ssh-tunnel-gui/">SSH tunnel</a>
+        <a href="/mongodb-explain-plan-gui/">Explain plans</a>
+        <a href="/mongodb-aggregation-pipeline-gui/">Aggregation pipelines</a>
+        <a href="/mongodb-schema-analysis-tool/">Schema analysis</a>
+        <a href="/mongodb-gridfs-gui/">GridFS browser</a>
+        <a href="/mongodb-gui-no-telemetry/">No telemetry</a>
       </div>
       <div>
         <h4>Project</h4>

--- a/website/src/components/WorkflowLanding.astro
+++ b/website/src/components/WorkflowLanding.astro
@@ -1,0 +1,166 @@
+---
+// Reusable SEO landing-page template for workflow / platform keyword pages.
+// Keeps every page on one shared layout + style so the set stays consistent.
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Download from './Download.astro';
+import { SITE } from '../consts';
+
+interface Step { title: string; body: string }
+interface Feature { h3: string; p: string }
+interface Props {
+  title: string;
+  description: string;
+  eyebrow: string;
+  h1: string;
+  grad: string;
+  lede: string;
+  ctaLabel?: string;
+  screenshot?: { src: string; alt: string };
+  stepsTitle?: string;
+  steps?: Step[];
+  featuresTitle?: string;
+  features?: Feature[];
+}
+const {
+  title, description, eyebrow, h1, grad, lede,
+  ctaLabel = 'Download for free',
+  screenshot, stepsTitle, steps = [], featuresTitle, features = [],
+} = Astro.props as Props;
+---
+
+<BaseLayout title={title} description={description}>
+  <section class="hero">
+    <div class="container hero-inner">
+      <span class="eyebrow">{eyebrow}</span>
+      <h1>{h1} <span class="grad">{grad}</span></h1>
+      <p class="lede" set:html={lede} />
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#download">{ctaLabel}</a>
+        <a class="btn btn-ghost" href={SITE.repo} target="_blank" rel="noopener">Star on GitHub ★</a>
+      </div>
+      <p class="hero-note">Free &amp; open source (Apache-2.0) · No telemetry · No account.</p>
+    </div>
+  </section>
+
+  {screenshot && (
+    <section class="section-tight">
+      <div class="container shot-wrap">
+        <a href={screenshot.src} target="_blank" rel="noopener" aria-label="Open full-size screenshot">
+          <img src={screenshot.src} alt={screenshot.alt} loading="lazy" width="1280" height="800" />
+        </a>
+      </div>
+    </section>
+  )}
+
+  {steps.length > 0 && (
+    <section class="section">
+      <div class="container">
+        <div class="sec-head">
+          <span class="eyebrow">Step by step</span>
+          <h2>{stepsTitle}</h2>
+        </div>
+        <ol class="steps">
+          {steps.map((s) => (
+            <li>
+              <h3>{s.title}</h3>
+              <p set:html={s.body} />
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  )}
+
+  {features.length > 0 && (
+    <section class="section">
+      <div class="container">
+        <div class="sec-head">
+          <span class="eyebrow">Why MQLens</span>
+          <h2>{featuresTitle}</h2>
+        </div>
+        <div class="feat-grid">
+          {features.map((f) => (
+            <article class="feat-card">
+              <h3>{f.h3}</h3>
+              <p set:html={f.p} />
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <section class="section-tight" id="download">
+    <div class="container">
+      <h2 class="dl-heading">Download {SITE.name} — it's free</h2>
+      <Download />
+    </div>
+  </section>
+
+  <section class="section cta">
+    <div class="container cta-inner">
+      <h2>Point {SITE.name} at your MongoDB cluster.</h2>
+      <p>Free, open source, native — yours to inspect and run.</p>
+      <a class="btn btn-primary" href="#download">{ctaLabel}</a>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero {
+    padding: 96px 0 64px;
+    background:
+      radial-gradient(1100px 480px at 50% -140px, hsla(200, 90%, 50%, 0.20), transparent 70%),
+      radial-gradient(900px 460px at 92% 120%, hsla(268, 85%, 65%, 0.12), transparent 70%);
+    border-bottom: 1px solid var(--border);
+  }
+  .hero-inner { text-align: center; max-width: 820px; margin: 0 auto; }
+  .hero h1 { font-size: clamp(2.1rem, 5.5vw, 3.2rem); margin: 18px 0 0; font-weight: 700; }
+  .grad {
+    background: linear-gradient(100deg, var(--accent-bright), var(--accent-teal));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .lede { font-size: 1.12rem; color: var(--text-dim); margin: 22px auto 0; max-width: 700px; }
+  .hero-cta { display: flex; gap: 12px; justify-content: center; margin-top: 30px; flex-wrap: wrap; }
+  .hero-note { color: var(--text-dim); font-size: 0.9rem; margin-top: 22px; }
+
+  .shot-wrap { max-width: 960px; }
+  .shot-wrap img {
+    width: 100%; height: auto; border-radius: var(--radius);
+    border: 1px solid var(--border); box-shadow: var(--shadow, 0 20px 50px rgba(0,0,0,0.25));
+  }
+
+  .dl-heading { text-align: center; margin: 0 0 28px; font-size: 1.6rem; }
+  .sec-head { text-align: center; max-width: 640px; margin: 0 auto 40px; }
+  .sec-head h2 { font-size: clamp(1.8rem, 4vw, 2.4rem); margin: 12px 0 0; }
+
+  .steps { counter-reset: step; list-style: none; padding: 0; margin: 0 auto; max-width: 760px; display: flex; flex-direction: column; gap: 14px; }
+  .steps li {
+    position: relative; padding: 20px 22px 20px 64px;
+    background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+  }
+  .steps li::before {
+    counter-increment: step; content: counter(step);
+    position: absolute; left: 20px; top: 20px;
+    width: 28px; height: 28px; border-radius: 8px;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--bg-soft); color: var(--accent-bright); font-weight: 700; font-size: 0.95rem;
+  }
+  .steps h3 { margin: 0 0 6px; font-size: 1.05rem; }
+  .steps p { margin: 0; color: var(--text-dim); font-size: 0.95rem; }
+
+  .feat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 18px; }
+  .feat-card {
+    background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+    padding: 24px; transition: border-color 0.15s ease, transform 0.08s ease;
+  }
+  .feat-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+  .feat-card h3 { margin: 0 0 10px; font-size: 1.12rem; }
+  .feat-card p { margin: 0; color: var(--text-dim); font-size: 0.95rem; }
+
+  .cta-inner { text-align: center; }
+  .cta-inner h2 { font-size: clamp(1.8rem, 4vw, 2.6rem); margin: 0; }
+  .cta-inner p { color: var(--text-dim); margin: 14px 0 26px; }
+</style>

--- a/website/src/pages/mongodb-aggregation-pipeline-gui.astro
+++ b/website/src/pages/mongodb-aggregation-pipeline-gui.astro
@@ -1,0 +1,25 @@
+---
+import WorkflowLanding from '../components/WorkflowLanding.astro';
+---
+<WorkflowLanding
+  title="MongoDB aggregation pipeline GUI"
+  description="Build and run MongoDB aggregation pipelines in a multi-stage editor with a visual query builder and explain plans. Free native GUI, Apache-2.0, zero telemetry."
+  eyebrow="Aggregation pipelines"
+  h1="Build MongoDB aggregation pipelines."
+  grad="Visually or in code."
+  lede="Compose multi-stage aggregation pipelines in a stage editor, keep the raw pipeline editable, and run it against real documents — then read the explain plan to see how each stage executes."
+  screenshot={{ src: '/screenshots/mqlens-visual-builder.png', alt: 'MQLens visual query builder beside MongoDB documents' }}
+  stepsTitle="From idea to result"
+  steps={[
+    { title: 'Pick a collection', body: 'Start a new pipeline against any collection.' },
+    { title: 'Add stages', body: 'Chain <code>$match</code>, <code>$group</code>, <code>$lookup</code>, <code>$project</code>, and more in the multi-stage editor.' },
+    { title: 'Run and iterate', body: 'Execute against live data and refine stages as you go — the raw pipeline stays editable.' },
+    { title: 'Explain the pipeline', body: 'Render the explain plan to see stage-by-stage execution and index usage.' },
+  ]}
+  featuresTitle="A real pipeline workbench"
+  features={[
+    { h3: 'Multi-stage editor', p: 'Build pipelines stage by stage, with the editable raw view right alongside.' },
+    { h3: 'Visual query builder', p: 'For <code>find</code>, build filters/sort/projection visually next to the raw query.' },
+    { h3: 'Explain for aggregate', p: 'Visual plan tree for aggregations, so you can actually tune them.' },
+  ]}
+/>

--- a/website/src/pages/mongodb-client-for-mac.astro
+++ b/website/src/pages/mongodb-client-for-mac.astro
@@ -1,0 +1,21 @@
+---
+import WorkflowLanding from '../components/WorkflowLanding.astro';
+---
+<WorkflowLanding
+  title="MongoDB client for Mac"
+  description="A fast native MongoDB client for macOS — Apple Silicon & Intel, notarized .dmg, Touch ID unlock, every auth mode, SSH/TLS, explain plans. Free, Apache-2.0, zero telemetry."
+  eyebrow="macOS · Apple Silicon & Intel"
+  h1="A native MongoDB client for Mac."
+  grad="Notarized, tiny, Touch ID."
+  ctaLabel="Download for macOS"
+  lede="MQLens is a ~14 MB native macOS app (Tauri/Rust, not Electron) — an Apple-notarized <code>.dmg</code> for Apple Silicon and Intel, with Touch ID unlock for your encrypted credential vault. Every feature is here: all auth modes, TLS / SSH / SOCKS5, aggregation pipelines, visual explain plans, schema analysis, GridFS, and an embedded mongosh."
+  screenshot={{ src: '/screenshots/mqlens-documents.png', alt: 'MQLens running on macOS browsing MongoDB documents' }}
+  featuresTitle="Everything, the Mac-native way"
+  features={[
+    { h3: 'Apple Silicon + Intel', p: 'Notarized universal-friendly <code>.dmg</code> builds for both architectures.' },
+    { h3: 'Touch ID unlock', p: 'Unlock your AES-256-GCM credential vault with Touch ID.' },
+    { h3: 'Every connection mode', p: 'All auth mechanisms (SCRAM, X.509, AWS IAM, Kerberos, LDAP) plus TLS / SSH / SOCKS5.' },
+    { h3: 'Full feature set', p: 'Aggregation pipelines, explain plans, schema analysis, GridFS, and embedded mongosh.' },
+    { h3: 'Private &amp; free', p: 'Zero telemetry, no account, Apache-2.0.' },
+  ]}
+/>

--- a/website/src/pages/mongodb-client-for-windows.astro
+++ b/website/src/pages/mongodb-client-for-windows.astro
@@ -1,0 +1,21 @@
+---
+import WorkflowLanding from '../components/WorkflowLanding.astro';
+---
+<WorkflowLanding
+  title="MongoDB client for Windows"
+  description="A fast native MongoDB client for Windows — signed .msi/.exe installer, every auth mode, SSH/TLS, aggregation pipelines, explain plans. Free, Apache-2.0, zero telemetry."
+  eyebrow="Windows 10 / 11"
+  h1="A native MongoDB client for Windows."
+  grad="Signed, lightweight, complete."
+  ctaLabel="Download for Windows"
+  lede="MQLens is a small native Windows app (Tauri + WebView2, not Electron) with a code-signed <code>.msi</code> / <code>.exe</code> installer. Every feature is here: all auth modes, TLS / SSH / SOCKS5, aggregation pipelines, visual explain plans, schema analysis, GridFS, and an embedded mongosh."
+  screenshot={{ src: '/screenshots/mqlens-documents.png', alt: 'MQLens running on Windows browsing MongoDB documents' }}
+  featuresTitle="Everything, in a tiny signed installer"
+  features={[
+    { h3: 'Signed installer', p: 'Code-signed <code>.msi</code> / <code>.exe</code> via Azure Trusted Signing.' },
+    { h3: 'Every connection mode', p: 'All auth mechanisms (SCRAM, X.509, AWS IAM, Kerberos, LDAP) plus TLS / SSH / SOCKS5.' },
+    { h3: 'Encrypted vault', p: 'Connection credentials encrypted locally with AES-256-GCM and Argon2id.' },
+    { h3: 'Full feature set', p: 'Aggregation pipelines, explain plans, schema analysis, GridFS, and embedded mongosh.' },
+    { h3: 'Private &amp; free', p: 'Zero telemetry, no account, Apache-2.0.' },
+  ]}
+/>

--- a/website/src/pages/mongodb-explain-plan-gui.astro
+++ b/website/src/pages/mongodb-explain-plan-gui.astro
@@ -1,0 +1,25 @@
+---
+import WorkflowLanding from '../components/WorkflowLanding.astro';
+---
+<WorkflowLanding
+  title="MongoDB explain plan GUI"
+  description="Read MongoDB explain plans as a visual tree for find and aggregate — see index usage, collection scans, and stage costs at a glance. Free native GUI, Apache-2.0, zero telemetry."
+  eyebrow="Visual explain plans"
+  h1="See exactly what your MongoDB query does."
+  grad="Explain plans as a visual tree."
+  lede="Raw <code>explain()</code> output is a deeply nested JSON blob. MQLens renders the winning plan as a readable tree for both <code>find</code> and <code>aggregate</code> — so index usage, <code>COLLSCAN</code>s, in-memory sorts, and stage costs are obvious at a glance."
+  screenshot={{ src: '/screenshots/mqlens-index-detail.png', alt: 'MQLens query analysis and index detail view' }}
+  stepsTitle="Read an explain plan"
+  steps={[
+    { title: 'Run your query', body: 'Execute a <code>find</code> or aggregation with your filters, sort, and projection.' },
+    { title: 'Open the explain view', body: 'Switch to Explain to render the winning plan as a tree.' },
+    { title: 'Spot the problem', body: 'Collection scans and unindexed sorts stand out immediately, with the documents examined vs returned.' },
+    { title: 'Add the right index', body: 'Create indexes from the GUI with real key patterns and unique / sparse flags, then re-explain to confirm the win.' },
+  ]}
+  featuresTitle="Tune queries without leaving the GUI"
+  features={[
+    { h3: 'Find + aggregate explain', p: 'Visual plan tree for both query types, not just a JSON dump.' },
+    { h3: 'Index management', p: 'Create, inspect, and drop indexes with real key patterns and unique/sparse flags.' },
+    { h3: 'Embedded mongosh', p: 'A real shell wired to your connection for the moments a GUI can’t reach.' },
+  ]}
+/>

--- a/website/src/pages/mongodb-gridfs-gui.astro
+++ b/website/src/pages/mongodb-gridfs-gui.astro
@@ -1,0 +1,25 @@
+---
+import WorkflowLanding from '../components/WorkflowLanding.astro';
+---
+<WorkflowLanding
+  title="MongoDB GridFS GUI"
+  description="Browse and download MongoDB GridFS files from a native GUI — buckets, metadata, downloads — no shell scripts. MQLens is free, Apache-2.0, zero telemetry."
+  eyebrow="GridFS browser"
+  h1="Browse MongoDB GridFS files."
+  grad="No shell scripts."
+  lede="GridFS spreads each file across <code>.files</code> and <code>.chunks</code> collections, which is awkward to inspect by hand. MQLens shows GridFS buckets as a first-class part of the database tree — browse files, read metadata, and download them to disk straight from the GUI."
+  screenshot={{ src: '/screenshots/mqlens-gridfs.png', alt: 'MQLens GridFS browser showing files in a bucket' }}
+  stepsTitle="Work with GridFS in the GUI"
+  steps={[
+    { title: 'Connect to your database', body: 'Open any connection that has GridFS buckets.' },
+    { title: 'Open a bucket', body: 'GridFS buckets appear in the sidebar tree alongside collections.' },
+    { title: 'Inspect files', body: 'See file name, size, upload date, and stored metadata.' },
+    { title: 'Download to disk', body: 'Pull any stored file back to your machine in one click.' },
+  ]}
+  featuresTitle="One app for the whole workflow"
+  features={[
+    { h3: 'First-class buckets', p: 'GridFS lives in the tree, not behind a script.' },
+    { h3: 'Direct downloads', p: 'Reconstruct and save files without touching the shell.' },
+    { h3: 'Everything else too', p: 'Queries, aggregation pipelines, schema analysis, and an embedded mongosh in the same app.' },
+  ]}
+/>

--- a/website/src/pages/mongodb-gui-no-telemetry.astro
+++ b/website/src/pages/mongodb-gui-no-telemetry.astro
@@ -1,0 +1,21 @@
+---
+import WorkflowLanding from '../components/WorkflowLanding.astro';
+---
+<WorkflowLanding
+  title="MongoDB GUI with no telemetry"
+  description="A MongoDB GUI that collects zero telemetry, requires no account, and encrypts credentials locally. MQLens is native, open source (Apache-2.0), and free."
+  eyebrow="Private by design"
+  h1="A MongoDB GUI that doesn't phone home."
+  grad="Zero telemetry, no account."
+  lede="Most database GUIs ship usage analytics on by default, and some require an account just to connect. MQLens collects <strong>nothing</strong> — no telemetry, no crash beacons, no sign-up. Your hosts, queries, and credentials stay on your machine, and the source is Apache-2.0 so you can verify it."
+  screenshot={{ src: '/screenshots/mqlens-quick-start.png', alt: 'MQLens quick start screen' }}
+  featuresTitle="What 'private' actually means here"
+  features={[
+    { h3: 'Zero telemetry', p: 'No usage analytics, no crash reporters, no beacons. Nothing is tracked or sent.' },
+    { h3: 'No account', p: 'Download and connect. No sign-up, no email, no license server.' },
+    { h3: 'Credentials encrypted locally', p: 'Connection profiles are encrypted with AES-256-GCM (Argon2id key derivation) behind a master password, with biometric unlock.' },
+    { h3: 'Open source', p: 'Apache-2.0 — read exactly what the app does and build it yourself.' },
+    { h3: 'Signed builds', p: 'macOS-notarized, Windows-signed, and GPG-signed Linux artifacts you can verify before running.' },
+    { h3: 'Native, not Electron', p: 'A ~14 MB Tauri/Rust app — small attack surface, no bundled Chromium runtime.' },
+  ]}
+/>

--- a/website/src/pages/mongodb-schema-analysis-tool.astro
+++ b/website/src/pages/mongodb-schema-analysis-tool.astro
@@ -1,0 +1,25 @@
+---
+import WorkflowLanding from '../components/WorkflowLanding.astro';
+---
+<WorkflowLanding
+  title="MongoDB schema analysis tool"
+  description="Analyze MongoDB schema from a GUI — per-field types, presence/coverage, and nested paths — by sampling a collection. Free native tool, Apache-2.0, zero telemetry."
+  eyebrow="Schema analysis"
+  h1="Understand your MongoDB schema."
+  grad="Without writing scripts."
+  lede="MongoDB is schemaless, so the real shape of a collection lives in the data. MQLens samples a collection and reports per-field types, presence / coverage, and nested paths — surfacing mixed types and optional fields you’d otherwise discover the hard way."
+  screenshot={{ src: '/screenshots/mqlens-schema.png', alt: 'MQLens schema analysis showing per-field types and coverage' }}
+  stepsTitle="Analyze a collection"
+  steps={[
+    { title: 'Open a collection', body: 'Pick the collection whose shape you want to understand.' },
+    { title: 'Run schema analysis', body: 'Choose a sample size and let MQLens scan the documents.' },
+    { title: 'Read types &amp; coverage', body: 'See each field’s types and how often it’s present, including nested paths.' },
+    { title: 'Act on it', body: 'Spot mixed types, missing fields, and stragglers — then add indexes or fix data from the same app.' },
+  ]}
+  featuresTitle="See the real shape of your data"
+  features={[
+    { h3: 'Per-field types + coverage', p: 'Exactly which types appear in each field, and in what percentage of documents.' },
+    { h3: 'Nested paths', p: 'Coverage for embedded documents and arrays, not just top-level fields.' },
+    { h3: 'Fix what you find', p: 'Pairs with visual explain plans and index management to act on the gaps.' },
+  ]}
+/>

--- a/website/src/pages/mongodb-ssh-tunnel-gui.astro
+++ b/website/src/pages/mongodb-ssh-tunnel-gui.astro
@@ -1,0 +1,26 @@
+---
+import WorkflowLanding from '../components/WorkflowLanding.astro';
+---
+<WorkflowLanding
+  title="MongoDB SSH tunnel GUI"
+  description="Connect to MongoDB through an SSH tunnel from a native GUI — bastion / jump host, key or password auth, no manual port-forwarding. MQLens is free, Apache-2.0, zero telemetry."
+  eyebrow="SSH tunnel · Bastion / jump host"
+  h1="Connect to MongoDB through an SSH tunnel."
+  grad="No manual port-forwarding."
+  lede="Many production MongoDB deployments only accept connections from inside a private network. MQLens opens the SSH tunnel for you — through your bastion / jump host, with key or password auth — and points the driver at the forwarded port automatically. No <code>ssh -L</code> juggling in a side terminal."
+  screenshot={{ src: '/screenshots/mqlens-connection-manager.png', alt: 'MQLens connection manager with an SSH tunnel configured' }}
+  stepsTitle="Connect over SSH in under a minute"
+  steps={[
+    { title: 'Create a connection', body: 'Open the connection manager and enter your MongoDB URI as seen <em>from the jump host</em> (e.g. <code>mongodb://localhost:27017</code>).' },
+    { title: 'Enable the SSH tunnel', body: 'Toggle SSH on and enter the bastion host and port.' },
+    { title: 'Add your credentials', body: 'Authenticate to the bastion with an SSH private key (optional passphrase) or a password.' },
+    { title: 'Test the connection', body: 'The staged tester reports each real phase — parse → DNS → connect → ping — so you see exactly where a failure happens.' },
+    { title: 'Browse your data', body: 'Once it goes green, browse databases and collections, run queries, and build pipelines as usual — all over the tunnel.' },
+  ]}
+  featuresTitle="Built for locked-down deployments"
+  features={[
+    { h3: 'Key or password auth', p: 'Reach the bastion with an SSH private key (with passphrase) or a password. Credentials are encrypted locally with AES-256-GCM.' },
+    { h3: 'TLS + SOCKS5 too', p: 'Stack TLS (system / custom CA / client cert) on top of the tunnel, or route through a SOCKS5 proxy when everything must go through one.' },
+    { h3: 'Native &amp; private', p: 'A ~14 MB native app (Tauri/Rust, not Electron) with zero telemetry — nothing about your hosts or queries leaves your machine.' },
+  ]}
+/>


### PR DESCRIPTION
Adds keyword-targeted landing pages (from the growth plan) on a shared, consistent template.

## New pages
**Workflows:** `/mongodb-ssh-tunnel-gui`, `/mongodb-explain-plan-gui`, `/mongodb-aggregation-pipeline-gui`, `/mongodb-schema-analysis-tool`, `/mongodb-gridfs-gui`, `/mongodb-gui-no-telemetry`
**Platforms:** `/mongodb-client-for-mac`, `/mongodb-client-for-windows`

Each has a unique `<title>`/meta description/H1, a short step-by-step or feature grid, a relevant screenshot, and a download CTA.

## Implementation
- New reusable `WorkflowLanding.astro` component (one layout + style for all pages — no per-page CSS duplication).
- Footer gains **Platforms** and **Workflows** columns so the pages are internally linked (crawlable); the sitemap auto-includes them.
- Skipped a `client-for-linux` page to avoid duplicating the existing `/mongodb-gui-for-linux`.

## Verified
- `npm run build` succeeds (21 pages). Preview-rendered the SSH page — hero, steps, screenshot, and CTA all render correctly in the site's design.