### PR TITLE
feat: show UI zoom percentage in footer status bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -199,7 +199,7 @@ const tabLabelFor = (
 
 function Workspace() {
   const { toast, confirm, choose, prompt } = useDialogs();
-  const { config, resolvedMode, setMode, setSpacingDensity } = useTheme();
+  const { config, resolvedMode, setMode, setSpacingDensity, resetZoom } = useTheme();
   const density = config.spacingDensity;
   // Open the Quick Start tab by default so the app never starts on a blank canvas.
   const [tabs, setTabs] = useState<QueryTab[]>([createQuickStartTab()]);
@@ -1515,6 +1515,8 @@ function Workspace() {
           memory={resUsage ? formatBytes(resUsage.memory_bytes) : undefined}
           mongoVersion={mongoVersion ?? undefined}
           appVersion={appVersion ? `v${appVersion}` : undefined}
+          zoomPercent={Math.round(config.uiZoom * 100)}
+          onZoomReset={resetZoom}
         />
       }
       overlays={

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,10 +1,18 @@
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface StatusBarProps {
   cpu?: string;
   memory?: string;
   mongoVersion?: string;
   appVersion?: string;
+  /** User UI zoom (75–150); hidden at 100%. */
+  zoomPercent?: number;
+  onZoomReset?: () => void;
   className?: string;
 }
 
@@ -13,8 +21,12 @@ export function StatusBar({
   memory,
   mongoVersion,
   appVersion,
+  zoomPercent,
+  onZoomReset,
   className,
 }: StatusBarProps) {
+  const showZoom = zoomPercent != null && zoomPercent !== 100;
+
   return (
     <footer
       data-testid="bottom-bar"
@@ -27,6 +39,23 @@ export function StatusBar({
       {cpu && <span>CPU {cpu}</span>}
       {memory && <span>RAM {memory}</span>}
       {mongoVersion && <span>MongoDB {mongoVersion}</span>}
+      {showZoom && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              data-testid="status-bar-zoom"
+              className="font-mono tabular-nums transition-colors hover:text-foreground"
+              onClick={onZoomReset}
+            >
+              {zoomPercent}%
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            Reset zoom (⌘0 / Ctrl+0)
+          </TooltipContent>
+        </Tooltip>
+      )}
       <span className="ml-auto">MQLens {appVersion ?? ""}</span>
     </footer>
   );

--- a/src/components/layout/__tests__/StatusBar.test.tsx
+++ b/src/components/layout/__tests__/StatusBar.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { StatusBar } from '../StatusBar';
+
+function renderStatusBar(props: React.ComponentProps<typeof StatusBar>) {
+  return render(
+    <TooltipProvider>
+      <StatusBar {...props} />
+    </TooltipProvider>
+  );
+}
+
+describe('StatusBar', () => {
+  it('hides zoom indicator at 100%', () => {
+    renderStatusBar({ zoomPercent: 100 });
+    expect(screen.queryByTestId('status-bar-zoom')).toBeNull();
+  });
+
+  it('shows zoom indicator when not at 100%', () => {
+    renderStatusBar({ zoomPercent: 110 });
+    expect(screen.getByTestId('status-bar-zoom')).toHaveTextContent('110%');
+  });
+
+  it('shows minimum zoom (75%)', () => {
+    renderStatusBar({ zoomPercent: 75 });
+    expect(screen.getByTestId('status-bar-zoom')).toHaveTextContent('75%');
+  });
+
+  it('shows maximum zoom (150%)', () => {
+    renderStatusBar({ zoomPercent: 150 });
+    expect(screen.getByTestId('status-bar-zoom')).toHaveTextContent('150%');
+  });
+
+  it('calls onZoomReset when the zoom chip is clicked', () => {
+    const onZoomReset = vi.fn();
+    renderStatusBar({ zoomPercent: 125, onZoomReset });
+    fireEvent.click(screen.getByTestId('status-bar-zoom'));
+    expect(onZoomReset).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Shows the current user UI zoom level in the footer status bar (e.g. `110%`) when not at 100%
- Updates live as the user presses `Cmd/Ctrl` `+` / `−` / `0`
- Clicking the indicator resets zoom to 100%, with a tooltip noting the keyboard shortcut
- Uses `config.uiZoom` only (not auto DPI scale), matching what the zoom shortcuts control

Fixes #119

## Test plan

- [x] `npm test -- src/components/layout/__tests__/StatusBar.test.tsx`
- [x] `npx tsc --noEmit`
- [ ] Press `Cmd/Ctrl` `+` — footer shows updated percentage (e.g. `105%`)
- [ ] Press `Cmd/Ctrl` `0` — indicator hides at 100%
- [ ] Click the zoom chip — resets to 100%
- [ ] Zoom to 75% and 150% — percentage reads correctly at range limits