### PR TITLE
docs: add ROADMAP.md and link GitHub project board

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,8 @@ By participating, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
 - **Report a bug or workflow issue** — use the in-app **Help → Report a bug**, or
   open a [bug report](https://github.com/mqlens/mqlens-mongodb/issues/new?template=bug_report.yml).
 - **Request a feature** — open a [feature request](https://github.com/mqlens/mqlens-mongodb/issues/new?template=feature_request.yml).
-  Larger ideas are tracked under the [`roadmap`](https://github.com/mqlens/mqlens-mongodb/labels/roadmap) label.
+  Larger ideas are tracked on the [roadmap board](https://github.com/orgs/mqlens/projects/2) and under the
+  [`roadmap`](https://github.com/mqlens/mqlens-mongodb/labels/roadmap) label — see [docs/ROADMAP.md](../docs/ROADMAP.md).
 - **Pick up an issue** — [`good first issue`](https://github.com/mqlens/mqlens-mongodb/labels/good%20first%20issue)
   is a good place to start. Comment to claim it.
 - **Improve docs** — README, in-app text, or the website under `website/`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,95 @@
+# MQLens Roadmap
+
+> **Live board:** [MQLens Roadmap (GitHub Project)](https://github.com/orgs/mqlens/projects/2)  
+> **Milestones:** [github.com/mqlens/mqlens-mongodb/milestones](https://github.com/mqlens/mqlens-mongodb/milestones)
+
+Current stable release: **[v0.8.0](https://github.com/mqlens/mqlens-mongodb/releases/latest)**
+
+## v0.9.0 — Stability & polish
+
+Target: **Jul 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/1)
+
+Bug fixes, UX polish, and test coverage before the next feature wave.
+
+| Issue | Title |
+|-------|-------|
+| [#120](https://github.com/mqlens/mqlens-mongodb/issues/120) | Query editor state leaks across collections |
+| [#131](https://github.com/mqlens/mqlens-mongodb/issues/131) | ⌘/Ctrl+F sidebar search shortcut not implemented |
+| [#119](https://github.com/mqlens/mqlens-mongodb/issues/119) | Show UI zoom % in status bar |
+| [#34](https://github.com/mqlens/mqlens-mongodb/issues/34) | Per-connection color tag picker UI |
+| [#133](https://github.com/mqlens/mqlens-mongodb/issues/133) | Updater: graceful offline behavior |
+| [#132](https://github.com/mqlens/mqlens-mongodb/issues/132) | Keyboard shortcuts reference page |
+| [#134](https://github.com/mqlens/mqlens-mongodb/issues/134) | Tests: ExportView + TaskManager |
+
+## v0.10.0 — Import, export & migration
+
+Target: **Aug 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/2)
+
+Complete data movement workflows for production use.
+
+| Issue | Title |
+|-------|-------|
+| [#126](https://github.com/mqlens/mqlens-mongodb/issues/126) | GridFS: upload + delete |
+| [#127](https://github.com/mqlens/mqlens-mongodb/issues/127) | BSON + NDJSON import/export |
+| [#128](https://github.com/mqlens/mqlens-mongodb/issues/128) | Streaming background import |
+| [#129](https://github.com/mqlens/mqlens-mongodb/issues/129) | Export filtered query results |
+| [#122](https://github.com/mqlens/mqlens-mongodb/issues/122) | Copy DBs/collections across clusters |
+| [#115](https://github.com/mqlens/mqlens-mongodb/issues/115) | Connection URI import/export + redaction |
+
+## Docs & community
+
+Target: **Aug 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/6)
+
+| Issue | Title |
+|-------|-------|
+| [#29](https://github.com/mqlens/mqlens-mongodb/issues/29) | Windows install notes |
+| [#30](https://github.com/mqlens/mqlens-mongodb/issues/30) | Linux install notes |
+| [#31](https://github.com/mqlens/mqlens-mongodb/issues/31) | Local demo database guide |
+| [#28](https://github.com/mqlens/mqlens-mongodb/issues/28) | Workflow feedback (meta) |
+
+## v0.11.0 — Shell & connections
+
+Target: **Sep 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/3)
+
+Zero-friction mongosh and enterprise SSH workflows.
+
+| Issue | Title |
+|-------|-------|
+| [#124](https://github.com/mqlens/mqlens-mongodb/issues/124) | Mongosh: auto-detect + guided install |
+| [#125](https://github.com/mqlens/mqlens-mongodb/issues/125) | Mongosh: optional bundled binary |
+| [#130](https://github.com/mqlens/mqlens-mongodb/issues/130) | SSH agent / certificate auth |
+
+## v0.12.0 — DBA & operations
+
+Target: **Oct 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/4)
+
+| Issue | Title |
+|-------|-------|
+| [#90](https://github.com/mqlens/mqlens-mongodb/issues/90) | Index usage stats + suggestions |
+| [#93](https://github.com/mqlens/mqlens-mongodb/issues/93) | Validation rules editor ($jsonSchema) |
+| [#114](https://github.com/mqlens/mqlens-mongodb/issues/114) | Cluster health monitor (replica set) |
+| [#92](https://github.com/mqlens/mqlens-mongodb/issues/92) | Document diff |
+
+## v1.0.0 — Platform & ecosystem
+
+Target: **Dec 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/5)
+
+| Issue | Title |
+|-------|-------|
+| [#123](https://github.com/mqlens/mqlens-mongodb/issues/123) | Internationalization (i18n) |
+| [#97](https://github.com/mqlens/mqlens-mongodb/issues/97) | Multi-panel / detachable tabs |
+| [#98](https://github.com/mqlens/mqlens-mongodb/issues/98) | MCP server (expose MQLens as AI tools) |
+| [#91](https://github.com/mqlens/mqlens-mongodb/issues/91) | Data generation (Faker) |
+
+## Shipped recently
+
+- Command palette (#94)
+- Sidebar folders, pins, favorites (#95)
+- Curated theme system (#96)
+- Font size setting (#113)
+- MongoDB user management UI (#108)
+- Cluster monitoring tab (#50)
+
+## Suggest something new
+
+Open a [feature request](https://github.com/mqlens/mqlens-mongodb/issues/new?template=feature_request.yml) or comment on [#28](https://github.com/mqlens/mqlens-mongodb/issues/28).


### PR DESCRIPTION
## Summary
- Add `docs/ROADMAP.md` documenting the v0.9 → v1.0 milestone plan with linked issues
- Update `CONTRIBUTING.md` to point contributors at the public [MQLens Roadmap](https://github.com/orgs/mqlens/projects/2) project board

## Context
The roadmap commit was initially made on `fix/security-codeql-findings` by mistake after that branch had already merged to `dev` (#121). This PR moves the docs-only change onto a dedicated branch.

## Test plan
- [x] Verify `docs/ROADMAP.md` links resolve
- [x] Verify `CONTRIBUTING.md` relative link to `docs/ROADMAP.md` is correct

Made with [Cursor](https://cursor.com)