### PR TITLE
test: add ExportView and TaskManager component coverage

### DIFF
--- a/src/components/__tests__/ExportView.test.tsx
+++ b/src/components/__tests__/ExportView.test.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-with-providers';
+import { DialogProvider, useDialogs } from '../dialogs/DialogProvider';
+import { ExportView } from '../ExportView';
+import type { ExportTaskInfo } from '../TaskManager';
+
+const mockInvoke = vi.fn();
+const saveMock = vi.fn();
+const writeTextFileMock = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  save: (...args: unknown[]) => saveMock(...args),
+}));
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  writeTextFile: (...args: unknown[]) => writeTextFileMock(...args),
+}));
+
+const baseProps = {
+  connectionName: 'Local',
+  databaseName: 'sales_db',
+  collectionName: 'customers',
+  currentResultCount: 3,
+  tasks: [] as ExportTaskInfo[],
+  onExport: vi.fn(),
+  onRefreshTasks: vi.fn(),
+  onClearFinishedTasks: vi.fn(),
+};
+
+function renderExportView(overrides: Partial<typeof baseProps> = {}) {
+  const props = { ...baseProps, ...overrides };
+  return renderWithProviders(
+    <DialogProvider>
+      <ExportView {...props} />
+    </DialogProvider>
+  );
+}
+
+/** Mirrors App handleExportForTab enough to exercise invoke + error toasts. */
+function ExportViewHarness({
+  currentResultCount = 3,
+  invokeFails = false,
+}: {
+  currentResultCount?: number;
+  invokeFails?: boolean;
+}) {
+  const { toast } = useDialogs();
+  const [tasks, setTasks] = useState<ExportTaskInfo[]>([]);
+
+  const onExport = async (format: 'json' | 'csv', scope: 'current' | 'full') => {
+    if (scope === 'current' && currentResultCount === 0) return;
+    try {
+      const path = await saveMock({
+        defaultPath: `customers${scope === 'full' ? '.full' : ''}.${format}`,
+      });
+      if (!path) return;
+      if (scope === 'full') {
+        if (invokeFails) throw new Error('disk full');
+        const task = await mockInvoke('start_collection_export', {
+          id: 'conn-1',
+          database: 'sales_db',
+          collection: 'customers',
+          format,
+          path,
+        });
+        setTasks([task]);
+        return;
+      }
+      await writeTextFileMock(path, '[]');
+      toast(`Exported ${currentResultCount} document(s) to ${path}`, 'success');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast(`Export failed: ${message}`, 'error');
+    }
+  };
+
+  return (
+    <ExportView
+      connectionName="Local"
+      databaseName="sales_db"
+      collectionName="customers"
+      currentResultCount={currentResultCount}
+      tasks={tasks}
+      onExport={onExport}
+      onRefreshTasks={vi.fn()}
+      onClearFinishedTasks={vi.fn()}
+    />
+  );
+}
+
+describe('ExportView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMock.mockResolvedValue('/tmp/customers.json');
+    writeTextFileMock.mockResolvedValue(undefined);
+    mockInvoke.mockResolvedValue({
+      id: 'task-1',
+      kind: 'collection_export',
+      label: 'Export sales_db.customers as JSON',
+      status: 'running',
+      processed: 0,
+      total: null,
+      message: 'Queued',
+      path: '/tmp/customers.full.json',
+      error: null,
+      createdAtMs: 1,
+      finishedAtMs: null,
+    });
+  });
+
+  it('renders namespace and result count', () => {
+    renderExportView();
+    expect(screen.getByTestId('export-view')).toBeInTheDocument();
+    expect(screen.getByText(/Local \/ sales_db\.customers/)).toBeInTheDocument();
+    expect(screen.getByText('3 loaded documents')).toBeInTheDocument();
+  });
+
+  it('disables current-result export buttons when there are no loaded documents', () => {
+    renderExportView({ currentResultCount: 0 });
+    expect(screen.getByTestId('export-current-json-btn')).toBeDisabled();
+    expect(screen.getByTestId('export-current-csv-btn')).toBeDisabled();
+  });
+
+  it('starts a current-results JSON export with the selected format', () => {
+    const onExport = vi.fn();
+    renderExportView({ onExport });
+    fireEvent.click(screen.getByTestId('export-current-json-btn'));
+    expect(onExport).toHaveBeenCalledWith('json', 'current');
+    fireEvent.click(screen.getByTestId('export-current-csv-btn'));
+    expect(onExport).toHaveBeenCalledWith('csv', 'current');
+  });
+
+  it('starts a full-collection export in the chosen format', () => {
+    const onExport = vi.fn();
+    renderExportView({ onExport });
+    fireEvent.click(screen.getByTestId('export-full-json-btn'));
+    expect(onExport).toHaveBeenCalledWith('json', 'full');
+    fireEvent.click(screen.getByTestId('export-full-csv-btn'));
+    expect(onExport).toHaveBeenCalledWith('csv', 'full');
+  });
+
+  it('refreshes export tasks from the header action', () => {
+    const onRefreshTasks = vi.fn();
+    renderExportView({ onRefreshTasks });
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh Tasks' }));
+    expect(onRefreshTasks).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a background export via invoke when full collection JSON is chosen', async () => {
+    renderWithProviders(
+      <DialogProvider>
+        <ExportViewHarness />
+      </DialogProvider>
+    );
+
+    fireEvent.click(screen.getByTestId('export-full-json-btn'));
+
+    await waitFor(() => {
+      expect(saveMock).toHaveBeenCalled();
+      expect(mockInvoke).toHaveBeenCalledWith('start_collection_export', {
+        id: 'conn-1',
+        database: 'sales_db',
+        collection: 'customers',
+        format: 'json',
+        path: '/tmp/customers.json',
+      });
+    });
+    expect(await screen.findByTestId('task-manager')).toBeInTheDocument();
+    expect(screen.getByText(/Export sales_db\.customers as JSON/)).toBeInTheDocument();
+  });
+
+  it('surfaces export failures from invoke as an error toast', async () => {
+    renderWithProviders(
+      <DialogProvider>
+        <ExportViewHarness invokeFails />
+      </DialogProvider>
+    );
+
+    fireEvent.click(screen.getByTestId('export-full-json-btn'));
+
+    expect(await screen.findByText('Export failed: disk full')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-with-providers';
+import { TaskManager, type ExportTaskInfo } from '../TaskManager';
+
+const runningTask: ExportTaskInfo = {
+  id: 'task-running',
+  kind: 'collection_export',
+  label: 'Export sales_db.customers as JSON',
+  status: 'running',
+  processed: 50,
+  total: 100,
+  message: 'Exporting documents…',
+  path: '/tmp/customers.json',
+  error: null,
+  createdAtMs: 1,
+  finishedAtMs: null,
+};
+
+const completedTask: ExportTaskInfo = {
+  id: 'task-done',
+  kind: 'collection_export',
+  label: 'Export sales_db.orders as CSV',
+  status: 'completed',
+  processed: 200,
+  total: 200,
+  message: 'Finished',
+  path: '/tmp/orders.csv',
+  error: null,
+  createdAtMs: 2,
+  finishedAtMs: 3,
+};
+
+const failedTask: ExportTaskInfo = {
+  id: 'task-failed',
+  kind: 'collection_export',
+  label: 'Export sales_db.users as JSON',
+  status: 'failed',
+  processed: 12,
+  total: 100,
+  message: 'Export failed',
+  path: '/tmp/users.json',
+  error: 'Permission denied',
+  createdAtMs: 4,
+  finishedAtMs: 5,
+};
+
+function renderTaskManager(
+  tasks: ExportTaskInfo[] = [],
+  handlers: { onRefresh?: () => void; onClearFinished?: () => void } = {}
+) {
+  const onRefresh = handlers.onRefresh ?? vi.fn();
+  const onClearFinished = handlers.onClearFinished ?? vi.fn();
+  renderWithProviders(
+    <TaskManager tasks={tasks} onRefresh={onRefresh} onClearFinished={onClearFinished} />
+  );
+  return { onRefresh, onClearFinished };
+}
+
+describe('TaskManager', () => {
+  it('shows an empty state when there are no tasks', () => {
+    renderTaskManager();
+    expect(screen.getByTestId('task-manager')).toBeInTheDocument();
+    expect(screen.getByTestId('task-empty')).toHaveTextContent('No export tasks yet.');
+  });
+
+  it('renders running, completed, and failed tasks', () => {
+    renderTaskManager([runningTask, completedTask, failedTask]);
+    expect(screen.getAllByTestId('task-row')).toHaveLength(3);
+    expect(screen.getByText('Export sales_db.customers as JSON')).toBeInTheDocument();
+    expect(screen.getByText('Export sales_db.orders as CSV')).toBeInTheDocument();
+    expect(screen.getByText('Export sales_db.users as JSON')).toBeInTheDocument();
+  });
+
+  it('shows a running-count badge and progress percentage', () => {
+    renderTaskManager([runningTask]);
+    expect(screen.getByText('1 running')).toBeInTheDocument();
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('50/100')).toBeInTheDocument();
+  });
+
+  it('updates displayed progress when task totals change', () => {
+    const { rerender } = renderWithProviders(
+      <TaskManager
+        tasks={[runningTask]}
+        onRefresh={vi.fn()}
+        onClearFinished={vi.fn()}
+      />
+    );
+    expect(screen.getByText('50%')).toBeInTheDocument();
+
+    rerender(
+      <TaskManager
+        tasks={[{ ...runningTask, processed: 75 }]}
+        onRefresh={vi.fn()}
+        onClearFinished={vi.fn()}
+      />
+    );
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    expect(screen.getByText('75/100')).toBeInTheDocument();
+  });
+
+  it('shows failed task errors instead of the success message', () => {
+    renderTaskManager([failedTask]);
+    expect(screen.getByText('Permission denied')).toBeInTheDocument();
+  });
+
+  it('refreshes tasks when the refresh control is clicked', () => {
+    const { onRefresh } = renderTaskManager([completedTask]);
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh tasks' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses finished tasks when clear is clicked', () => {
+    const { onClearFinished } = renderTaskManager([completedTask, failedTask]);
+    fireEvent.click(screen.getByRole('button', { name: 'Clear finished tasks' }));
+    expect(onClearFinished).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ExportView.test.tsx` covering format selection, current vs full export actions, task refresh, mocked `start_collection_export` invoke flow, and error toast handling
- Adds `TaskManager.test.tsx` covering empty state, task list rendering, running badge/progress, progress updates on rerender, failed-task errors, refresh, and clear-finished dismiss
- Uses `renderWithProviders` and mocked Tauri `invoke`/dialog/fs — no `MQLENS_TEST_MONGO_URI` required

Fixes #134

## Test plan

- [x] `npm test -- src/components/__tests__/ExportView.test.tsx`
- [x] `npm test -- src/components/__tests__/TaskManager.test.tsx`
- [x] `npx tsc --noEmit`