### PR TITLE
fix: implement sidebar search shortcut

### DIFF
--- a/src/components/QuickStart.tsx
+++ b/src/components/QuickStart.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import brandMark from '../assets/mqlens-mark.png';
 import type { ConnectionProfile } from '../lib/connection';
+import { primaryShortcutModifier } from '../lib/quickStartUtils';
 import { ConnectionCard } from './ConnectionCard';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -47,13 +48,6 @@ const QUICK_ACTIONS: {
   { id: 'sample', label: 'Load sample data', icon: Download, onClickKey: 'onLoadSampleData' as const, emptyOnly: true },
   { id: 'settings', label: 'Settings', icon: Settings, onClickKey: 'onOpenSettings' },
 ];
-
-const SHORTCUTS = [
-  { keys: '⌘ ↵', label: 'Run the current query' },
-  { keys: '⌘ F', label: 'Search the sidebar tree' },
-  { keys: '⌘ K', label: 'Open command palette' },
-  { keys: '⌘ + / −', label: 'Zoom interface in or out' },
-] as const;
 
 export const QuickStart: React.FC<QuickStartProps> = ({
   onConnect,
@@ -89,6 +83,13 @@ export const QuickStart: React.FC<QuickStartProps> = ({
   const isEmpty = sorted.length === 0;
   const activeIds = new Set(activeConnections.map((c) => c.profileId));
   const activeCount = sorted.filter((p) => activeIds.has(p.id)).length;
+  const modifier = primaryShortcutModifier();
+  const shortcuts = [
+    { keys: `${modifier} ↵`, label: 'Run the current query' },
+    { keys: `${modifier} F`, label: 'Search the sidebar tree' },
+    { keys: `${modifier} K`, label: 'Open command palette' },
+    { keys: `${modifier} + / −`, label: 'Zoom interface in or out' },
+  ] as const;
 
   const handleQuickConnect = async (p: ConnectionProfile) => {
     setConnectingId(p.id);
@@ -302,7 +303,7 @@ export const QuickStart: React.FC<QuickStartProps> = ({
                   <CardTitle className="text-sm">Keyboard shortcuts</CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-col gap-3 pt-0">
-                  {SHORTCUTS.map(({ keys, label }) => (
+                  {shortcuts.map(({ keys, label }) => (
                     <div key={keys} className="flex items-start gap-2.5 text-xs text-muted-foreground">
                       <kbd className="mt-0.5 shrink-0 rounded-md border border-border bg-muted px-2 py-0.5 font-mono text-[10px] text-foreground">
                         {keys}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -254,9 +254,43 @@ export const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const { toast, confirm, prompt } = useDialogs();
   const [filterQuery, setFilterQuery] = useState('');
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
   useEffect(() => {
     onFilterQueryChange?.(filterQuery);
   }, [filterQuery, onFilterQueryChange]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.altKey ||
+        event.shiftKey ||
+        !(event.metaKey || event.ctrlKey) ||
+        event.key.toLowerCase() !== 'f'
+      ) {
+        return;
+      }
+
+      const searchInput = searchInputRef.current;
+      if (!searchInput) return;
+
+      const target = event.target;
+      if (target instanceof Element && target !== searchInput) {
+        const isEditable =
+          target.closest('.monaco-editor') ||
+          target.closest('input, textarea, select, [contenteditable="true"]');
+        if (isEditable) return;
+      }
+
+      event.preventDefault();
+      searchInput.focus();
+      searchInput.select();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
 
   const [sectionsOpen, setSectionsOpen] = useState({
     connections: true,
@@ -1649,6 +1683,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           <div className="relative">
             <Search size={12} className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
             <Input
+              ref={searchInputRef}
               type="text"
               value={filterQuery}
               onChange={(e) => setFilterQuery(e.target.value)}

--- a/src/components/__tests__/QuickStart.test.tsx
+++ b/src/components/__tests__/QuickStart.test.tsx
@@ -67,4 +67,14 @@ describe('QuickStart', () => {
     fireEvent.click(await screen.findByTestId('qs-load-sample'));
     expect(onLoadSampleData).toHaveBeenCalled();
   });
+
+  it('shows platform-aware shortcut labels', async () => {
+    const platform = vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('Win32');
+    invokeMock.mockResolvedValueOnce([]);
+
+    setup();
+
+    expect(await screen.findByText('Ctrl F')).toBeInTheDocument();
+    platform.mockRestore();
+  });
 });

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -84,6 +84,71 @@ describe('Sidebar Component', () => {
     expect(screen.getByText('user_analytics')).toBeInTheDocument();
   });
 
+  it.each([
+    ['Ctrl', { ctrlKey: true }],
+    ['Command', { metaKey: true }],
+  ])('focuses sidebar search with %s+F', async (_label, modifier) => {
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    const search = screen.getByTestId('sidebar-search');
+    const event = new KeyboardEvent('keydown', {
+      key: 'f',
+      ...modifier,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+
+    expect(search).toHaveFocus();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does not steal Ctrl+F from Monaco editors', () => {
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    const monaco = document.createElement('div');
+    monaco.className = 'monaco-editor';
+    const textarea = document.createElement('textarea');
+    monaco.appendChild(textarea);
+    document.body.appendChild(monaco);
+    textarea.focus();
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'f',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    textarea.dispatchEvent(event);
+
+    expect(textarea).toHaveFocus();
+    expect(screen.getByTestId('sidebar-search')).not.toHaveFocus();
+    expect(event.defaultPrevented).toBe(false);
+
+    monaco.remove();
+  });
+
   it('handles rendering multiple connections, databases, collections, and indexes', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {

--- a/src/lib/__tests__/quickStartUtils.test.ts
+++ b/src/lib/__tests__/quickStartUtils.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { hostFromUri, avatarColor, initial, topology, AVATAR_PALETTE } from '../quickStartUtils';
+import {
+  hostFromUri,
+  avatarColor,
+  initial,
+  topology,
+  AVATAR_PALETTE,
+  primaryShortcutModifier,
+} from '../quickStartUtils';
+
+describe('primaryShortcutModifier', () => {
+  it('uses the Command symbol on Apple platforms', () => {
+    expect(primaryShortcutModifier('MacIntel')).toBe('⌘');
+    expect(primaryShortcutModifier('iPhone')).toBe('⌘');
+  });
+
+  it('uses Ctrl on other platforms', () => {
+    expect(primaryShortcutModifier('Win32')).toBe('Ctrl');
+    expect(primaryShortcutModifier('Linux x86_64')).toBe('Ctrl');
+  });
+});
 
 describe('topology', () => {
   it('labels srv uris as SRV cluster', () => {

--- a/src/lib/quickStartUtils.ts
+++ b/src/lib/quickStartUtils.ts
@@ -8,6 +8,10 @@ export const AVATAR_PALETTE = [
   '#1f6f7a', // teal
 ] as const;
 
+export function primaryShortcutModifier(platform = navigator.platform): '⌘' | 'Ctrl' {
+  return /Mac|iPhone|iPad|iPod/i.test(platform) ? '⌘' : 'Ctrl';
+}
+
 /** Host[:port] parsed from a mongodb URI, credentials stripped. '' if unparseable. */
 export function hostFromUri(uri: string): string {
   try {


### PR DESCRIPTION
## Summary

- Add `Ctrl+F` / `Command+F` handling that focuses and selects the sidebar search field when it is available.
- Preserve Monaco and other editable controls by yielding when the key event is already handled or originates from an editor/input.
- Show platform-appropriate shortcut labels in Quick Start and add regression coverage for focus and platform behavior.

## Related issue

Closes #131

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## Validation

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes: 45 files, 491 tests
- [x] `npm run build` passes
- [x] `git diff --check` passes
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml`: 103 passed, 1 unrelated environment-sensitive failure. `test_run_connection_test_phases` expected `nonexistent.invalid` to fail during DNS resolution, but this Windows environment advanced to the ping phase. No backend files changed.
- [ ] Native app smoke test was not run; the shortcut behavior is covered by focused jsdom tests for both modifiers and Monaco focus protection.

## Notes

- No dependency, lockfile, backend, telemetry, or compatibility changes.
- The browser's normal find behavior remains available when sidebar search is absent or focus is inside an editable control.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commit follows Conventional Commits
- [x] No telemetry, secrets, or real connection strings added
- [x] Quick Start text was updated with the behavior change
