### PR TITLE
Add community health files (CoC, contributing, security, PR template)

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at **vrshu112@gmail.com**. All complaints will be
+reviewed and investigated promptly and fairly. All maintainers are obligated to
+respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to MQLens
+
+Thanks for your interest in improving MQLens! This guide covers how to set up the
+project, the development workflow, and how to get changes merged.
+
+By participating, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report a bug or workflow issue** — use the in-app **Help → Report a bug**, or
+  open a [bug report](https://github.com/mqlens/mqlens-mongodb/issues/new?template=bug_report.yml).
+- **Request a feature** — open a [feature request](https://github.com/mqlens/mqlens-mongodb/issues/new?template=feature_request.yml).
+  Larger ideas are tracked under the [`roadmap`](https://github.com/mqlens/mqlens-mongodb/labels/roadmap) label.
+- **Pick up an issue** — [`good first issue`](https://github.com/mqlens/mqlens-mongodb/labels/good%20first%20issue)
+  is a good place to start. Comment to claim it.
+- **Improve docs** — README, in-app text, or the website under `website/`.
+
+## Prerequisites
+
+- **Node.js 20+** and **npm**
+- **Rust** (stable, via [rustup](https://rustup.rs))
+- Platform build dependencies for [Tauri v2](https://tauri.app/start/prerequisites/).
+  On Debian/Ubuntu: `libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev
+  libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev libssl-dev libkrb5-dev
+  clang libclang-dev build-essential`.
+
+## Getting started
+
+```bash
+git clone https://github.com/mqlens/mqlens-mongodb.git
+cd mqlens-mongodb
+npm ci
+npm run tauri dev      # run the desktop app (Rust backend + React frontend)
+```
+
+Other useful scripts:
+
+```bash
+npm run dev            # frontend only (Vite), no Tauri backend
+npm run build          # type-check + production frontend build (tsc && vite build)
+npm run tauri build    # build the native app bundles
+```
+
+## Tests & checks
+
+Please make sure these pass before opening a PR:
+
+```bash
+npx tsc --noEmit                                   # TypeScript type-check
+npm test                                           # frontend tests (Vitest)
+cargo test --manifest-path src-tauri/Cargo.toml    # Rust tests
+```
+
+The CI workflow runs these on every PR.
+
+## Development workflow
+
+- **Branch from `dev`** and open your PR **against `dev`** (the default branch).
+  `main` is release-only — merges to `main` cut a versioned release.
+- Use a focused branch name, e.g. `feat/...`, `fix/...`, `docs/...`.
+- Keep PRs scoped to one change; include tests for new behavior.
+- Follow [Conventional Commits](https://www.conventionalcommits.org) for commit
+  messages (`feat:`, `fix:`, `docs:`, `chore:`, …) — the release version is
+  derived automatically from these on merge to `main`.
+- Match the surrounding code's style and patterns; this repo favors small,
+  focused files with clear responsibilities.
+
+## Privacy & security expectations
+
+MQLens is local-first with **zero telemetry**. Please don't add analytics,
+crash reporters, network beacons, or anything that phones home. Never commit
+secrets, credentials, or real connection strings. For security issues, see
+[SECURITY.md](SECURITY.md) — do **not** open a public issue.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [Apache-2.0](../LICENSE) license.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!-- Thanks for contributing to MQLens! PRs target the `dev` branch. -->
+
+## Summary
+
+<!-- What does this change and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / chore
+- [ ] Documentation
+- [ ] Website
+
+## How was this tested?
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm test` (Vitest) passes
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` passes (if backend touched)
+- [ ] Manually verified in the running app (`npm run tauri dev`)
+
+## Screenshots
+
+<!-- For UI changes, before/after screenshots help. -->
+
+## Checklist
+
+- [ ] This PR targets `dev` (not `main`)
+- [ ] Commits follow Conventional Commits (`feat:`, `fix:`, …)
+- [ ] No telemetry, secrets, or real connection strings added
+- [ ] Docs / README / website updated if behavior changed

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+MQLens is a local-first MongoDB GUI that handles connection credentials, so we
+take security seriously. Thank you for helping keep users safe.
+
+## Supported versions
+
+Security fixes target the **latest release**. Please upgrade to the newest
+version (the in-app updater or the [Releases](https://github.com/mqlens/mqlens-mongodb/releases/latest)
+page) before reporting.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately, using either:
+
+1. **GitHub Private Vulnerability Reporting** (preferred) — on the repository's
+   **Security** tab, click **Report a vulnerability**. This keeps the report
+   confidential until a fix is released.
+2. **Email** — **vrshu112@gmail.com** with subject `MQLens security`.
+
+Please include:
+
+- A description of the issue and its impact
+- Steps to reproduce (or a proof of concept)
+- Affected version and OS
+- Any suggested remediation
+
+We aim to acknowledge reports within a few days and to coordinate a fix and
+disclosure timeline with you. We'll credit reporters who wish to be named once a
+fix ships.
+
+## Scope
+
+In scope: the desktop app and its handling of credentials, the encrypted vault,
+the connection layer (TLS/SSH/SOCKS5/auth), the in-app updater, and the build
+artifacts. Out of scope: vulnerabilities in MongoDB itself or in third-party
+services you connect to.
+
+## Security model (for context)
+
+- **No telemetry** — nothing is tracked or transmitted.
+- **No account** — there is no MQLens backend.
+- **Credentials encrypted at rest** with AES-256-GCM and Argon2id key
+  derivation, behind a master password (with optional biometric unlock).
+- **Signed builds** — macOS notarized, Windows signed, and GPG-signed Linux
+  artifacts; updater artifacts are signed and verified before install.
+- **Apache-2.0** — the source is open for review.


### PR DESCRIPTION
Completes the remaining items on GitHub's **Community Standards** checklist.

Adds (in `.github/`, where GitHub recognizes them):
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (maintainer contact for enforcement).
- **CONTRIBUTING.md** — prerequisites, setup (`npm ci`, `npm run tauri dev`), the test/check commands, the branch-off-`dev` / PR-to-`dev` workflow, Conventional Commits, and the no-telemetry/secrets expectations.
- **SECURITY.md** — private vulnerability reporting (GitHub Security tab / email), supported versions, scope, and the security model.
- **PULL_REQUEST_TEMPLATE.md** — summary / related issue / type / testing checklist.

Already satisfied: Description, README, License, Issue templates.

Not a file (repo setting): **"Repository admins accept content reports"** — enable it under **Settings → Moderation options** when ready.