### PR TITLE
Release v0.6.0: EJSON autocomplete, aggregation UX, query code export

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,6 +20,7 @@
         "minHeight": 600,
         "resizable": true,
         "center": true,
+        "dragDropEnabled": false,
         "windowEffects": {
           "effects": ["mica", "sidebar"],
           "state": "active"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Sidebar } from './components/Sidebar';
+import { CommandPalette, type PaletteAction } from './components/CommandPalette';
 import { DocumentViewer } from './components/DocumentViewer';
 import { DataGrid } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
@@ -767,11 +768,10 @@ function Workspace() {
     }
   };
 
-  const handleCloseTab = (e: React.MouseEvent, tabId: string) => {
-    e.stopPropagation();
+  const closeTabById = (tabId: string) => {
     const updatedTabs = tabs.filter(t => t.id !== tabId);
     setTabs(updatedTabs);
-    
+
     if (activeTabId === tabId) {
       if (updatedTabs.length > 0) {
         setActiveTabId(updatedTabs[updatedTabs.length - 1].id);
@@ -780,6 +780,55 @@ function Workspace() {
       }
     }
   };
+
+  const handleCloseTab = (e: React.MouseEvent, tabId: string) => {
+    e.stopPropagation();
+    closeTabById(tabId);
+  };
+
+  const cycleTab = (dir: 1 | -1) => {
+    if (tabs.length < 2) return;
+    const idx = tabs.findIndex(t => t.id === activeTabId);
+    setActiveTabId(tabs[(idx + dir + tabs.length) % tabs.length].id);
+  };
+
+  const openQuickStartTab = () => {
+    setTabs(prev => prev.some(t => t.id === QUICK_START_TAB_ID) ? prev : [...prev, createQuickStartTab()]);
+    setActiveTabId(QUICK_START_TAB_ID);
+  };
+
+  // Command palette: Cmd/Ctrl+K from anywhere in the workspace.
+  const [isPaletteOpen, setIsPaletteOpen] = useState(false);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setIsPaletteOpen(v => !v);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  const paletteActions: PaletteAction[] = [
+    { id: 'new-connection', title: 'New Connection…', keywords: 'connect database add server', run: () => setIsConnectionModalOpen(true) },
+    { id: 'toggle-theme', title: 'Toggle Light/Dark Theme', keywords: 'appearance color mode', run: toggleTheme },
+    { id: 'open-settings', title: 'Open Settings', keywords: 'preferences config density', run: handleOpenSettingsTab },
+    { id: 'open-quickstart', title: 'Open Quick Start', keywords: 'welcome home help', run: openQuickStartTab },
+    { id: 'density-roomy', title: 'Density: Roomy', keywords: 'layout spacing', run: () => setDensity('roomy') },
+    { id: 'density-cozy', title: 'Density: Cozy', keywords: 'layout spacing', run: () => setDensity('cozy') },
+    { id: 'density-compact', title: 'Density: Compact', keywords: 'layout spacing dense', run: () => setDensity('compact') },
+    ...(activeTab && activeTab.type === 'collection' ? [
+      { id: 'open-shell', title: 'Open mongosh Shell', hint: `${activeTab.db}.${activeTab.collection}`, keywords: 'terminal mongosh script', run: () => handleOpenShell(activeTab.connectionId, activeTab.db, activeTab.collection) },
+      { id: 'export-collection', title: 'Export Collection…', hint: `${activeTab.db}.${activeTab.collection}`, keywords: 'download json csv import', run: () => handleOpenExportTab(activeTab) },
+      { id: 'analyze-schema', title: 'Analyze Schema', hint: `${activeTab.db}.${activeTab.collection}`, keywords: 'fields types', run: () => handleOpenSchemaTab(activeTab.connectionId, activeTab.db, activeTab.collection) },
+    ] : []),
+    ...(activeTabId ? [{ id: 'close-tab', title: 'Close Tab', keywords: 'tab', run: () => closeTabById(activeTabId) }] : []),
+    ...(tabs.length > 1 ? [
+      { id: 'next-tab', title: 'Next Tab', keywords: 'tab switch', run: () => cycleTab(1) },
+      { id: 'prev-tab', title: 'Previous Tab', keywords: 'tab switch', run: () => cycleTab(-1) },
+    ] : []),
+  ];
 
   const handleExecuteQuery = async (query: { filter: string; sort: string; projection: string; limit: number; skip: number }) => {
     if (!activeTab) return;
@@ -1248,6 +1297,12 @@ function Workspace() {
           className="mql-resizer"
           onMouseDown={startResizing}
           data-testid="sidebar-resizer"
+        />
+
+        <CommandPalette
+          open={isPaletteOpen}
+          onClose={() => setIsPaletteOpen(false)}
+          actions={paletteActions}
         />
 
         <ConnectionManager

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,9 @@ import { DialogProvider, useDialogs } from './components/dialogs/DialogProvider'
 import { formatBytes } from './lib/format';
 import type { QueryCodeSpec } from './lib/queryCodeGen';
 import { docToShell } from './lib/shellDoc';
-import { recordHistory, loadCollectionQueries } from './lib/queryStore';
+import { recordHistory, loadCollectionQueries, type SavedQueryBody } from './lib/queryStore';
+import { loadNamespaceIndex } from './lib/paletteIndex';
+import { CHECK_UPDATE_EVENT } from './components/UpdatePrompt';
 import type { ConnectionProfile } from './lib/connection';
 import { save, open } from '@tauri-apps/plugin-dialog';
 import { writeTextFile, readTextFile } from '@tauri-apps/plugin-fs';
@@ -318,36 +320,45 @@ function Workspace() {
     }
   }, [tabs.length]);
 
-  const handleSelectCollection = async (connectionId: string, dbName: string, collName: string) => {
+  // savedQuery (palette "jump to saved query") runs instead of the pinned
+  // default — for existing tabs it re-runs in place.
+  const handleSelectCollection = async (connectionId: string, dbName: string, collName: string, savedQuery?: SavedQueryBody) => {
     if (!connectionId || !dbName || !collName) return;
 
     const tabId = `${connectionId}.${dbName}.${collName}`;
     const tabExists = tabs.some(t => t.id === tabId);
 
-    if (!tabExists) {
-      const newTab: QueryTab = {
-        id: tabId,
-        type: 'collection',
-        connectionId,
-        db: dbName,
-        collection: collName,
-        results: [],
-        loading: true,
-        error: null,
-        explainResult: null,
-        lastQuery: DEFAULT_QUERY,
-      };
-      setTabs(prev => [...prev, newTab]);
+    if (!tabExists || savedQuery) {
+      if (!tabExists) {
+        const newTab: QueryTab = {
+          id: tabId,
+          type: 'collection',
+          connectionId,
+          db: dbName,
+          collection: collName,
+          results: [],
+          loading: true,
+          error: null,
+          explainResult: null,
+          lastQuery: DEFAULT_QUERY,
+        };
+        setTabs(prev => [...prev, newTab]);
+      } else {
+        setTabs(prev => prev.map(t => t.id === tabId ? { ...t, loading: true, error: null } : t));
+      }
       setActiveTabId(tabId);
 
       try {
-        // A pinned default query loads instead of the plain {} find.
-        let def: any = null;
-        try {
-          const cq = await loadCollectionQueries(connectionNameFor(connectionId), dbName, collName);
-          def = cq.default;
-        } catch {
-          def = null;
+        // A saved query (palette) wins; otherwise a pinned default query loads
+        // instead of the plain {} find.
+        let def: any = savedQuery ?? null;
+        if (!def) {
+          try {
+            const cq = await loadCollectionQueries(connectionNameFor(connectionId), dbName, collName);
+            def = cq.default;
+          } catch {
+            def = null;
+          }
         }
 
         if (def && def.queryType === 'aggregate') {
@@ -812,6 +823,48 @@ function Workspace() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
+  // Dynamic palette items, loaded when the palette opens: every database and
+  // collection of the active connections (cached per connection), plus saved
+  // queries of the collections that have open tabs.
+  const [paletteDynamicItems, setPaletteDynamicItems] = useState<PaletteAction[]>([]);
+  useEffect(() => {
+    if (!isPaletteOpen) return;
+    let alive = true;
+    (async () => {
+      const items: PaletteAction[] = [];
+      const namespaces = await loadNamespaceIndex(activeConnections.map(c => ({ id: c.id, name: c.name })));
+      for (const ns of namespaces) {
+        for (const coll of ns.collections) {
+          items.push({
+            id: `coll:${ns.connectionId}:${ns.db}:${coll}`,
+            title: coll,
+            hint: `${ns.connectionName} · ${ns.db}`,
+            keywords: `collection ${ns.db} ${ns.connectionName}`,
+            run: () => { void handleSelectCollection(ns.connectionId, ns.db, coll); },
+          });
+        }
+      }
+      const collTabs = tabs.filter(t => t.type === 'collection');
+      await Promise.all(collTabs.map(async (t) => {
+        try {
+          const cq = await loadCollectionQueries(connectionNameFor(t.connectionId), t.db, t.collection);
+          for (const s of cq.saved) {
+            items.push({
+              id: `saved:${t.id}:${s.id}`,
+              title: `Saved query: ${s.name}`,
+              hint: `${t.db}.${t.collection}`,
+              keywords: `saved query ${t.collection} ${t.db}`,
+              run: () => { void handleSelectCollection(t.connectionId, t.db, t.collection, s.query); },
+            });
+          }
+        } catch { /* store unavailable — skip */ }
+      }));
+      if (alive) setPaletteDynamicItems(items);
+    })();
+    return () => { alive = false; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPaletteOpen]);
+
   const paletteActions: PaletteAction[] = [
     { id: 'new-connection', title: 'New Connection…', keywords: 'connect database add server', run: () => setIsConnectionModalOpen(true) },
     { id: 'toggle-theme', title: 'Toggle Light/Dark Theme', keywords: 'appearance color mode', run: toggleTheme },
@@ -830,6 +883,14 @@ function Workspace() {
       { id: 'next-tab', title: 'Next Tab', keywords: 'tab switch', run: () => cycleTab(1) },
       { id: 'prev-tab', title: 'Previous Tab', keywords: 'tab switch', run: () => cycleTab(-1) },
     ] : []),
+    ...activeConnections.map(c => ({
+      id: `monitoring:${c.id}`,
+      title: `Open Monitoring: ${c.name}`,
+      keywords: 'monitoring metrics server status profiler',
+      run: () => handleOpenMonitoringTab(c.id),
+    })),
+    { id: 'check-updates', title: 'Check for Updates', keywords: 'version upgrade release', run: () => window.dispatchEvent(new Event(CHECK_UPDATE_EVENT)) },
+    ...paletteDynamicItems,
   ];
 
   const handleExecuteQuery = async (query: { filter: string; sort: string; projection: string; limit: number; skip: number }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1393,12 +1393,14 @@ function Workspace() {
                                         ? `Monitor: ${connectionNameFor(tab.connectionId)}`
                                         : tab.collection}
                       </span>
-                      <span
+                      <button
                         onClick={(e) => handleCloseTab(e, tab.id)}
                         className="mql-tab-close"
+                        aria-label="Close tab"
+                        title="Close tab"
                       >
                         <X size={10} />
-                      </span>
+                      </button>
                     </div>
                   );
                 })}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import { writeTextFile, readTextFile } from '@tauri-apps/plugin-fs';
 import { toJson, toCsv, parseJson, parseCsv } from './lib/dataTransfer';
 import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
-import { FolderCode, X, KeyRound, Play, Settings, Terminal, Rocket, Download, Table2, Eye, HardDrive, Activity } from 'lucide-react';
+import { FolderCode, X, KeyRound, Play, Settings, Terminal, Rocket, Download, Table2, Eye, HardDrive, Activity, Copy } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 interface QueryTab {
@@ -1400,8 +1400,16 @@ function Workspace() {
                   >
                     <div className="flex-grow flex flex-col min-h-0 min-w-0">
                       {activeTab.error && (
-                        <div className="p-3 bg-rose-950/20 border-b border-[var(--border-color)] text-rose-400 font-mono text-[11px] select-text">
-                          Error loading dataset: {activeTab.error}
+                        <div className="p-3 bg-rose-950/20 border-b border-[var(--border-color)] text-rose-400 font-mono text-[11px] select-text flex items-start gap-2">
+                          <span className="flex-grow">Error loading dataset: {activeTab.error}</span>
+                          <button
+                            className="mql-btn flex-shrink-0"
+                            title="Copy error message"
+                            onClick={() => { try { navigator.clipboard?.writeText(String(activeTab.error)); } catch { /* clipboard unavailable */ } }}
+                          >
+                            <Copy size={11} />
+                            <span>Copy</span>
+                          </button>
                         </div>
                       )}
                       {activeTab.loading ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { VaultGate } from './components/VaultGate';
 import { UpdatePrompt } from './components/UpdatePrompt';
 import { DialogProvider, useDialogs } from './components/dialogs/DialogProvider';
 import { formatBytes } from './lib/format';
-import { buildRunnableCommand } from './lib/mongoCommand';
+import type { QueryCodeSpec } from './lib/queryCodeGen';
 import { docToShell } from './lib/shellDoc';
 import { recordHistory, loadCollectionQueries } from './lib/queryStore';
 import type { ConnectionProfile } from './lib/connection';
@@ -62,9 +62,9 @@ const isEmptyFilter = (s: string): boolean => {
   return t === '' || t === '{}';
 };
 
-// Build the full mongosh-runnable command for whatever a tab last executed,
-// shown formatted in the DataGrid "Query Code" tab. Returns null before any run.
-const buildTabQueryCode = (tab: QueryTab): string | null => {
+// Describe whatever a tab last executed, for the DataGrid "Query Code" tab
+// (rendered there as runnable driver code per language). Null before any run.
+const buildTabQuerySpec = (tab: QueryTab): QueryCodeSpec | null => {
   const parse = (s: string): unknown => {
     try {
       return s.trim() ? JSON.parse(s) : {};
@@ -73,15 +73,18 @@ const buildTabQueryCode = (tab: QueryTab): string | null => {
     }
   };
   if (tab.lastAggregate) {
-    return buildRunnableCommand(
-      { queryType: 'aggregate', pipeline: tab.lastAggregate },
-      tab.collection
-    );
+    return {
+      db: tab.db,
+      collection: tab.collection,
+      query: { queryType: 'aggregate', pipeline: tab.lastAggregate },
+    };
   }
   if (tab.lastQuery) {
     const q = tab.lastQuery;
-    return buildRunnableCommand(
-      {
+    return {
+      db: tab.db,
+      collection: tab.collection,
+      query: {
         queryType: 'find',
         filter: parse(q.filter),
         sort: parse(q.sort),
@@ -89,8 +92,7 @@ const buildTabQueryCode = (tab: QueryTab): string | null => {
         limit: q.limit,
         skip: q.skip,
       },
-      tab.collection
-    );
+    };
   }
   return null;
 };
@@ -1481,7 +1483,7 @@ function Workspace() {
                           documents={activeTab.results}
                           density={density}
                           explainResult={activeTab.explainResult}
-                          queryCode={buildTabQueryCode(activeTab)}
+                          querySpec={buildTabQuerySpec(activeTab)}
                           onInsertDocument={handleInsertDocument}
                           onEditDocument={handleEditDocument}
                           onDuplicateDocument={handleDuplicateDocument}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import { formatBytes } from './lib/format';
 import type { QueryCodeSpec } from './lib/queryCodeGen';
 import { docToShell } from './lib/shellDoc';
 import { recordHistory, loadCollectionQueries, type SavedQueryBody } from './lib/queryStore';
-import { loadNamespaceIndex } from './lib/paletteIndex';
+import { clearNamespaceIndex, loadNamespaceIndex, matchesNamespaceScope } from './lib/paletteIndex';
 import { CHECK_UPDATE_EVENT } from './components/UpdatePrompt';
 import type { ConnectionProfile } from './lib/connection';
 import { save, open } from '@tauri-apps/plugin-dialog';
@@ -180,6 +180,7 @@ function Workspace() {
   } | null>(null);
   const [indexMutationTrigger, setIndexMutationTrigger] = useState(0);
   const [collectionMutationTrigger, setCollectionMutationTrigger] = useState(0);
+  const [sidebarFilterQuery, setSidebarFilterQuery] = useState('');
   const [sidebarWidth, setSidebarWidth] = useState(300);
   const [isResizing, setIsResizing] = useState(false);
 
@@ -621,9 +622,11 @@ function Workspace() {
       const current = tabs.find(t => t.id === prev);
       return current ? renameTab(current).id : prev;
     });
+    invalidatePaletteNamespaceIndex(connectionId);
   };
 
   const handleDatabaseDropped = (connectionId: string, dbName: string) => {
+    invalidatePaletteNamespaceIndex(connectionId);
     setTabs(prev => {
       const updated = prev.filter(t => t.connectionId !== connectionId || t.db !== dbName);
       const activeWasDropped = activeTabId
@@ -674,6 +677,7 @@ function Workspace() {
       const current = tabs.find(t => t.id === prev);
       return current ? renameTab(current).id : prev;
     });
+    invalidatePaletteNamespaceIndex(connectionId);
   };
 
   const handleOpenIndexModalForCreate = (connectionId: string, dbName: string, collName: string) => {
@@ -823,18 +827,45 @@ function Workspace() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  // Dynamic palette items, loaded when the palette opens: every database and
-  // collection of the active connections (cached per connection), plus saved
-  // queries of the collections that have open tabs.
+  // Dynamic palette items load only after the user starts searching, so opening
+  // command mode does not immediately inventory every connected cluster.
   const [paletteDynamicItems, setPaletteDynamicItems] = useState<PaletteAction[]>([]);
+  const [paletteQuery, setPaletteQuery] = useState('');
+  const paletteDynamicLoadKey = React.useRef<string | null>(null);
+  const paletteNamespaceScope = sidebarFilterQuery.trim();
+  const shouldLoadPaletteDynamic =
+    isPaletteOpen && (paletteQuery.trim().length >= 2 || paletteNamespaceScope.length >= 2);
+  const invalidatePaletteNamespaceIndex = React.useCallback((connectionId?: string) => {
+    clearNamespaceIndex(connectionId);
+    paletteDynamicLoadKey.current = null;
+    setPaletteDynamicItems(prev => prev.length === 0 ? prev : []);
+  }, []);
   useEffect(() => {
-    if (!isPaletteOpen) return;
+    if (collectionMutationTrigger > 0) invalidatePaletteNamespaceIndex();
+  }, [collectionMutationTrigger, invalidatePaletteNamespaceIndex]);
+  useEffect(() => {
+    if (!shouldLoadPaletteDynamic) {
+      paletteDynamicLoadKey.current = null;
+      setPaletteDynamicItems(prev => prev.length === 0 ? prev : []);
+      return;
+    }
+    const collTabs = tabs.filter(t => t.type === 'collection');
+    const loadKey = [
+      activeConnections.map(c => `${c.id}:${c.name}`).join('|'),
+      collTabs.map(t => `${t.id}:${t.connectionId}:${t.db}:${t.collection}`).join('|'),
+      paletteNamespaceScope,
+    ].join('::');
+    if (paletteDynamicLoadKey.current === loadKey) return;
+    paletteDynamicLoadKey.current = loadKey;
     let alive = true;
     (async () => {
       const items: PaletteAction[] = [];
       const namespaces = await loadNamespaceIndex(activeConnections.map(c => ({ id: c.id, name: c.name })));
       for (const ns of namespaces) {
         for (const coll of ns.collections) {
+          if (!matchesNamespaceScope(paletteNamespaceScope, { connectionName: ns.connectionName, db: ns.db, collection: coll })) {
+            continue;
+          }
           items.push({
             id: `coll:${ns.connectionId}:${ns.db}:${coll}`,
             title: coll,
@@ -844,10 +875,13 @@ function Workspace() {
           });
         }
       }
-      const collTabs = tabs.filter(t => t.type === 'collection');
       await Promise.all(collTabs.map(async (t) => {
         try {
-          const cq = await loadCollectionQueries(connectionNameFor(t.connectionId), t.db, t.collection);
+          const connectionName = connectionNameFor(t.connectionId);
+          if (!matchesNamespaceScope(paletteNamespaceScope, { connectionName, db: t.db, collection: t.collection })) {
+            return;
+          }
+          const cq = await loadCollectionQueries(connectionName, t.db, t.collection);
           for (const s of cq.saved) {
             items.push({
               id: `saved:${t.id}:${s.id}`,
@@ -863,13 +897,14 @@ function Workspace() {
     })();
     return () => { alive = false; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPaletteOpen]);
+  }, [shouldLoadPaletteDynamic, activeConnections, tabs, paletteNamespaceScope]);
 
   const paletteActions: PaletteAction[] = [
     { id: 'new-connection', title: 'New Connection…', keywords: 'connect database add server', run: () => setIsConnectionModalOpen(true) },
     { id: 'toggle-theme', title: 'Toggle Light/Dark Theme', keywords: 'appearance color mode', run: toggleTheme },
     { id: 'open-settings', title: 'Open Settings', keywords: 'preferences config density', run: handleOpenSettingsTab },
     { id: 'open-quickstart', title: 'Open Quick Start', keywords: 'welcome home help', run: openQuickStartTab },
+    { id: 'refresh-palette-index', title: 'Refresh Command Palette Index', keywords: 'reload databases collections namespaces cache stale', run: () => invalidatePaletteNamespaceIndex() },
     { id: 'density-roomy', title: 'Density: Roomy', keywords: 'layout spacing', run: () => setDensity('roomy') },
     { id: 'density-cozy', title: 'Density: Cozy', keywords: 'layout spacing', run: () => setDensity('cozy') },
     { id: 'density-compact', title: 'Density: Compact', keywords: 'layout spacing dense', run: () => setDensity('compact') },
@@ -1327,6 +1362,8 @@ function Workspace() {
             onCollectionRenamed={handleCollectionRenamed}
             onDatabaseDropped={handleDatabaseDropped}
             onDatabaseRenamed={handleDatabaseRenamed}
+            onNamespaceMutated={invalidatePaletteNamespaceIndex}
+            onFilterQueryChange={setSidebarFilterQuery}
             indexMutationTrigger={indexMutationTrigger}
             activeCollection={activeTab ? { connectionId: activeTab.connectionId, db: activeTab.db, collection: activeTab.collection, indexName: activeTab.indexName } : null}
             activeConnections={activeConnections}
@@ -1364,8 +1401,13 @@ function Workspace() {
 
         <CommandPalette
           open={isPaletteOpen}
-          onClose={() => setIsPaletteOpen(false)}
+          onClose={() => {
+            setIsPaletteOpen(false);
+            setPaletteQuery('');
+          }}
           actions={paletteActions}
+          scopeLabel={paletteNamespaceScope}
+          onQueryChange={setPaletteQuery}
         />
 
         <ConnectionManager

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Search } from 'lucide-react';
+
+export interface PaletteAction {
+  id: string;
+  title: string;
+  hint?: string;      // right-aligned context, e.g. the target namespace
+  keywords?: string;  // extra match terms not shown in the UI
+  run: () => void;
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  actions: PaletteAction[];
+}
+
+const matches = (query: string, action: PaletteAction): boolean => {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const haystack = `${action.title} ${action.keywords ?? ''}`.toLowerCase();
+  return q.split(/\s+/).every((part) => haystack.includes(part));
+};
+
+export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, actions }) => {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const visible = useMemo(() => actions.filter((a) => matches(query, a)), [actions, query]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setSelected(0);
+      // Focus after the panel mounts.
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  useEffect(() => { setSelected(0); }, [query]);
+
+  if (!open) return null;
+
+  const runAction = (action: PaletteAction | undefined) => {
+    if (!action) return;
+    onClose();
+    action.run();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') { e.preventDefault(); onClose(); }
+    else if (e.key === 'ArrowDown') { e.preventDefault(); setSelected((s) => Math.min(s + 1, visible.length - 1)); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setSelected((s) => Math.max(s - 1, 0)); }
+    else if (e.key === 'Enter') { e.preventDefault(); runAction(visible[selected]); }
+  };
+
+  return (
+    <div className="mql-palette-backdrop" onMouseDown={onClose} data-testid="command-palette">
+      <div className="mql-palette" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="mql-palette-search">
+          <Search size={13} className="mql-palette-search-icon" />
+          <input
+            ref={inputRef}
+            className="mql-palette-input"
+            placeholder="Type a command…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            data-testid="command-palette-input"
+            aria-label="Command palette"
+          />
+        </div>
+        <div className="mql-palette-list" role="listbox">
+          {visible.length === 0 && <div className="mql-palette-empty">No matching commands</div>}
+          {visible.map((a, i) => (
+            <div
+              key={a.id}
+              role="option"
+              aria-selected={i === selected}
+              className={`mql-palette-item${i === selected ? ' is-selected' : ''}`}
+              onMouseEnter={() => setSelected(i)}
+              onClick={() => runAction(a)}
+            >
+              <span className="mql-palette-title">{a.title}</span>
+              {a.hint && <span className="mql-palette-hint">{a.hint}</span>}
+            </div>
+          ))}
+        </div>
+        <div className="mql-palette-footer">
+          <span>↑↓ navigate</span><span>⏎ run</span><span>esc close</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -14,7 +14,11 @@ interface CommandPaletteProps {
   open: boolean;
   onClose: () => void;
   actions: PaletteAction[];
+  scopeLabel?: string;
+  onQueryChange?: (query: string) => void;
 }
+
+const MAX_VISIBLE_ACTIONS = 80;
 
 // Rank by fuzzy score: title matches outrank keyword-only matches. An empty
 // query scores everything 0, so the caller's original order is kept.
@@ -25,17 +29,19 @@ const scoreAction = (query: string, action: PaletteAction): number | null => {
   return Math.max(title ?? -Infinity, keywords !== null ? keywords - 50 : -Infinity);
 };
 
-export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, actions }) => {
+export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, actions, scopeLabel = '', onQueryChange }) => {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const visible = useMemo(() => {
     const q = query.trim();
+    if (!q) return actions.slice(0, MAX_VISIBLE_ACTIONS);
     return actions
       .map((a) => ({ a, score: scoreAction(q, a) }))
       .filter((x): x is { a: PaletteAction; score: number } => x.score !== null)
       .sort((x, y) => y.score - x.score)
+      .slice(0, MAX_VISIBLE_ACTIONS)
       .map((x) => x.a);
   }, [actions, query]);
 
@@ -49,6 +55,10 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, a
   }, [open]);
 
   useEffect(() => { setSelected(0); }, [query]);
+  useEffect(() => { onQueryChange?.(query); }, [onQueryChange, query]);
+  useEffect(() => {
+    setSelected((s) => Math.min(s, Math.max(visible.length - 1, 0)));
+  }, [visible.length]);
 
   if (!open) return null;
 
@@ -81,6 +91,12 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, a
             aria-label="Command palette"
           />
         </div>
+        {scopeLabel.trim() && (
+          <div className="mql-palette-scope" title={`Sidebar filter: ${scopeLabel}`}>
+            <span className="mql-palette-scope-label">Sidebar</span>
+            <span className="mql-palette-scope-value">{scopeLabel}</span>
+          </div>
+        )}
         <div className="mql-palette-list" role="listbox">
           {visible.length === 0 && <div className="mql-palette-empty">No matching commands</div>}
           {visible.map((a, i) => (

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Search } from 'lucide-react';
+import { fuzzyScore } from '../lib/fuzzyMatch';
 
 export interface PaletteAction {
   id: string;
@@ -15,11 +16,13 @@ interface CommandPaletteProps {
   actions: PaletteAction[];
 }
 
-const matches = (query: string, action: PaletteAction): boolean => {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  const haystack = `${action.title} ${action.keywords ?? ''}`.toLowerCase();
-  return q.split(/\s+/).every((part) => haystack.includes(part));
+// Rank by fuzzy score: title matches outrank keyword-only matches. An empty
+// query scores everything 0, so the caller's original order is kept.
+const scoreAction = (query: string, action: PaletteAction): number | null => {
+  const title = fuzzyScore(query, action.title);
+  const keywords = action.keywords ? fuzzyScore(query, action.keywords) : null;
+  if (title === null && keywords === null) return null;
+  return Math.max(title ?? -Infinity, keywords !== null ? keywords - 50 : -Infinity);
 };
 
 export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, actions }) => {
@@ -27,7 +30,14 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose, a
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const visible = useMemo(() => actions.filter((a) => matches(query, a)), [actions, query]);
+  const visible = useMemo(() => {
+    const q = query.trim();
+    return actions
+      .map((a) => ({ a, score: scoreAction(q, a) }))
+      .filter((x): x is { a: PaletteAction; score: number } => x.score !== null)
+      .sort((x, y) => y.score - x.score)
+      .map((x) => x.a);
+  }, [actions, query]);
 
   useEffect(() => {
     if (open) {

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -3,6 +3,7 @@ import { invoke, Channel } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 import { useDialogs } from './dialogs/DialogProvider';
 import { PasswordInput } from './PasswordInput';
+import { useEscapeClose } from '../lib/useEscapeClose';
 import {
   Plus, X, Server, Play, Edit3, Trash2, Check, AlertCircle, RefreshCw,
   Folder, FolderPlus, FolderOpen, Search, ChevronDown, ChevronRight,
@@ -355,6 +356,8 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       loadFoldersFromStorage();
     }
   }, [isOpen]);
+
+  useEscapeClose(isOpen, onClose);
 
   const loadFoldersFromStorage = () => {
     try {

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -4,7 +4,9 @@ import { List } from 'react-window';
 import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3 } from 'lucide-react';
 import { ChartView } from './ChartView';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
-import { generateQueryCode, CODE_LANGUAGES, type CodeLanguage, type QueryCodeSpec } from '../lib/queryCodeGen';
+import Editor from '@monaco-editor/react';
+import { generateQueryCode, CODE_LANGUAGES, CODE_LANGUAGE_MONACO_IDS, type CodeLanguage, type QueryCodeSpec } from '../lib/queryCodeGen';
+import { useMonacoTheme } from '../lib/useMonacoTheme';
 import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
 
 interface DataGridProps {
@@ -505,6 +507,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
   const [queryCopied, setQueryCopied] = useState(false);
 
   // Query Code tab: generate runnable driver code in the selected language.
+  const monacoTheme = useMonacoTheme();
   const [codeLang, setCodeLang] = useState<CodeLanguage>(() => {
     const saved = localStorage.getItem('mqlens-codegen-lang') as CodeLanguage | null;
     return saved && (CODE_LANGUAGES as readonly string[]).includes(saved) ? saved : 'mongosh';
@@ -1444,13 +1447,29 @@ export const DataGrid: React.FC<DataGridProps> = ({
         /* Query Code Workspace */
         <div className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden" data-testid="query-code-panel">
           {queryCode ? (
-            <div className="flex-1 overflow-auto bg-[var(--bg-base)] p-4 select-text">
-              <pre
-                className="text-[11px] text-[var(--syntax-key)] font-mono select-text leading-relaxed whitespace-pre-wrap"
-                data-testid="query-code-content"
-              >
-                {queryCode}
-              </pre>
+            <div className="flex-1 min-h-0 bg-[var(--bg-base)]">
+              <Editor
+                height="100%"
+                language={CODE_LANGUAGE_MONACO_IDS[codeLang]}
+                value={queryCode}
+                theme={monacoTheme}
+                wrapperProps={{ 'data-testid': 'query-code-content' }}
+                options={{
+                  readOnly: true,
+                  domReadOnly: true,
+                  minimap: { enabled: false },
+                  lineNumbers: 'on',
+                  lineNumbersMinChars: 3,
+                  scrollBeyondLastLine: false,
+                  wordWrap: 'on',
+                  fontSize: 12,
+                  fontFamily: 'JetBrains Mono, SF Mono, Consolas, monospace',
+                  renderLineHighlight: 'none',
+                  automaticLayout: true,
+                  contextmenu: false,
+                  padding: { top: 10 },
+                }}
+              />
             </div>
           ) : (
             <div className="flex-1 flex flex-col items-center justify-center text-[var(--text-muted)] select-none p-6 bg-[var(--bg-base)]">

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -459,6 +459,47 @@ export const DataGrid: React.FC<DataGridProps> = ({
   const docViewerContext = useContext(DocumentViewerContext);
   const [viewMode, setViewMode] = useState<ViewMode>('json');
   const [activeTab, setActiveTab] = useState<'results' | 'explain' | 'query'>('results');
+
+  // Column resize: table view keeps per-column widths (session-scoped — the
+  // column set changes per collection); the tree view's key column persists.
+  const [colWidths, setColWidths] = useState<Record<string, number>>({});
+  const colWidth = (col: string) => colWidths[col] ?? 180;
+  const [treeKeyWidth, setTreeKeyWidth] = useState<number>(() => {
+    const saved = Number(localStorage.getItem('mqlens-treekey-width'));
+    return saved >= 140 && saved <= 800 ? saved : 320;
+  });
+  useEffect(() => { localStorage.setItem('mqlens-treekey-width', String(treeKeyWidth)); }, [treeKeyWidth]);
+
+  const clampCol = (w: number, min = 80, max = 800) => Math.min(max, Math.max(min, w));
+  const startColResize = (e: React.MouseEvent, startWidth: number, apply: (w: number) => void, min = 80) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const startX = e.clientX;
+    const move = (ev: MouseEvent) => apply(clampCol(startWidth + ev.clientX - startX, min));
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+  // Shared handle: drag or focus + arrow keys. A render helper (not a nested
+  // component) so re-renders update the same DOM node instead of remounting.
+  const renderColResizer = (label: string, width: number, apply: (w: number) => void, min = 80) => (
+    <div
+      className="mql-col-resizer"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={`Resize ${label} column`}
+      tabIndex={0}
+      onMouseDown={(e) => startColResize(e, width, apply, min)}
+      onKeyDown={(e) => {
+        if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+        e.preventDefault();
+        apply(clampCol(width + (e.key === 'ArrowRight' ? 16 : -16), min));
+      }}
+    />
+  );
   const [copied, setCopied] = useState(false);
   const [queryCopied, setQueryCopied] = useState(false);
 
@@ -981,7 +1022,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
           <div
             key={col}
             className="px-3 border-r border-[var(--border-color)] h-full flex items-center truncate text-[var(--text-main)]"
-            style={{ width: '180px', flexShrink: 0 }}
+            style={{ width: `${colWidth(col)}px`, flexShrink: 0 }}
             onContextMenu={(e) => openCtxMenu(e, rawDoc, col, rawDoc[col])}
           >
             {renderColoredCell(rawDoc[col])}
@@ -1249,9 +1290,16 @@ export const DataGrid: React.FC<DataGridProps> = ({
           </div>
         ) : viewMode === 'tree' ? (
           /* Virtualized tree-table: Key | Value | Type */
-          <div className="mql-treetable flex-1 flex flex-col min-h-0 min-w-0" data-testid="tree-view">
+          <div
+            className="mql-treetable flex-1 flex flex-col min-h-0 min-w-0"
+            data-testid="tree-view"
+            style={{ '--treetable-keyw': `${treeKeyWidth}px` } as React.CSSProperties}
+          >
             <div className="mql-treetable-head">
-              <div className="mql-treetable-key">Key</div>
+              <div className="mql-treetable-key relative">
+                Key
+                {renderColResizer('key', treeKeyWidth, setTreeKeyWidth, 140)}
+              </div>
               <div className="mql-treetable-value">Value</div>
               <div className="mql-treetable-type">Type</div>
             </div>
@@ -1278,10 +1326,11 @@ export const DataGrid: React.FC<DataGridProps> = ({
                 {columns.map((col) => (
                   <div
                     key={col}
-                    className="px-3 border-r border-[var(--border-color)] flex items-center truncate"
-                    style={{ width: '180px', flexShrink: 0 }}
+                    className="px-3 border-r border-[var(--border-color)] flex items-center truncate relative"
+                    style={{ width: `${colWidth(col)}px`, flexShrink: 0 }}
                   >
                     {col}
+                    {renderColResizer(col, colWidth(col), (w) => setColWidths((p) => ({ ...p, [col]: w })))}
                   </div>
                 ))}
                 {hasRowActions && (
@@ -1299,7 +1348,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
                 rowHeight={getRowHeight()}
                 rowComponent={Row}
                 rowProps={{}}
-                style={{ height: '100%', width: '100%', minWidth: viewMode === 'table' ? `${(columns.length * 180) + 48 + (hasRowActions ? 72 : 0)}px` : '100%' }}
+                style={{ height: '100%', width: '100%', minWidth: viewMode === 'table' ? `${columns.reduce((s, c) => s + colWidth(c), 0) + 48 + (hasRowActions ? 72 : 0)}px` : '100%' }}
               />
             </div>
           </div>

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -4,15 +4,16 @@ import { List } from 'react-window';
 import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3 } from 'lucide-react';
 import { ChartView } from './ChartView';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
+import { generateQueryCode, CODE_LANGUAGES, type CodeLanguage, type QueryCodeSpec } from '../lib/queryCodeGen';
 import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
 
 interface DataGridProps {
   documents: Array<Record<string, any>>;
   density?: 'roomy' | 'cozy' | 'compact';
   explainResult?: string | null;
-  // The full mongosh-runnable command for the query that produced these results,
-  // shown formatted in the "Query Code" tab. Null when no query has run yet.
-  queryCode?: string | null;
+  // The query that produced these results, rendered as runnable driver code
+  // (per selected language) in the "Query Code" tab. Null before any run.
+  querySpec?: QueryCodeSpec | null;
   onInsertDocument?: () => void;
   onEditDocument?: (doc: Record<string, any>) => void;
   onDuplicateDocument?: (doc: Record<string, any>) => void;
@@ -402,7 +403,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
   documents,
   density = 'cozy',
   explainResult = null,
-  queryCode = null,
+  querySpec = null,
   onInsertDocument,
   onEditDocument,
   onDuplicateDocument,
@@ -502,6 +503,17 @@ export const DataGrid: React.FC<DataGridProps> = ({
   );
   const [copied, setCopied] = useState(false);
   const [queryCopied, setQueryCopied] = useState(false);
+
+  // Query Code tab: generate runnable driver code in the selected language.
+  const [codeLang, setCodeLang] = useState<CodeLanguage>(() => {
+    const saved = localStorage.getItem('mqlens-codegen-lang') as CodeLanguage | null;
+    return saved && (CODE_LANGUAGES as readonly string[]).includes(saved) ? saved : 'mongosh';
+  });
+  useEffect(() => { localStorage.setItem('mqlens-codegen-lang', codeLang); }, [codeLang]);
+  const queryCode = useMemo(
+    () => (querySpec ? generateQueryCode(codeLang, querySpec) : null),
+    [querySpec, codeLang],
+  );
 
   const handleCopyQueryCode = () => {
     if (!queryCode) return;
@@ -1246,15 +1258,28 @@ export const DataGrid: React.FC<DataGridProps> = ({
           ) : (
             /* Query Code Tools */
             queryCode && (
-              <button
-                onClick={handleCopyQueryCode}
-                className="px-2.5 py-1 rounded bg-[var(--bg-item-active)] hover:bg-[var(--bg-item-hover)] text-[var(--text-muted)] hover:text-[var(--text-main)] border border-[var(--border-color)] flex items-center gap-1.5 text-[11px] font-semibold transition-all cursor-pointer"
-                title="Copy query code"
-                data-testid="copy-query-code-btn"
-              >
-                {queryCopied ? <Check size={12} className="text-emerald-500" /> : <Copy size={12} />}
-                <span>{queryCopied ? 'Copied!' : 'Copy'}</span>
-              </button>
+              <>
+                <select
+                  value={codeLang}
+                  onChange={(e) => setCodeLang(e.target.value as CodeLanguage)}
+                  className="px-2 py-1 rounded bg-[var(--bg-base)] text-[var(--text-main)] border border-[var(--border-color)] text-[11px] font-medium cursor-pointer"
+                  aria-label="Code language"
+                  data-testid="query-code-lang"
+                >
+                  {CODE_LANGUAGES.map((lang) => (
+                    <option key={lang} value={lang}>{lang}</option>
+                  ))}
+                </select>
+                <button
+                  onClick={handleCopyQueryCode}
+                  className="px-2.5 py-1 rounded bg-[var(--bg-item-active)] hover:bg-[var(--bg-item-hover)] text-[var(--text-muted)] hover:text-[var(--text-main)] border border-[var(--border-color)] flex items-center gap-1.5 text-[11px] font-semibold transition-all cursor-pointer"
+                  title="Copy query code"
+                  data-testid="copy-query-code-btn"
+                >
+                  {queryCopied ? <Check size={12} className="text-emerald-500" /> : <Copy size={12} />}
+                  <span>{queryCopied ? 'Copied!' : 'Copy'}</span>
+                </button>
+              </>
             )
           )}
         </div>

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1400,7 +1400,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
                 </div>
               ) : (
                 <div className="flex-1 overflow-auto bg-[var(--bg-base)] p-4 select-text">
-                  <pre className="text-[11px] text-sky-200 font-mono select-text leading-relaxed whitespace-pre-wrap">
+                  <pre className="text-[11px] text-[var(--syntax-key)] font-mono select-text leading-relaxed whitespace-pre-wrap">
                     {explainResult}
                   </pre>
                 </div>
@@ -1421,7 +1421,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
           {queryCode ? (
             <div className="flex-1 overflow-auto bg-[var(--bg-base)] p-4 select-text">
               <pre
-                className="text-[11px] text-sky-200 font-mono select-text leading-relaxed whitespace-pre-wrap"
+                className="text-[11px] text-[var(--syntax-key)] font-mono select-text leading-relaxed whitespace-pre-wrap"
                 data-testid="query-code-content"
               >
                 {queryCode}

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { X, FileJson } from 'lucide-react';
 import Editor from '@monaco-editor/react';
 import { shellToEjson } from '../lib/shellDoc';
+import { useMonacoTheme } from '../lib/useMonacoTheme';
 
 // Validate the (shell-syntax) document text: convert to Extended JSON and parse.
 // Returns an error message, or null when valid. Shell types (ISODate/ObjectId/…)
@@ -39,10 +40,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const validationError = useMemo(() => validateDocument(json), [json]);
-  const theme =
-    typeof document !== 'undefined' && document.documentElement.getAttribute('data-theme') === 'light'
-      ? 'light'
-      : 'vs-dark';
+  const theme = useMonacoTheme();
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -3,6 +3,7 @@ import { X, FileJson } from 'lucide-react';
 import Editor from '@monaco-editor/react';
 import { shellToEjson } from '../lib/shellDoc';
 import { useMonacoTheme } from '../lib/useMonacoTheme';
+import { useEscapeClose } from '../lib/useEscapeClose';
 
 // Validate the (shell-syntax) document text: convert to Extended JSON and parse.
 // Returns an error message, or null when valid. Shell types (ISODate/ObjectId/…)
@@ -41,6 +42,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   const [saving, setSaving] = useState(false);
   const validationError = useMemo(() => validateDocument(json), [json]);
   const theme = useMonacoTheme();
+  useEscapeClose(isOpen, onClose);
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -37,7 +37,10 @@ import {
   Plus,
   Download,
   Upload,
-  X
+  X,
+  Eye,
+  EyeOff,
+  GripVertical
 } from 'lucide-react';
 
 interface VisualRule {
@@ -66,7 +69,7 @@ interface BuilderState {
   projectionQuery: string;
   limit: string;
   skip: string;
-  stages: { id: string; operator: string; content: string }[];
+  stages: { id: string; operator: string; content: string; disabled?: boolean }[];
 }
 
 // Serialize the current builder state into a GeneratedQuery — the same value
@@ -82,7 +85,7 @@ export function builderStateToQuery(state: BuilderState): GeneratedQuery {
   };
   if (state.queryMode === 'aggregate') {
     const pipeline = state.stages
-      .filter((stage) => stage.content.trim())
+      .filter((stage) => !stage.disabled && stage.content.trim())
       .map((stage) => ({ [stage.operator]: parseShellJson(stage.content) }));
     return { queryType: 'aggregate', pipeline };
   }
@@ -415,6 +418,9 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     id: string;
     operator: string;
     content: string;
+    // Disabled stages stay in the builder but are excluded from every
+    // pipeline build (run, run-to-here, explain, shell command, saved query).
+    disabled?: boolean;
   }
   const [stages, setStages] = useState<PipelineStage[]>([
     { id: 'stage-1', operator: '$match', content: '{\n  \n}' }
@@ -442,6 +448,39 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
 
   const updateStageContent = (id: string, content: string) => {
     setStages(prev => prev.map(s => s.id === id ? { ...s, content } : s));
+  };
+
+  const toggleStageDisabled = (id: string) => {
+    setStages(prev => prev.map(s => s.id === id ? { ...s, disabled: !s.disabled } : s));
+  };
+
+  // Drag-to-reorder: header is the drag handle; dropping on a stage moves the
+  // dragged stage to that position.
+  const [dragStageIndex, setDragStageIndex] = useState<number | null>(null);
+  const dropStageAt = (target: number) => {
+    setStages(prev => {
+      if (dragStageIndex === null || dragStageIndex === target) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(dragStageIndex, 1);
+      next.splice(target, 0, moved);
+      return next;
+    });
+    setDragStageIndex(null);
+  };
+
+  // Run the pipeline truncated after `index` (enabled stages only) — a quick
+  // preview of what the data looks like at that point.
+  const runToStage = (index: number) => {
+    if (!onExecuteAggregate) return;
+    setError(null);
+    try {
+      const pipeline = stages.slice(0, index + 1)
+        .filter(s => !s.disabled && s.content.trim())
+        .map(s => ({ [s.operator]: parseShellJson(s.content) }));
+      onExecuteAggregate(pipeline);
+    } catch (e: any) {
+      setError(`Invalid JSON syntax: ${e.message}`);
+    }
   };
 
   const moveStageUp = (index: number) => {
@@ -935,7 +974,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   // Shared by Run and Explain so both act on the full pipeline.
   const buildAggregatePipeline = (): Record<string, unknown>[] =>
     stages
-      .filter(stage => stage.content.trim())
+      .filter(stage => !stage.disabled && stage.content.trim())
       .map(stage => ({ [stage.operator]: parseShellJson(stage.content) }));
 
   const handleRun = () => {
@@ -970,7 +1009,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         let compiledSkip = 0;
 
         stages.forEach(stage => {
-          if (!stage.content.trim()) return;
+          if (stage.disabled || !stage.content.trim()) return;
           const body = parseShellJson(stage.content);
           if (stage.operator === '$match') {
             compiledFilter = { ...compiledFilter, ...body };
@@ -1001,7 +1040,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
 
     if (queryMode === 'aggregate') {
       const pipeline = stages
-        .filter((stage) => stage.content.trim())
+        .filter((stage) => !stage.disabled && stage.content.trim())
         .map((stage) => {
           try {
             return { [stage.operator]: parseShellJson(stage.content) };
@@ -1045,7 +1084,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         // Fallback (no aggregate explainer wired): approximate with the $match stages.
         let compiledFilter = {};
         stages.forEach(stage => {
-          if (stage.operator === '$match' && stage.content.trim()) {
+          if (!stage.disabled && stage.operator === '$match' && stage.content.trim()) {
             try {
               const body = parseShellJson(stage.content);
               compiledFilter = { ...compiledFilter, ...body };
@@ -1599,9 +1638,24 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                 {stages.map((stage, index) => {
                   const isValid = checkIsValidJson(stage.content);
                   return (
-                    <React.Fragment key={stage.id}>
-                      <div className={`mql-stage ${!isValid ? 'is-invalid' : ''}`} data-testid={`pipeline-stage-${index}`}>
-                        <div className="mql-stage-h">
+                    // Keyed by position, NOT stage.id: with id keys a reorder makes
+                    // React move the mounted Monaco editor's DOM subtree, which
+                    // crashes Monaco's scheduled renders ("this.domNode.domNode").
+                    // With index keys a reorder is just a value-prop update.
+                    <React.Fragment key={index}>
+                      <div
+                        className={`mql-stage ${!isValid ? 'is-invalid' : ''}${stage.disabled ? ' is-disabled' : ''}`}
+                        data-testid={`pipeline-stage-${index}`}
+                        onDragOver={(e) => { if (dragStageIndex !== null) e.preventDefault(); }}
+                        onDrop={() => dropStageAt(index)}
+                      >
+                        <div
+                          className="mql-stage-h"
+                          draggable
+                          onDragStart={() => setDragStageIndex(index)}
+                          onDragEnd={() => setDragStageIndex(null)}
+                        >
+                          <GripVertical size={11} className="mql-stage-grip" aria-hidden="true" />
                           <span className="mql-stage-num">{index + 1}</span>
                           <div className="mql-stage-op-wrap">
                             <select
@@ -1620,13 +1674,30 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                             <ChevronDown size={10} className="mql-stage-op-caret text-[var(--text-dim)]" />
                           </div>
                           <div style={{ flexGrow: 1 }} />
-                          <button onClick={() => moveStageUp(index)} disabled={index === 0} className="query-plane-icon-btn">
+                          <button
+                            onClick={() => runToStage(index)}
+                            disabled={loading || stage.disabled}
+                            className="query-plane-icon-btn"
+                            title={`Run pipeline to stage ${index + 1}`}
+                            aria-label={`Run pipeline to stage ${index + 1}`}
+                          >
+                            <Play size={11} />
+                          </button>
+                          <button
+                            onClick={() => toggleStageDisabled(stage.id)}
+                            className="query-plane-icon-btn"
+                            title={stage.disabled ? `Enable stage ${index + 1}` : `Disable stage ${index + 1}`}
+                            aria-label={stage.disabled ? `Enable stage ${index + 1}` : `Disable stage ${index + 1}`}
+                          >
+                            {stage.disabled ? <EyeOff size={11} /> : <Eye size={11} />}
+                          </button>
+                          <button onClick={() => moveStageUp(index)} disabled={index === 0} className="query-plane-icon-btn" aria-label={`Move stage ${index + 1} up`}>
                             <ChevronUp size={11} />
                           </button>
-                          <button onClick={() => moveStageDown(index)} disabled={index === stages.length - 1} className="query-plane-icon-btn">
+                          <button onClick={() => moveStageDown(index)} disabled={index === stages.length - 1} className="query-plane-icon-btn" aria-label={`Move stage ${index + 1} down`}>
                             <ChevronDown size={11} />
                           </button>
-                          <button onClick={() => removeStage(stage.id)} className="query-plane-icon-btn text-rose-400">
+                          <button onClick={() => removeStage(stage.id)} className="query-plane-icon-btn text-rose-400" aria-label={`Remove stage ${index + 1}`}>
                             <Trash2 size={11} />
                           </button>
                         </div>

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { AIChatPanel } from './AIChatPanel';
 import { QueryEditor } from './QueryEditor';
 import { useCollectionSchema } from '../lib/useCollectionSchema';
@@ -40,7 +40,9 @@ import {
   X,
   Eye,
   EyeOff,
-  GripVertical
+  GripVertical,
+  Undo2,
+  Redo2
 } from 'lucide-react';
 
 interface VisualRule {
@@ -463,6 +465,8 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     // Disabled stages stay in the builder but are excluded from every
     // pipeline build (run, run-to-here, explain, shell command, saved query).
     disabled?: boolean;
+    // Collapsed stages hide their body editor; purely visual.
+    collapsed?: boolean;
   }
   const [stages, setStages] = useState<PipelineStage[]>([
     { id: 'stage-1', operator: '$match', content: '{\n  \n}' }
@@ -471,21 +475,50 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   // AI chat assistant — open/close only; the panel owns its own chat state.
   const [isAIHelperOpen, setIsAIHelperOpen] = useState(false);
 
+  // Pipeline undo/redo: every stage mutation goes through commitStages, which
+  // snapshots the previous list. Keystroke-level content edits coalesce via a
+  // key so undo steps back over whole edits, not single characters.
+  const stagesPast = useRef<PipelineStage[][]>([]);
+  const stagesFuture = useRef<PipelineStage[][]>([]);
+  const lastStageEditRef = useRef<string | null>(null);
+  const commitStages = (next: PipelineStage[], coalesceKey?: string) => {
+    if (!coalesceKey || lastStageEditRef.current !== coalesceKey) {
+      stagesPast.current = [...stagesPast.current.slice(-99), stages];
+      stagesFuture.current = [];
+    }
+    lastStageEditRef.current = coalesceKey ?? null;
+    setStages(next);
+  };
+  const undoStages = () => {
+    const prev = stagesPast.current.pop();
+    if (!prev) return;
+    stagesFuture.current.push(stages);
+    lastStageEditRef.current = null;
+    setStages(prev);
+  };
+  const redoStages = () => {
+    const next = stagesFuture.current.pop();
+    if (!next) return;
+    stagesPast.current.push(stages);
+    lastStageEditRef.current = null;
+    setStages(next);
+  };
+
   const addStage = () => {
     const newStage = {
       id: `stage-${Math.random().toString(36).substr(2, 9)}`,
       operator: '$match',
       content: '{\n  \n}'
     };
-    setStages(prev => [...prev, newStage]);
+    commitStages([...stages, newStage]);
   };
 
   const removeStage = (id: string) => {
-    setStages(prev => prev.filter(s => s.id !== id));
+    commitStages(stages.filter(s => s.id !== id));
   };
 
   const updateStageOperator = (id: string, operator: string) => {
-    setStages(prev => prev.map(s => s.id === id
+    commitStages(stages.map(s => s.id === id
       ? {
           ...s,
           operator,
@@ -496,24 +529,54 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   };
 
   const updateStageContent = (id: string, content: string) => {
-    setStages(prev => prev.map(s => s.id === id ? { ...s, content } : s));
+    commitStages(stages.map(s => s.id === id ? { ...s, content } : s), `content:${id}`);
   };
 
   const toggleStageDisabled = (id: string) => {
-    setStages(prev => prev.map(s => s.id === id ? { ...s, disabled: !s.disabled } : s));
+    commitStages(stages.map(s => s.id === id ? { ...s, disabled: !s.disabled } : s));
+  };
+
+  // Collapse is visual only — collapsed stages still run.
+  const toggleStageCollapsed = (id: string) => {
+    commitStages(stages.map(s => s.id === id ? { ...s, collapsed: !s.collapsed } : s));
+  };
+
+  // $lookup form helper: read/write the four common parameters directly in the
+  // stage body so the user doesn't have to hand-edit the JSON.
+  const lookupFieldValue = (stage: PipelineStage, key: string): string => {
+    try {
+      const body = parseShellJson(stage.content);
+      return body && typeof body === 'object' && typeof (body as Record<string, unknown>)[key] === 'string'
+        ? (body as Record<string, string>)[key]
+        : '';
+    } catch {
+      return '';
+    }
+  };
+  const updateLookupField = (id: string, key: string, value: string) => {
+    const stage = stages.find(s => s.id === id);
+    if (!stage) return;
+    let body: Record<string, unknown> = {};
+    try {
+      const parsed = parseShellJson(stage.content);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) body = parsed as Record<string, unknown>;
+    } catch { /* unparseable body — rebuild from the form */ }
+    body[key] = value;
+    commitStages(
+      stages.map(s => s.id === id ? { ...s, content: JSON.stringify(body, null, 2) } : s),
+      `lookup:${id}:${key}`,
+    );
   };
 
   // Drag-to-reorder: header is the drag handle; dropping on a stage moves the
   // dragged stage to that position.
   const [dragStageIndex, setDragStageIndex] = useState<number | null>(null);
   const dropStageAt = (target: number) => {
-    setStages(prev => {
-      if (dragStageIndex === null || dragStageIndex === target) return prev;
-      const next = [...prev];
-      const [moved] = next.splice(dragStageIndex, 1);
-      next.splice(target, 0, moved);
-      return next;
-    });
+    if (dragStageIndex === null || dragStageIndex === target) { setDragStageIndex(null); return; }
+    const next = [...stages];
+    const [moved] = next.splice(dragStageIndex, 1);
+    next.splice(target, 0, moved);
+    commitStages(next);
     setDragStageIndex(null);
   };
 
@@ -534,24 +597,16 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
 
   const moveStageUp = (index: number) => {
     if (index === 0) return;
-    setStages(prev => {
-      const next = [...prev];
-      const temp = next[index];
-      next[index] = next[index - 1];
-      next[index - 1] = temp;
-      return next;
-    });
+    const next = [...stages];
+    [next[index - 1], next[index]] = [next[index], next[index - 1]];
+    commitStages(next);
   };
 
   const moveStageDown = (index: number) => {
-    setStages(prev => {
-      if (index === prev.length - 1) return prev;
-      const next = [...prev];
-      const temp = next[index];
-      next[index] = next[index + 1];
-      next[index + 1] = temp;
-      return next;
-    });
+    if (index === stages.length - 1) return;
+    const next = [...stages];
+    [next[index], next[index + 1]] = [next[index + 1], next[index]];
+    commitStages(next);
   };
 
   // Build pipeline stages ({id, operator, content}) from a MongoDB pipeline array.
@@ -570,7 +625,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   const handleInsertQuery = (query: GeneratedQuery) => {
     if (query.queryType === 'aggregate') {
       const pipeline = query.pipeline && query.pipeline.length > 0 ? query.pipeline : [{ $match: {} }];
-      setStages(stagesFromPipeline(pipeline));
+      commitStages(stagesFromPipeline(pipeline));
       setQueryMode('aggregate');
       triggerNotification('Aggregation pipeline applied');
     } else {
@@ -1680,6 +1735,24 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                   <Plus size={11} />
                   <span>Add Stage</span>
                 </button>
+                <button
+                  onClick={undoStages}
+                  disabled={stagesPast.current.length === 0}
+                  className="query-plane-icon-btn"
+                  aria-label="Undo pipeline change"
+                  title="Undo pipeline change"
+                >
+                  <Undo2 size={11} />
+                </button>
+                <button
+                  onClick={redoStages}
+                  disabled={stagesFuture.current.length === 0}
+                  className="query-plane-icon-btn"
+                  aria-label="Redo pipeline change"
+                  title="Redo pipeline change"
+                >
+                  <Redo2 size={11} />
+                </button>
                 <div style={{ flexGrow: 1 }} />
               </header>
 
@@ -1714,6 +1787,14 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                           onDragEnd={() => setDragStageIndex(null)}
                         >
                           <GripVertical size={11} className="mql-stage-grip" aria-hidden="true" />
+                          <button
+                            onClick={() => toggleStageCollapsed(stage.id)}
+                            className="query-plane-icon-btn"
+                            aria-label={stage.collapsed ? `Expand stage ${index + 1}` : `Collapse stage ${index + 1}`}
+                            title={stage.collapsed ? `Expand stage ${index + 1}` : `Collapse stage ${index + 1}`}
+                          >
+                            {stage.collapsed ? <ChevronRight size={11} /> : <ChevronDown size={11} />}
+                          </button>
                           <span className="mql-stage-num">{index + 1}</span>
                           <div className="mql-stage-op-wrap">
                             <select
@@ -1759,16 +1840,32 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                             <Trash2 size={11} />
                           </button>
                         </div>
-                        <QueryEditor
-                          surface="aggStage"
-                          stageOperator={stage.operator}
-                          onRun={handleRun}
-                          value={stage.content}
-                          onChange={(v) => updateStageContent(stage.id, v)}
-                          fields={fields}
-                          schema={schema}
-                          height={120}
-                        />
+                        {stage.operator === '$lookup' && !stage.collapsed && (
+                          <div className="mql-lookup-form" data-testid={`lookup-form-${index}`}>
+                            {(['from', 'localField', 'foreignField', 'as'] as const).map((key) => (
+                              <label key={key} className="mql-lookup-field">
+                                <span>{key}</span>
+                                <input
+                                  value={lookupFieldValue(stage, key)}
+                                  onChange={(e) => updateLookupField(stage.id, key, e.target.value)}
+                                  aria-label={`$lookup ${key}`}
+                                />
+                              </label>
+                            ))}
+                          </div>
+                        )}
+                        {!stage.collapsed && (
+                          <QueryEditor
+                            surface="aggStage"
+                            stageOperator={stage.operator}
+                            onRun={handleRun}
+                            value={stage.content}
+                            onChange={(v) => updateStageContent(stage.id, v)}
+                            fields={fields}
+                            schema={schema}
+                            height={120}
+                          />
+                        )}
                       </div>
                       {index < stages.length - 1 && (
                         <div className="mql-pipeline-flow">

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -3,6 +3,7 @@ import { AIChatPanel } from './AIChatPanel';
 import { QueryEditor } from './QueryEditor';
 import { useCollectionSchema } from '../lib/useCollectionSchema';
 import { collectionRef, type GeneratedQuery } from '../lib/mongoCommand';
+import { parseShellJson } from '../lib/shellDoc';
 import {
   loadCollectionQueries,
   saveQuery,
@@ -74,7 +75,7 @@ interface BuilderState {
 export function builderStateToQuery(state: BuilderState): GeneratedQuery {
   const parse = (s: string): unknown => {
     try {
-      return s.trim() ? JSON.parse(s) : {};
+      return s.trim() ? parseShellJson(s) : {};
     } catch {
       return {};
     }
@@ -82,7 +83,7 @@ export function builderStateToQuery(state: BuilderState): GeneratedQuery {
   if (state.queryMode === 'aggregate') {
     const pipeline = state.stages
       .filter((stage) => stage.content.trim())
-      .map((stage) => ({ [stage.operator]: JSON.parse(stage.content) }));
+      .map((stage) => ({ [stage.operator]: parseShellJson(stage.content) }));
     return { queryType: 'aggregate', pipeline };
   }
   return {
@@ -289,7 +290,7 @@ const parseFieldQuery = (field: string, value: any): VisualRule[] => {
 
 const syncRulesFromQuery = (jsonStr: string): { rules: VisualRule[], matchType: 'and' | 'or' } => {
   try {
-    const query = JSON.parse(jsonStr);
+    const query = parseShellJson(jsonStr);
     if (!query || typeof query !== 'object' || Array.isArray(query)) {
       return { rules: [], matchType: 'and' };
     }
@@ -318,7 +319,7 @@ const syncRulesFromQuery = (jsonStr: string): { rules: VisualRule[], matchType: 
 
 const syncProjectionFromQuery = (jsonStr: string): ProjectionRule[] => {
   try {
-    const query = JSON.parse(jsonStr);
+    const query = parseShellJson(jsonStr);
     if (!query || typeof query !== 'object' || Array.isArray(query)) {
       return [];
     }
@@ -338,7 +339,7 @@ const syncProjectionFromQuery = (jsonStr: string): ProjectionRule[] => {
 
 const syncSortFromQuery = (jsonStr: string): SortRule[] => {
   try {
-    const query = JSON.parse(jsonStr);
+    const query = parseShellJson(jsonStr);
     if (!query || typeof query !== 'object' || Array.isArray(query)) {
       return [];
     }
@@ -584,7 +585,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   useEffect(() => {
     try {
       if (filterQuery.trim()) {
-        JSON.parse(filterQuery);
+        parseShellJson(filterQuery);
       }
       setIsFilterValid(true);
     } catch {
@@ -595,7 +596,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   useEffect(() => {
     try {
       if (projectionQuery.trim()) {
-        JSON.parse(projectionQuery);
+        parseShellJson(projectionQuery);
       }
       setIsProjectionValid(true);
     } catch {
@@ -606,7 +607,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   useEffect(() => {
     try {
       if (sortQuery.trim()) {
-        JSON.parse(sortQuery);
+        parseShellJson(sortQuery);
       }
       setIsSortValid(true);
     } catch {
@@ -633,7 +634,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         return;
       }
       try {
-        const parsedCurrent = JSON.parse(filterQuery);
+        const parsedCurrent = parseShellJson(filterQuery);
         const compiledCurrent = JSON.parse(compileRulesToQuery(rules, queryMatchType));
         if (JSON.stringify(parsedCurrent) !== JSON.stringify(compiledCurrent)) {
           const synced = syncRulesFromQuery(filterQuery);
@@ -659,7 +660,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         return;
       }
       try {
-        const parsedCurrent = JSON.parse(projectionQuery);
+        const parsedCurrent = parseShellJson(projectionQuery);
         const compiledCurrent = JSON.parse(compileProjectionRules(projectionRules));
         if (JSON.stringify(parsedCurrent) !== JSON.stringify(compiledCurrent)) {
           const synced = syncProjectionFromQuery(projectionQuery);
@@ -684,7 +685,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         return;
       }
       try {
-        const parsedCurrent = JSON.parse(sortQuery);
+        const parsedCurrent = parseShellJson(sortQuery);
         const compiledCurrent = JSON.parse(compileSortRules(sortRules));
         if (JSON.stringify(parsedCurrent) !== JSON.stringify(compiledCurrent)) {
           const synced = syncSortFromQuery(sortQuery);
@@ -935,18 +936,18 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   const buildAggregatePipeline = (): Record<string, unknown>[] =>
     stages
       .filter(stage => stage.content.trim())
-      .map(stage => ({ [stage.operator]: JSON.parse(stage.content) }));
+      .map(stage => ({ [stage.operator]: parseShellJson(stage.content) }));
 
   const handleRun = () => {
     setError(null);
     try {
       if (queryMode === 'find') {
-        const parsedFilter = filterQuery.trim() ? JSON.parse(filterQuery) : {};
-        const parsedSort = sortQuery.trim() ? JSON.parse(sortQuery) : {};
+        const parsedFilter = filterQuery.trim() ? parseShellJson(filterQuery) : {};
+        const parsedSort = sortQuery.trim() ? parseShellJson(sortQuery) : {};
         // Only send a projection when the user has enabled one.
         const parsedProjection =
           isProjectionEnabled && projectionQuery.trim() && projectionQuery.trim() !== '{}'
-            ? JSON.parse(projectionQuery)
+            ? parseShellJson(projectionQuery)
             : {};
 
         onExecute({
@@ -970,7 +971,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
 
         stages.forEach(stage => {
           if (!stage.content.trim()) return;
-          const body = JSON.parse(stage.content);
+          const body = parseShellJson(stage.content);
           if (stage.operator === '$match') {
             compiledFilter = { ...compiledFilter, ...body };
           } else if (stage.operator === '$sort') {
@@ -1003,7 +1004,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         .filter((stage) => stage.content.trim())
         .map((stage) => {
           try {
-            return { [stage.operator]: JSON.parse(stage.content) };
+            return { [stage.operator]: parseShellJson(stage.content) };
           } catch {
             return { [stage.operator]: stage.content };
           }
@@ -1014,9 +1015,9 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     let parsedFilter: unknown = {};
     let parsedProjection: unknown = {};
     let parsedSort: unknown = {};
-    try { parsedFilter = filterQuery.trim() ? JSON.parse(filterQuery) : {}; } catch { parsedFilter = filterQuery; }
-    try { parsedProjection = projectionQuery.trim() ? JSON.parse(projectionQuery) : {}; } catch { parsedProjection = projectionQuery; }
-    try { parsedSort = sortQuery.trim() ? JSON.parse(sortQuery) : {}; } catch { parsedSort = sortQuery; }
+    try { parsedFilter = filterQuery.trim() ? parseShellJson(filterQuery) : {}; } catch { parsedFilter = filterQuery; }
+    try { parsedProjection = projectionQuery.trim() ? parseShellJson(projectionQuery) : {}; } catch { parsedProjection = projectionQuery; }
+    try { parsedSort = sortQuery.trim() ? parseShellJson(sortQuery) : {}; } catch { parsedSort = sortQuery; }
 
     const projectionPart =
       parsedProjection && typeof parsedProjection === 'object' && Object.keys(parsedProjection as Record<string, unknown>).length > 0
@@ -1035,7 +1036,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     setExplainLoading(true);
     try {
       if (queryMode === 'find') {
-        const parsedFilter = filterQuery.trim() ? JSON.parse(filterQuery) : {};
+        const parsedFilter = filterQuery.trim() ? parseShellJson(filterQuery) : {};
         await onExplain(JSON.stringify(parsedFilter));
       } else if (onExplainAggregate) {
         // Explain the FULL pipeline (M1), not just a collapsed $match.
@@ -1046,7 +1047,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         stages.forEach(stage => {
           if (stage.operator === '$match' && stage.content.trim()) {
             try {
-              const body = JSON.parse(stage.content);
+              const body = parseShellJson(stage.content);
               compiledFilter = { ...compiledFilter, ...body };
             } catch {
               // Ignore invalid JSON inside match stage during explain preview

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -1695,13 +1695,22 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                       <div
                         className={`mql-stage ${!isValid ? 'is-invalid' : ''}${stage.disabled ? ' is-disabled' : ''}`}
                         data-testid={`pipeline-stage-${index}`}
-                        onDragOver={(e) => { if (dragStageIndex !== null) e.preventDefault(); }}
-                        onDrop={() => dropStageAt(index)}
+                        onDragOver={(e) => {
+                          if (dragStageIndex === null) return;
+                          e.preventDefault();
+                          e.dataTransfer.dropEffect = 'move';
+                        }}
+                        onDrop={(e) => { e.preventDefault(); dropStageAt(index); }}
                       >
                         <div
                           className="mql-stage-h"
                           draggable
-                          onDragStart={() => setDragStageIndex(index)}
+                          onDragStart={(e) => {
+                            // WebKit refuses to start a drag without payload data.
+                            e.dataTransfer.setData('text/plain', String(index));
+                            e.dataTransfer.effectAllowed = 'move';
+                            setDragStageIndex(index);
+                          }}
                           onDragEnd={() => setDragStageIndex(null)}
                         >
                           <GripVertical size={11} className="mql-stage-grip" aria-hidden="true" />

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -164,6 +164,48 @@ const STAGE_OPERATORS: { group: string; stages: string[] }[] = [
   },
 ];
 
+// Runnable starter body per stage operator, inserted when the user switches
+// the operator on a stage whose body they haven't edited yet.
+const STAGE_BODY_TEMPLATES: Record<string, string> = {
+  '$match': '{\n  \n}',
+  '$project': '{\n  \n}',
+  '$addFields': '{\n  \n}',
+  '$set': '{\n  \n}',
+  '$unset': '"field"',
+  '$replaceRoot': '{\n  "newRoot": "$field"\n}',
+  '$replaceWith': '"$field"',
+  '$redact': '{\n  \n}',
+  '$group': '{\n  "_id": null\n}',
+  '$bucket': '{\n  "groupBy": "$field",\n  "boundaries": [0, 10],\n  "default": "other"\n}',
+  '$bucketAuto': '{\n  "groupBy": "$field",\n  "buckets": 5\n}',
+  '$sortByCount': '"$field"',
+  '$count': '"count"',
+  '$facet': '{\n  \n}',
+  '$sort': '{\n  \n}',
+  '$limit': '10',
+  '$skip': '0',
+  '$sample': '{\n  "size": 10\n}',
+  '$unwind': '"$field"',
+  '$lookup': '{\n  "from": "collection",\n  "localField": "field",\n  "foreignField": "field",\n  "as": "joined"\n}',
+  '$graphLookup': '{\n  "from": "collection",\n  "startWith": "$field",\n  "connectFromField": "field",\n  "connectToField": "field",\n  "as": "linked"\n}',
+  '$unionWith': '"collection"',
+  '$setWindowFields': '{\n  "sortBy": {},\n  "output": {}\n}',
+  '$densify': '{\n  "field": "field",\n  "range": { "step": 1, "bounds": "full" }\n}',
+  '$fill': '{\n  "output": {}\n}',
+  '$geoNear': '{\n  "near": { "type": "Point", "coordinates": [0, 0] },\n  "distanceField": "distance"\n}',
+  '$documents': '[\n  \n]',
+  '$out': '"collection"',
+  '$merge': '{\n  "into": "collection"\n}',
+};
+
+// A body the user hasn't meaningfully edited: empty, bare braces, or exactly
+// one of the templates above (so switching operators keeps replacing it).
+const isUntouchedStageBody = (content: string): boolean => {
+  const flat = content.replace(/\s/g, '');
+  if (flat === '' || flat === '{}') return true;
+  return Object.values(STAGE_BODY_TEMPLATES).some((tpl) => tpl.replace(/\s/g, '') === flat);
+};
+
 const parseValue = (val: string): any => {
   const trimmed = val.trim();
   if (trimmed === '') return '';
@@ -443,7 +485,14 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   };
 
   const updateStageOperator = (id: string, operator: string) => {
-    setStages(prev => prev.map(s => s.id === id ? { ...s, operator } : s));
+    setStages(prev => prev.map(s => s.id === id
+      ? {
+          ...s,
+          operator,
+          // Seed the new operator's starter body unless the user already wrote one.
+          content: isUntouchedStageBody(s.content) ? (STAGE_BODY_TEMPLATES[operator] ?? '{\n  \n}') : s.content,
+        }
+      : s));
   };
 
   const updateStageContent = (id: string, content: string) => {
@@ -1703,6 +1752,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                         </div>
                         <QueryEditor
                           surface="aggStage"
+                          stageOperator={stage.operator}
                           onRun={handleRun}
                           value={stage.content}
                           onChange={(v) => updateStageContent(stage.id, v)}

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -1137,7 +1137,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                 onClick={handleRun}
                 disabled={loading || explainLoading}
                 className="query-plane-btn query-plane-btn-primary"
-                title="Execute Query"
+                title="Execute query (Ctrl/⌘ + Enter)"
               >
                 <Play size={11} fill="white" />
                 <span>Run</span>

--- a/src/components/IndexModal.tsx
+++ b/src/components/IndexModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { X, Plus, Trash2, Code, Layers } from 'lucide-react';
+import { useEscapeClose } from '../lib/useEscapeClose';
 
 interface IndexKeyRule {
   field: string;
@@ -37,6 +38,8 @@ export const IndexModal: React.FC<IndexModalProps> = ({
   // Raw JSON Mode State
   const [rawKeysJson, setRawKeysJson] = useState('{\n  "_id": 1\n}');
   const [jsonError, setJsonError] = useState<string | null>(null);
+
+  useEscapeClose(isOpen, onClose);
 
   // Sync state with initial data (when editing) or reset (when creating)
   useEffect(() => {

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -6,6 +6,7 @@ import { AIChatPanel } from './AIChatPanel';
 import { buildRunnableCommand, guardScriptRun, type GeneratedQuery } from '../lib/mongoCommand';
 import { DataGrid } from './DataGrid';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
+import { useMonacoTheme } from '../lib/useMonacoTheme';
 
 type ShellTab = 'console' | 'viewer';
 
@@ -203,6 +204,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     [collectionName, initialCommand]
   );
   const [command, setCommand] = useState(defaultCommand);
+  const monacoTheme = useMonacoTheme();
   const [isAIOpen, setIsAIOpen] = useState(false);
   const [pendingDestructive, setPendingDestructive] =
     useState<{ command: string; operation: string } | null>(null);
@@ -657,7 +659,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
             value={command}
             onChange={(value) => setCommand(value || '')}
             defaultLanguage="javascript"
-            theme="vs-dark"
+            theme={monacoTheme}
             options={{
               fontFamily: 'JetBrains Mono, SF Mono, Consolas, monospace',
               fontSize: 13,

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -33,6 +33,9 @@ interface QueryEditorProps {
   singleLine?: boolean;
   className?: string;
   onRun?: () => void;
+  // For aggStage editors that hold a single stage's body: drives
+  // operator-specific completions ($group → accumulators, $lookup → keys, …).
+  stageOperator?: string;
   'data-testid'?: string;
 }
 
@@ -46,11 +49,13 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   singleLine = false,
   className,
   onRun,
+  stageOperator,
   'data-testid': testid,
 }) => {
   const fieldsRef = useRef(fields); fieldsRef.current = fields;
   const schemaRef = useRef(schema); schemaRef.current = schema;
   const onRunRef = useRef(onRun); onRunRef.current = onRun;
+  const stageOperatorRef = useRef(stageOperator); stageOperatorRef.current = stageOperator;
   const uriRef = useRef<string | null>(null);
   const theme = useMonacoTheme();
 
@@ -137,6 +142,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
             surface,
             getFields: () => fieldsRef.current,
             getSchema: () => schemaRef.current,
+            getStageOperator: () => stageOperatorRef.current,
           });
           ed.onDidDispose(() => { if (uriRef.current) clearModelMeta(uriRef.current); });
         }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -63,12 +63,18 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
 
   const overflowWidgetsDomNode = getOverflowNode();
 
+  // JSON keys live inside string literals, where Monaco suppresses
+  // quick suggestions by default — enable them so field/operator
+  // completions keep filtering while the user types a quoted key.
+  const quickSuggestions = { other: true, comments: false, strings: true };
+
   const multiLineOptions = {
     minimap: { enabled: false }, lineNumbers: 'off' as const, folding: false,
     scrollBeyondLastLine: false, wordWrap: 'on' as const, fontSize: 12,
     scrollbar: { vertical: 'auto' as const, horizontal: 'auto' as const }, overviewRulerLanes: 0,
     renderLineHighlight: 'none' as const, tabSize: 2,
     fixedOverflowWidgets: true, overflowWidgetsDomNode,
+    quickSuggestions,
     // Enter accepts an open suggestion; otherwise inserts a newline.
     acceptSuggestionOnEnter: 'on' as const,
   };
@@ -98,6 +104,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
     fixedOverflowWidgets: true,
     overflowWidgetsDomNode,
     tabSize: 2,
+    quickSuggestions,
   };
 
   const editor = (

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -3,6 +3,7 @@ import Editor, { type Monaco } from '@monaco-editor/react';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
 import type { Surface } from '../lib/mongoCompletions';
 import type { SchemaMap } from '../lib/useCollectionSchema';
+import { useMonacoTheme } from '../lib/useMonacoTheme';
 
 // A single body-level node where Monaco renders overflow widgets (the suggest
 // dropdown). Without this, the widget is trapped inside the query-row's stacking
@@ -51,7 +52,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   const schemaRef = useRef(schema); schemaRef.current = schema;
   const onRunRef = useRef(onRun); onRunRef.current = onRun;
   const uriRef = useRef<string | null>(null);
-  const theme = typeof document !== 'undefined' && document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'vs-dark';
+  const theme = useMonacoTheme();
 
   const editorHeight = height ?? (singleLine ? 22 : 120);
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { useDialogs } from './dialogs/DialogProvider';
+import { fuzzyMatch } from '../lib/fuzzyMatch';
 import {
   Database,
   Folder,
@@ -931,15 +932,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
         {activeConnections.length > 0 ? (
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             {activeConnections.map((conn) => {
-              const q = filterQuery.trim().toLowerCase();
+              const q = filterQuery.trim();
               const filterActive = q.length > 0;
               const connDbs = databases[conn.id] || [];
-              const connNameMatch = filterActive && conn.name.toLowerCase().includes(q);
+              const connNameMatch = filterActive && fuzzyMatch(q, conn.name);
               const visibleDbs = connDbs.filter((dbName) =>
                 !filterActive ||
                 connNameMatch ||
-                dbName.toLowerCase().includes(q) ||
-                (collections[`${conn.id}/${dbName}`] || []).some((c) => c.name.toLowerCase().includes(q))
+                fuzzyMatch(q, dbName) ||
+                (collections[`${conn.id}/${dbName}`] || []).some((c) => fuzzyMatch(q, c.name))
               );
               // Hide a connection entirely when nothing under it matches.
               if (filterActive && !connNameMatch && visibleDbs.length === 0) return null;
@@ -949,8 +950,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
               return (
                 <div key={conn.id} className="mql-tree-node">
                   {/* Connection Node */}
-                  <div 
+                  <div
                     className="mql-conn-row"
+                    role="button"
+                    aria-expanded={isConnExpanded}
+                    aria-label={`Connection ${conn.name}`}
                     onClick={() => setExpandedConnections((prev) => ({ ...prev, [conn.id]: !prev[conn.id] }))}
                     onContextMenu={(e) => handleContextMenu(e, conn.id, undefined, undefined, undefined, false, true)}
                   >
@@ -987,9 +991,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         // When filtering and neither the connection nor the db name
                         // matches, narrow the db's collections to the matches and
                         // auto-expand so they're visible.
-                        const dbNameMatch = filterActive && (connNameMatch || dbName.toLowerCase().includes(q));
+                        const dbNameMatch = filterActive && (connNameMatch || fuzzyMatch(q, dbName));
                         const dbColls = filterActive && !dbNameMatch
-                          ? rawColls.filter((c) => c.name.toLowerCase().includes(q))
+                          ? rawColls.filter((c) => fuzzyMatch(q, c.name))
                           : rawColls;
                         const autoExpandDb = filterActive && !dbNameMatch && dbColls.length > 0;
                         const isDbExpanded = expandedDbs[dbKey] || autoExpandDb;
@@ -1034,8 +1038,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         return (
                           <div key={dbName} className="mql-tree-node">
                             {/* Database Node */}
-                            <div 
+                            <div
                               className="mql-row-h mql-tree-row"
+                              role="button"
+                              aria-expanded={isDbExpanded}
+                              aria-label={`Database ${dbName}`}
                               onClick={() => toggleDb(conn.id, dbName)}
                               onContextMenu={(e) => handleContextMenu(e, conn.id, dbName)}
                             >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -82,6 +82,8 @@ interface SidebarProps {
   onCollectionRenamed?: (connectionId: string, dbName: string, oldName: string, newName: string) => void;
   onDatabaseDropped?: (connectionId: string, dbName: string) => void;
   onDatabaseRenamed?: (connectionId: string, oldName: string, newName: string) => void;
+  onNamespaceMutated?: (connectionId?: string) => void;
+  onFilterQueryChange?: (query: string) => void;
   indexMutationTrigger?: number;
   collectionMutationTrigger?: number;
 }
@@ -159,12 +161,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onCollectionRenamed,
   onDatabaseDropped,
   onDatabaseRenamed,
+  onNamespaceMutated,
+  onFilterQueryChange,
   indexMutationTrigger,
   collectionMutationTrigger,
 }) => {
   const { toast, confirm, prompt } = useDialogs();
   // Tree filter: matches connection / database / (loaded) collection names.
   const [filterQuery, setFilterQuery] = useState('');
+  useEffect(() => {
+    onFilterQueryChange?.(filterQuery);
+  }, [filterQuery, onFilterQueryChange]);
   const [helpOpen, setHelpOpen] = useState(false);
   // key: connectionId, value: database names list
   const [databases, setDatabases] = useState<{ [connectionId: string]: string[] }>({});
@@ -390,6 +397,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         ...prev,
         [connectionId]: [...(prev[connectionId] || []), name],
       }));
+      onNamespaceMutated?.(connectionId);
       return;
     }
 
@@ -404,6 +412,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     try {
       await invoke('create_collection', { id: connectionId, database: name, collection: firstColl });
       await loadDatabases(connectionId);
+      onNamespaceMutated?.(connectionId);
     } catch (err) {
       toast(`Failed to create database: ${err}`, 'error');
     }
@@ -443,12 +452,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
         ...prev,
         [key]: [...(prev[key] || []), { name, type: 'collection' }],
       }));
+      onNamespaceMutated?.(connectionId);
       return;
     }
 
     try {
       await invoke('create_collection', { id: connectionId, database: dbName, collection: name });
       await handleRefreshDb(connectionId, dbName);
+      onNamespaceMutated?.(connectionId);
     } catch (err) {
       toast(`Failed to create collection: ${err}`, 'error');
     }
@@ -484,6 +495,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         [key]: (prev[key] || []).filter((c) => c.name !== collName),
       }));
       clearActiveIfDropped();
+      onNamespaceMutated?.(connectionId);
       return;
     }
 
@@ -491,6 +503,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       await invoke('drop_collection', { id: connectionId, database: dbName, collection: collName });
       clearActiveIfDropped();
       await handleRefreshDb(connectionId, dbName);
+      onNamespaceMutated?.(connectionId);
     } catch (err) {
       toast(`Failed to drop collection: ${err}`, 'error');
     }
@@ -548,6 +561,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         return next;
       });
       onCollectionRenamed?.(connectionId, dbName, collName, newName);
+      onNamespaceMutated?.(connectionId);
     };
 
     if (isMock) {
@@ -627,6 +641,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         return next;
       });
       onDatabaseDropped?.(connectionId, dbName);
+      onNamespaceMutated?.(connectionId);
     };
 
     if (isMock) {
@@ -719,6 +734,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         return next;
       });
       onDatabaseRenamed?.(connectionId, dbName, newName);
+      onNamespaceMutated?.(connectionId);
     };
 
     if (isMock) {

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -85,3 +85,26 @@ describe('CommandPalette', () => {
     expect(screen.getByText('shop.users')).toBeTruthy();
   });
 });
+
+describe('CommandPalette ranking', () => {
+  it('ranks stronger matches first (prefix beats subsequence)', () => {
+    const actions: PaletteAction[] = [
+      { id: 'a', title: 'Disconnect server', run: () => {} },
+      { id: 'b', title: 'Settings', run: () => {} },
+    ];
+    render(<CommandPalette open onClose={() => {}} actions={actions} />);
+    fireEvent.change(screen.getByTestId('command-palette-input'), { target: { value: 'set' } });
+    const options = screen.getAllByRole('option');
+    expect(options[0].textContent).toContain('Settings');
+  });
+
+  it('keeps the original order on an empty query', () => {
+    const actions: PaletteAction[] = [
+      { id: 'a', title: 'Zeta', run: () => {} },
+      { id: 'b', title: 'Alpha', run: () => {} },
+    ];
+    render(<CommandPalette open onClose={() => {}} actions={actions} />);
+    const options = screen.getAllByRole('option');
+    expect(options[0].textContent).toContain('Zeta');
+  });
+});

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CommandPalette, type PaletteAction } from '../CommandPalette';
+
+const makeActions = (): { actions: PaletteAction[]; ran: string[] } => {
+  const ran: string[] = [];
+  const actions: PaletteAction[] = [
+    { id: 'theme', title: 'Toggle Theme', run: () => ran.push('theme') },
+    { id: 'settings', title: 'Open Settings', run: () => ran.push('settings') },
+    { id: 'shell', title: 'Open Shell', hint: 'shop.users', keywords: 'mongosh terminal', run: () => ran.push('shell') },
+  ];
+  return { actions, ran };
+};
+
+describe('CommandPalette', () => {
+  it('renders nothing when closed', () => {
+    const { actions } = makeActions();
+    render(<CommandPalette open={false} onClose={() => {}} actions={actions} />);
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+  });
+
+  it('lists all actions when open with an empty query', () => {
+    const { actions } = makeActions();
+    render(<CommandPalette open onClose={() => {}} actions={actions} />);
+    expect(screen.getByText('Toggle Theme')).toBeTruthy();
+    expect(screen.getByText('Open Settings')).toBeTruthy();
+    expect(screen.getByText('Open Shell')).toBeTruthy();
+  });
+
+  it('filters actions by title', () => {
+    const { actions } = makeActions();
+    render(<CommandPalette open onClose={() => {}} actions={actions} />);
+    fireEvent.change(screen.getByTestId('command-palette-input'), { target: { value: 'theme' } });
+    expect(screen.getByText('Toggle Theme')).toBeTruthy();
+    expect(screen.queryByText('Open Settings')).toBeNull();
+  });
+
+  it('matches keywords too', () => {
+    const { actions } = makeActions();
+    render(<CommandPalette open onClose={() => {}} actions={actions} />);
+    fireEvent.change(screen.getByTestId('command-palette-input'), { target: { value: 'mongosh' } });
+    expect(screen.getByText('Open Shell')).toBeTruthy();
+    expect(screen.queryByText('Toggle Theme')).toBeNull();
+  });
+
+  it('runs the selected action and closes on Enter', () => {
+    const { actions, ran } = makeActions();
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} actions={actions} />);
+    fireEvent.keyDown(screen.getByTestId('command-palette-input'), { key: 'Enter' });
+    expect(ran).toEqual(['theme']);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('moves the selection with arrow keys', () => {
+    const { actions, ran } = makeActions();
+    render(<CommandPalette open onClose={() => {}} actions={actions} />);
+    const input = screen.getByTestId('command-palette-input');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(ran).toEqual(['settings']);
+  });
+
+  it('closes on Escape without running anything', () => {
+    const { actions, ran } = makeActions();
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} actions={actions} />);
+    fireEvent.keyDown(screen.getByTestId('command-palette-input'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+    expect(ran).toEqual([]);
+  });
+
+  it('runs an action on click', () => {
+    const { actions, ran } = makeActions();
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} actions={actions} />);
+    fireEvent.click(screen.getByText('Open Settings'));
+    expect(ran).toEqual(['settings']);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the hint when provided', () => {
+    const { actions } = makeActions();
+    render(<CommandPalette open onClose={() => {}} actions={actions} />);
+    expect(screen.getByText('shop.users')).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -43,6 +43,15 @@ describe('CommandPalette', () => {
     expect(screen.queryByText('Toggle Theme')).toBeNull();
   });
 
+  it('shows sidebar scope separately without putting it in the search input', () => {
+    const { actions } = makeActions();
+    render(<CommandPalette open onClose={() => {}} actions={actions} scopeLabel="widas" />);
+    expect(screen.getByTestId('command-palette-input')).toHaveValue('');
+    expect(screen.getByText('Sidebar')).toBeTruthy();
+    expect(screen.getByText('widas')).toBeTruthy();
+    expect(screen.getByText('Toggle Theme')).toBeTruthy();
+  });
+
   it('runs the selected action and closes on Enter', () => {
     const { actions, ran } = makeActions();
     const onClose = vi.fn();
@@ -83,6 +92,18 @@ describe('CommandPalette', () => {
     const { actions } = makeActions();
     render(<CommandPalette open onClose={() => {}} actions={actions} />);
     expect(screen.getByText('shop.users')).toBeTruthy();
+  });
+
+  it('limits large empty-query lists so the palette does not render every namespace', () => {
+    const actions = Array.from({ length: 120 }, (_, i) => ({
+      id: `action-${i}`,
+      title: `Action ${i}`,
+      run: () => {},
+    }));
+    render(<CommandPalette open onClose={() => {}} actions={actions} />);
+    expect(screen.getAllByRole('option')).toHaveLength(80);
+    expect(screen.getByText('Action 0')).toBeTruthy();
+    expect(screen.queryByText('Action 119')).toBeNull();
   });
 });
 

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -295,3 +295,38 @@ describe('DataGrid Component', () => {
     expect(screen.getAllByLabelText('Copied').length).toBeGreaterThan(0);
   });
 });
+
+describe('DataGrid column resize', () => {
+  it('renders a resize handle per table column and resizes with the keyboard', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    const handle = screen.getByLabelText('Resize name column');
+    const headerCell = handle.parentElement as HTMLElement;
+    expect(headerCell.style.width).toBe('180px');
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    expect(headerCell.style.width).toBe('196px');
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    expect(headerCell.style.width).toBe('164px');
+  });
+
+  it('resizes the tree view key column with the keyboard', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /tree/i }));
+    const handle = screen.getByLabelText('Resize key column');
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    const tree = screen.getByTestId('tree-view');
+    expect(tree.style.getPropertyValue('--treetable-keyw')).toBe('336px');
+  });
+
+  it('resizes a table column by mouse drag', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    const handle = screen.getByLabelText('Resize name column');
+    const headerCell = handle.parentElement as HTMLElement;
+    fireEvent.mouseDown(handle, { clientX: 300 });
+    fireEvent.mouseMove(window, { clientX: 360 });
+    fireEvent.mouseUp(window);
+    expect(headerCell.style.width).toBe('240px');
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -190,17 +190,27 @@ describe('DataGrid Component', () => {
     expect(screen.getByText(/"David Miller"/)).toBeInTheDocument();
   });
 
-  it('shows a Query Code tab with the formatted runnable command when queryCode is provided', () => {
-    const code = 'db.products.aggregate([\n  {\n    "$count": "n"\n  }\n])';
-    render(<DataGrid documents={mockDocuments} queryCode={code} />);
+  it('shows a Query Code tab rendering the query spec in the selected language', () => {
+    const spec = {
+      db: 'shop',
+      collection: 'products',
+      query: { queryType: 'aggregate' as const, pipeline: [{ $count: 'n' }] },
+    };
+    render(<DataGrid documents={mockDocuments} querySpec={spec} />);
 
-    // The tab appears and opens the formatted query code.
+    // The tab appears and opens with the mongosh command by default.
     fireEvent.click(screen.getByTestId('query-code-tab'));
     expect(screen.getByTestId('query-code-panel')).toBeInTheDocument();
-    expect(screen.getByTestId('query-code-content').textContent).toBe(code);
+    expect(screen.getByTestId('query-code-content').textContent).toContain('db.products.aggregate(');
+    expect(screen.getByTestId('query-code-content').textContent).toContain('$count');
+
+    // Switching the language regenerates the code.
+    fireEvent.change(screen.getByTestId('query-code-lang'), { target: { value: 'Python' } });
+    expect(screen.getByTestId('query-code-content').textContent).toContain('from pymongo import MongoClient');
+    fireEvent.change(screen.getByTestId('query-code-lang'), { target: { value: 'mongosh' } });
   });
 
-  it('hides the Query Code tab when no queryCode is provided', () => {
+  it('hides the Query Code tab when no query spec is provided', () => {
     render(<DataGrid documents={mockDocuments} />);
     expect(screen.queryByTestId('query-code-tab')).toBeNull();
   });

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+
+// Monaco renders the Query Code panel; mock it as a plain textarea (same shape
+// as the other component tests) so assertions can read the generated code.
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ value, wrapperProps }: { value: string; wrapperProps?: Record<string, unknown> }) => (
+    <textarea data-testid={wrapperProps?.['data-testid'] as string | undefined} value={value} readOnly />
+  ),
+}));
+
 import { DataGrid, getExplainTree } from '../DataGrid';
 
 // Collect every node name in the tree (depth-first) for assertions.
@@ -201,12 +210,13 @@ describe('DataGrid Component', () => {
     // The tab appears and opens with the mongosh command by default.
     fireEvent.click(screen.getByTestId('query-code-tab'));
     expect(screen.getByTestId('query-code-panel')).toBeInTheDocument();
-    expect(screen.getByTestId('query-code-content').textContent).toContain('db.products.aggregate(');
-    expect(screen.getByTestId('query-code-content').textContent).toContain('$count');
+    const content = () => (screen.getByTestId('query-code-content') as HTMLTextAreaElement).value;
+    expect(content()).toContain('db.products.aggregate(');
+    expect(content()).toContain('$count');
 
     // Switching the language regenerates the code.
     fireEvent.change(screen.getByTestId('query-code-lang'), { target: { value: 'Python' } });
-    expect(screen.getByTestId('query-code-content').textContent).toContain('from pymongo import MongoClient');
+    expect(content()).toContain('from pymongo import MongoClient');
     fireEvent.change(screen.getByTestId('query-code-lang'), { target: { value: 'mongosh' } });
   });
 

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1019,3 +1019,57 @@ describe('DocumentViewer query persistence (H1)', () => {
     });
   });
 });
+
+describe('Aggregation builder stage controls', () => {
+  const renderAgg = () => {
+    const onExecute = vi.fn();
+    const onExecuteAggregate = vi.fn();
+    render(
+      <DocumentViewer
+        connectionName="test-conn"
+        databaseName="test-db"
+        collectionName="test-coll"
+        onExecute={onExecute}
+        onExecuteAggregate={onExecuteAggregate}
+        onExplain={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId('mode-aggregate-tab'));
+    return { onExecute, onExecuteAggregate };
+  };
+
+  it('excludes disabled stages from Run and dims them', () => {
+    const { onExecuteAggregate } = renderAgg();
+    fireEvent.click(screen.getByRole('button', { name: /add stage/i }));
+    const stage1 = screen.getByTestId('pipeline-stage-1');
+    fireEvent.change(stage1.querySelector('select')!, { target: { value: '$limit' } });
+    fireEvent.change(stage1.querySelector('textarea')!, { target: { value: '5' } });
+
+    fireEvent.click(screen.getByLabelText('Disable stage 1'));
+    expect(screen.getByTestId('pipeline-stage-0').className).toContain('is-disabled');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    expect(onExecuteAggregate).toHaveBeenCalledWith([{ $limit: 5 }]);
+  });
+
+  it('re-enabling a stage includes it again', () => {
+    const { onExecuteAggregate } = renderAgg();
+    fireEvent.click(screen.getByLabelText('Disable stage 1'));
+    fireEvent.click(screen.getByLabelText('Enable stage 1'));
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    expect(onExecuteAggregate).toHaveBeenCalledWith([{ $match: {} }]);
+  });
+
+  it('run-to-here executes only stages up to and including the clicked one', () => {
+    const { onExecuteAggregate } = renderAgg();
+    fireEvent.click(screen.getByRole('button', { name: /add stage/i }));
+    const stage1 = screen.getByTestId('pipeline-stage-1');
+    fireEvent.change(stage1.querySelector('select')!, { target: { value: '$limit' } });
+    fireEvent.change(stage1.querySelector('textarea')!, { target: { value: '5' } });
+
+    fireEvent.click(screen.getByLabelText('Run pipeline to stage 1'));
+    expect(onExecuteAggregate).toHaveBeenCalledWith([{ $match: {} }]);
+    expect(onExecuteAggregate).not.toHaveBeenCalledWith([{ $match: {} }, { $limit: 5 }]);
+  });
+});

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1115,3 +1115,78 @@ describe('Aggregation stage body templates', () => {
     expect((stage0.querySelector('textarea') as HTMLTextAreaElement).value).toBe('10');
   });
 });
+
+describe('Aggregation builder: collapse, undo/redo, $lookup form (#89)', () => {
+  const renderAgg3 = () => {
+    const onExecuteAggregate = vi.fn();
+    render(
+      <DocumentViewer
+        connectionName="test-conn"
+        databaseName="test-db"
+        collectionName="test-coll"
+        onExecute={vi.fn()}
+        onExecuteAggregate={onExecuteAggregate}
+        onExplain={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId('mode-aggregate-tab'));
+    return { onExecuteAggregate };
+  };
+
+  it('collapses a stage body without removing it from the pipeline', () => {
+    const { onExecuteAggregate } = renderAgg3();
+    const stage0 = screen.getByTestId('pipeline-stage-0');
+    expect(stage0.querySelector('textarea')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('Collapse stage 1'));
+    expect(screen.getByTestId('pipeline-stage-0').querySelector('textarea')).toBeNull();
+
+    // Collapsed is visual only — the stage still runs.
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    expect(onExecuteAggregate).toHaveBeenCalledWith([{ $match: {} }]);
+
+    fireEvent.click(screen.getByLabelText('Expand stage 1'));
+    expect(screen.getByTestId('pipeline-stage-0').querySelector('textarea')).toBeTruthy();
+  });
+
+  it('undoes and redoes pipeline changes', () => {
+    renderAgg3();
+    expect(screen.getByText('1 stage')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /add stage/i }));
+    expect(screen.getByText('2 stages')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Undo pipeline change'));
+    expect(screen.getByText('1 stage')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Redo pipeline change'));
+    expect(screen.getByText('2 stages')).toBeInTheDocument();
+  });
+
+  it('undo restores a removed stage', () => {
+    renderAgg3();
+    fireEvent.click(screen.getByRole('button', { name: /add stage/i }));
+    fireEvent.click(screen.getByLabelText('Remove stage 2'));
+    expect(screen.getByText('1 stage')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Undo pipeline change'));
+    expect(screen.getByText('2 stages')).toBeInTheDocument();
+  });
+
+  it('shows a $lookup form whose inputs sync into the stage body', () => {
+    renderAgg3();
+    const stage0 = screen.getByTestId('pipeline-stage-0');
+    fireEvent.change(stage0.querySelector('select')!, { target: { value: '$lookup' } });
+
+    // Form reflects the template body.
+    const fromInput = screen.getByLabelText('$lookup from') as HTMLInputElement;
+    expect(fromInput.value).toBe('collection');
+
+    fireEvent.change(fromInput, { target: { value: 'orders' } });
+    fireEvent.change(screen.getByLabelText('$lookup as'), { target: { value: 'userOrders' } });
+
+    const body = (screen.getByTestId('pipeline-stage-0').querySelector('textarea') as HTMLTextAreaElement).value;
+    expect(body).toContain('"from": "orders"');
+    expect(body).toContain('"as": "userOrders"');
+  });
+});

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1073,3 +1073,45 @@ describe('Aggregation builder stage controls', () => {
     expect(onExecuteAggregate).not.toHaveBeenCalledWith([{ $match: {} }, { $limit: 5 }]);
   });
 });
+
+describe('Aggregation stage body templates', () => {
+  const renderAgg2 = () => {
+    render(
+      <DocumentViewer
+        connectionName="test-conn"
+        databaseName="test-db"
+        collectionName="test-coll"
+        onExecute={vi.fn()}
+        onExecuteAggregate={vi.fn()}
+        onExplain={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId('mode-aggregate-tab'));
+  };
+
+  it('inserts a template body when the operator changes on an untouched stage', () => {
+    renderAgg2();
+    const stage0 = screen.getByTestId('pipeline-stage-0');
+    fireEvent.change(stage0.querySelector('select')!, { target: { value: '$lookup' } });
+    const body = (stage0.querySelector('textarea') as HTMLTextAreaElement).value;
+    expect(body).toContain('"from"');
+    expect(body).toContain('"localField"');
+  });
+
+  it('keeps user-edited content when the operator changes', () => {
+    renderAgg2();
+    const stage0 = screen.getByTestId('pipeline-stage-0');
+    fireEvent.change(stage0.querySelector('textarea')!, { target: { value: '{ "region": "EU" }' } });
+    fireEvent.change(stage0.querySelector('select')!, { target: { value: '$lookup' } });
+    expect((stage0.querySelector('textarea') as HTMLTextAreaElement).value).toBe('{ "region": "EU" }');
+  });
+
+  it('replaces a previous untouched template when switching operators again', () => {
+    renderAgg2();
+    const stage0 = screen.getByTestId('pipeline-stage-0');
+    fireEvent.change(stage0.querySelector('select')!, { target: { value: '$lookup' } });
+    fireEvent.change(stage0.querySelector('select')!, { target: { value: '$limit' } });
+    expect((stage0.querySelector('textarea') as HTMLTextAreaElement).value).toBe('10');
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -3222,6 +3222,25 @@ select:focus-visible {
 .mql-stage.is-invalid    { box-shadow: 0 0 0 1px var(--accent-red);  border-color: var(--accent-red); }
 /* Disabled stages stay editable but read as excluded from the pipeline. */
 .mql-stage.is-disabled { opacity: 0.55; }
+/* $lookup form helper: the four common parameters as labeled inputs. */
+.mql-lookup-form {
+  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px; padding: 6px 8px;
+  border-bottom: 1px solid var(--border-color);
+  background: hsla(0,0%,50%,0.03);
+}
+.mql-lookup-field { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.mql-lookup-field span {
+  font-size: 9px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.05em; color: var(--text-dim);
+}
+.mql-lookup-field input {
+  height: 22px; padding: 0 6px;
+  font-size: 11px; font-family: var(--font-mono);
+  background: var(--bg-base); border: 1px solid var(--border-color);
+  border-radius: 4px; color: var(--text-main);
+  outline: none; min-width: 0;
+}
 .mql-stage-h {
   display: flex; align-items: center; gap: 6px;
   padding: 5px 6px 5px 8px;

--- a/src/index.css
+++ b/src/index.css
@@ -818,12 +818,13 @@ select:focus-visible {
 .mql-treetable-doc-start {
   border-top: 1px solid var(--border-color);
 }
-/* Shared column geometry between header and rows. */
+/* Shared column geometry between header and rows. The key column width is a
+   variable so the header drag-handle resizes every (virtualized) row with it. */
 .mql-treetable-key {
   display: flex;
   align-items: center;
   gap: 4px;
-  width: 320px;
+  width: var(--treetable-keyw, 320px);
   flex-shrink: 0;
   min-width: 0;
   padding-right: 10px;
@@ -860,6 +861,20 @@ select:focus-visible {
 }
 .mql-treetable-fold-btn:hover { color: var(--text-main); }
 .mql-treetable-fold-spacer { display: inline-block; width: 11px; flex-shrink: 0; }
+/* Column drag handle on header cells (also keyboard-focusable: arrow keys resize). */
+.mql-col-resizer {
+  position: absolute;
+  top: 0; right: -4px;
+  width: 8px; height: 100%;
+  cursor: col-resize;
+  z-index: 2;
+}
+.mql-col-resizer:hover,
+.mql-col-resizer:focus-visible {
+  background: var(--accent-blue);
+  opacity: 0.45;
+  outline: none;
+}
 .mql-treetable-row:hover .mql-jsonview-actions { opacity: 1; }
 .mql-jsonview-num {
   position: sticky;
@@ -3201,12 +3216,17 @@ select:focus-visible {
 }
 .mql-stage:focus-within { box-shadow: 0 0 0 1px var(--accent-blue); border-color: var(--accent-blue); }
 .mql-stage.is-invalid    { box-shadow: 0 0 0 1px var(--accent-red);  border-color: var(--accent-red); }
+/* Disabled stages stay editable but read as excluded from the pipeline. */
+.mql-stage.is-disabled { opacity: 0.55; }
 .mql-stage-h {
   display: flex; align-items: center; gap: 6px;
   padding: 5px 6px 5px 8px;
   background: hsla(0,0%,50%,0.04);
   border-bottom: 1px solid var(--border-color);
+  cursor: grab;
 }
+.mql-stage-h:active { cursor: grabbing; }
+.mql-stage-grip { color: var(--text-dim); flex: none; }
 .mql-stage-num {
   width: 18px; height: 18px; flex: none;
   display: inline-flex; align-items: center; justify-content: center;
@@ -3905,8 +3925,7 @@ button, input, select, textarea {
 [data-density="compact"] .mql-qinput { height: 24px; padding: 0 8px; font-size: 11px; }
 [data-density="compact"] .mql-btn { height: 22px; padding: 0 8px; font-size: 10.5px; gap: 5px; }
 [data-density="compact"] .query-plane-btn { padding: 2.5px 8px; font-size: 10.5px; gap: 5px; }
-[data-density="compact"] .mql-th { padding: 3px 10px; font-size: 9.5px; }
-[data-density="compact"] .mql-td { padding: 3px 10px; }
+[data-density="compact"] .mql-treetable-head { font-size: 9.5px; }
 [data-density="compact"] .mql-statusbar { padding: 0 10px; }
 
 [data-density="roomy"] .mql-toolbar { padding: 9px 16px; gap: 10px; }
@@ -3916,8 +3935,7 @@ button, input, select, textarea {
 [data-density="roomy"] .mql-qinput { height: 34px; padding: 0 12px; font-size: 12px; }
 [data-density="roomy"] .mql-btn { height: 30px; padding: 0 12px; font-size: 12px; }
 [data-density="roomy"] .query-plane-btn { padding: 6.5px 12px; font-size: 12px; }
-[data-density="roomy"] .mql-th { padding: 8px 12px; font-size: 10.5px; }
-[data-density="roomy"] .mql-td { padding: 8px 12px; }
+[data-density="roomy"] .mql-treetable-head { font-size: 10.5px; }
 [data-density="roomy"] .mql-statusbar { padding: 0 14px; }
 
 /* Query Plane Styles */

--- a/src/index.css
+++ b/src/index.css
@@ -1427,6 +1427,62 @@ select:focus-visible {
   z-index: 1000;
   animation: mql-fade-up var(--dur-slow) var(--ease-out);
 }
+
+/* Command palette (Cmd/Ctrl+K) */
+.mql-palette-backdrop {
+  position: fixed; inset: 0;
+  background: var(--surface-modal-overlay);
+  display: flex; align-items: flex-start; justify-content: center;
+  padding-top: 12vh;
+  z-index: 1100;
+  animation: mql-fade-up var(--dur-fast) var(--ease-out);
+}
+.mql-palette {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  width: 480px; max-height: 60vh;
+  display: flex; flex-direction: column;
+  box-shadow: var(--shadow-large);
+  overflow: hidden;
+  backdrop-filter: blur(20px);
+}
+.mql-palette-search {
+  display: flex; align-items: center; gap: 8px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+.mql-palette-search-icon { color: var(--text-dim); flex: none; }
+.mql-palette-input {
+  flex: 1; height: 36px;
+  border: none; background: transparent; outline: none;
+  font-size: 13px; color: var(--text-main);
+}
+.mql-palette-input::placeholder { color: var(--text-dim); }
+.mql-palette-list { flex: 1; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 1px; }
+.mql-palette-item {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 6px 10px;
+  border-radius: 5px;
+  font-size: 12px; color: var(--text-main);
+  cursor: pointer;
+  user-select: none;
+}
+.mql-palette-item.is-selected { background: var(--bg-item-active); color: var(--accent-blue); }
+.mql-palette-hint {
+  font-size: 10.5px; color: var(--text-dim);
+  font-family: var(--font-mono);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.mql-palette-empty { padding: 14px; text-align: center; font-size: 12px; color: var(--text-dim); }
+.mql-palette-footer {
+  display: flex; gap: 14px;
+  padding: 5px 12px;
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-sidebar);
+  font-size: 10px; color: var(--text-dim);
+  user-select: none;
+}
 .mql-modal {
   background: var(--bg-panel);
   border: 1px solid var(--border-color);

--- a/src/index.css
+++ b/src/index.css
@@ -457,6 +457,19 @@ button { cursor: pointer; }
   box-shadow: var(--shadow-btn-hover);
 }
 .mql-btn-primary:disabled, .mql-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+/* Disabled buttons must not react to hover — a dead control that highlights reads as broken. */
+.mql-btn:disabled:hover { background: transparent; color: var(--text-muted); border-color: transparent; }
+.mql-btn-primary:disabled:hover { background: var(--brand-gradient); box-shadow: var(--shadow-btn); }
+
+/* Unified keyboard-focus ring across interactive controls (mouse clicks don't trigger :focus-visible). */
+.mql-btn:focus-visible,
+.mql-btn-primary:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 1px;
+}
 .mql-btn-outlined { border: 1px solid var(--border-color); color: var(--text-main); }
 .mql-btn-danger { color: var(--accent-red); }
 .mql-btn-danger:hover { color: var(--soft-red-text); background: var(--soft-red-bg); border-color: var(--soft-red-bd); }
@@ -3823,6 +3836,33 @@ button, input, select, textarea {
 [data-density="roomy"] .mql-quickstart-card-title { font-size: 13.5px; }
 [data-density="roomy"] .mql-quickstart-card-desc { font-size: 12px; }
 [data-density="roomy"] .mql-quickstart-tip { font-size: 12.5px; }
+
+/* Density: query toolbar, query bar, buttons, table chrome, status bar.
+   (Tree/table/JSON result rows scale in JS — DataGrid getRowHeight.) */
+[data-density="compact"] { --h-statusbar: 20px; }
+[data-density="roomy"]   { --h-statusbar: 26px; }
+
+[data-density="compact"] .mql-toolbar { padding: 3px 10px; gap: 6px; }
+[data-density="compact"] .query-plane-toolbar,
+[data-density="compact"] .query-plane-breadcrumbs { padding: 3px 10px; }
+[data-density="compact"] .mql-qbadge { height: 24px; padding: 0 8px; min-width: 76px; font-size: 9px; }
+[data-density="compact"] .mql-qinput { height: 24px; padding: 0 8px; font-size: 11px; }
+[data-density="compact"] .mql-btn { height: 22px; padding: 0 8px; font-size: 10.5px; gap: 5px; }
+[data-density="compact"] .query-plane-btn { padding: 2.5px 8px; font-size: 10.5px; gap: 5px; }
+[data-density="compact"] .mql-th { padding: 3px 10px; font-size: 9.5px; }
+[data-density="compact"] .mql-td { padding: 3px 10px; }
+[data-density="compact"] .mql-statusbar { padding: 0 10px; }
+
+[data-density="roomy"] .mql-toolbar { padding: 9px 16px; gap: 10px; }
+[data-density="roomy"] .query-plane-toolbar,
+[data-density="roomy"] .query-plane-breadcrumbs { padding: 9px 16px; }
+[data-density="roomy"] .mql-qbadge { height: 34px; padding: 0 12px; }
+[data-density="roomy"] .mql-qinput { height: 34px; padding: 0 12px; font-size: 12px; }
+[data-density="roomy"] .mql-btn { height: 30px; padding: 0 12px; font-size: 12px; }
+[data-density="roomy"] .query-plane-btn { padding: 6.5px 12px; font-size: 12px; }
+[data-density="roomy"] .mql-th { padding: 8px 12px; font-size: 10.5px; }
+[data-density="roomy"] .mql-td { padding: 8px 12px; }
+[data-density="roomy"] .mql-statusbar { padding: 0 14px; }
 
 /* Query Plane Styles */
 .query-plane-breadcrumbs {

--- a/src/index.css
+++ b/src/index.css
@@ -1467,13 +1467,45 @@ select:focus-visible {
   padding: 0 12px;
   border-bottom: 1px solid var(--border-color);
 }
+.mql-palette-search:focus-within {
+  border-bottom-color: var(--accent-blue);
+  box-shadow: inset 0 -1px 0 var(--accent-blue);
+}
 .mql-palette-search-icon { color: var(--text-dim); flex: none; }
 .mql-palette-input {
   flex: 1; height: 36px;
   border: none; background: transparent; outline: none;
   font-size: 13px; color: var(--text-main);
 }
+.mql-palette-input:focus-visible { outline: none; }
 .mql-palette-input::placeholder { color: var(--text-dim); }
+.mql-palette-scope {
+  display: flex; align-items: center; gap: 6px;
+  min-height: 24px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-sidebar);
+  font-size: 10.5px;
+  line-height: 1;
+  color: var(--text-dim);
+  min-width: 0;
+}
+.mql-palette-scope-label {
+  color: var(--text-dim);
+  flex: none;
+}
+.mql-palette-scope-value {
+  display: inline-flex; align-items: center;
+  height: 16px;
+  padding: 0 6px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-panel);
+  min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  color: var(--text-main);
+  font-weight: 500;
+}
 .mql-palette-list { flex: 1; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 1px; }
 .mql-palette-item {
   display: flex; align-items: center; justify-content: space-between; gap: 12px;

--- a/src/index.css
+++ b/src/index.css
@@ -3202,6 +3202,10 @@ select:focus-visible {
   padding: 10px 12px;
   max-height: 340px; overflow-y: auto;
 }
+/* Stages must keep their height once the list exceeds the max-height —
+   flex items default to shrink, which squashes every stage flat instead
+   of letting the container scroll. */
+.mql-pipeline-stages > * { flex-shrink: 0; }
 .mql-pipeline-flow {
   display: flex; justify-content: center;
   padding: 2px 0; color: var(--text-dim);

--- a/src/lib/__tests__/fuzzyMatch.test.ts
+++ b/src/lib/__tests__/fuzzyMatch.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { fuzzyMatch } from '../fuzzyMatch';
+
+describe('fuzzyMatch', () => {
+  it('matches plain substrings', () => {
+    expect(fuzzyMatch('bill', 'Billing')).toBe(true);
+    expect(fuzzyMatch('quota', 'Billing_QuotaOverUsage')).toBe(true);
+  });
+  it('is case-insensitive', () => {
+    expect(fuzzyMatch('BILLING', 'billing')).toBe(true);
+    expect(fuzzyMatch('billing', 'BILLING')).toBe(true);
+  });
+  it('matches in-order subsequences across word boundaries', () => {
+    expect(fuzzyMatch('cwsmap', 'cnips_UserWorkspaceMap')).toBe(true);
+    expect(fuzzyMatch('bqou', 'Billing_QuotaOverUsage')).toBe(true);
+    expect(fuzzyMatch('depinst', 'Deployment_Instance')).toBe(true);
+  });
+  it('rejects out-of-order characters', () => {
+    expect(fuzzyMatch('gnillib', 'Billing')).toBe(false);
+  });
+  it('rejects characters that are not present', () => {
+    expect(fuzzyMatch('billingz', 'Billing')).toBe(false);
+  });
+  it('matches everything on an empty query', () => {
+    expect(fuzzyMatch('', 'anything')).toBe(true);
+    expect(fuzzyMatch('   ', 'anything')).toBe(true);
+  });
+  it('does not match an empty target with a non-empty query', () => {
+    expect(fuzzyMatch('a', '')).toBe(false);
+  });
+});

--- a/src/lib/__tests__/fuzzyMatch.test.ts
+++ b/src/lib/__tests__/fuzzyMatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fuzzyMatch } from '../fuzzyMatch';
+import { fuzzyMatch, fuzzyScore } from '../fuzzyMatch';
 
 describe('fuzzyMatch', () => {
   it('matches plain substrings', () => {
@@ -27,5 +27,29 @@ describe('fuzzyMatch', () => {
   });
   it('does not match an empty target with a non-empty query', () => {
     expect(fuzzyMatch('a', '')).toBe(false);
+  });
+});
+
+describe('fuzzyScore', () => {
+  it('returns null when there is no match', () => {
+    expect(fuzzyScore('xyz', 'Billing')).toBeNull();
+  });
+  it('returns 0 for an empty query (no preference)', () => {
+    expect(fuzzyScore('', 'anything')).toBe(0);
+  });
+  it('ranks exact > prefix > substring > subsequence', () => {
+    const exact = fuzzyScore('billing', 'Billing')!;
+    const prefix = fuzzyScore('bill', 'Billing')!;
+    const substring = fuzzyScore('illing', 'Billing')!;
+    const subsequence = fuzzyScore('blng', 'Billing')!;
+    expect(exact).toBeGreaterThan(prefix);
+    expect(prefix).toBeGreaterThan(substring);
+    expect(substring).toBeGreaterThan(subsequence);
+  });
+  it('prefers shorter targets for the same prefix', () => {
+    expect(fuzzyScore('bill', 'Billing')!).toBeGreaterThan(fuzzyScore('bill', 'Billing_QuotaOverUsage')!);
+  });
+  it('penalizes scattered subsequences against tight ones', () => {
+    expect(fuzzyScore('bil', 'Billing')!).toBeGreaterThan(fuzzyScore('bqu', 'Billing_QuotaOverUsage')!);
   });
 });

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -103,3 +103,127 @@ describe('getCompletions — shell globals & chain methods', () => {
     expect(labels(items)).toEqual(expect.arrayContaining(['forEach', 'toArray', 'sort', 'limit', 'map']));
   });
 });
+
+const ALL_EJSON_LABELS = [
+  '$oid', '$date', '$numberInt', '$numberLong', '$numberDouble', '$numberDecimal',
+  '$regularExpression', '$timestamp', '$binary', '$uuid', '$code', '$symbol',
+  '$undefined', '$minKey', '$maxKey', '$dbPointer',
+];
+
+describe('getCompletions — EJSON in filter', () => {
+  it('offers every EJSON type wrapper at a value position', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "_id": ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(ALL_EJSON_LABELS));
+  });
+  it('EJSON value completions are snippets with escaped $ keys and a tab stop', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "_id": ', token: '$o' }));
+    const oid = items.find((i) => i.label === '$oid')!;
+    expect(oid.isSnippet).toBe(true);
+    expect(oid.insertText).toContain('\\$oid');
+    expect(oid.insertText).toContain('${1:');
+  });
+  it('still offers query operators alongside EJSON at a value position', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "_id": ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['$eq', '$in', '$gt']));
+  });
+  it('ranks $oid first for an objectId-typed field', () => {
+    const schema = new Map([['_id', { type: 'objectId' }]]);
+    const items = getCompletions(base({ textBeforeCursor: '{ "_id": ', token: '', schema }));
+    expect(items[0].label).toBe('$oid');
+  });
+  it('ranks $date first for a date-typed field', () => {
+    const schema = new Map([['created', { type: 'date' }]]);
+    const items = getCompletions(base({ textBeforeCursor: '{ "created": ', token: '', schema }));
+    expect(items[0].label).toBe('$date');
+  });
+  it('offers operator + EJSON keys (not field names) inside a field value object', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "_id": { ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['$eq', '$gt', '$oid', '$date']));
+    expect(labels(items)).not.toContain('region');
+  });
+  it('quotes EJSON keys in the JSON surface', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "_id": { ', token: '$o' }));
+    expect(items.find((i) => i.label === '$oid')!.insertText).toBe('"$oid"');
+  });
+  it('does not double-quote EJSON keys when already inside a quote', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "_id": { "$o', token: '$o' }));
+    expect(items.find((i) => i.label === '$oid')!.insertText).toBe('$oid');
+  });
+  it('offers fields + operators inside $elemMatch', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "tags": { "$elemMatch": { ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['region', '$eq']));
+  });
+  it('offers operators inside $not', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "age": { "$not": { ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['$gt', '$regex']));
+    expect(labels(items)).not.toContain('region');
+  });
+  it('value-object detection survives earlier closed objects', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "a": { "$gt": 1 }, ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['region', '$and']));
+  });
+});
+
+describe('getCompletions — shell value constructors', () => {
+  it('offers shell constructors (not EJSON wrappers) at a value position in find()', () => {
+    const items = getCompletions(base({ surface: 'shell', textBeforeCursor: 'db.c.find({ _id: ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['ObjectId', 'ISODate', 'NumberLong', 'UUID']));
+    expect(labels(items)).not.toContain('$oid');
+  });
+  it('shell constructors are snippets with a cursor inside the parens', () => {
+    const items = getCompletions(base({ surface: 'shell', textBeforeCursor: 'db.c.find({ _id: Obj', token: 'Obj' }));
+    const ctor = items.find((i) => i.label === 'ObjectId')!;
+    expect(ctor.isSnippet).toBe(true);
+    expect(ctor.insertText).toContain('ObjectId("${1:');
+  });
+});
+
+describe('getCompletions — projection operators & EJSON', () => {
+  it('offers 1/0 and projection operator snippets at a value position', () => {
+    const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ "comments": ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['1', '0', '$slice', '$elemMatch', '$meta']));
+  });
+  it('projection operator value completions are snippets', () => {
+    const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ "comments": ', token: '$s' }));
+    const slice = items.find((i) => i.label === '$slice')!;
+    expect(slice.isSnippet).toBe(true);
+    expect(slice.insertText).toContain('\\$slice');
+  });
+  it('offers EJSON wrappers at a projection value position', () => {
+    const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ "comments": ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['$oid', '$date']));
+  });
+  it('offers projection operator keys inside a field value object', () => {
+    const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ "comments": { ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['$slice', '$elemMatch', '$meta']));
+    expect(items.find((i) => i.label === '$slice')!.insertText).toBe('"$slice"');
+  });
+  it('offers fields + query operators inside a projection $elemMatch', () => {
+    const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ "comments": { "$elemMatch": { ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['region', '$eq']));
+  });
+  it('keeps fields only at the top-level key position', () => {
+    const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['region', 'plan', '_id']));
+    expect(labels(items)).not.toContain('$slice');
+  });
+});
+
+describe('getCompletions — sort $meta', () => {
+  it('offers 1, -1 and $meta at a sort value position', () => {
+    const items = getCompletions(base({ surface: 'sort', textBeforeCursor: '{ "score": ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['1', '-1', '$meta']));
+  });
+});
+
+describe('getCompletions — aggStage position awareness', () => {
+  it('does not suggest stages inside a $match body', () => {
+    const items = getCompletions(base({ surface: 'aggStage', textBeforeCursor: '{ "$match": { ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['region']));
+    expect(labels(items)).not.toContain('$lookup');
+  });
+  it('offers EJSON at a value position inside $match', () => {
+    const items = getCompletions(base({ surface: 'aggStage', textBeforeCursor: '{ "$match": { "_id": ', token: '' }));
+    expect(labels(items)).toEqual(expect.arrayContaining(['$oid', '$eq']));
+  });
+});

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -400,3 +400,53 @@ describe('getCompletions — aggStage position awareness', () => {
     expect(labels(items)).toEqual(expect.arrayContaining(['$oid', '$eq']));
   });
 });
+
+describe('getCompletions — per-stage body editor (stageOperator)', () => {
+  const stage = (op: string, text: string, token = '', extra: Partial<CompletionCtx> = {}) =>
+    base({ surface: 'aggStage', stageOperator: op, textBeforeCursor: text, token, ...extra });
+
+  it('$match body suggests fields, never stage names', () => {
+    const items = getCompletions(stage('$match', '{ '));
+    expect(labels(items)).toEqual(expect.arrayContaining(['region', 'plan']));
+    expect(labels(items)).not.toContain('$lookup');
+    expect(labels(items)).not.toContain('$match');
+  });
+  it('$match body value position offers EJSON and operators', () => {
+    const items = getCompletions(stage('$match', '{ "_id": '));
+    expect(labels(items)).toEqual(expect.arrayContaining(['$oid', '$eq']));
+  });
+  it('$sort body behaves like the sort surface', () => {
+    const items = getCompletions(stage('$sort', '{ '));
+    expect(items.find((i) => i.label === 'region')!.insertText).toBe('"region": ${1|1,-1|}');
+  });
+  it('$project body behaves like the projection surface', () => {
+    const items = getCompletions(stage('$project', '{ '));
+    expect(items.find((i) => i.label === 'region')!.insertText).toBe('"region": ${1|1,0|}');
+  });
+  it('$group body suggests _id at the top-level key position', () => {
+    const items = getCompletions(stage('$group', '{ '));
+    expect(labels(items)).toContain('_id');
+    expect(labels(items)).not.toContain('$lookup');
+  });
+  it('$group body offers accumulators at a value position', () => {
+    const items = getCompletions(stage('$group', '{ "total": ', '$s'));
+    expect(items.find((i) => i.label === '$sum')!.insertText).toBe('{"\\$sum": ${1:1}}');
+  });
+  it('$group body offers field path refs at a value position', () => {
+    const items = getCompletions(stage('$group', '{ "_id": ', '$reg'));
+    expect(items.find((i) => i.label === '$region')!.insertText).toBe('"$region"');
+  });
+  it('$lookup body suggests its parameter keys with value scaffolds', () => {
+    const items = getCompletions(stage('$lookup', '{ '));
+    expect(labels(items)).toEqual(expect.arrayContaining(['from', 'localField', 'foreignField', 'as']));
+    expect(items.find((i) => i.label === 'from')!.insertText).toBe('"from": "${1:collection}"');
+  });
+  it('$lookup localField value offers field names as strings', () => {
+    const items = getCompletions(stage('$lookup', '{ "localField": ', 'reg'));
+    expect(items.find((i) => i.label === 'region')!.insertText).toBe('"region"');
+  });
+  it('$unwind body suggests field path refs', () => {
+    const items = getCompletions(stage('$unwind', '', '$reg'));
+    expect(items.find((i) => i.label === '$region')!.insertText).toBe('"$region"');
+  });
+});

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getCompletions, type CompletionCtx } from '../mongoCompletions';
+import { getCompletions, TYPE_VALUE_SCAFFOLDS, type CompletionCtx } from '../mongoCompletions';
 
 const base = (over: Partial<CompletionCtx>): CompletionCtx => ({
   surface: 'filter', textBeforeCursor: '', token: '', fields: ['region', 'plan', '_id'], ...over,
@@ -206,6 +206,101 @@ describe('getCompletions — projection operators & EJSON', () => {
     const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ ', token: '' }));
     expect(labels(items)).toEqual(expect.arrayContaining(['region', 'plan', '_id']));
     expect(labels(items)).not.toContain('$slice');
+  });
+});
+
+describe('getCompletions — typed field scaffolds at key position', () => {
+  const schema = new Map([
+    ['_id', { type: 'objectId' }],
+    ['createdTime', { type: 'date' }],
+    ['region', { type: 'string' }],
+  ]);
+  it('objectId field inserts the full key + $oid wrapper as a snippet', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ ', token: '', schema, fields: ['_id', 'createdTime', 'region'] }));
+    const id = items.find((i) => i.label === '_id')!;
+    expect(id.isSnippet).toBe(true);
+    expect(id.insertText).toContain('"_id": {"\\$oid": "${1:');
+  });
+  it('date field inserts the full key + $date wrapper as a snippet', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ ', token: '', schema, fields: ['_id', 'createdTime', 'region'] }));
+    const created = items.find((i) => i.label === 'createdTime')!;
+    expect(created.isSnippet).toBe(true);
+    expect(created.insertText).toContain('"createdTime": {"\\$date": "${1:');
+  });
+  it('string fields scaffold a quoted value', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ ', token: '', schema, fields: ['_id', 'createdTime', 'region'] }));
+    const region = items.find((i) => i.label === 'region')!;
+    expect(region.isSnippet).toBe(true);
+    expect(region.insertText).toBe('"region": "${1:value}"');
+  });
+  it('fields without schema info keep the plain quoted-key insert', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ ', token: '', schema, fields: ['unknownField'] }));
+    expect(items.find((i) => i.label === 'unknownField')!.insertText).toBe('"unknownField"');
+  });
+  it('covers every BSON type label the schema analyzer emits', () => {
+    const labels = ['double', 'string', 'object', 'array', 'bool', 'null', 'regex', 'int', 'long',
+      'timestamp', 'binary', 'objectId', 'date', 'decimal', 'javascript', 'symbol',
+      'minKey', 'maxKey', 'undefined', 'dbPointer'];
+    for (const t of labels) {
+      expect(TYPE_VALUE_SCAFFOLDS[t], `missing scaffold for type "${t}"`).toBeDefined();
+      expect(TYPE_VALUE_SCAFFOLDS[t].json).toBeTruthy();
+      expect(TYPE_VALUE_SCAFFOLDS[t].shell).toBeTruthy();
+    }
+  });
+  it('numeric types scaffold correctly (int plain, long/decimal wrapped)', () => {
+    const numSchema = new Map([
+      ['age', { type: 'int' }],
+      ['views', { type: 'long' }],
+      ['price', { type: 'decimal' }],
+      ['score', { type: 'double' }],
+    ]);
+    const items = getCompletions(base({ textBeforeCursor: '{ ', token: '', schema: numSchema, fields: ['age', 'views', 'price', 'score'] }));
+    expect(items.find((i) => i.label === 'age')!.insertText).toBe('"age": ${1:0}');
+    expect(items.find((i) => i.label === 'views')!.insertText).toBe('"views": {"\\$numberLong": "${1:0}"}');
+    expect(items.find((i) => i.label === 'price')!.insertText).toBe('"price": {"\\$numberDecimal": "${1:0}"}');
+    expect(items.find((i) => i.label === 'score')!.insertText).toBe('"score": ${1:0.0}');
+  });
+  it('bool, regex, and binary scaffold their EJSON shapes', () => {
+    const s = new Map([
+      ['active', { type: 'bool' }],
+      ['pattern', { type: 'regex' }],
+      ['blob', { type: 'binary' }],
+    ]);
+    const items = getCompletions(base({ textBeforeCursor: '{ ', token: '', schema: s, fields: ['active', 'pattern', 'blob'] }));
+    expect(items.find((i) => i.label === 'active')!.insertText).toBe('"active": ${1:true}');
+    expect(items.find((i) => i.label === 'pattern')!.insertText).toContain('"\\$regularExpression"');
+    expect(items.find((i) => i.label === 'blob')!.insertText).toContain('"\\$binary"');
+  });
+  it('shell uses native literals for numeric and regex types', () => {
+    const s = new Map([
+      ['views', { type: 'long' }],
+      ['pattern', { type: 'regex' }],
+    ]);
+    const items = getCompletions(base({ surface: 'shell', textBeforeCursor: 'db.c.find({ ', token: '', schema: s, fields: ['views', 'pattern'] }));
+    expect(items.find((i) => i.label === 'views')!.insertText).toBe('views: NumberLong("${1:0}")');
+    expect(items.find((i) => i.label === 'pattern')!.insertText).toBe('pattern: /${1:pattern}/${2:i}');
+  });
+  it('completes the scaffold without doubling the quote when already inside one', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "_i', token: '_i', schema, fields: ['_id'] }));
+    const id = items.find((i) => i.label === '_id')!;
+    expect(id.insertText.startsWith('_id": {"\\$oid"')).toBe(true);
+  });
+  it('uses shell constructors for typed fields in the shell surface', () => {
+    const items = getCompletions(base({ surface: 'shell', textBeforeCursor: 'db.c.find({ ', token: '', schema, fields: ['_id', 'createdTime'] }));
+    expect(items.find((i) => i.label === '_id')!.insertText).toContain('_id: ObjectId("${1:');
+    expect(items.find((i) => i.label === 'createdTime')!.insertText).toContain('createdTime: ISODate("${1:');
+  });
+  it('scaffolds typed fields inside $elemMatch bodies too', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "refs": { "$elemMatch": { ', token: '', schema, fields: ['_id'] }));
+    expect(items.find((i) => i.label === '_id')!.insertText).toContain('"_id": {"\\$oid"');
+  });
+  it('does NOT scaffold values in projection (value must stay 1/0)', () => {
+    const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ ', token: '', schema, fields: ['_id'] }));
+    expect(items.find((i) => i.label === '_id')!.insertText).toBe('"_id"');
+  });
+  it('does NOT scaffold values in sort', () => {
+    const items = getCompletions(base({ surface: 'sort', textBeforeCursor: '{ ', token: '', schema, fields: ['createdTime'] }));
+    expect(items.find((i) => i.label === 'createdTime')!.insertText).toBe('"createdTime"');
   });
 });
 

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -360,13 +360,17 @@ describe('getCompletions — typed field scaffolds at key position', () => {
     const items = getCompletions(base({ textBeforeCursor: '{ "refs": { "$elemMatch": { ', token: '', schema, fields: ['_id'] }));
     expect(items.find((i) => i.label === '_id')!.insertText).toContain('"_id": {"\\$oid"');
   });
-  it('does NOT scaffold values in projection (value must stay 1/0)', () => {
+  it('projection fields scaffold an include/exclude choice instead of a typed value', () => {
     const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ ', token: '', schema, fields: ['_id'] }));
-    expect(items.find((i) => i.label === '_id')!.insertText).toBe('"_id"');
+    const id = items.find((i) => i.label === '_id')!;
+    expect(id.isSnippet).toBe(true);
+    expect(id.insertText).toBe('"_id": ${1|1,0|}');
   });
-  it('does NOT scaffold values in sort', () => {
+  it('sort fields scaffold a direction choice instead of a typed value', () => {
     const items = getCompletions(base({ surface: 'sort', textBeforeCursor: '{ ', token: '', schema, fields: ['createdTime'] }));
-    expect(items.find((i) => i.label === 'createdTime')!.insertText).toBe('"createdTime"');
+    const created = items.find((i) => i.label === 'createdTime')!;
+    expect(created.isSnippet).toBe(true);
+    expect(created.insertText).toBe('"createdTime": ${1|1,-1|}');
   });
 });
 
@@ -374,6 +378,14 @@ describe('getCompletions — sort $meta', () => {
   it('offers 1, -1 and $meta at a sort value position', () => {
     const items = getCompletions(base({ surface: 'sort', textBeforeCursor: '{ "score": ', token: '' }));
     expect(labels(items)).toEqual(expect.arrayContaining(['1', '-1', '$meta']));
+  });
+  it('offers the $meta key with its value inside a sort value object', () => {
+    const items = getCompletions(base({ surface: 'sort', textBeforeCursor: '{ "score": { ', token: '$' }));
+    expect(items.find((i) => i.label === '$meta')!.insertText).toBe('"\\$meta": "${1:textScore}"');
+  });
+  it('does not double-quote sort fields when already inside a quote', () => {
+    const items = getCompletions(base({ surface: 'sort', textBeforeCursor: '{ "reg', token: 'reg' }));
+    expect(items.find((i) => i.label === 'region')!.insertText).toBe('region": ${1|1,-1|}');
   });
 });
 

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -70,9 +70,9 @@ describe('getCompletions — JSON key quoting', () => {
     const items = getCompletions(base({ surface: 'shell', textBeforeCursor: 'db.customers.find({ ', token: '', fields: ['region'] }));
     expect(items.find((i) => i.label === 'region')!.insertText).toBe('region');
   });
-  it('quotes $operator keys in filter', () => {
+  it('quotes $operator keys in filter and scaffolds their value shape', () => {
     const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ ', token: '$' }));
-    expect(items.find((i) => i.label === '$and')!.insertText).toBe('"$and"');
+    expect(items.find((i) => i.label === '$and')!.insertText).toBe('"\\$and": [{$1}]');
   });
 });
 
@@ -141,13 +141,13 @@ describe('getCompletions — EJSON in filter', () => {
     expect(labels(items)).toEqual(expect.arrayContaining(['$eq', '$gt', '$oid', '$date']));
     expect(labels(items)).not.toContain('region');
   });
-  it('quotes EJSON keys in the JSON surface', () => {
+  it('quotes EJSON keys in the JSON surface and scaffolds their value', () => {
     const items = getCompletions(base({ textBeforeCursor: '{ "_id": { ', token: '$o' }));
-    expect(items.find((i) => i.label === '$oid')!.insertText).toBe('"$oid"');
+    expect(items.find((i) => i.label === '$oid')!.insertText).toBe('"\\$oid": "${1:objectId}"');
   });
   it('does not double-quote EJSON keys when already inside a quote', () => {
     const items = getCompletions(base({ textBeforeCursor: '{ "_id": { "$o', token: '$o' }));
-    expect(items.find((i) => i.label === '$oid')!.insertText).toBe('$oid');
+    expect(items.find((i) => i.label === '$oid')!.insertText).toBe('\\$oid": "${1:objectId}"');
   });
   it('offers fields + operators inside $elemMatch', () => {
     const items = getCompletions(base({ textBeforeCursor: '{ "tags": { "$elemMatch": { ', token: '' }));
@@ -193,10 +193,10 @@ describe('getCompletions — projection operators & EJSON', () => {
     const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ "comments": ', token: '' }));
     expect(labels(items)).toEqual(expect.arrayContaining(['$oid', '$date']));
   });
-  it('offers projection operator keys inside a field value object', () => {
+  it('offers projection operator keys with value scaffolds inside a field value object', () => {
     const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ "comments": { ', token: '' }));
     expect(labels(items)).toEqual(expect.arrayContaining(['$slice', '$elemMatch', '$meta']));
-    expect(items.find((i) => i.label === '$slice')!.insertText).toBe('"$slice"');
+    expect(items.find((i) => i.label === '$slice')!.insertText).toBe('"\\$slice": ${1:5}');
   });
   it('offers fields + query operators inside a projection $elemMatch', () => {
     const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ "comments": { "$elemMatch": { ', token: '' }));
@@ -206,6 +206,72 @@ describe('getCompletions — projection operators & EJSON', () => {
     const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ ', token: '' }));
     expect(labels(items)).toEqual(expect.arrayContaining(['region', 'plan', '_id']));
     expect(labels(items)).not.toContain('$slice');
+  });
+});
+
+describe('getCompletions — operator value scaffolds', () => {
+  it('array operators scaffold an array value ($in/$nin/$all)', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "qty": { ', token: '$' }));
+    expect(items.find((i) => i.label === '$in')!.insertText).toBe('"\\$in": [$1]');
+    expect(items.find((i) => i.label === '$all')!.insertText).toBe('"\\$all": [$1]');
+  });
+  it('logical operators scaffold an array of condition objects', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ ', token: '$' }));
+    expect(items.find((i) => i.label === '$or')!.insertText).toBe('"\\$or": [{$1}]');
+    expect(items.find((i) => i.label === '$nor')!.insertText).toBe('"\\$nor": [{$1}]');
+  });
+  it('object operators scaffold an object value ($elemMatch, $not)', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "tags": { ', token: '$' }));
+    expect(items.find((i) => i.label === '$elemMatch')!.insertText).toBe('"\\$elemMatch": {$1}');
+    expect(items.find((i) => i.label === '$not')!.insertText).toBe('"\\$not": {$1}');
+  });
+  it('scalar operators scaffold typed placeholders ($exists, $regex, $mod, $size)', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "x": { ', token: '$' }));
+    expect(items.find((i) => i.label === '$exists')!.insertText).toBe('"\\$exists": ${1:true}');
+    expect(items.find((i) => i.label === '$regex')!.insertText).toBe('"\\$regex": "${1:pattern}"');
+    expect(items.find((i) => i.label === '$mod')!.insertText).toBe('"\\$mod": [${1:divisor}, ${2:remainder}]');
+    expect(items.find((i) => i.label === '$size')!.insertText).toBe('"\\$size": ${1:0}');
+  });
+  it('comparison operators use the field schema type for their value', () => {
+    const schema = new Map([['createdTime', { type: 'date' }]]);
+    const items = getCompletions(base({ textBeforeCursor: '{ "createdTime": { ', token: '$g', schema }));
+    expect(items.find((i) => i.label === '$gt')!.insertText).toBe('"\\$gt": {"\\$date": "${1:2024-01-01T00:00:00Z}"}');
+  });
+  it('operator chosen at a value position wraps itself in an object', () => {
+    const schema = new Map([['createdTime', { type: 'date' }]]);
+    const items = getCompletions(base({ textBeforeCursor: '{ "createdTime": ', token: '$gt', schema }));
+    expect(items.find((i) => i.label === '$gt')!.insertText).toBe('{"\\$gt": {"\\$date": "${1:2024-01-01T00:00:00Z}"}}');
+  });
+  it('comparison operators fall back to a bare tab stop without schema', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "x": { ', token: '$gt' }));
+    expect(items.find((i) => i.label === '$gt')!.insertText).toBe('"\\$gt": $1');
+  });
+  it('shell surface scaffolds operators with bare keys', () => {
+    const items = getCompletions(base({ surface: 'shell', textBeforeCursor: 'db.c.find({ qty: { ', token: '$' }));
+    expect(items.find((i) => i.label === '$in')!.insertText).toBe('\\$in: [$1]');
+  });
+  it('agg stages scaffold their body shape', () => {
+    const items = getCompletions(base({ surface: 'aggStage', textBeforeCursor: '{ ', token: '$' }));
+    expect(items.find((i) => i.label === '$match')!.insertText).toBe('"\\$match": {$1}');
+    expect(items.find((i) => i.label === '$limit')!.insertText).toBe('"\\$limit": ${1:10}');
+    expect(items.find((i) => i.label === '$unwind')!.insertText).toBe('"\\$unwind": "\\$${1:field}"');
+    expect(items.find((i) => i.label === '$lookup')!.insertText).toContain('"from": "${1:collection}"');
+  });
+  it('group accumulators scaffold their value', () => {
+    const items = getCompletions(base({ surface: 'aggStage', textBeforeCursor: '{ "$group": { "_id": "$region", "t": { ', token: '$' }));
+    expect(items.find((i) => i.label === '$sum')!.insertText).toBe('"\\$sum": ${1:1}');
+    expect(items.find((i) => i.label === '$push')!.insertText).toBe('"\\$push": "\\$${1:field}"');
+  });
+});
+
+describe('getCompletions — shell constructors in the JSON query bar', () => {
+  it('offers shell constructors at a filter value position (query bar parses them)', () => {
+    const items = getCompletions(base({ textBeforeCursor: '{ "x": ', token: '' }));
+    const ctor = items.find((i) => i.label === 'ObjectId')!;
+    expect(ctor).toBeDefined();
+    expect(ctor.isSnippet).toBe(true);
+    expect(ctor.insertText).toBe('ObjectId("${1:objectId}")');
+    expect(labels(items)).toEqual(expect.arrayContaining(['ISODate', 'NumberLong', 'UUID']));
   });
 });
 

--- a/src/lib/__tests__/paletteIndex.test.ts
+++ b/src/lib/__tests__/paletteIndex.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args: unknown[]) => invoke(...args) }));
+
+import { loadNamespaceIndex, __clearNamespaceIndex } from '../paletteIndex';
+
+beforeEach(() => {
+  invoke.mockReset();
+  __clearNamespaceIndex();
+});
+
+const wireMock = () => {
+  invoke.mockImplementation(async (cmd: string, args: { id: string; db?: string }) => {
+    if (cmd === 'list_databases') return ['shop', 'logs'];
+    if (cmd === 'list_collections') return args.db === 'shop'
+      ? [{ name: 'users' }, { name: 'orders' }]
+      : [{ name: 'events' }];
+    throw new Error(`unexpected ${cmd}`);
+  });
+};
+
+describe('loadNamespaceIndex', () => {
+  it('lists databases and collections per active connection', async () => {
+    wireMock();
+    const ns = await loadNamespaceIndex([{ id: 'c1', name: 'prod' }]);
+    expect(ns).toEqual([
+      { connectionId: 'c1', connectionName: 'prod', db: 'shop', collections: ['users', 'orders'] },
+      { connectionId: 'c1', connectionName: 'prod', db: 'logs', collections: ['events'] },
+    ]);
+  });
+
+  it('caches per connection — repeated loads do not refetch', async () => {
+    wireMock();
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }]);
+    const calls = invoke.mock.calls.length;
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }]);
+    expect(invoke.mock.calls.length).toBe(calls);
+  });
+
+  it('returns an empty index for a failing connection without throwing', async () => {
+    invoke.mockRejectedValue(new Error('down'));
+    const ns = await loadNamespaceIndex([{ id: 'c1', name: 'prod' }]);
+    expect(ns).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/paletteIndex.test.ts
+++ b/src/lib/__tests__/paletteIndex.test.ts
@@ -1,13 +1,35 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const invoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args: unknown[]) => invoke(...args) }));
 
-import { loadNamespaceIndex, __clearNamespaceIndex } from '../paletteIndex';
+import { loadNamespaceIndex, matchesNamespaceScope, __clearNamespaceIndex } from '../paletteIndex';
 
 beforeEach(() => {
   invoke.mockReset();
   __clearNamespaceIndex();
+});
+
+describe('matchesNamespaceScope', () => {
+  const target = {
+    connectionName: 'm01-test-01',
+    db: 'cidaas-widas-test',
+    collection: 'ReleaseManagement_UpdateRequest',
+  };
+
+  it('matches sidebar-style filters against connection, database, and collection text', () => {
+    expect(matchesNamespaceScope('widas', target)).toBe(true);
+    expect(matchesNamespaceScope('release', target)).toBe(true);
+    expect(matchesNamespaceScope('m01', target)).toBe(true);
+  });
+
+  it('rejects namespaces outside the sidebar filter scope', () => {
+    expect(matchesNamespaceScope('camlog', target)).toBe(false);
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 const wireMock = () => {
@@ -36,6 +58,34 @@ describe('loadNamespaceIndex', () => {
     const calls = invoke.mock.calls.length;
     await loadNamespaceIndex([{ id: 'c1', name: 'prod' }]);
     expect(invoke.mock.calls.length).toBe(calls);
+  });
+
+  it('can force refresh cached namespaces', async () => {
+    wireMock();
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }]);
+    const calls = invoke.mock.calls.length;
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }], { forceRefresh: true });
+    expect(invoke.mock.calls.length).toBeGreaterThan(calls);
+  });
+
+  it('expires cached namespaces after the TTL', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    wireMock();
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }], { ttlMs: 100 });
+    const calls = invoke.mock.calls.length;
+    vi.setSystemTime(101);
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }], { ttlMs: 100 });
+    expect(invoke.mock.calls.length).toBeGreaterThan(calls);
+  });
+
+  it('clears one cached connection without clearing others', async () => {
+    wireMock();
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }, { id: 'c2', name: 'stage' }]);
+    const calls = invoke.mock.calls.length;
+    __clearNamespaceIndex('c1');
+    await loadNamespaceIndex([{ id: 'c1', name: 'prod' }, { id: 'c2', name: 'stage' }]);
+    expect(invoke.mock.calls.length).toBe(calls + 3);
   });
 
   it('returns an empty index for a failing connection without throwing', async () => {

--- a/src/lib/__tests__/queryCodeGen.test.ts
+++ b/src/lib/__tests__/queryCodeGen.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { generateQueryCode, CODE_LANGUAGES, type QueryCodeSpec } from '../queryCodeGen';
+
+const findSpec: QueryCodeSpec = {
+  db: 'shop',
+  collection: 'users',
+  query: {
+    queryType: 'find',
+    filter: { _id: { $oid: '603d779f4f102e3a185c3220' } },
+    sort: { createdAt: -1 },
+    projection: { name: 1 },
+    limit: 50,
+    skip: 10,
+  },
+};
+
+const aggSpec: QueryCodeSpec = {
+  db: 'shop',
+  collection: 'orders',
+  query: {
+    queryType: 'aggregate',
+    pipeline: [{ $match: { status: 'paid' } }, { $limit: 5 }],
+  },
+};
+
+describe('generateQueryCode', () => {
+  it('exposes the language list with mongosh first', () => {
+    expect(CODE_LANGUAGES[0]).toBe('mongosh');
+    expect(CODE_LANGUAGES).toEqual(expect.arrayContaining(['Node.js', 'Python', 'Java', 'C#', 'Go']));
+  });
+
+  it('every language embeds the namespace and produces non-empty output for find and aggregate', () => {
+    for (const lang of CODE_LANGUAGES) {
+      const find = generateQueryCode(lang, findSpec);
+      const agg = generateQueryCode(lang, aggSpec);
+      expect(find.length, lang).toBeGreaterThan(20);
+      expect(agg.length, lang).toBeGreaterThan(20);
+      expect(find, lang).toContain('users');
+      expect(agg, lang).toContain('orders');
+      if (lang !== 'mongosh') {
+        expect(find, lang).toContain('shop');
+        expect(find, lang).toContain('mongodb://');
+      }
+    }
+  });
+
+  it('mongosh matches the existing runnable command', () => {
+    const code = generateQueryCode('mongosh', findSpec);
+    expect(code).toContain('db.users.find(');
+    expect(code).toContain('.sort(');
+    expect(code).toContain('.skip(10)');
+    expect(code).toContain('.limit(50)');
+  });
+
+  it('Node.js parses the filter with EJSON and applies cursor options', () => {
+    const code = generateQueryCode('Node.js', findSpec);
+    expect(code).toContain("require('mongodb')");
+    expect(code).toContain('EJSON.parse');
+    expect(code).toContain('"$oid"');
+    expect(code).toContain('.sort(');
+    expect(code).toContain('.skip(10)');
+    expect(code).toContain('.limit(50)');
+  });
+
+  it('Python uses json_util.loads and sorts via list of pairs', () => {
+    const code = generateQueryCode('Python', findSpec);
+    expect(code).toContain('from pymongo import MongoClient');
+    expect(code).toContain('json_util');
+    expect(code).toContain('loads(');
+    expect(code).toContain('"$oid"');
+    expect(code).toContain('.skip(10)');
+    expect(code).toContain('.limit(50)');
+  });
+
+  it('Java escapes the embedded JSON for Document.parse', () => {
+    const code = generateQueryCode('Java', findSpec);
+    expect(code).toContain('Document.parse(');
+    expect(code).toContain('\\"$oid\\"');
+    expect(code).toContain('.skip(10)');
+    expect(code).toContain('.limit(50)');
+  });
+
+  it('C# uses BsonDocument.Parse with verbatim strings', () => {
+    const code = generateQueryCode('C#', findSpec);
+    expect(code).toContain('BsonDocument.Parse(');
+    expect(code).toContain('""$oid""');
+    expect(code).toContain('.Skip(10)');
+    expect(code).toContain('.Limit(50)');
+  });
+
+  it('Go unmarshals extended JSON', () => {
+    const code = generateQueryCode('Go', findSpec);
+    expect(code).toContain('bson.UnmarshalExtJSON');
+    expect(code).toContain('"$oid"');
+    expect(code).toContain('SetSkip(10)');
+    expect(code).toContain('SetLimit(50)');
+  });
+
+  it('omits unset find options', () => {
+    const bare: QueryCodeSpec = { db: 'shop', collection: 'users', query: { queryType: 'find', filter: {} } };
+    for (const lang of CODE_LANGUAGES) {
+      const code = generateQueryCode(lang, bare);
+      expect(code.toLowerCase(), lang).not.toContain('skip(');
+      expect(code.toLowerCase(), lang).not.toContain('sort(');
+    }
+  });
+
+  it('aggregate embeds every stage', () => {
+    for (const lang of CODE_LANGUAGES) {
+      const code = generateQueryCode(lang, aggSpec);
+      expect(code, lang).toContain('$match');
+      expect(code, lang).toContain('$limit');
+    }
+  });
+});

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ObjectId, Long, Decimal128, Int32 } from 'bson';
-import { docToShell, shellToEjson } from '../shellDoc';
+import { docToShell, shellToEjson, parseShellJson } from '../shellDoc';
 
 describe('docToShell', () => {
   it('renders EJSON-shaped values as shell constructors', () => {
@@ -56,5 +56,27 @@ describe('shellToEjson', () => {
   it('round-trips docToShell -> shellToEjson', () => {
     const doc = { _id: { $oid: '507f1f77bcf86cd799439011' }, when: { $date: '2025-01-04T00:00:00.000Z' }, tags: ['a', 'b'] };
     expect(JSON.parse(shellToEjson(docToShell(doc)))).toEqual(doc);
+  });
+});
+
+describe('parseShellJson', () => {
+  it('parses plain JSON', () => {
+    expect(parseShellJson('{"a": 1}')).toEqual({ a: 1 });
+  });
+  it('parses shell constructors into EJSON shapes', () => {
+    expect(parseShellJson('{"_id": ObjectId("507f1f77bcf86cd799439011")}'))
+      .toEqual({ _id: { $oid: '507f1f77bcf86cd799439011' } });
+    expect(parseShellJson('{"when": {"$gte": ISODate("2025-01-04T00:00:00.000Z")}}'))
+      .toEqual({ when: { $gte: { $date: '2025-01-04T00:00:00.000Z' } } });
+  });
+  it('leaves EJSON wrappers untouched', () => {
+    expect(parseShellJson('{"_id": {"$oid": "507f1f77bcf86cd799439011"}}'))
+      .toEqual({ _id: { $oid: '507f1f77bcf86cd799439011' } });
+  });
+  it('does not convert constructor-like text inside strings', () => {
+    expect(parseShellJson('{"note": "ObjectId(fake)"}')).toEqual({ note: 'ObjectId(fake)' });
+  });
+  it('throws on invalid input', () => {
+    expect(() => parseShellJson('{nope')).toThrow();
   });
 });

--- a/src/lib/__tests__/useMonacoTheme.test.ts
+++ b/src/lib/__tests__/useMonacoTheme.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useMonacoTheme } from '../useMonacoTheme';
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('useMonacoTheme', () => {
+  it('defaults to vs-dark', () => {
+    const { result } = renderHook(() => useMonacoTheme());
+    expect(result.current).toBe('vs-dark');
+  });
+
+  it('returns light when the app theme is light', () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const { result } = renderHook(() => useMonacoTheme());
+    expect(result.current).toBe('light');
+  });
+
+  it('updates when the app theme changes after mount', async () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const { result } = renderHook(() => useMonacoTheme());
+    expect(result.current).toBe('vs-dark');
+
+    document.documentElement.setAttribute('data-theme', 'light');
+    await waitFor(() => expect(result.current).toBe('light'));
+
+    document.documentElement.setAttribute('data-theme', 'dark');
+    await waitFor(() => expect(result.current).toBe('vs-dark'));
+  });
+});

--- a/src/lib/fuzzyMatch.ts
+++ b/src/lib/fuzzyMatch.ts
@@ -13,3 +13,27 @@ export function fuzzyMatch(query: string, target: string): boolean {
   }
   return true;
 }
+
+// Ranking companion to fuzzyMatch: higher is better, null means no match.
+// Exact match > prefix > substring > scattered subsequence; shorter targets
+// win ties. Powers the command palette result ordering.
+export function fuzzyScore(query: string, target: string): number | null {
+  const q = query.trim().toLowerCase();
+  if (!q) return 0;
+  const t = target.toLowerCase();
+  if (t === q) return 1000;
+  if (t.startsWith(q)) return 500 - t.length / 10;
+  const idx = t.indexOf(q);
+  if (idx >= 0) return 250 - idx - t.length / 10;
+  let ti = 0;
+  let gaps = 0;
+  let last = -1;
+  for (const ch of q) {
+    ti = t.indexOf(ch, ti);
+    if (ti === -1) return null;
+    if (last >= 0 && ti > last + 1) gaps++;
+    last = ti;
+    ti++;
+  }
+  return 100 - gaps * 5 - t.length / 10;
+}

--- a/src/lib/fuzzyMatch.ts
+++ b/src/lib/fuzzyMatch.ts
@@ -1,0 +1,15 @@
+// Case-insensitive fuzzy match: true when every query character appears in the
+// target in order (substrings match trivially). Powers the sidebar tree filter,
+// so e.g. "cwsmap" finds "cnips_UserWorkspaceMap" in a 100-collection database.
+export function fuzzyMatch(query: string, target: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const t = target.toLowerCase();
+  let ti = 0;
+  for (const ch of q) {
+    ti = t.indexOf(ch, ti);
+    if (ti === -1) return false;
+    ti++;
+  }
+  return true;
+}

--- a/src/lib/monacoMongo.ts
+++ b/src/lib/monacoMongo.ts
@@ -2,7 +2,7 @@ import type { Monaco } from '@monaco-editor/react';
 import { getCompletions, type Surface, type CompletionKind } from './mongoCompletions';
 import type { SchemaMap } from './useCollectionSchema';
 
-interface ModelMeta { surface: Surface; getFields: () => string[]; getSchema: () => SchemaMap | undefined; getCollections?: () => string[]; }
+interface ModelMeta { surface: Surface; getFields: () => string[]; getSchema: () => SchemaMap | undefined; getCollections?: () => string[]; getStageOperator?: () => string | undefined; }
 const modelMeta = new Map<string, ModelMeta>();
 let registered = false;
 
@@ -60,6 +60,7 @@ export function registerMongoCompletionProvider(monaco: Monaco) {
       const items = getCompletions({
         surface: meta.surface, textBeforeCursor, token,
         fields: meta.getFields(), schema: meta.getSchema(), collections: meta.getCollections?.(),
+        stageOperator: meta.getStageOperator?.(),
       });
       const range = {
         startLineNumber: position.lineNumber, endLineNumber: position.lineNumber,

--- a/src/lib/monacoMongo.ts
+++ b/src/lib/monacoMongo.ts
@@ -45,10 +45,11 @@ export function registerMongoCompletionProvider(monaco: Monaco) {
   }
 
   const provider = {
-    // Only trigger on word-starting characters — '.' (db.<coll>, field paths)
-    // and '$' (operators). NOT space/brace/quote, so the dropdown doesn't pop
-    // until you actually start typing a word.
-    triggerCharacters: ['.', '$'],
+    // Word-starting characters: '.' (db.<coll>, field paths), '$' (operators),
+    // and '"' — in the JSON surfaces every key starts with a quote, so without
+    // it the dropdown never opens for field names (Monaco's quickSuggestions
+    // are disabled inside strings by default).
+    triggerCharacters: ['.', '$', '"'],
     provideCompletionItems(model: any, position: any) {
       const meta = modelMeta.get(model.uri.toString());
       if (!meta) return { suggestions: [] };

--- a/src/lib/monacoMongo.ts
+++ b/src/lib/monacoMongo.ts
@@ -17,6 +17,7 @@ function kindToMonaco(monaco: Monaco, kind: CompletionKind) {
     case 'stage': return k.Keyword;
     case 'method': return k.Method;
     case 'enum': return k.EnumMember;
+    case 'ejson': return k.Struct;
     default: return k.Text;
   }
 }
@@ -65,9 +66,15 @@ export function registerMongoCompletionProvider(monaco: Monaco) {
         startColumn: position.column - token.length, endColumn: position.column,
       };
       return {
-        suggestions: items.map((it) => ({
+        // sortText preserves getCompletions' intentional order (e.g. the
+        // schema-matched EJSON wrapper first) against Monaco's default sort.
+        suggestions: items.map((it, idx) => ({
           label: it.label, kind: kindToMonaco(monaco, it.kind),
           insertText: it.insertText, detail: it.detail, range,
+          sortText: String(idx).padStart(4, '0'),
+          insertTextRules: it.isSnippet
+            ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+            : undefined,
         })),
       };
     },

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -10,6 +10,10 @@ export interface CompletionCtx {
   fields: string[];
   schema?: Map<string, FieldSchema>;
   collections?: string[];   // collection names, for `db.<coll>` in the shell
+  // Set for the per-stage aggregation body editors: the editor holds the
+  // OPERATOR'S BODY (e.g. the object after "$group":), so completions are
+  // driven by the operator instead of guessing from the text.
+  stageOperator?: string;
 }
 
 export interface CompletionItem {
@@ -79,6 +83,16 @@ export const EJSON_TYPES: EjsonType[] = [
   { key: '$minKey', detail: 'EJSON MinKey', inner: '1' },
   { key: '$maxKey', detail: 'EJSON MaxKey', inner: '1' },
   { key: '$dbPointer', detail: 'EJSON DBPointer', inner: '{"\\$ref": "${1:collection}", "\\$id": {"\\$oid": "${2:objectId}"}}' },
+];
+
+// $lookup body parameters with value scaffolds.
+export const LOOKUP_KEYS: EjsonType[] = [
+  { key: 'from', detail: 'source collection', inner: '"${1:collection}"' },
+  { key: 'localField', detail: 'field in this collection', inner: '"${1:field}"' },
+  { key: 'foreignField', detail: 'field in the source collection', inner: '"${1:field}"' },
+  { key: 'as', detail: 'output array field', inner: '"${1:joined}"' },
+  { key: 'let', detail: 'pipeline variables', inner: '{$1}' },
+  { key: 'pipeline', detail: 'sub-pipeline', inner: '[$1]' },
 ];
 
 // Projection-only operators ({field: {$slice: …}}).
@@ -334,8 +348,53 @@ function keyScaffoldItems(ctx: CompletionCtx, list: EjsonType[], kind: Completio
   }));
 }
 
+// `"$field"` aggregation path references (for $group/$unwind/$sortByCount bodies).
+function fieldRefItems(ctx: CompletionCtx): CompletionItem[] {
+  return ctx.fields.map((name) => ({
+    label: `$${name}`, kind: 'field' as const, insertText: `"$${name}"`, detail: 'field path',
+  }));
+}
+
+// Field names as plain string values ($lookup localField/foreignField).
+function fieldStringItems(ctx: CompletionCtx): CompletionItem[] {
+  return ctx.fields.map((name) => ({
+    label: name, kind: 'field' as const, insertText: `"${name}"`, detail: ctx.schema?.get(name)?.type,
+  }));
+}
+
 export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
   const { surface, textBeforeCursor, token } = ctx;
+
+  // Per-stage aggregation body editor: the text is the operator's body, so
+  // route by operator instead of the generic stage heuristics.
+  if (surface === 'aggStage' && ctx.stageOperator) {
+    const op = ctx.stageOperator;
+    if (op === '$sort') return getCompletions({ ...ctx, surface: 'sort', stageOperator: undefined });
+    if (op === '$project') return getCompletions({ ...ctx, surface: 'projection', stageOperator: undefined });
+    if (op === '$group') {
+      if (atValuePosition(textBeforeCursor)) {
+        return byPrefix([
+          ...fieldRefItems(ctx),
+          ...opScaffoldItems(ctx, GROUP_ACCUMULATORS, 'accumulator', 'value', ACCUMULATOR_SCAFFOLDS),
+        ], token);
+      }
+      const parent = atKeyPosition(textBeforeCursor) ? parentKeyOfOpenObject(textBeforeCursor) : null;
+      if (parent) {
+        return byPrefix(opScaffoldItems(ctx, GROUP_ACCUMULATORS, 'accumulator', 'key', ACCUMULATOR_SCAFFOLDS), token);
+      }
+      return byPrefix([{ label: '_id', kind: 'field' as const, insertText: keyInsert(ctx, '_id'), detail: 'group key' }], token);
+    }
+    if (op === '$lookup') {
+      if (atValuePosition(textBeforeCursor)) return byPrefix(fieldStringItems(ctx), token);
+      return byPrefix(keyScaffoldItems(ctx, LOOKUP_KEYS, 'field'), token);
+    }
+    if (op === '$unwind' || op === '$sortByCount') {
+      return byPrefix(fieldRefItems(ctx), token);
+    }
+    // $match, $addFields, $set, and the rest: filter-like semantics — fall
+    // through to the shared filter logic below (the legacy stage-name and
+    // $group-text heuristics are skipped because stageOperator is set).
+  }
 
   if (surface === 'projection') {
     if (atValuePosition(textBeforeCursor)) {
@@ -392,14 +451,14 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
     // otherwise (inside find({...}), aggregate([...])) → behave like a filter (fall through)
   }
 
-  const aggStageStart = surface === 'aggStage' && atKeyPosition(textBeforeCursor)
+  const aggStageStart = surface === 'aggStage' && !ctx.stageOperator && atKeyPosition(textBeforeCursor)
     && parentKeyOfOpenObject(textBeforeCursor) === null
     && !/\$group/.test(textBeforeCursor.slice(textBeforeCursor.indexOf('{')));
 
   if (aggStageStart) {
     return byPrefix(opScaffoldItems(ctx, AGG_STAGES, 'stage', 'key', STAGE_SCAFFOLDS, 'stage'), token);
   }
-  if (surface === 'aggStage' && /\$group/.test(textBeforeCursor) && atKeyPosition(textBeforeCursor)) {
+  if (surface === 'aggStage' && !ctx.stageOperator && /\$group/.test(textBeforeCursor) && atKeyPosition(textBeforeCursor)) {
     return byPrefix([...opScaffoldItems(ctx, GROUP_ACCUMULATORS, 'accumulator', 'key', ACCUMULATOR_SCAFFOLDS), ...fieldItems(ctx)], token);
   }
 

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -130,6 +130,51 @@ function fieldItems(ctx: CompletionCtx): CompletionItem[] {
   });
 }
 
+// Value scaffolds per schema type, keyed by the labels the backend schema
+// analyzer emits (src-tauri/src/db/schema.rs bson_type_label). `json` is for
+// the EJSON surfaces, `shell` for mongosh. Every label must have an entry.
+export const TYPE_VALUE_SCAFFOLDS: Record<string, { json: string; shell: string }> = {
+  objectId: { json: '{"\\$oid": "${1:objectId}"}', shell: 'ObjectId("${1:objectId}")' },
+  date: { json: '{"\\$date": "${1:2024-01-01T00:00:00Z}"}', shell: 'ISODate("${1:2024-01-01T00:00:00Z}")' },
+  string: { json: '"${1:value}"', shell: '"${1:value}"' },
+  int: { json: '${1:0}', shell: '${1:0}' },
+  long: { json: '{"\\$numberLong": "${1:0}"}', shell: 'NumberLong("${1:0}")' },
+  double: { json: '${1:0.0}', shell: '${1:0.0}' },
+  decimal: { json: '{"\\$numberDecimal": "${1:0}"}', shell: 'NumberDecimal("${1:0}")' },
+  bool: { json: '${1:true}', shell: '${1:true}' },
+  null: { json: 'null', shell: 'null' },
+  array: { json: '[$1]', shell: '[$1]' },
+  object: { json: '{$1}', shell: '{$1}' },
+  regex: { json: '{"\\$regularExpression": {"pattern": "${1:pattern}", "options": "${2:i}"}}', shell: '/${1:pattern}/${2:i}' },
+  timestamp: { json: '{"\\$timestamp": {"t": ${1:0}, "i": ${2:1}}}', shell: 'Timestamp(${1:0}, ${2:1})' },
+  binary: { json: '{"\\$binary": {"base64": "${1:base64}", "subType": "${2:00}"}}', shell: 'BinData(${1:0}, "${2:base64}")' },
+  javascript: { json: '{"\\$code": "${1:code}"}', shell: 'Code("${1:code}")' },
+  symbol: { json: '{"\\$symbol": "${1:symbol}"}', shell: '"${1:symbol}"' },
+  minKey: { json: '{"\\$minKey": 1}', shell: 'MinKey()' },
+  maxKey: { json: '{"\\$maxKey": 1}', shell: 'MaxKey()' },
+  undefined: { json: '{"\\$undefined": true}', shell: 'undefined' },
+  dbPointer: { json: '{"\\$dbPointer": {"\\$ref": "${1:collection}", "\\$id": {"\\$oid": "${2:objectId}"}}}', shell: 'DBPointer("${1:collection}", ObjectId("${2:objectId}"))' },
+};
+
+// Field completions for filter-like key positions: a schema-typed field
+// inserts the whole `"field": <typed value scaffold>` (shell: `field: …`) so
+// the user lands directly in the value placeholder. Untyped fields insert the
+// plain key, leaving operator choice open.
+function typedFieldItems(ctx: CompletionCtx): CompletionItem[] {
+  return ctx.fields.map((name) => {
+    const fs = ctx.schema?.get(name);
+    const shell = ctx.surface === 'shell';
+    const scaffold = fs?.type ? TYPE_VALUE_SCAFFOLDS[fs.type] : undefined;
+    if (!scaffold) {
+      return { label: name, kind: 'field' as const, insertText: keyInsert(ctx, name), detail: fs?.type };
+    }
+    // keyInsert semantics inline: shell keys are bare; in JSON we open a quote
+    // unless the user already typed one, and always close it before the colon.
+    const key = shell ? name : inQuote(ctx.textBeforeCursor) ? `${name}"` : `"${name}"`;
+    return { label: name, kind: 'field' as const, insertText: `${key}: ${shell ? scaffold.shell : scaffold.json}`, detail: fs?.type, isSnippet: true };
+  });
+}
+
 function quoteForType(value: string, type?: string): string {
   // string/objectId/date → quoted; numeric/bool → raw.
   if (type === 'int' || type === 'long' || type === 'double' || type === 'decimal' || type === 'bool') return value;
@@ -226,7 +271,7 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
     }
     const parent = atKeyPosition(textBeforeCursor) ? parentKeyOfOpenObject(textBeforeCursor) : null;
     if (parent === '$elemMatch') {
-      return byPrefix([...fieldItems(ctx), ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
+      return byPrefix([...typedFieldItems(ctx), ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
     }
     if (parent) {
       return byPrefix([...keyItems(ctx, PROJECTION_OPERATORS), ...opItems(ctx, QUERY_OPERATORS, 'query operator'), ...keyItems(ctx, EJSON_TYPES)], token);
@@ -293,10 +338,10 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
       return byPrefix([...opItems(ctx, QUERY_OPERATORS, 'query operator'), ...keyItems(ctx, EJSON_TYPES)], token);
     }
     if (parent.startsWith('$')) {
-      return byPrefix([...fieldItems(ctx), ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
+      return byPrefix([...typedFieldItems(ctx), ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
     }
     return byPrefix([...opItems(ctx, QUERY_OPERATORS, 'query operator'), ...keyItems(ctx, EJSON_TYPES)], token);
   }
   // top-level key position
-  return byPrefix([...fieldItems(ctx), ...opItems(ctx, LOGICAL_OPERATORS, 'logical')], token);
+  return byPrefix([...typedFieldItems(ctx), ...opItems(ctx, LOGICAL_OPERATORS, 'logical')], token);
 }

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -56,40 +56,72 @@ export const SHELL_GLOBALS = [
   'NumberLong', 'NumberInt', 'NumberDecimal', 'BinData', 'sleep', 'load', 'quit', 'version', 'use',
 ];
 
-// Extended JSON (EJSON v2) type wrappers. `value` is the full wrapper object as
-// a Monaco snippet; `key` is offered when the user has already opened the
-// wrapper object themselves ({"_id": {"$oi…). The relaxed `$date` (ISO string)
-// form is used because the backend's serde_json→bson path accepts it.
-export interface EjsonType { key: string; detail: string; value: string; }
+// Extended JSON (EJSON v2) type wrappers. `inner` is the wrapper's value part
+// as a Monaco snippet; the full `{"$key": inner}` object is derived for value
+// positions, and `"$key": inner` for key positions inside an open object.
+// The relaxed `$date` (ISO string) form is used because the backend's
+// serde_json→bson path accepts it.
+export interface EjsonType { key: string; detail: string; inner: string; }
 export const EJSON_TYPES: EjsonType[] = [
-  { key: '$oid', detail: 'EJSON ObjectId', value: '{"\\$oid": "${1:objectId}"}' },
-  { key: '$date', detail: 'EJSON Date (ISO-8601)', value: '{"\\$date": "${1:2024-01-01T00:00:00Z}"}' },
-  { key: '$numberInt', detail: 'EJSON Int32', value: '{"\\$numberInt": "${1:0}"}' },
-  { key: '$numberLong', detail: 'EJSON Int64', value: '{"\\$numberLong": "${1:0}"}' },
-  { key: '$numberDouble', detail: 'EJSON Double', value: '{"\\$numberDouble": "${1:0.0}"}' },
-  { key: '$numberDecimal', detail: 'EJSON Decimal128', value: '{"\\$numberDecimal": "${1:0}"}' },
-  { key: '$regularExpression', detail: 'EJSON Regex', value: '{"\\$regularExpression": {"pattern": "${1:pattern}", "options": "${2:i}"}}' },
-  { key: '$timestamp', detail: 'EJSON Timestamp', value: '{"\\$timestamp": {"t": ${1:0}, "i": ${2:1}}}' },
-  { key: '$binary', detail: 'EJSON Binary', value: '{"\\$binary": {"base64": "${1:base64}", "subType": "${2:00}"}}' },
-  { key: '$uuid', detail: 'EJSON UUID', value: '{"\\$uuid": "${1:00000000-0000-0000-0000-000000000000}"}' },
-  { key: '$code', detail: 'EJSON JavaScript code', value: '{"\\$code": "${1:code}"}' },
-  { key: '$symbol', detail: 'EJSON Symbol', value: '{"\\$symbol": "${1:symbol}"}' },
-  { key: '$undefined', detail: 'EJSON Undefined', value: '{"\\$undefined": true}' },
-  { key: '$minKey', detail: 'EJSON MinKey', value: '{"\\$minKey": 1}' },
-  { key: '$maxKey', detail: 'EJSON MaxKey', value: '{"\\$maxKey": 1}' },
-  { key: '$dbPointer', detail: 'EJSON DBPointer', value: '{"\\$dbPointer": {"\\$ref": "${1:collection}", "\\$id": {"\\$oid": "${2:objectId}"}}}' },
+  { key: '$oid', detail: 'EJSON ObjectId', inner: '"${1:objectId}"' },
+  { key: '$date', detail: 'EJSON Date (ISO-8601)', inner: '"${1:2024-01-01T00:00:00Z}"' },
+  { key: '$numberInt', detail: 'EJSON Int32', inner: '"${1:0}"' },
+  { key: '$numberLong', detail: 'EJSON Int64', inner: '"${1:0}"' },
+  { key: '$numberDouble', detail: 'EJSON Double', inner: '"${1:0.0}"' },
+  { key: '$numberDecimal', detail: 'EJSON Decimal128', inner: '"${1:0}"' },
+  { key: '$regularExpression', detail: 'EJSON Regex', inner: '{"pattern": "${1:pattern}", "options": "${2:i}"}' },
+  { key: '$timestamp', detail: 'EJSON Timestamp', inner: '{"t": ${1:0}, "i": ${2:1}}' },
+  { key: '$binary', detail: 'EJSON Binary', inner: '{"base64": "${1:base64}", "subType": "${2:00}"}' },
+  { key: '$uuid', detail: 'EJSON UUID', inner: '"${1:00000000-0000-0000-0000-000000000000}"' },
+  { key: '$code', detail: 'EJSON JavaScript code', inner: '"${1:code}"' },
+  { key: '$symbol', detail: 'EJSON Symbol', inner: '"${1:symbol}"' },
+  { key: '$undefined', detail: 'EJSON Undefined', inner: 'true' },
+  { key: '$minKey', detail: 'EJSON MinKey', inner: '1' },
+  { key: '$maxKey', detail: 'EJSON MaxKey', inner: '1' },
+  { key: '$dbPointer', detail: 'EJSON DBPointer', inner: '{"\\$ref": "${1:collection}", "\\$id": {"\\$oid": "${2:objectId}"}}' },
 ];
 
 // Projection-only operators ({field: {$slice: …}}).
 export const PROJECTION_OPERATORS: EjsonType[] = [
-  { key: '$slice', detail: 'array slice', value: '{"\\$slice": ${1:5}}' },
-  { key: '$elemMatch', detail: 'first matching element', value: '{"\\$elemMatch": {$1}}' },
-  { key: '$meta', detail: 'text score', value: '{"\\$meta": "${1:textScore}"}' },
+  { key: '$slice', detail: 'array slice', inner: '${1:5}' },
+  { key: '$elemMatch', detail: 'first matching element', inner: '{$1}' },
+  { key: '$meta', detail: 'text score', inner: '"${1:textScore}"' },
 ];
 
+// Value shape inserted after an operator key. Operators not listed here are
+// comparisons whose value takes the matched field's schema-type scaffold.
+export const OPERATOR_VALUE_SCAFFOLDS: Record<string, string> = {
+  $and: '[{$1}]', $or: '[{$1}]', $nor: '[{$1}]',
+  $in: '[$1]', $nin: '[$1]', $all: '[$1]',
+  $mod: '[${1:divisor}, ${2:remainder}]',
+  $not: '{$1}', $elemMatch: '{$1}',
+  $exists: '${1:true}',
+  $regex: '"${1:pattern}"',
+  $type: '"${1:string}"',
+  $size: '${1:0}',
+};
+
+// Aggregation stage bodies ($count differs between stage and accumulator, so
+// these live in their own tables).
+export const STAGE_SCAFFOLDS: Record<string, string> = {
+  $match: '{$1}', $group: '{"_id": "\\$${1:field}"}', $project: '{$1}', $sort: '{$1}',
+  $limit: '${1:10}', $skip: '${1:0}', $unwind: '"\\$${1:field}"',
+  $lookup: '{"from": "${1:collection}", "localField": "${2:field}", "foreignField": "${3:field}", "as": "${4:result}"}',
+  $addFields: '{$1}', $set: '{$1}', $unset: '"${1:field}"',
+  $count: '"${1:count}"', $facet: '{$1}', $sortByCount: '"\\$${1:field}"',
+  $replaceRoot: '{"newRoot": "\\$${1:field}"}',
+};
+export const ACCUMULATOR_SCAFFOLDS: Record<string, string> = {
+  $sum: '${1:1}', $avg: '"\\$${1:field}"', $min: '"\\$${1:field}"', $max: '"\\$${1:field}"',
+  $first: '"\\$${1:field}"', $last: '"\\$${1:field}"', $push: '"\\$${1:field}"', $addToSet: '"\\$${1:field}"',
+  $count: '{}',
+};
+
 // mongosh does NOT parse EJSON wrappers as types, so the shell surface offers
-// constructor calls at value positions instead.
-export const SHELL_VALUE_CTORS: EjsonType[] = [
+// constructor calls at value positions instead. The query bar parses shell
+// constructors too (parseShellJson), so these are offered there as well.
+export interface SnippetDef { key: string; detail: string; value: string; }
+export const SHELL_VALUE_CTORS: SnippetDef[] = [
   { key: 'ObjectId', detail: 'ObjectId', value: 'ObjectId("${1:objectId}")' },
   { key: 'ISODate', detail: 'Date', value: 'ISODate("${1:2024-01-01T00:00:00Z}")' },
   { key: 'NumberInt', detail: 'Int32', value: 'NumberInt(${1:0})' },
@@ -119,8 +151,31 @@ function keyInsert(ctx: CompletionCtx, s: string): string {
   return ctx.surface !== 'shell' && !inQuote(ctx.textBeforeCursor) ? `"${s}"` : s;
 }
 
-function opItems(ctx: CompletionCtx, ops: string[], detail: string): CompletionItem[] {
-  return ops.map((op) => ({ label: op, kind: 'operator' as const, insertText: keyInsert(ctx, op), detail }));
+// Snippet-escaped key (`\$op`), quoted per surface; reuses keyInsert's rules.
+function snippetKey(ctx: CompletionCtx, key: string): string {
+  const esc = key.startsWith('$') ? `\\${key}` : key;
+  if (ctx.surface === 'shell') return esc;
+  return inQuote(ctx.textBeforeCursor) ? `${esc}"` : `"${esc}"`;
+}
+
+// Operator completions that auto-insert the operator's value shape.
+// mode 'key': caret is at a key position → `"$op": <shape>`.
+// mode 'value': caret is after `field:` → `{"$op": <shape>}`.
+// Comparison operators (not in the table) take the matched field's
+// schema-type scaffold so e.g. a date field's $gt scaffolds {"$date": …}.
+function opScaffoldItems(
+  ctx: CompletionCtx, ops: string[], detail: string, mode: 'key' | 'value',
+  table: Record<string, string> = OPERATOR_VALUE_SCAFFOLDS, kind: CompletionKind = 'operator',
+): CompletionItem[] {
+  const shell = ctx.surface === 'shell';
+  const fieldKey = mode === 'value' ? lastFieldKey(ctx.textBeforeCursor) : parentKeyOfOpenObject(ctx.textBeforeCursor);
+  const ftype = fieldKey && !fieldKey.startsWith('$') ? ctx.schema?.get(fieldKey)?.type : undefined;
+  const typed = ftype ? TYPE_VALUE_SCAFFOLDS[ftype] : undefined;
+  return ops.map((op) => {
+    const inner = table[op] ?? (typed ? (shell ? typed.shell : typed.json) : '$1');
+    const pair = `${snippetKey(ctx, op)}: ${inner}`;
+    return { label: op, kind, insertText: mode === 'value' ? `{${pair}}` : pair, detail, isSnippet: true };
+  });
 }
 
 function fieldItems(ctx: CompletionCtx): CompletionItem[] {
@@ -237,14 +292,21 @@ function parentKeyOfOpenObject(text: string): string | null {
   return m ? m[1] : null;
 }
 
-function snippetItems(list: EjsonType[], kind: CompletionKind): CompletionItem[] {
+function snippetItems(list: SnippetDef[], kind: CompletionKind): CompletionItem[] {
   return list.map((t) => ({ label: t.key, kind, insertText: t.value, detail: t.detail, isSnippet: true }));
+}
+
+// Full `{"$key": inner}` wrapper objects for value positions.
+function wrapperItems(list: EjsonType[], kind: CompletionKind): CompletionItem[] {
+  return list.map((t) => ({
+    label: t.key, kind, insertText: `{"\\${t.key}": ${t.inner}}`, detail: t.detail, isSnippet: true,
+  }));
 }
 
 // EJSON wrapper snippets for a value position; the wrapper matching the
 // field's schema type (objectId/date) ranks first.
 function ejsonValueItems(ctx: CompletionCtx): CompletionItem[] {
-  const items = snippetItems(EJSON_TYPES, 'ejson');
+  const items = wrapperItems(EJSON_TYPES, 'ejson');
   const field = lastFieldKey(ctx.textBeforeCursor);
   const type = field ? ctx.schema?.get(field)?.type : undefined;
   const first = type === 'objectId' ? '$oid' : type === 'date' ? '$date' : null;
@@ -252,9 +314,12 @@ function ejsonValueItems(ctx: CompletionCtx): CompletionItem[] {
   return [...items.filter((i) => i.label === first), ...items.filter((i) => i.label !== first)];
 }
 
-// Bare `$key` completions for when the user already opened the wrapper object.
-function keyItems(ctx: CompletionCtx, list: EjsonType[]): CompletionItem[] {
-  return list.map((t) => ({ label: t.key, kind: 'ejson' as const, insertText: keyInsert(ctx, t.key), detail: t.detail }));
+// `"$key": inner` completions for when the user already opened the wrapper
+// object ({"_id": {"$oi…) — the value shape comes along with the key.
+function keyScaffoldItems(ctx: CompletionCtx, list: EjsonType[], kind: CompletionKind): CompletionItem[] {
+  return list.map((t) => ({
+    label: t.key, kind, insertText: `${snippetKey(ctx, t.key)}: ${t.inner}`, detail: t.detail, isSnippet: true,
+  }));
 }
 
 export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
@@ -265,16 +330,20 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
       return byPrefix([
         { label: '1', kind: 'operator' as const, insertText: '1', detail: 'include' },
         { label: '0', kind: 'operator' as const, insertText: '0', detail: 'exclude' },
-        ...snippetItems(PROJECTION_OPERATORS, 'operator'),
+        ...wrapperItems(PROJECTION_OPERATORS, 'operator'),
         ...ejsonValueItems(ctx),
       ], token);
     }
     const parent = atKeyPosition(textBeforeCursor) ? parentKeyOfOpenObject(textBeforeCursor) : null;
     if (parent === '$elemMatch') {
-      return byPrefix([...typedFieldItems(ctx), ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
+      return byPrefix([...typedFieldItems(ctx), ...opScaffoldItems(ctx, QUERY_OPERATORS, 'query operator', 'key')], token);
     }
     if (parent) {
-      return byPrefix([...keyItems(ctx, PROJECTION_OPERATORS), ...opItems(ctx, QUERY_OPERATORS, 'query operator'), ...keyItems(ctx, EJSON_TYPES)], token);
+      return byPrefix([
+        ...keyScaffoldItems(ctx, PROJECTION_OPERATORS, 'operator'),
+        ...opScaffoldItems(ctx, QUERY_OPERATORS, 'query operator', 'key'),
+        ...keyScaffoldItems(ctx, EJSON_TYPES, 'ejson'),
+      ], token);
     }
     return byPrefix([...fieldItems(ctx),
       { label: '1', kind: 'operator', insertText: '1', detail: 'include' },
@@ -317,17 +386,20 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
     && !/\$group/.test(textBeforeCursor.slice(textBeforeCursor.indexOf('{')));
 
   if (aggStageStart) {
-    return byPrefix(AGG_STAGES.map((s) => ({ label: s, kind: 'stage' as const, insertText: keyInsert(ctx, s) })), token);
+    return byPrefix(opScaffoldItems(ctx, AGG_STAGES, 'stage', 'key', STAGE_SCAFFOLDS, 'stage'), token);
   }
   if (surface === 'aggStage' && /\$group/.test(textBeforeCursor) && atKeyPosition(textBeforeCursor)) {
-    return byPrefix([...opItems(ctx, GROUP_ACCUMULATORS, 'accumulator'), ...fieldItems(ctx)], token);
+    return byPrefix([...opScaffoldItems(ctx, GROUP_ACCUMULATORS, 'accumulator', 'key', ACCUMULATOR_SCAFFOLDS), ...fieldItems(ctx)], token);
   }
 
   // filter (and shell-inside-find, and agg $match body) — value position:
-  // enum values, EJSON type wrappers (shell constructors in the JS shell), operators.
+  // enum values, EJSON wrappers + shell constructors (the query bar parses
+  // both; the JS shell gets constructors only), operators with value shapes.
   if (atValuePosition(textBeforeCursor)) {
-    const typed = surface === 'shell' ? snippetItems(SHELL_VALUE_CTORS, 'method') : ejsonValueItems(ctx);
-    return byPrefix([...enumItemsForLastField(ctx), ...typed, ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
+    const typed = surface === 'shell'
+      ? snippetItems(SHELL_VALUE_CTORS, 'method')
+      : [...ejsonValueItems(ctx), ...snippetItems(SHELL_VALUE_CTORS, 'method')];
+    return byPrefix([...enumItemsForLastField(ctx), ...typed, ...opScaffoldItems(ctx, QUERY_OPERATORS, 'query operator', 'value')], token);
   }
   // key position inside an open value object ({"_id": { …): the keys are
   // operators or EJSON wrappers, not field names — except filter-document
@@ -335,13 +407,14 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
   const parent = atKeyPosition(textBeforeCursor) ? parentKeyOfOpenObject(textBeforeCursor) : null;
   if (parent) {
     if (parent === '$not') {
-      return byPrefix([...opItems(ctx, QUERY_OPERATORS, 'query operator'), ...keyItems(ctx, EJSON_TYPES)], token);
+      return byPrefix([...opScaffoldItems(ctx, QUERY_OPERATORS, 'query operator', 'key'), ...keyScaffoldItems(ctx, EJSON_TYPES, 'ejson')], token);
     }
     if (parent.startsWith('$')) {
-      return byPrefix([...typedFieldItems(ctx), ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
+      return byPrefix([...typedFieldItems(ctx), ...opScaffoldItems(ctx, QUERY_OPERATORS, 'query operator', 'key')], token);
     }
-    return byPrefix([...opItems(ctx, QUERY_OPERATORS, 'query operator'), ...keyItems(ctx, EJSON_TYPES)], token);
+    // $not applies per-field ({field: {$not: …}}), so it joins the operators here.
+    return byPrefix([...opScaffoldItems(ctx, [...QUERY_OPERATORS, '$not'], 'query operator', 'key'), ...keyScaffoldItems(ctx, EJSON_TYPES, 'ejson')], token);
   }
   // top-level key position
-  return byPrefix([...typedFieldItems(ctx), ...opItems(ctx, LOGICAL_OPERATORS, 'logical')], token);
+  return byPrefix([...typedFieldItems(ctx), ...opScaffoldItems(ctx, LOGICAL_OPERATORS, 'logical', 'key')], token);
 }

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -1,5 +1,5 @@
 export type Surface = 'filter' | 'projection' | 'sort' | 'aggStage' | 'shell';
-export type CompletionKind = 'field' | 'operator' | 'stage' | 'method' | 'enum';
+export type CompletionKind = 'field' | 'operator' | 'stage' | 'method' | 'enum' | 'ejson';
 
 export interface FieldSchema { type?: string; enumValues?: string[]; }
 
@@ -17,6 +17,8 @@ export interface CompletionItem {
   kind: CompletionKind;
   insertText: string;
   detail?: string;
+  // Monaco snippet syntax: `${1:placeholder}` tab stops, literal `$` escaped as `\$`.
+  isSnippet?: boolean;
 }
 
 export const QUERY_OPERATORS = [
@@ -52,6 +54,50 @@ export const DB_METHODS = [
 export const SHELL_GLOBALS = [
   'db', 'print', 'printjson', 'ObjectId', 'ISODate', 'UUID', 'Date',
   'NumberLong', 'NumberInt', 'NumberDecimal', 'BinData', 'sleep', 'load', 'quit', 'version', 'use',
+];
+
+// Extended JSON (EJSON v2) type wrappers. `value` is the full wrapper object as
+// a Monaco snippet; `key` is offered when the user has already opened the
+// wrapper object themselves ({"_id": {"$oi…). The relaxed `$date` (ISO string)
+// form is used because the backend's serde_json→bson path accepts it.
+export interface EjsonType { key: string; detail: string; value: string; }
+export const EJSON_TYPES: EjsonType[] = [
+  { key: '$oid', detail: 'EJSON ObjectId', value: '{"\\$oid": "${1:objectId}"}' },
+  { key: '$date', detail: 'EJSON Date (ISO-8601)', value: '{"\\$date": "${1:2024-01-01T00:00:00Z}"}' },
+  { key: '$numberInt', detail: 'EJSON Int32', value: '{"\\$numberInt": "${1:0}"}' },
+  { key: '$numberLong', detail: 'EJSON Int64', value: '{"\\$numberLong": "${1:0}"}' },
+  { key: '$numberDouble', detail: 'EJSON Double', value: '{"\\$numberDouble": "${1:0.0}"}' },
+  { key: '$numberDecimal', detail: 'EJSON Decimal128', value: '{"\\$numberDecimal": "${1:0}"}' },
+  { key: '$regularExpression', detail: 'EJSON Regex', value: '{"\\$regularExpression": {"pattern": "${1:pattern}", "options": "${2:i}"}}' },
+  { key: '$timestamp', detail: 'EJSON Timestamp', value: '{"\\$timestamp": {"t": ${1:0}, "i": ${2:1}}}' },
+  { key: '$binary', detail: 'EJSON Binary', value: '{"\\$binary": {"base64": "${1:base64}", "subType": "${2:00}"}}' },
+  { key: '$uuid', detail: 'EJSON UUID', value: '{"\\$uuid": "${1:00000000-0000-0000-0000-000000000000}"}' },
+  { key: '$code', detail: 'EJSON JavaScript code', value: '{"\\$code": "${1:code}"}' },
+  { key: '$symbol', detail: 'EJSON Symbol', value: '{"\\$symbol": "${1:symbol}"}' },
+  { key: '$undefined', detail: 'EJSON Undefined', value: '{"\\$undefined": true}' },
+  { key: '$minKey', detail: 'EJSON MinKey', value: '{"\\$minKey": 1}' },
+  { key: '$maxKey', detail: 'EJSON MaxKey', value: '{"\\$maxKey": 1}' },
+  { key: '$dbPointer', detail: 'EJSON DBPointer', value: '{"\\$dbPointer": {"\\$ref": "${1:collection}", "\\$id": {"\\$oid": "${2:objectId}"}}}' },
+];
+
+// Projection-only operators ({field: {$slice: …}}).
+export const PROJECTION_OPERATORS: EjsonType[] = [
+  { key: '$slice', detail: 'array slice', value: '{"\\$slice": ${1:5}}' },
+  { key: '$elemMatch', detail: 'first matching element', value: '{"\\$elemMatch": {$1}}' },
+  { key: '$meta', detail: 'text score', value: '{"\\$meta": "${1:textScore}"}' },
+];
+
+// mongosh does NOT parse EJSON wrappers as types, so the shell surface offers
+// constructor calls at value positions instead.
+export const SHELL_VALUE_CTORS: EjsonType[] = [
+  { key: 'ObjectId', detail: 'ObjectId', value: 'ObjectId("${1:objectId}")' },
+  { key: 'ISODate', detail: 'Date', value: 'ISODate("${1:2024-01-01T00:00:00Z}")' },
+  { key: 'NumberInt', detail: 'Int32', value: 'NumberInt(${1:0})' },
+  { key: 'NumberLong', detail: 'Int64', value: 'NumberLong("${1:0}")' },
+  { key: 'NumberDecimal', detail: 'Decimal128', value: 'NumberDecimal("${1:0}")' },
+  { key: 'UUID', detail: 'UUID', value: 'UUID("${1:00000000-0000-0000-0000-000000000000}")' },
+  { key: 'BinData', detail: 'Binary', value: 'BinData(${1:0}, "${2:base64}")' },
+  { key: 'Timestamp', detail: 'Timestamp', value: 'Timestamp(${1:0}, ${2:1})' },
 ];
 
 function byPrefix<T extends { label: string }>(items: T[], token: string): T[] {
@@ -119,15 +165,84 @@ function atValuePosition(text: string): boolean {
   return /:\s*["']?[\w.$]*$/.test(text) && !atKeyPosition(text);
 }
 
+// Index of the innermost still-open `{`, skipping braces inside string literals.
+function lastOpenBraceIndex(text: string): number {
+  const stack: number[] = [];
+  let quote: string | null = null;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (quote) {
+      if (c === '\\') i++;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") quote = c;
+    else if (c === '{') stack.push(i);
+    else if (c === '}') stack.pop();
+  }
+  return stack.length ? stack[stack.length - 1] : -1;
+}
+
+// The key whose value the innermost open object is, e.g. `_id` for
+// `{"_id": {` — null when the open object is the top level or an array element.
+function parentKeyOfOpenObject(text: string): string | null {
+  const idx = lastOpenBraceIndex(text);
+  if (idx <= 0) return null;
+  const m = text.slice(0, idx).match(/["']?([\w$.]+)["']?\s*:\s*$/);
+  return m ? m[1] : null;
+}
+
+function snippetItems(list: EjsonType[], kind: CompletionKind): CompletionItem[] {
+  return list.map((t) => ({ label: t.key, kind, insertText: t.value, detail: t.detail, isSnippet: true }));
+}
+
+// EJSON wrapper snippets for a value position; the wrapper matching the
+// field's schema type (objectId/date) ranks first.
+function ejsonValueItems(ctx: CompletionCtx): CompletionItem[] {
+  const items = snippetItems(EJSON_TYPES, 'ejson');
+  const field = lastFieldKey(ctx.textBeforeCursor);
+  const type = field ? ctx.schema?.get(field)?.type : undefined;
+  const first = type === 'objectId' ? '$oid' : type === 'date' ? '$date' : null;
+  if (!first) return items;
+  return [...items.filter((i) => i.label === first), ...items.filter((i) => i.label !== first)];
+}
+
+// Bare `$key` completions for when the user already opened the wrapper object.
+function keyItems(ctx: CompletionCtx, list: EjsonType[]): CompletionItem[] {
+  return list.map((t) => ({ label: t.key, kind: 'ejson' as const, insertText: keyInsert(ctx, t.key), detail: t.detail }));
+}
+
 export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
   const { surface, textBeforeCursor, token } = ctx;
 
   if (surface === 'projection') {
+    if (atValuePosition(textBeforeCursor)) {
+      return byPrefix([
+        { label: '1', kind: 'operator' as const, insertText: '1', detail: 'include' },
+        { label: '0', kind: 'operator' as const, insertText: '0', detail: 'exclude' },
+        ...snippetItems(PROJECTION_OPERATORS, 'operator'),
+        ...ejsonValueItems(ctx),
+      ], token);
+    }
+    const parent = atKeyPosition(textBeforeCursor) ? parentKeyOfOpenObject(textBeforeCursor) : null;
+    if (parent === '$elemMatch') {
+      return byPrefix([...fieldItems(ctx), ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
+    }
+    if (parent) {
+      return byPrefix([...keyItems(ctx, PROJECTION_OPERATORS), ...opItems(ctx, QUERY_OPERATORS, 'query operator'), ...keyItems(ctx, EJSON_TYPES)], token);
+    }
     return byPrefix([...fieldItems(ctx),
       { label: '1', kind: 'operator', insertText: '1', detail: 'include' },
       { label: '0', kind: 'operator', insertText: '0', detail: 'exclude' }], token);
   }
   if (surface === 'sort') {
+    if (atValuePosition(textBeforeCursor)) {
+      return byPrefix([
+        { label: '1', kind: 'operator' as const, insertText: '1', detail: 'ascending' },
+        { label: '-1', kind: 'operator' as const, insertText: '-1', detail: 'descending' },
+        { label: '$meta', kind: 'operator' as const, insertText: '{"\\$meta": "${1:textScore}"}', detail: 'sort by text score', isSnippet: true },
+      ], token);
+    }
     return byPrefix([...fieldItems(ctx),
       { label: '1', kind: 'operator', insertText: '1', detail: 'ascending' },
       { label: '-1', kind: 'operator', insertText: '-1', detail: 'descending' }], token);
@@ -153,6 +268,7 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
   }
 
   const aggStageStart = surface === 'aggStage' && atKeyPosition(textBeforeCursor)
+    && parentKeyOfOpenObject(textBeforeCursor) === null
     && !/\$group/.test(textBeforeCursor.slice(textBeforeCursor.indexOf('{')));
 
   if (aggStageStart) {
@@ -162,10 +278,25 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
     return byPrefix([...opItems(ctx, GROUP_ACCUMULATORS, 'accumulator'), ...fieldItems(ctx)], token);
   }
 
-  // filter (and shell-inside-find, and agg $match body)
+  // filter (and shell-inside-find, and agg $match body) — value position:
+  // enum values, EJSON type wrappers (shell constructors in the JS shell), operators.
   if (atValuePosition(textBeforeCursor)) {
-    return byPrefix([...enumItemsForLastField(ctx), ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
+    const typed = surface === 'shell' ? snippetItems(SHELL_VALUE_CTORS, 'method') : ejsonValueItems(ctx);
+    return byPrefix([...enumItemsForLastField(ctx), ...typed, ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
   }
-  // key position
+  // key position inside an open value object ({"_id": { …): the keys are
+  // operators or EJSON wrappers, not field names — except filter-document
+  // bodies ($elemMatch, $match, …) where fields apply again.
+  const parent = atKeyPosition(textBeforeCursor) ? parentKeyOfOpenObject(textBeforeCursor) : null;
+  if (parent) {
+    if (parent === '$not') {
+      return byPrefix([...opItems(ctx, QUERY_OPERATORS, 'query operator'), ...keyItems(ctx, EJSON_TYPES)], token);
+    }
+    if (parent.startsWith('$')) {
+      return byPrefix([...fieldItems(ctx), ...opItems(ctx, QUERY_OPERATORS, 'query operator')], token);
+    }
+    return byPrefix([...opItems(ctx, QUERY_OPERATORS, 'query operator'), ...keyItems(ctx, EJSON_TYPES)], token);
+  }
+  // top-level key position
   return byPrefix([...fieldItems(ctx), ...opItems(ctx, LOGICAL_OPERATORS, 'logical')], token);
 }

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -185,6 +185,18 @@ function fieldItems(ctx: CompletionCtx): CompletionItem[] {
   });
 }
 
+// Field completions for projection/sort key positions: the value is a fixed
+// choice (include/exclude or direction), offered as a snippet choice dropdown.
+function choiceFieldItems(ctx: CompletionCtx, choices: string): CompletionItem[] {
+  return ctx.fields.map((name) => {
+    const fs = ctx.schema?.get(name);
+    const key = inQuote(ctx.textBeforeCursor) ? `${name}"` : `"${name}"`;
+    return { label: name, kind: 'field' as const, insertText: `${key}: \${1|${choices}|}`, detail: fs?.type, isSnippet: true };
+  });
+}
+
+const SORT_META: EjsonType = { key: '$meta', detail: 'sort by text score', inner: '"${1:textScore}"' };
+
 // Value scaffolds per schema type, keyed by the labels the backend schema
 // analyzer emits (src-tauri/src/db/schema.rs bson_type_label). `json` is for
 // the EJSON surfaces, `shell` for mongosh. Every label must have an entry.
@@ -345,9 +357,7 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
         ...keyScaffoldItems(ctx, EJSON_TYPES, 'ejson'),
       ], token);
     }
-    return byPrefix([...fieldItems(ctx),
-      { label: '1', kind: 'operator', insertText: '1', detail: 'include' },
-      { label: '0', kind: 'operator', insertText: '0', detail: 'exclude' }], token);
+    return byPrefix(choiceFieldItems(ctx, '1,0'), token);
   }
   if (surface === 'sort') {
     if (atValuePosition(textBeforeCursor)) {
@@ -357,9 +367,10 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
         { label: '$meta', kind: 'operator' as const, insertText: '{"\\$meta": "${1:textScore}"}', detail: 'sort by text score', isSnippet: true },
       ], token);
     }
-    return byPrefix([...fieldItems(ctx),
-      { label: '1', kind: 'operator', insertText: '1', detail: 'ascending' },
-      { label: '-1', kind: 'operator', insertText: '-1', detail: 'descending' }], token);
+    if (atKeyPosition(textBeforeCursor) && parentKeyOfOpenObject(textBeforeCursor)) {
+      return byPrefix(keyScaffoldItems(ctx, [SORT_META], 'operator'), token);
+    }
+    return byPrefix(choiceFieldItems(ctx, '1,-1'), token);
   }
   if (surface === 'shell') {
     // db.<partial> (collection slot — exactly one dot after db) → collection names + db methods

--- a/src/lib/paletteIndex.ts
+++ b/src/lib/paletteIndex.ts
@@ -1,0 +1,50 @@
+import { invoke } from '@tauri-apps/api/core';
+
+// Lazily-built namespace index for the command palette: databases and
+// collections per active connection, cached per connection id so opening the
+// palette repeatedly does not refetch. The cache lives for the app session;
+// a reconnect gets a new connection id and therefore a fresh entry.
+export interface NamespaceEntry {
+  connectionId: string;
+  connectionName: string;
+  db: string;
+  collections: string[];
+}
+
+const cache = new Map<string, Promise<NamespaceEntry[]>>();
+
+export function __clearNamespaceIndex() {
+  cache.clear();
+}
+
+async function fetchConnection(id: string, name: string): Promise<NamespaceEntry[]> {
+  try {
+    const dbs = await invoke<string[]>('list_databases', { id });
+    return await Promise.all(
+      dbs.map(async (db) => ({
+        connectionId: id,
+        connectionName: name,
+        db,
+        collections: (await invoke<{ name: string }[]>('list_collections', { id, db })).map((c) => c.name),
+      })),
+    );
+  } catch {
+    return [];
+  }
+}
+
+export async function loadNamespaceIndex(
+  connections: { id: string; name: string }[],
+): Promise<NamespaceEntry[]> {
+  const perConnection = await Promise.all(
+    connections.map((c) => {
+      let entry = cache.get(c.id);
+      if (!entry) {
+        entry = fetchConnection(c.id, c.name);
+        cache.set(c.id, entry);
+      }
+      return entry;
+    }),
+  );
+  return perConnection.flat();
+}

--- a/src/lib/paletteIndex.ts
+++ b/src/lib/paletteIndex.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import { fuzzyMatch } from './fuzzyMatch';
 
 // Lazily-built namespace index for the command palette: databases and
 // collections per active connection, cached per connection id so opening the
@@ -11,10 +12,30 @@ export interface NamespaceEntry {
   collections: string[];
 }
 
-const cache = new Map<string, Promise<NamespaceEntry[]>>();
+export interface NamespaceScopeTarget {
+  connectionName: string;
+  db: string;
+  collection: string;
+}
 
-export function __clearNamespaceIndex() {
-  cache.clear();
+interface CacheEntry {
+  loadedAt: number;
+  promise: Promise<NamespaceEntry[]>;
+}
+
+export const NAMESPACE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+const cache = new Map<string, CacheEntry>();
+
+export function clearNamespaceIndex(connectionId?: string) {
+  if (connectionId) cache.delete(connectionId);
+  else cache.clear();
+}
+
+export function matchesNamespaceScope(scope: string, target: NamespaceScopeTarget): boolean {
+  const q = scope.trim();
+  if (!q) return true;
+  return fuzzyMatch(q, `${target.connectionName} ${target.db} ${target.collection}`);
 }
 
 async function fetchConnection(id: string, name: string): Promise<NamespaceEntry[]> {
@@ -35,16 +56,22 @@ async function fetchConnection(id: string, name: string): Promise<NamespaceEntry
 
 export async function loadNamespaceIndex(
   connections: { id: string; name: string }[],
+  options: { forceRefresh?: boolean; ttlMs?: number } = {},
 ): Promise<NamespaceEntry[]> {
+  const now = Date.now();
+  const ttlMs = options.ttlMs ?? NAMESPACE_CACHE_TTL_MS;
   const perConnection = await Promise.all(
     connections.map((c) => {
       let entry = cache.get(c.id);
-      if (!entry) {
-        entry = fetchConnection(c.id, c.name);
+      const isExpired = entry ? now - entry.loadedAt > ttlMs : true;
+      if (!entry || options.forceRefresh || isExpired) {
+        entry = { loadedAt: now, promise: fetchConnection(c.id, c.name) };
         cache.set(c.id, entry);
       }
-      return entry;
+      return entry.promise;
     }),
   );
   return perConnection.flat();
 }
+
+export const __clearNamespaceIndex = clearNamespaceIndex;

--- a/src/lib/queryCodeGen.ts
+++ b/src/lib/queryCodeGen.ts
@@ -1,0 +1,288 @@
+// Driver code generation for the "Query Code" tab: render the last-run query
+// as a runnable program in each supported language. Every generator embeds the
+// query as canonical Extended JSON and feeds it to that driver's EJSON parser
+// (EJSON.parse / json_util.loads / Document.parse / BsonDocument.Parse /
+// bson.UnmarshalExtJSON), so all BSON types survive in every language.
+import { buildRunnableCommand, type GeneratedQuery } from './mongoCommand';
+
+export interface QueryCodeSpec {
+  db: string;
+  collection: string;
+  query: GeneratedQuery;
+}
+
+export const CODE_LANGUAGES = ['mongosh', 'Node.js', 'Python', 'Java', 'C#', 'Go'] as const;
+export type CodeLanguage = (typeof CODE_LANGUAGES)[number];
+
+const URI = 'mongodb://host:port/';
+
+const isEmptyDoc = (v: unknown): boolean =>
+  v == null || (typeof v === 'object' && !Array.isArray(v) && Object.keys(v as object).length === 0);
+
+const ejson = (v: unknown): string => JSON.stringify(v ?? {});
+
+// Escape for a Java/JS-style double-quoted string literal.
+const dq = (s: string): string => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+// Escape for a C# verbatim string (@"..."): double the quotes.
+const verbatim = (s: string): string => s.replace(/"/g, '""');
+// Single-quoted literal for JS/Python.
+const sq = (s: string): string => s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+function nodeJs(spec: QueryCodeSpec): string {
+  const { query } = spec;
+  const lines: string[] = [
+    "const { MongoClient } = require('mongodb');",
+    "const { EJSON } = require('bson');",
+    '',
+    'async function run() {',
+    `  const client = new MongoClient('${URI}');`,
+    '  try {',
+    `    const collection = client.db('${sq(spec.db)}').collection('${sq(spec.collection)}');`,
+  ];
+  if (query.queryType === 'aggregate') {
+    lines.push(`    const pipeline = EJSON.parse('${sq(ejson(query.pipeline ?? []))}');`);
+    lines.push('    const cursor = collection.aggregate(pipeline);');
+  } else {
+    lines.push(`    const filter = EJSON.parse('${sq(ejson(query.filter))}');`);
+    let cursor = '    const cursor = collection.find(filter)';
+    if (!isEmptyDoc(query.projection)) cursor += `\n      .project(EJSON.parse('${sq(ejson(query.projection))}'))`;
+    if (!isEmptyDoc(query.sort)) cursor += `\n      .sort(EJSON.parse('${sq(ejson(query.sort))}'))`;
+    if (query.skip) cursor += `\n      .skip(${query.skip})`;
+    if (query.limit) cursor += `\n      .limit(${query.limit})`;
+    lines.push(cursor + ';');
+  }
+  lines.push(
+    '    for await (const doc of cursor) {',
+    '      console.log(doc);',
+    '    }',
+    '  } finally {',
+    '    await client.close();',
+    '  }',
+    '}',
+    '',
+    'run().catch(console.dir);',
+  );
+  return lines.join('\n');
+}
+
+function python(spec: QueryCodeSpec): string {
+  const { query } = spec;
+  const lines: string[] = [
+    'from pymongo import MongoClient',
+    'from bson.json_util import loads',
+    '',
+    `client = MongoClient('${URI}')`,
+    `collection = client['${sq(spec.db)}']['${sq(spec.collection)}']`,
+    '',
+  ];
+  if (query.queryType === 'aggregate') {
+    lines.push(`pipeline = loads('${sq(ejson(query.pipeline ?? []))}')`);
+    lines.push('cursor = collection.aggregate(pipeline)');
+  } else {
+    lines.push(`query_filter = loads('${sq(ejson(query.filter))}')`);
+    let call = 'cursor = collection.find(query_filter';
+    if (!isEmptyDoc(query.projection)) call += `, loads('${sq(ejson(query.projection))}')`;
+    call += ')';
+    if (!isEmptyDoc(query.sort)) call += `.sort(list(loads('${sq(ejson(query.sort))}').items()))`;
+    if (query.skip) call += `.skip(${query.skip})`;
+    if (query.limit) call += `.limit(${query.limit})`;
+    lines.push(call);
+  }
+  lines.push('', 'for doc in cursor:', '    print(doc)');
+  return lines.join('\n');
+}
+
+function java(spec: QueryCodeSpec): string {
+  const { query } = spec;
+  const isAgg = query.queryType === 'aggregate';
+  const lines: string[] = [
+    'import com.mongodb.client.MongoClient;',
+    'import com.mongodb.client.MongoClients;',
+    'import com.mongodb.client.MongoCollection;',
+    'import org.bson.Document;',
+  ];
+  if (isAgg) lines.push('import java.util.Arrays;');
+  lines.push(
+    '',
+    'public class MongoDBQuery {',
+    '    public static void main(String[] args) {',
+    `        try (MongoClient client = MongoClients.create("${URI}")) {`,
+    '            MongoCollection<Document> collection = client',
+    `                .getDatabase("${dq(spec.db)}")`,
+    `                .getCollection("${dq(spec.collection)}");`,
+    '',
+  );
+  if (isAgg) {
+    const stages = (query.pipeline ?? [])
+      .map((stage) => `Document.parse("${dq(JSON.stringify(stage))}")`)
+      .join(',\n                ');
+    lines.push(
+      '            Iterable<Document> docs = collection.aggregate(Arrays.asList(',
+      `                ${stages}`,
+      '            ));',
+    );
+  } else {
+    let chain = `            Iterable<Document> docs = collection.find(Document.parse("${dq(ejson(query.filter))}"))`;
+    if (!isEmptyDoc(query.projection)) chain += `\n                .projection(Document.parse("${dq(ejson(query.projection))}"))`;
+    if (!isEmptyDoc(query.sort)) chain += `\n                .sort(Document.parse("${dq(ejson(query.sort))}"))`;
+    if (query.skip) chain += `\n                .skip(${query.skip})`;
+    if (query.limit) chain += `\n                .limit(${query.limit})`;
+    lines.push(chain + ';');
+  }
+  lines.push(
+    '',
+    '            for (Document doc : docs) {',
+    '                System.out.println(doc.toJson());',
+    '            }',
+    '        }',
+    '    }',
+    '}',
+  );
+  return lines.join('\n');
+}
+
+function csharp(spec: QueryCodeSpec): string {
+  const { query } = spec;
+  const isAgg = query.queryType === 'aggregate';
+  const lines: string[] = [
+    'using MongoDB.Bson;',
+    'using MongoDB.Driver;',
+    'using System;',
+    '',
+    'class Program',
+    '{',
+    '    static void Main(string[] args)',
+    '    {',
+    `        var client = new MongoClient("${URI}");`,
+    '        var collection = client',
+    `            .GetDatabase("${dq(spec.db)}")`,
+    `            .GetCollection<BsonDocument>("${dq(spec.collection)}");`,
+    '',
+  ];
+  if (isAgg) {
+    const stages = (query.pipeline ?? [])
+      .map((stage) => `BsonDocument.Parse(@"${verbatim(JSON.stringify(stage))}")`)
+      .join(',\n            ');
+    lines.push(
+      '        var pipeline = new[]',
+      '        {',
+      `            ${stages}`,
+      '        };',
+      '        var docs = collection.Aggregate<BsonDocument>(pipeline).ToList();',
+    );
+  } else {
+    lines.push(`        var filter = BsonDocument.Parse(@"${verbatim(ejson(query.filter))}");`);
+    let chain = '        var docs = collection.Find(filter)';
+    if (!isEmptyDoc(query.projection)) chain += `\n            .Project(BsonDocument.Parse(@"${verbatim(ejson(query.projection))}"))`;
+    if (!isEmptyDoc(query.sort)) chain += `\n            .Sort(BsonDocument.Parse(@"${verbatim(ejson(query.sort))}"))`;
+    if (query.skip) chain += `\n            .Skip(${query.skip})`;
+    if (query.limit) chain += `\n            .Limit(${query.limit})`;
+    chain += '\n            .ToList();';
+    lines.push(chain);
+  }
+  lines.push(
+    '',
+    '        foreach (var doc in docs)',
+    '        {',
+    '            Console.WriteLine(doc.ToJson());',
+    '        }',
+    '    }',
+    '}',
+  );
+  return lines.join('\n');
+}
+
+function go(spec: QueryCodeSpec): string {
+  const { query } = spec;
+  const isAgg = query.queryType === 'aggregate';
+  const lines: string[] = [
+    'package main',
+    '',
+    'import (',
+    '\t"context"',
+    '\t"fmt"',
+    '\t"log"',
+    '',
+    '\t"go.mongodb.org/mongo-driver/bson"',
+    '\t"go.mongodb.org/mongo-driver/mongo"',
+    '\t"go.mongodb.org/mongo-driver/mongo/options"',
+    ')',
+    '',
+    'func main() {',
+    '\tctx := context.Background()',
+    `\tclient, err := mongo.Connect(ctx, options.Client().ApplyURI("${URI}"))`,
+    '\tif err != nil {',
+    '\t\tlog.Fatal(err)',
+    '\t}',
+    '\tdefer client.Disconnect(ctx)',
+    '',
+    `\tcollection := client.Database("${dq(spec.db)}").Collection("${dq(spec.collection)}")`,
+    '',
+  ];
+  if (isAgg) {
+    lines.push(
+      '\tvar pipeline []bson.D',
+      `\tif err := bson.UnmarshalExtJSON([]byte(\`${ejson(query.pipeline ?? [])}\`), true, &pipeline); err != nil {`,
+      '\t\tlog.Fatal(err)',
+      '\t}',
+      '\tcursor, err := collection.Aggregate(ctx, pipeline)',
+    );
+  } else {
+    lines.push(
+      '\tvar filter bson.D',
+      `\tif err := bson.UnmarshalExtJSON([]byte(\`${ejson(query.filter)}\`), true, &filter); err != nil {`,
+      '\t\tlog.Fatal(err)',
+      '\t}',
+    );
+    const opts: string[] = [];
+    if (!isEmptyDoc(query.projection)) {
+      lines.push(
+        '\tvar projection bson.D',
+        `\tif err := bson.UnmarshalExtJSON([]byte(\`${ejson(query.projection)}\`), true, &projection); err != nil {`,
+        '\t\tlog.Fatal(err)',
+        '\t}',
+      );
+      opts.push('SetProjection(projection)');
+    }
+    if (!isEmptyDoc(query.sort)) {
+      lines.push(
+        '\tvar sort bson.D',
+        `\tif err := bson.UnmarshalExtJSON([]byte(\`${ejson(query.sort)}\`), true, &sort); err != nil {`,
+        '\t\tlog.Fatal(err)',
+        '\t}',
+      );
+      opts.push('SetSort(sort)');
+    }
+    if (query.skip) opts.push(`SetSkip(${query.skip})`);
+    if (query.limit) opts.push(`SetLimit(${query.limit})`);
+    const optsExpr = opts.length ? `options.Find().${opts.join('.')}` : 'options.Find()';
+    lines.push(`\tcursor, err := collection.Find(ctx, filter, ${optsExpr})`);
+  }
+  lines.push(
+    '\tif err != nil {',
+    '\t\tlog.Fatal(err)',
+    '\t}',
+    '\tdefer cursor.Close(ctx)',
+    '',
+    '\tfor cursor.Next(ctx) {',
+    '\t\tvar doc bson.M',
+    '\t\tif err := cursor.Decode(&doc); err != nil {',
+    '\t\t\tlog.Fatal(err)',
+    '\t\t}',
+    '\t\tfmt.Println(doc)',
+    '\t}',
+    '}',
+  );
+  return lines.join('\n');
+}
+
+export function generateQueryCode(lang: CodeLanguage, spec: QueryCodeSpec): string {
+  switch (lang) {
+    case 'mongosh': return buildRunnableCommand(spec.query, spec.collection);
+    case 'Node.js': return nodeJs(spec);
+    case 'Python': return python(spec);
+    case 'Java': return java(spec);
+    case 'C#': return csharp(spec);
+    case 'Go': return go(spec);
+  }
+}

--- a/src/lib/queryCodeGen.ts
+++ b/src/lib/queryCodeGen.ts
@@ -14,6 +14,16 @@ export interface QueryCodeSpec {
 export const CODE_LANGUAGES = ['mongosh', 'Node.js', 'Python', 'Java', 'C#', 'Go'] as const;
 export type CodeLanguage = (typeof CODE_LANGUAGES)[number];
 
+// Monaco language ids for syntax highlighting in the Query Code tab.
+export const CODE_LANGUAGE_MONACO_IDS: Record<CodeLanguage, string> = {
+  mongosh: 'javascript',
+  'Node.js': 'javascript',
+  Python: 'python',
+  Java: 'java',
+  'C#': 'csharp',
+  Go: 'go',
+};
+
 const URI = 'mongodb://host:port/';
 
 const isEmptyDoc = (v: unknown): boolean =>

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -77,6 +77,12 @@ function ctorToEjson(name: string, arg: string): string {
   }
 }
 
+// Parse user query text that may mix JSON, EJSON wrappers, and shell
+// constructors (ObjectId(…), ISODate(…)) — the query bar accepts all three.
+export function parseShellJson(text: string): any {
+  return JSON.parse(shellToEjson(text));
+}
+
 // shell-style source text -> Extended JSON string. String literals are copied
 // verbatim so e.g. a value "call ISODate()" is not mangled.
 export function shellToEjson(text: string): string {

--- a/src/lib/useEscapeClose.ts
+++ b/src/lib/useEscapeClose.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+// Close an open modal on Escape — standard dialog affordance.
+export function useEscapeClose(active: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [active, onClose]);
+}

--- a/src/lib/useMonacoTheme.ts
+++ b/src/lib/useMonacoTheme.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+const current = (): 'light' | 'vs-dark' =>
+  typeof document !== 'undefined' && document.documentElement.getAttribute('data-theme') === 'light'
+    ? 'light'
+    : 'vs-dark';
+
+// Monaco theme that tracks the app theme reactively. Reading the data-theme
+// attribute during render goes stale: the attribute is set in an effect AFTER
+// the toggle's render, so an editor that only reads at render lags one render
+// behind (or, with a hardcoded theme, never updates at all).
+export function useMonacoTheme(): 'light' | 'vs-dark' {
+  const [theme, setTheme] = useState(current);
+  useEffect(() => {
+    const observer = new MutationObserver(() => setTheme(current()));
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    setTheme(current()); // catch a flip between first render and observation
+    return () => observer.disconnect();
+  }, []);
+  return theme;
+}


### PR DESCRIPTION
Release PR — merges `dev` into `main`.

## Included

- **EJSON autocomplete & enterprise query UX (#103)** — schema-aware autocomplete across query, projection, sort, and aggregation editors; mongosh shell syntax (`ObjectId(...)`, `ISODate(...)`); operator-aware value shapes; layout density across the workspace; copyable query errors and clearer focus states.
- **Command palette (#103, #105)** — Cmd/Ctrl+K quick actions; jump to any collection and run saved queries; faster namespace loading for large connection trees.
- **Aggregation pipeline UX (#103)** — drag-reorder stages, per-stage disable, run-to-here preview; collapse, undo/redo, and a `$lookup` form; stage editors suggest code for the selected operator; scrollable stage list.
- **Query Code tab (#103)** — generate driver code in Node.js, Python, Java, C#, and Go with syntax highlighting and line numbers.
- **Results & sidebar polish (#103)** — resizable columns in table and tree views; sidebar search by any part of the collection name; Escape closes dialogs; accessible tab close buttons.
- **Light mode fixes (#103)** — shell editor, query code, and explain text readable in light mode.

## Versioning

Merge to `main` triggers automatic semver from Conventional Commits (many `feat:` commits since `mqlens-v0.5.0` → expected **v0.6.0** minor release).

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] `npx vitest run` — frontend suite passing
- [ ] `npm run build` succeeds
- [ ] `cargo test` — backend suite passing
- [ ] Smoke-test command palette (Cmd/Ctrl+K) on a large connection
- [ ] Smoke-test EJSON autocomplete in query + aggregation editors
- [ ] Smoke-test Query Code tab code generation
- [ ] Verify release workflow produces stable `mqlens-v0.6.0` assets after merge


Made with [Cursor](https://cursor.com)