### PR TITLE
[codex] Improve command palette namespace loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import { formatBytes } from './lib/format';
 import type { QueryCodeSpec } from './lib/queryCodeGen';
 import { docToShell } from './lib/shellDoc';
 import { recordHistory, loadCollectionQueries, type SavedQueryBody } from './lib/queryStore';
-import { loadNamespaceIndex } from './lib/paletteIndex';
+import { clearNamespaceIndex, loadNamespaceIndex, matchesNamespaceScope } from './lib/paletteIndex';
 import { CHECK_UPDATE_EVENT } from './components/UpdatePrompt';
 import type { ConnectionProfile } from './lib/connection';
 import { save, open } from '@tauri-apps/plugin-dialog';
@@ -180,6 +180,7 @@ function Workspace() {
   } | null>(null);
   const [indexMutationTrigger, setIndexMutationTrigger] = useState(0);
   const [collectionMutationTrigger, setCollectionMutationTrigger] = useState(0);
+  const [sidebarFilterQuery, setSidebarFilterQuery] = useState('');
   const [sidebarWidth, setSidebarWidth] = useState(300);
   const [isResizing, setIsResizing] = useState(false);
 
@@ -621,9 +622,11 @@ function Workspace() {
       const current = tabs.find(t => t.id === prev);
       return current ? renameTab(current).id : prev;
     });
