### PR TITLE
Use dev@mqlens.com for community contact

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -48,7 +48,7 @@ an individual is officially representing the community in public spaces.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the maintainers at **vrshu112@gmail.com**. All complaints will be
+reported to the maintainers at **dev@mqlens.com**. All complaints will be
 reviewed and investigated promptly and fairly. All maintainers are obligated to
 respect the privacy and security of the reporter of any incident.
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -18,7 +18,7 @@ Report privately, using either:
 1. **GitHub Private Vulnerability Reporting** (preferred) — on the repository's
    **Security** tab, click **Report a vulnerability**. This keeps the report
    confidential until a fix is released.
-2. **Email** — **vrshu112@gmail.com** with subject `MQLens security`.
+2. **Email** — **dev@mqlens.com** with subject `MQLens security`.
 
 Please include:
 


### PR DESCRIPTION
Switch the public contact address in the Code of Conduct and Security Policy from a personal email to **dev@mqlens.com** (consistent across both files).