### PR TITLE
docs: add Linux and Windows install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,32 @@ Grab the latest build for your OS from
 **[Releases](https://github.com/mqlens/mqlens-mongodb/releases/latest)**:
 
 - **macOS** — download the `.dmg` (Apple-notarized; Touch ID unlock supported).
-- **Windows** — download the `.msi` or `.exe` (signed via Azure Trusted Signing).
+
+### Windows
+
+Download the `.exe` or `.msi` installer from the
+[latest release](https://github.com/mqlens/mqlens-mongodb/releases/latest).
+Requires Windows 10 or later (x64). Installers are signed via Azure Trusted
+Signing.
+
+**Setup (.exe, recommended)**
+
+1. Double-click `MQLens_*_x64-setup.exe`.
+2. Approve the UAC prompt if Windows asks for permission.
+3. Follow the setup wizard, then launch **MQLens** from the Start menu.
+
+**Setup (.msi)**
+
+Double-click `MQLens_*.msi` and follow the prompts, or install from an elevated
+Command Prompt or PowerShell:
+
+```powershell
+msiexec /i MQLens_*.msi
+```
+
+If SmartScreen shows "Windows protected your PC", choose **More info** → **Run
+anyway**. The installer is signed; SmartScreen may still warn on first download
+until reputation builds.
 
 ### Linux
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,29 @@ Grab the latest build for your OS from
 
 - **macOS** — download the `.dmg` (Apple-notarized; Touch ID unlock supported).
 - **Windows** — download the `.msi` or `.exe` (signed via Azure Trusted Signing).
-- **Linux** — download the `.AppImage` (`chmod +x` and run) or install the `.deb`.
+
+### Linux
+
+Download the `.deb` or `.AppImage` from the
+[latest release](https://github.com/mqlens/mqlens-mongodb/releases/latest).
+
+**Debian / Ubuntu (.deb)**
+
+```bash
+sudo apt install ./MQLens_*.deb
+# or:
+sudo dpkg -i MQLens_*.deb
+```
+
+**Any distro (.AppImage)**
+
+```bash
+chmod +x MQLens_*.AppImage
+./MQLens_*.AppImage
+```
+
+If the AppImage won't start ("Permission denied"), the execute bit was likely
+stripped on download — run `chmod +x` on the file again.
 
 No account, no sign-up, no telemetry.
 

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -37,8 +37,28 @@ const toc = [
         <p>Download the build for your platform from the <a href="/#download">download section</a> or the <a href={SITE.releasesLatest} target="_blank" rel="noopener">latest release</a>:</p>
         <ul>
           <li><strong>macOS</strong> — open the <code>.dmg</code> and drag {SITE.name} to Applications. Builds are Apple-notarized, so Gatekeeper will let it run.</li>
-          <li><strong>Windows</strong> — run the <code>.msi</code> or <code>.exe</code> installer. Installers are Azure Trusted Signing–signed.</li>
         </ul>
+
+        <h3>Windows</h3>
+        <p>
+          Download the <code>.exe</code> or <code>.msi</code> installer from the
+          <a href={SITE.releasesLatest} target="_blank" rel="noopener">latest release page</a>.
+          Requires Windows 10 or later (x64). Installers are Azure Trusted Signing–signed.
+        </p>
+        <p><strong>Setup (.exe, recommended)</strong></p>
+        <ol>
+          <li>Double-click <code>MQLens_*_x64-setup.exe</code>.</li>
+          <li>Approve the UAC prompt if Windows asks for permission.</li>
+          <li>Follow the setup wizard, then launch <strong>{SITE.name}</strong> from the Start menu.</li>
+        </ol>
+        <p><strong>Setup (.msi)</strong></p>
+        <p>Double-click <code>MQLens_*.msi</code> and follow the prompts, or install from an elevated Command Prompt or PowerShell:</p>
+        <pre><code>msiexec /i MQLens_*.msi</code></pre>
+        <p>
+          <strong>Troubleshooting:</strong> if SmartScreen shows "Windows protected your PC",
+          choose <strong>More info</strong> → <strong>Run anyway</strong>. The installer is signed;
+          SmartScreen may still warn on first download until reputation builds.
+        </p>
 
         <h3>Linux</h3>
         <p>

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -34,12 +34,31 @@ const toc = [
         </p>
 
         <h2 id="install">Install</h2>
-        <p>Download the build for your platform from the <a href="/#download">download section</a> or the <a href={SITE.releases} target="_blank" rel="noopener">releases page</a>:</p>
+        <p>Download the build for your platform from the <a href="/#download">download section</a> or the <a href={SITE.releasesLatest} target="_blank" rel="noopener">latest release</a>:</p>
         <ul>
           <li><strong>macOS</strong> — open the <code>.dmg</code> and drag {SITE.name} to Applications. Builds are Apple-notarized, so Gatekeeper will let it run.</li>
           <li><strong>Windows</strong> — run the <code>.msi</code> or <code>.exe</code> installer. Installers are Azure Trusted Signing–signed.</li>
-          <li><strong>Linux</strong> — install the <code>.deb</code> (<code>sudo apt install ./MQLens_*.deb</code>) or make the <code>.AppImage</code> executable and run it.</li>
         </ul>
+
+        <h3>Linux</h3>
+        <p>
+          Grab the <code>.deb</code> or <code>.AppImage</code> from the
+          <a href={SITE.releasesLatest} target="_blank" rel="noopener">latest release page</a>.
+        </p>
+        <p><strong>Debian / Ubuntu (.deb)</strong></p>
+        <pre><code>sudo apt install ./MQLens_*.deb
+# or:
+sudo dpkg -i MQLens_*.deb</code></pre>
+        <p><strong>Any distro (.AppImage)</strong></p>
+        <pre><code>chmod +x MQLens_*.AppImage
+./MQLens_*.AppImage</code></pre>
+        <p>
+          <strong>Troubleshooting:</strong> if the AppImage says "Permission denied" or
+          refuses to start, the execute bit was probably lost during download — run
+          <code>chmod +x</code> on the file again. Some browsers save AppImages without
+          the executable flag until you set it manually.
+        </p>
+
         <p>To use the embedded shell you'll also need <a href="https://www.mongodb.com/docs/mongodb-shell/" target="_blank" rel="noopener"><code>mongosh</code></a> on your <code>PATH</code>.</p>
 
         <h2 id="first-connection">Your first connection</h2>


### PR DESCRIPTION
## Summary

- Add a dedicated **Linux** install section to the website docs and README (`.deb`, `.AppImage`, `chmod +x`, troubleshooting for lost execute permissions)
- Add a **Windows** install section to the website docs and README (`.exe` / `.msi` setup steps, UAC prompt, SmartScreen troubleshooting)
- Link install sections to the [latest release page](https://github.com/mqlens/mqlens-mongodb/releases/latest)

Closes #30

## Test plan

- [x] Reviewed `/docs/` locally — Linux and Windows subsections render correctly
- [x] README Install section matches website docs content
- [ ] CI passes

Made with [Cursor](https://cursor.com)