+    invalidatePaletteNamespaceIndex(connectionId);
   };
 
   const handleDatabaseDropped = (connectionId: string, dbName: string) => {
+    invalidatePaletteNamespaceIndex(connectionId);
     setTabs(prev => {
       const updated = prev.filter(t => t.connectionId !== connectionId || t.db !== dbName);
       const activeWasDropped = activeTabId
@@ -674,6 +677,7 @@ function Workspace() {
       const current = tabs.find(t => t.id === prev);
       return current ? renameTab(current).id : prev;
     });
+    invalidatePaletteNamespaceIndex(connectionId);
   };
 
   const handleOpenIndexModalForCreate = (connectionId: string, dbName: string, collName: string) => {
@@ -823,18 +827,45 @@ function Workspace() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  // Dynamic palette items, loaded when the palette opens: every database and
-  // collection of the active connections (cached per connection), plus saved
-  // queries of the collections that have open tabs.
+  // Dynamic palette items load only after the user starts searching, so opening
+  // command mode does not immediately inventory every connected cluster.
   const [paletteDynamicItems, setPaletteDynamicItems] = useState<PaletteAction[]>([]);
+  const [paletteQuery, setPaletteQuery] = useState('');
+  const paletteDynamicLoadKey = React.useRef<string | null>(null);
+  const paletteNamespaceScope = sidebarFilterQuery.trim();
+  const shouldLoadPaletteDynamic =
+    isPaletteOpen && (paletteQuery.trim().length >= 2 || paletteNamespaceScope.length >= 2);
+  const invalidatePaletteNamespaceIndex = React.useCallback((connectionId?: string) => {
+    clearNamespaceIndex(connectionId);
+    paletteDynamicLoadKey.current = null;
+    setPaletteDynamicItems(prev => prev.length === 0 ? prev : []);
+  }, []);
   useEffect(() => {
-    if (!isPaletteOpen) return;
+    if (collectionMutationTrigger > 0) invalidatePaletteNamespaceIndex();
+  }, [collectionMutationTrigger, invalidatePaletteNamespaceIndex]);
+  useEffect(() => {
+    if (!shouldLoadPaletteDynamic) {
+      paletteDynamicLoadKey.current = null;
+      setPaletteDynamicItems(prev => prev.length === 0 ? prev : []);
+      return;
+    }
+    const collTabs = tabs.filter(t => t.type === 'collection');
+    const loadKey = [
+      activeConnections.map(c => `${c.id}:${c.name}`).join('|'),
+      collTabs.map(t => `${t.id}:${t.connectionId}:${t.db}:${t.collection}`).join('|'),
+      paletteNamespaceScope,
+    ].join('::');
+    if (paletteDynamicLoadKey.current === loadKey) return;
+    paletteDynamicLoadKey.current = loadKey;
     let alive = true;
     (async () => {
       const items: PaletteAction[] = [];
       const namespaces = await loadNamespaceIndex(activeConnections.map(c => ({ id: c.id, name: c.name })));
       for (const ns of namespaces) {
         for (const coll of ns.collections) {
+          if (!matchesNamespaceScope(paletteNamespaceScope, { connectionName: ns.connectionName, db: ns.db, collection: coll })) {
+            continue;
+          }
           items.push({
             id: `coll:${ns.connectionId}:${ns.db}:${coll}`,
             title: coll,
@@ -844,10 +875,13 @@ function Workspace() {
           });
         }
       }
-      const collTabs = tabs.filter(t => t.type === 'collection');
       await Promise.all(collTabs.map(async (t) => {
         try {
-          const cq = await loadCollectionQueries(connectionNameFor(t.connectionId), t.db, t.collection);
+          const connectionName = connectionNameFor(t.connectionId);
+          if (!matchesNamespaceScope(paletteNamespaceScope, { connectionName, db: t.db, collection: t.collection })) {
+            return;
+          }
+          const cq = await loadCollectionQueries(connectionName, t.db, t.collection);
           for (const s of cq.saved) {
             items.push({
               id: `saved:${t.id}:${s.id}`,
@@ -863,13 +897,14 @@ function Workspace() {
     })();
     return () => { alive = false; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPaletteOpen]);
+  }, [shouldLoadPaletteDynamic, activeConnections, tabs, paletteNamespaceScope]);
 
   const paletteActions: PaletteAction[] = [
     { id: 'new-connection', title: 'New Connection…', keywords: 'connect database add server', run: () => setIsConnectionModalOpen(true) },
     { id: 'toggle-theme', title: 'Toggle Light/Dark Theme', keywords: 'appearance color mode', run: toggleTheme },
     { id: 'open-settings', title: 'Open Settings', keywords: 'preferences config density', run: handleOpenSettingsTab },
     { id: 'open-quickstart', title: 'Open Quick Start', keywords: 'welcome home help', run: openQuickStartTab },
+    { id: 'refresh-palette-index', title: 'Refresh Command Palette Index', keywords: 'reload databases collections namespaces cache stale', run: () => invalidatePaletteNamespaceIndex() },
     { id: 'density-roomy', title: 'Density: Roomy', keywords: 'layout spacing', run: () => setDensity('roomy') },
     { id: 'density-cozy', title: 'Density: Cozy', keywords: 'layout spacing', run: () => setDensity('cozy') },
     { id: 'density-compact', title: 'Density: Compact', keywords: 'layout spacing dense', run: () => setDensity('compact') },
@@ -1327,6 +1362,8 @@ function Workspace() {
             onCollectionRenamed={handleCollectionRenamed}
             onDatabaseDropped={handleDatabaseDropped}
             onDatabaseRenamed={handleDatabaseRenamed}
+            onNamespaceMutated={invalidatePaletteNamespaceIndex}
+            onFilterQueryChange={setSidebarFilterQuery}
             indexMutationTrigger={indexMutationTrigger}
             activeCollection={activeTab ? { connectionId: activeTab.connectionId, db: activeTab.db, collection: activeTab.collection, indexName: activeTab.indexName } : null}
             activeConnections={activeConnections}
@@ -1364,8 +1401,13 @@ function Workspace() {
 
         <CommandPalette
           open={isPaletteOpen}
-          onClose={() => setIsPaletteOpen(false)}
+          onClose={() => {
+            setIsPaletteOpen(false);
+            setPaletteQuery('');
+          }}
           actions={paletteActions}
+          scopeLabel={paletteNamespaceScope}
+          onQueryChange={setPaletteQuery}
         />
 
         <ConnectionManager

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -14,7 +14,11 @@ interface CommandPaletteProps {
   open: boolean;
   onClose: () => void;
   actions: PaletteAction[];
+  scopeLabel?: string;
+  onQueryChange?: (query: string) => void;
 }
+
+const MAX_VISIBLE_ACTIONS = 80;
 
 // Rank by fuzzy score: title matches outrank keyword-only matches. An empty
 // query scores everything 0, so the caller's original order is kept.
@@ -25,17 +29,19 @@ const scoreAction = (query: string, action: PaletteAction): number | null => {
   return Math.max(title ?? -Infinity, keywords !== null ? keywords - 50 : -Infinity);
 };
 
-export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, actions }) => {
+export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, actions, scopeLabel = '', onQueryChange }) => {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const visible = useMemo(() => {
     const q = query.trim();
+    if (!q) return actions.slice(0, MAX_VISIBLE_ACTIONS);
     return actions
       .map((a) => ({ a, score: scoreAction(q, a) }))
       .filter((x): x is { a: PaletteAction; score: number } => x.score !== null)
       .sort((x, y) => y.score - x.score)
+      .slice(0, MAX_VISIBLE_ACTIONS)
       .map((x) => x.a);
   }, [actions, query]);
 
@@ -49,6 +55,10 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, a
   }, [open]);
 
   useEffect(() => { setSelected(0); }, [query]);
+  useEffect(() => { onQueryChange?.(query); }, [onQueryChange, query]);
+  useEffect(() => {
+    setSelected((s) => Math.min(s, Math.max(visible.length - 1, 0)));
+  }, [visible.length]);
 
   if (!open) return null;
 
@@ -81,6 +91,12 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, a
             aria-label="Command palette"
           />
         </div>
+        {scopeLabel.trim() && (
+          <div className="mql-palette-scope" title={`Sidebar filter: ${scopeLabel}`}>
+            <span className="mql-palette-scope-label">Sidebar</span>
+            <span className="mql-palette-scope-value">{scopeLabel}</span>
+          </div>
+        )}
         <div className="mql-palette-list" role="listbox">
           {visible.length === 0 && <div className="mql-palette-empty">No matching commands</div>}
           {visible.map((a, i) => (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -82,6 +82,8 @@ interface SidebarProps {
   onCollectionRenamed?: (connectionId: string, dbName: string, oldName: string, newName: string) => void;
   onDatabaseDropped?: (connectionId: string, dbName: string) => void;
   onDatabaseRenamed?: (connectionId: string, oldName: string, newName: string) => void;
+  onNamespaceMutated?: (connectionId?: string) => void;
+  onFilterQueryChange?: (query: string) => void;
   indexMutationTrigger?: number;
   collectionMutationTrigger?: number;
 }
@@ -159,12 +161,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onCollectionRenamed,
   onDatabaseDropped,
   onDatabaseRenamed,
+  onNamespaceMutated,
+  onFilterQueryChange,
   indexMutationTrigger,
   collectionMutationTrigger,
 }) => {
   const { toast, confirm, prompt } = useDialogs();
   // Tree filter: matches connection / database / (loaded) collection names.
   const [filterQuery, setFilterQuery] = useState('');
+  useEffect(() => {
+    onFilterQueryChange?.(filterQuery);
+  }, [filterQuery, onFilterQueryChange]);
   const [helpOpen, setHelpOpen] = useState(false);
   // key: connectionId, value: database names list
   const [databases, setDatabases] = useState<{ [connectionId: string]: string[] }>({});
@@ -390,6 +397,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         ...prev,
         [connectionId]: [...(prev[connectionId] || []), name],
       }));
+      onNamespaceMutated?.(connectionId);
       return;
     }
 
@@ -404,6 +412,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     try {
       await invoke('create_collection', { id: connectionId, database: name, collection: firstColl });
       await loadDatabases(connectionId);
+      onNamespaceMutated?.(connectionId);
     } catch (err) {
       toast(`Failed to create database: ${err}`, 'error');
     }
@@ -443,12 +452,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
         ...prev,
         [key]: [...(prev[key] || []), { name, type: 'collection' }],
       }));
+      onNamespaceMutated?.(connectionId);
       return;
     }
 
     try {
       await invoke('create_collection', { id: connectionId, database: dbName, collection: name });
       await handleRefreshDb(connectionId, dbName);
+      onNamespaceMutated?.(connectionId);
     } catch (err) {
       toast(`Failed to create collection: ${err}`, 'error');
     }
@@ -484,6 +495,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         [key]: (prev[key] || []).filter((c) => c.name !== collName),
       }));
       clearActiveIfDropped();
