### PR TITLE
fix: preserve per-tab query editor state when switching collections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { AppShell } from '@/components/layout/AppShell';
 import { WorkspaceTabBar } from '@/components/layout/WorkspaceTabBar';
 import { StatusBar } from '@/components/layout/StatusBar';
@@ -6,7 +6,7 @@ import { Toaster } from '@/components/ui/sonner';
 import { useTheme } from '@/hooks/use-theme';
 import { Sidebar } from './components/Sidebar';
 import { CommandPalette, type PaletteAction } from './components/CommandPalette';
-import { DocumentViewer } from './components/DocumentViewer';
+import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import { DataGrid } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
 import { SettingsView } from './components/SettingsModal';
@@ -204,6 +204,10 @@ function Workspace() {
   // Open the Quick Start tab by default so the app never starts on a blank canvas.
   const [tabs, setTabs] = useState<QueryTab[]>([createQuickStartTab()]);
   const [activeTabId, setActiveTabId] = useState<string | null>(QUICK_START_TAB_ID);
+  const tabBuilderStateCache = useRef(new Map<string, BuilderState>());
+  const handleBuilderStateChange = useCallback((tabId: string, state: BuilderState) => {
+    tabBuilderStateCache.current.set(tabId, state);
+  }, []);
   const [activeConnections, setActiveConnections] = useState<ActiveConnection[]>([]);
   const [profilesRefreshKey, setProfilesRefreshKey] = useState(0);
   const [isConnectionModalOpen, setIsConnectionModalOpen] = useState(false);
@@ -871,6 +875,7 @@ function Workspace() {
   };
 
   const closeTabById = (tabId: string) => {
+    tabBuilderStateCache.current.delete(tabId);
     const updatedTabs = tabs.filter(t => t.id !== tabId);
     setTabs(updatedTabs);
 
@@ -1603,6 +1608,11 @@ function Workspace() {
                     connectionUser={connectionUser}
                     databaseName={activeTab.db}
                     collectionName={activeTab.collection}
+                    initialBuilderState={
+                      tabBuilderStateCache.current.get(activeTab.id)
+                      ?? builderStateFromQueryTab(activeTab.lastQuery, activeTab.lastAggregate)
+                    }
+                    onBuilderStateChange={(state) => handleBuilderStateChange(activeTab.id, state)}
                     onExecute={handleExecuteQuery}
                     onExecuteAggregate={handleExecuteAggregate}
                     onExplain={handleExplainQuery}

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -90,14 +90,69 @@ interface SortRule {
   direction: 1 | -1;
 }
 
-interface BuilderState {
+export interface PipelineStage {
+  id: string;
+  operator: string;
+  content: string;
+  disabled?: boolean;
+  collapsed?: boolean;
+}
+
+export interface BuilderState {
   queryMode: 'find' | 'aggregate';
   filterQuery: string;
   sortQuery: string;
   projectionQuery: string;
   limit: string;
   skip: string;
-  stages: { id: string; operator: string; content: string; disabled?: boolean }[];
+  stages: PipelineStage[];
+}
+
+export const DEFAULT_BUILDER_STATE: BuilderState = {
+  queryMode: 'find',
+  filterQuery: '{}',
+  sortQuery: '{}',
+  projectionQuery: '{}',
+  limit: '50',
+  skip: '0',
+  stages: [{ id: 'stage-1', operator: '$match', content: '{\n  \n}' }],
+};
+
+const stagesFromPipeline = (pipeline: unknown[]): PipelineStage[] =>
+  pipeline.map((stage, i) => {
+    const obj = (stage && typeof stage === 'object' ? stage : {}) as Record<string, unknown>;
+    const operator = Object.keys(obj)[0] ?? '$match';
+    return {
+      id: `stage-${i + 1}`,
+      operator,
+      content: JSON.stringify(obj[operator] ?? {}, null, 2),
+    };
+  });
+
+/** Derive editor state from a tab's last executed find or aggregate query. */
+export function builderStateFromQueryTab(
+  lastQuery?: { filter: string; sort: string; projection: string; limit: number; skip: number },
+  lastAggregate?: Record<string, unknown>[]
+): BuilderState {
+  if (lastAggregate && lastAggregate.length > 0) {
+    return {
+      ...DEFAULT_BUILDER_STATE,
+      queryMode: 'aggregate',
+      stages: stagesFromPipeline(lastAggregate),
+    };
+  }
+  if (lastQuery) {
+    return {
+      ...DEFAULT_BUILDER_STATE,
+      queryMode: 'find',
+      filterQuery: lastQuery.filter,
+      sortQuery: lastQuery.sort,
+      projectionQuery: lastQuery.projection,
+      limit: String(lastQuery.limit),
+      skip: String(lastQuery.skip),
+    };
+  }
+  return DEFAULT_BUILDER_STATE;
 }
 
 // Serialize the current builder state into a GeneratedQuery — the same value
@@ -144,6 +199,9 @@ interface DocumentViewerProps {
   onImport?: () => void;
   loading: boolean;
   availableFields?: string[];
+  /** Restored when remounting this tab's viewer (see App tab cache). */
+  initialBuilderState?: BuilderState;
+  onBuilderStateChange?: (state: BuilderState) => void;
   children?: React.ReactNode;
 }
 
@@ -452,15 +510,17 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   onImport,
   loading,
   availableFields = [],
+  initialBuilderState = DEFAULT_BUILDER_STATE,
+  onBuilderStateChange,
   children
 }) => {
   const { prompt, toast } = useDialogs();
   const { schema } = useCollectionSchema(connectionId, databaseName, collectionName);
-  const [filterQuery, setFilterQuery] = useState('{}');
-  const [projectionQuery, setProjectionQuery] = useState('{}');
-  const [sortQuery, setSortQuery] = useState('{}');
-  const [limit, setLimit] = useState('50');
-  const [skip, setSkip] = useState('0');
+  const [filterQuery, setFilterQuery] = useState(initialBuilderState.filterQuery);
+  const [projectionQuery, setProjectionQuery] = useState(initialBuilderState.projectionQuery);
+  const [sortQuery, setSortQuery] = useState(initialBuilderState.sortQuery);
+  const [limit, setLimit] = useState(initialBuilderState.limit);
+  const [skip, setSkip] = useState(initialBuilderState.skip);
   const [explainLoading, setExplainLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
@@ -500,22 +560,20 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   }, [refreshStoredQueries]);
 
   // Query mode: traditional find vs aggregate pipeline
-  const [queryMode, setQueryMode] = useState<'find' | 'aggregate'>('find');
-  
-  // Aggregation stages state
-  interface PipelineStage {
-    id: string;
-    operator: string;
-    content: string;
-    // Disabled stages stay in the builder but are excluded from every
-    // pipeline build (run, run-to-here, explain, shell command, saved query).
-    disabled?: boolean;
-    // Collapsed stages hide their body editor; purely visual.
-    collapsed?: boolean;
-  }
-  const [stages, setStages] = useState<PipelineStage[]>([
-    { id: 'stage-1', operator: '$match', content: '{\n  \n}' }
-  ]);
+  const [queryMode, setQueryMode] = useState<'find' | 'aggregate'>(initialBuilderState.queryMode);
+  const [stages, setStages] = useState<PipelineStage[]>(initialBuilderState.stages);
+
+  useEffect(() => {
+    onBuilderStateChange?.({
+      queryMode,
+      filterQuery,
+      sortQuery,
+      projectionQuery,
+      limit,
+      skip,
+      stages,
+    });
+  }, [queryMode, filterQuery, sortQuery, projectionQuery, limit, skip, stages, onBuilderStateChange]);
 
   // AI chat assistant — open/close only; the panel owns its own chat state.
   const [isAIHelperOpen, setIsAIHelperOpen] = useState(false);
@@ -653,18 +711,6 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     [next[index], next[index + 1]] = [next[index + 1], next[index]];
     commitStages(next);
   };
-
-  // Build pipeline stages ({id, operator, content}) from a MongoDB pipeline array.
-  const stagesFromPipeline = (pipeline: unknown[]): PipelineStage[] =>
-    pipeline.map((stage, i) => {
-      const obj = (stage && typeof stage === 'object' ? stage : {}) as Record<string, unknown>;
-      const operator = Object.keys(obj)[0] ?? '$match';
-      return {
-        id: `stage-${i + 1}`,
-        operator,
-        content: JSON.stringify(obj[operator] ?? {}, null, 2),
-      };
-    });
 
   // Apply a generated query to the editor; auto-switch to aggregation mode for pipelines.
   const handleInsertQuery = (query: GeneratedQuery) => {

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -787,7 +787,7 @@ describe('App Component', () => {
     expect(calls.find((c) => c.cmd === 'import_documents')).toBeFalsy();
   });
 
-  it('resets query editor state when switching collections (#120)', async () => {
+  it('isolates query editor state per collection tab (#120)', async () => {
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === 'execute_mql_query') {
         return Promise.resolve([JSON.stringify({ _id: '1', name: 'Sample' })]);
@@ -819,5 +819,23 @@ describe('App Component', () => {
     fireEvent.click(screen.getByTestId('toggle-query-builder'));
     const ordersFilter = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
     expect(ordersFilter.value).toBe('{}');
+
+    // Type a different filter on orders.
+    fireEvent.change(ordersFilter, { target: { value: '{"shipped":true}' } });
+    expect(ordersFilter.value).toContain('"shipped"');
+
+    // Switch back to customers — customers filter must be restored.
+    fireEvent.click(screen.getByTestId('select-collection-btn'));
+    await screen.findByText(/"Sample"/);
+    fireEvent.click(screen.getByTestId('toggle-query-builder'));
+    const customersFilterAgain = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    expect(customersFilterAgain.value).toContain('"status"');
+
+    // Switch back to orders — orders filter must be restored.
+    fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
+    await screen.findByText(/"Sample"/);
+    fireEvent.click(screen.getByTestId('toggle-query-builder'));
+    const ordersFilterAgain = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    expect(ordersFilterAgain.value).toContain('"shipped"');
   });
 });


### PR DESCRIPTION
## Summary

- Fixes a regression from #139 where remounting `DocumentViewer` per tab stopped query leakage but also discarded in-progress drafts when switching back
- Adds a per-tab builder state cache in `App` that restores filter/pipeline text on remount
- Falls back to each tab's `lastQuery` / `lastAggregate` when no draft has been cached yet
- Clears cached state when a tab is closed

Fixes #120

## Test plan

- [x] `npm test -- src/components/__tests__/App.test.tsx`
- [x] `npm test -- src/components/__tests__/DocumentViewer.test.tsx`
- [x] `npx tsc --noEmit`
- [ ] Open collection A, type a filter, switch to collection B — editor shows `{}`
- [ ] Switch back to collection A — editor restores collection A's filter
- [ ] Type a different filter on B, switch between A and B — each tab keeps its own query


