### PR TITLE
[codex] Add selectable document JSON copy support

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -317,6 +317,87 @@ interface TreeRow {
   doc?: Record<string, any>;
 }
 
+// Extra (per-render) data handed to the JSON view's virtualized rows.
+interface JsonRowExtra {
+  lines: JsonLine[];
+  collapsedFolds: Set<number>;
+  toggleFold: (id: number) => void;
+  documents: Array<Record<string, any>>;
+  openCtxMenu: (
+    e: React.MouseEvent,
+    doc: Record<string, any> | undefined,
+    field?: string,
+    value?: any,
+  ) => void;
+  renderContent: (line: JsonLine) => React.ReactNode;
+  hasRowActions: boolean;
+  RowActions: React.ComponentType<{ doc: Record<string, any> }>;
+}
+
+// Virtualized row for the JSON view (one descriptor per row).
+//
+// Defined at module scope on purpose: react-window remounts every row whenever
+// the `rowComponent` reference changes, and a remount replaces the row's DOM —
+// which silently wipes out any active text selection. When this lived inline in
+// DataGrid it was a brand-new function on each render, so any unrelated
+// re-render dropped the user's selection mid-copy. A stable identity lets
+// re-renders reconcile in place, so the selection survives. Per-render data is
+// passed through `rowProps` instead of closures.
+const JsonRow = ({
+  index,
+  style,
+  lines,
+  collapsedFolds,
+  toggleFold,
+  documents,
+  openCtxMenu,
+  renderContent,
+  hasRowActions,
+  RowActions,
+}: { index: number; style: React.CSSProperties } & JsonRowExtra) => {
+  const line = lines[index];
+  if (!line) return null;
+  const folded = line.foldId !== undefined && collapsedFolds.has(line.foldId);
+  return (
+    <div
+      style={style}
+      className={`mql-jsonview-line${line.isDocRoot && line.docIndex > 0 ? ' mql-jsonview-doc-start' : ''}`}
+      data-doc-even={line.docIndex % 2 === 0}
+      onContextMenu={(e) => openCtxMenu(e, documents[line.docIndex], line.kind === 'scalar' ? line.keyName ?? undefined : undefined, line.value)}
+    >
+      <span className="mql-jsonview-num" data-num={line.num} aria-hidden="true" />
+      <span className="mql-jsonview-fold">
+        {line.foldId !== undefined && (
+          <button
+            type="button"
+            onClick={() => toggleFold(line.foldId!)}
+            className="mql-jsonview-fold-btn"
+            data-testid="json-fold-btn"
+            aria-label={folded ? 'Expand' : 'Collapse'}
+          >
+            {folded ? <ChevronRight size={11} /> : <ChevronDown size={11} />}
+          </button>
+        )}
+      </span>
+      <span className="mql-jsonview-content" style={{ paddingLeft: line.depth * 18 }}>
+        {renderContent(line)}
+        {folded && (
+          <span className="text-[var(--text-dim)]">
+            {' … '}
+            {line.closeChar}
+            {line.hasComma ? ',' : ''}
+          </span>
+        )}
+        {line.isDocRoot && hasRowActions && line.doc && (
+          <span className="mql-jsonview-actions">
+            <RowActions doc={line.doc} />
+          </span>
+        )}
+      </span>
+    </div>
+  );
+};
+
 export const DataGrid: React.FC<DataGridProps> = ({
   documents,
   density = 'cozy',
@@ -936,51 +1017,6 @@ export const DataGrid: React.FC<DataGridProps> = ({
     return 24; // cozy
   };
 
-  // Virtualized row for the JSON view (one descriptor per row).
-  const JsonRow = ({ index, style }: { index: number; style: React.CSSProperties }) => {
-    const line = visibleJsonLines[index];
-    if (!line) return null;
-    const folded = line.foldId !== undefined && collapsedFolds.has(line.foldId);
-    return (
-      <div
-        style={style}
-        className={`mql-jsonview-line${line.isDocRoot && line.docIndex > 0 ? ' mql-jsonview-doc-start' : ''}`}
-        data-doc-even={line.docIndex % 2 === 0}
-        onContextMenu={(e) => openCtxMenu(e, documents[line.docIndex], line.kind === 'scalar' ? line.keyName ?? undefined : undefined, line.value)}
-      >
-        <span className="mql-jsonview-num" data-num={line.num} aria-hidden="true" />
-        <span className="mql-jsonview-fold">
-          {line.foldId !== undefined && (
-            <button
-              type="button"
-              onClick={() => toggleFold(line.foldId!)}
-              className="mql-jsonview-fold-btn"
-              data-testid="json-fold-btn"
-              aria-label={folded ? 'Expand' : 'Collapse'}
-            >
-              {folded ? <ChevronRight size={11} /> : <ChevronDown size={11} />}
-            </button>
-          )}
-        </span>
-        <span className="mql-jsonview-content" style={{ paddingLeft: line.depth * 18 }}>
-          {renderJsonLineContent(line)}
-          {folded && (
-            <span className="text-[var(--text-dim)]">
-              {' … '}
-              {line.closeChar}
-              {line.hasComma ? ',' : ''}
-            </span>
-          )}
-          {line.isDocRoot && hasRowActions && line.doc && (
-            <span className="mql-jsonview-actions">
-              <RowActions doc={line.doc} />
-            </span>
-          )}
-        </span>
-      </div>
-    );
-  };
-
   // Virtualized row for the tree-table view (Key | Value | Type).
   const TreeRowComponent = ({ index, style }: { index: number; style: React.CSSProperties }) => {
     const row = visibleTreeRows[index];
@@ -1193,11 +1229,20 @@ export const DataGrid: React.FC<DataGridProps> = ({
           /* Virtualized, line-numbered, collapsible JSON code panel */
           <div className="mql-jsonview flex-1 flex flex-col min-h-0 min-w-0" data-testid="json-view">
             <div className="flex-1 min-w-0 overflow-auto">
-              <List<{}>
+              <List<JsonRowExtra>
                 rowCount={visibleJsonLines.length}
                 rowHeight={getRowHeight()}
                 rowComponent={JsonRow}
-                rowProps={{}}
+                rowProps={{
+                  lines: visibleJsonLines,
+                  collapsedFolds,
+                  toggleFold,
+                  documents,
+                  openCtxMenu,
+                  renderContent: renderJsonLineContent,
+                  hasRowActions,
+                  RowActions,
+                }}
                 style={{ height: '100%', width: `${jsonMaxWidthPx}px`, minWidth: '100%' }}
               />
             </div>

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -948,7 +948,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
         data-doc-even={line.docIndex % 2 === 0}
         onContextMenu={(e) => openCtxMenu(e, documents[line.docIndex], line.kind === 'scalar' ? line.keyName ?? undefined : undefined, line.value)}
       >
-        <span className="mql-jsonview-num">{line.num}</span>
+        <span className="mql-jsonview-num" data-num={line.num} aria-hidden="true" />
         <span className="mql-jsonview-fold">
           {line.foldId !== undefined && (
             <button

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -818,13 +818,39 @@ export const DataGrid: React.FC<DataGridProps> = ({
     return <span className="text-[var(--text-dim)]">{`{ ${row.childCount} ${row.childCount === 1 ? 'field' : 'fields'} }`}</span>;
   };
 
-  const hasRowActions = Boolean(onEditDocument || onDeleteDocument);
+  // Every document now carries at least a copy control, so the actions
+  // area is always present; edit/delete remain gated on their handlers.
+  const hasRowActions = true;
 
-  // Per-row edit/delete controls, shared across all view modes.
+  // One-click "Copy JSON" for a single document, with a brief "Copied"
+  // confirmation. Copies the pretty-printed (2-space) document, matching the
+  // "Copy document (JSON)" context-menu action.
+  const CopyDocButton = ({ doc }: { doc: Record<string, any> }) => {
+    const [copied, setCopied] = useState(false);
+    const handleCopy = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      writeClipboard(JSON.stringify(doc, null, 2));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    };
+    return (
+      <button
+        onClick={handleCopy}
+        className="p-1 rounded text-[var(--text-dim)] hover:text-[var(--accent-blue)] hover:bg-[var(--bg-item-active)] cursor-pointer"
+        title={copied ? 'Copied' : 'Copy document (JSON)'}
+        aria-label={copied ? 'Copied' : 'Copy document'}
+        data-testid="copy-doc-btn"
+      >
+        {copied ? <Check size={12} className="text-[var(--accent-green)]" /> : <Copy size={12} />}
+      </button>
+    );
+  };
+
+  // Per-row copy/edit/delete controls, shared across all view modes.
   const RowActions = ({ doc }: { doc: Record<string, any> }) => {
-    if (!hasRowActions) return null;
     return (
       <div className="flex items-center gap-1 flex-shrink-0">
+        <CopyDocButton doc={doc} />
         {onEditDocument && (
           <button
             onClick={(e) => {

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -273,4 +273,20 @@ describe('DataGrid Component', () => {
     expect(screen.getByTestId('context-menu')).toBeInTheDocument();
     expect(screen.getByText('Edit document')).toBeInTheDocument();
   });
+
+  it('copies a document as pretty-printed JSON via the copy button and shows a confirmation', () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    // No edit/delete handlers: the copy control must still be present on every document.
+    render(<DataGrid documents={mockDocuments} />);
+    // Table view renders one row (and one copy control) per document.
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    const copyButtons = screen.getAllByTestId('copy-doc-btn');
+    expect(copyButtons).toHaveLength(mockDocuments.length);
+
+    fireEvent.click(copyButtons[0]);
+    expect(writeText).toHaveBeenCalledWith(JSON.stringify(mockDocuments[0], null, 2));
+    // The control flips to a "Copied" confirmation state.
+    expect(screen.getAllByLabelText('Copied').length).toBeGreaterThan(0);
+  });
 });

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -93,9 +93,14 @@ describe('DataGrid Component', () => {
     fireEvent.click(screen.getByRole('button', { name: /json/i }));
 
     // The continuous, line-numbered code panel (not per-document boxes).
-    expect(screen.getByTestId('json-view')).toBeInTheDocument();
-    // Line-number gutter starts at 1.
-    expect(screen.getByText('1')).toBeInTheDocument();
+    const jsonView = screen.getByTestId('json-view');
+    expect(jsonView).toBeInTheDocument();
+    // Line-number gutter starts at 1. The number is exposed via data-num and
+    // rendered through a ::before pseudo-element (not a text node) so that
+    // selecting and copying JSON never picks up the gutter numbers.
+    const firstGutter = jsonView.querySelector('.mql-jsonview-num');
+    expect(firstGutter).toHaveAttribute('data-num', '1');
+    expect(firstGutter).toBeEmptyDOMElement();
 
     // Foldable: each object/array opens a collapse toggle.
     const folds = screen.getAllByTestId('json-fold-btn');

--- a/src/index.css
+++ b/src/index.css
@@ -888,6 +888,14 @@ button { cursor: pointer; }
   padding-right: 16px;
   color: var(--text-main);
 }
+/* Opt out of the global `user-select: none` so the JSON can be selected and
+   copied with the mouse/keyboard. Line numbers (.mql-jsonview-num) stay
+   unselectable so a drag-copy yields clean JSON without gutter numbers. */
+.mql-jsonview-content,
+.mql-jsonview-content * {
+  user-select: text;
+  -webkit-user-select: text;
+}
 .mql-jsonview-actions {
   display: inline-flex;
   margin-left: 10px;

--- a/src/index.css
+++ b/src/index.css
@@ -857,7 +857,16 @@ button { cursor: pointer; }
   text-align: right;
   color: var(--text-dim);
   user-select: none;
+  -webkit-user-select: none;
   background: inherit;
+}
+/* Render the line number as generated content so it is never part of the
+   document text: WebKit (the macOS Tauri webview) still copies the text of
+   `user-select: none` nodes when a selection spans them, so a real text node
+   here would leak gutter numbers into copied JSON. Pseudo-element content is
+   excluded from selection/copy in every engine. */
+.mql-jsonview-num::before {
+  content: attr(data-num);
 }
 .mql-jsonview-fold {
   position: sticky;


### PR DESCRIPTION
## Summary

Adds per-document JSON copy support to the DataGrid document view and keeps JSON text selection stable while rows are virtualized. The changes also exclude gutter line numbers from copied selections and add regression coverage for the Copy JSON flow.

## Impact

This affects DataGrid document rendering and clipboard behavior. GitNexus change detection reported HIGH risk because DataGrid, JSON row rendering, writeClipboard, and valueToText participate in shared rendering and clipboard execution flows.

Untracked local docs/ and scripts/ directories were intentionally left out of this PR because they appear separate from the committed DataGrid branch scope.

## Validation

- npm test - 33 files passed, 323 tests passed
- npm run build - passed; Vite emitted the existing large-chunk warning