+      onNamespaceMutated?.(connectionId);
       return;
     }
 
@@ -491,6 +503,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       await invoke('drop_collection', { id: connectionId, database: dbName, collection: collName });
       clearActiveIfDropped();
       await handleRefreshDb(connectionId, dbName);
+      onNamespaceMutated?.(connectionId);
     } catch (err) {
       toast(`Failed to drop collection: ${err}`, 'error');
     }
@@ -548,6 +561,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         return next;
       });
       onCollectionRenamed?.(connectionId, dbName, collName, newName);
+      onNamespaceMutated?.(connectionId);
     };
 
     if (isMock) {
@@ -627,6 +641,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         return next;
       });
       onDatabaseDropped?.(connectionId, dbName);
+      onNamespaceMutated?.(connectionId);
     };
 
     if (isMock) {
@@ -719,6 +734,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         return next;
       });
       onDatabaseRenamed?.(connectionId, dbName, newName);
+      onNamespaceMutated?.(connectionId);
     };
 
     if (isMock) {

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -43,6 +43,15 @@ describe('CommandPalette', () => {
     expect(screen.queryByText('Toggle Theme')).toBeNull();
   });
 
+  it('shows sidebar scope separately without putting it in the search input', () => {
+    const { actions } = makeActions();
+    render(<CommandPalette open onClose={() => {}} actions={actions} scopeLabel="widas" />);
+    expect(screen.getByTestId('command-palette-input')).toHaveValue('');
+    expect(screen.getByText('Sidebar')).toBeTruthy();
+    expect(screen.getByText('widas')).toBeTruthy();
+    expect(screen.getByText('Toggle Theme')).toBeTruthy();
+  });
+
   it('runs the selected action and closes on Enter', () => {
     const { actions, ran } = makeActions();
     const onClose = vi.fn();
@@ -83,6 +92,18 @@ describe('CommandPalette', () => {
     const { actions } = makeActions();
     render(<CommandPalette open onClose={() => {}} actions={actions} />);
     expect(screen.getByText('shop.users')).toBeTruthy();
+  });
+
+  it('limits large empty-query lists so the palette does not render every namespace', () => {
+    const actions = Array.from({ length: 120 }, (_, i) => ({
+      id: `action-${i}`,
+      title: `Action ${i}`,
+      run: () => {},
+    }));
+    render(<CommandPalette open onClose={() => {}} actions={actions} />);
+    expect(screen.getAllByRole('option')).toHaveLength(80);
+    expect(screen.getByText('Action 0')).toBeTruthy();
+    expect(screen.queryByText('Action 119')).toBeNull();
   });
 });
 

--- a/src/index.css
+++ b/src/index.css
@@ -1467,13 +1467,45 @@ select:focus-visible {
   padding: 0 12px;
   border-bottom: 1px solid var(--border-color);
 }
+.mql-palette-search:focus-within {
+  border-bottom-color: var(--accent-blue);
+  box-shadow: inset 0 -1px 0 var(--accent-blue);
+}
 .mql-palette-search-icon { color: var(--text-dim); flex: none; }
 .mql-palette-input {
   flex: 1; height: 36px;
   border: none; background: transparent; outline: none;
   font-size: 13px; color: var(--text-main);
 }
+.mql-palette-input:focus-visible { outline: none; }
 .mql-palette-input::placeholder { color: var(--text-dim); }
+.mql-palette-scope {
+  display: flex; align-items: center; gap: 6px;
+  min-height: 24px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-sidebar);
+  font-size: 10.5px;
+  line-height: 1;
+  color: var(--text-dim);
+  min-width: 0;
+}
+.mql-palette-scope-label {
+  color: var(--text-dim);
+  flex: none;
+}
+.mql-palette-scope-value {
+  display: inline-flex; align-items: center;
+  height: 16px;
+  padding: 0 6px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-panel);
+  min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  color: var(--text-main);
+  font-weight: 500;
+}
 .mql-palette-list { flex: 1; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 1px; }
 .mql-palette-item {
   display: flex; align-items: center; justify-content: space-between; gap: 12px;

--- a/src/lib/__tests__/paletteIndex.test.ts
+++ b/src/lib/__tests__/paletteIndex.test.ts
@@ -1,13 +1,35 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const invoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args: unknown[]) => invoke(...args) }));
 
-import { loadNamespaceIndex, __clearNamespaceIndex } from '../paletteIndex';
+import { loadNamespaceIndex, matchesNamespaceScope, __clearNamespaceIndex } from '../paletteIndex';
 
 beforeEach(() => {
   invoke.mockReset();
   __clearNamespaceIndex();
+});
+
+describe('matchesNamespaceScope', () => {
+  const target = {
+    connectionName: 'm01-test-01',
+    db: 'cidaas-widas-test',
+    collection: 'ReleaseManagement_UpdateRequest',
+  };
+
+  it('matches sidebar-style filters against connection, database, and collection text', () => {
+    expect(matchesNamespaceScope('widas', target)).toBe(true);
+    expect(matchesNamespaceScope('release', target)).toBe(true);
+    expect(matchesNamespaceScope('m01', target)).toBe(true);
+  });
+
+  it('rejects namespaces outside the sidebar filter scope', () => {
+    expect(matchesNamespaceScope('camlog', target)).toBe(false);
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 const wireMock = () => {
@@ -36,6 +58,34 @@ describe('loadNamespaceIndex', () => {
     const calls = invoke.mock.calls.length;
     await loadNamespaceIndex([{ id: 'c1', name: 'prod' }]);
     expect(invoke.mock.calls.length).toBe(calls);
+  });
+
+  it('can force refresh cached namespaces', async () => {
+    wireMock();
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }]);
+    const calls = invoke.mock.calls.length;
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }], { forceRefresh: true });
+    expect(invoke.mock.calls.length).toBeGreaterThan(calls);
+  });
+
+  it('expires cached namespaces after the TTL', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    wireMock();
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }], { ttlMs: 100 });
+    const calls = invoke.mock.calls.length;
+    vi.setSystemTime(101);
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }], { ttlMs: 100 });
+    expect(invoke.mock.calls.length).toBeGreaterThan(calls);
+  });
+
+  it('clears one cached connection without clearing others', async () => {
+    wireMock();
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }, { id: 'c2', name: 'stage' }]);
+    const calls = invoke.mock.calls.length;
+    __clearNamespaceIndex('c1');
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }, { id: 'c2', name: 'stage' }]);
+    expect(invoke.mock.calls.length).toBe(calls + 3);
   });
 
   it('returns an empty index for a failing connection without throwing', async () => {

--- a/src/lib/paletteIndex.ts
+++ b/src/lib/paletteIndex.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import { fuzzyMatch } from './fuzzyMatch';
 
 // Lazily-built namespace index for the command palette: databases and
 // collections per active connection, cached per connection id so opening the
@@ -11,10 +12,30 @@ export interface NamespaceEntry {
   collections: string[];
 }
 
-const cache = new Map<string, Promise<NamespaceEntry[]>>();
+export interface NamespaceScopeTarget {
+  connectionName: string;
+  db: string;
+  collection: string;
+}
 
-export function __clearNamespaceIndex() {
-  cache.clear();
+interface CacheEntry {
+  loadedAt: number;
+  promise: Promise<NamespaceEntry[]>;
+}
+
+export const NAMESPACE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+const cache = new Map<string, CacheEntry>();
+
+export function clearNamespaceIndex(connectionId?: string) {
+  if (connectionId) cache.delete(connectionId);
+  else cache.clear();
+}
+
+export function matchesNamespaceScope(scope: string, target: NamespaceScopeTarget): boolean {
+  const q = scope.trim();
+  if (!q) return true;
+  return fuzzyMatch(q, `${target.connectionName} ${target.db} ${target.collection}`);
 }
 
 async function fetchConnection(id: string, name: string): Promise<NamespaceEntry[]> {
@@ -35,16 +56,22 @@ async function fetchConnection(id: string, name: string): Promise<NamespaceEntry
 
 export async function loadNamespaceIndex(
   connections: { id: string; name: string }[],
+  options: { forceRefresh?: boolean; ttlMs?: number } = {},
 ): Promise<NamespaceEntry[]> {
+  const now = Date.now();
+  const ttlMs = options.ttlMs ?? NAMESPACE_CACHE_TTL_MS;
   const perConnection = await Promise.all(
     connections.map((c) => {
       let entry = cache.get(c.id);
-      if (!entry) {
-        entry = fetchConnection(c.id, c.name);
+      const isExpired = entry ? now - entry.loadedAt > ttlMs : true;
+      if (!entry || options.forceRefresh || isExpired) {
+        entry = { loadedAt: now, promise: fetchConnection(c.id, c.name) };
         cache.set(c.id, entry);
       }
-      return entry;
+      return entry.promise;
     }),
   );
   return perConnection.flat();
 }
+
+export const __clearNamespaceIndex = clearNamespaceIndex;


### PR DESCRIPTION
## Summary

- Keep command mode fast by deferring namespace loading until the user enters a 2+ character search.
- Cap rendered palette results so large clusters do not render every namespace at once.
- Add a session-local namespace cache TTL, targeted invalidation, and a manual `Refresh Command Palette Index` command.
- Carry the sidebar filter into command mode so palette results stay restricted when the explorer is already filtered.

## Validation

- `npm test -- src/components/__tests__/CommandPalette.test.tsx src/lib/__tests__/paletteIndex.test.ts`
- `npm test -- src/components/__tests__/Sidebar.test.tsx`
- `npm run build`
- `npx gitnexus analyze`
- `gitnexus_detect_changes(scope: staged)`
