### PR TITLE
feat: add per-connection color tags for quick identification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,7 +233,7 @@ function Workspace() {
     if (existing) return existing.id;
     try {
       const id = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
-      addActiveConnection(id, profile.name, profile.uri, profile.id, profile.color_tag);
+      addActiveConnection(id, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined);
       return id;
     } catch (e) {
       toast(`Could not connect to ${profile.name}: ${(e as any)?.message || String(e)}`, 'error');
@@ -1536,7 +1536,7 @@ function Workspace() {
             isOpen={isConnectionModalOpen}
             onClose={() => { setIsConnectionModalOpen(false); setProfilesRefreshKey((k) => k + 1); }}
             onConnect={(id, name, uri, profileId, colorTag) => {
-              addActiveConnection(id, name, uri, profileId, colorTag);
+              addActiveConnection(id, name, uri, profileId, colorTag ?? undefined);
               setIsConnectionModalOpen(false);
               setProfilesRefreshKey((k) => k + 1);
             }}

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -7,7 +7,7 @@ import { useEscapeClose } from '../lib/useEscapeClose';
 import {
   Plus, X, Server, Play, Edit3, Trash2, Check, AlertCircle, RefreshCw,
   Folder, FolderPlus, FolderOpen, Search, ChevronRight,
-  Copy, ExternalLink, ShieldAlert, Eye, EyeOff, LayoutGrid, ClipboardPaste
+  Copy, ExternalLink, ShieldAlert, Eye, EyeOff, LayoutGrid, ClipboardPaste, Pipette
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -37,6 +37,7 @@ import {
   loadConnectionFolders,
   saveConnectionFolders,
 } from '@/lib/connectionFolders';
+import { CONNECTION_COLOR_PALETTE, colorInputValue, isPresetConnectionColor, normalizeHexColor } from '@/lib/connectionColors';
 
 // Mirrors the backend ssh_tunnel::SshConfig (auth is internally tagged).
 export type SshConfig = {
@@ -53,14 +54,14 @@ interface ConnectionProfile {
   id: string;
   name: string;
   uri: string;
-  color_tag?: string;
+  color_tag?: string | null;
   ssh?: SshConfig | null;
 }
 
 interface ConnectionManagerProps {
   isOpen: boolean;
   onClose: () => void;
-  onConnect: (id: string, name: string, uri: string, profileId: string, colorTag?: string) => void;
+  onConnect: (id: string, name: string, uri: string, profileId: string, colorTag?: string | null) => void;
   activeConnections?: { id: string; profileId: string; name: string; uri: string }[];
 }
 
@@ -116,6 +117,7 @@ const BLANK_CONN = {
   compression: 'none',
   name: 'New Connection',
   folder: '',
+  colorTag: '',
 };
 
 const sidebarPanelClass =
@@ -140,6 +142,16 @@ const treeRowClass = (active?: boolean) =>
       ? 'bg-background font-medium text-foreground shadow-sm ring-1 ring-border'
       : 'text-muted-foreground hover:bg-sidebar-accent/70 hover:text-foreground',
   );
+
+const ConnectionColorDot = ({ color, className }: { color?: string | null; className?: string }) =>
+  color ? (
+    <span
+      className={cn('h-2 w-2 shrink-0 rounded-full', className)}
+      style={{ backgroundColor: color }}
+      title="Connection color"
+      data-testid="connection-color-dot"
+    />
+  ) : null;
 
 const TABS = [
   { id: 'server', label: 'Server', icon: Server },
@@ -487,6 +499,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       uri: profile.uri,
       ...parsed,
       folder: profileFolderMap[profile.id] || '',
+      colorTag: profile.color_tag || '',
       ...sshFields,
     });
 
@@ -509,6 +522,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       topology: profile.uri.includes('replicaSet=') ? 'replicaSet' : 'standalone',
       hosts: [{ host: 'localhost', port: '27017' }],
       folder: profileFolderMap[profile.id] || '',
+      colorTag: profile.color_tag || '',
     });
     setError(null);
     setTestResult(null);
@@ -564,6 +578,9 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       name: editorState.name,
       uri: uriToSave,
       ssh: buildSshConfig(editorState),
+      color_tag: editorState.colorTag
+        ? normalizeHexColor(editorState.colorTag) ?? editorState.colorTag
+        : null,
     };
 
     setLoading(true);
@@ -626,7 +643,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
     setError(null);
     try {
       const connId = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
-      onConnect(connId, profile.name, profile.uri, profile.id, profile.color_tag);
+      onConnect(connId, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined);
     } catch (err: any) {
       setError(String(err));
     } finally {
@@ -876,6 +893,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                               onClick={() => handleSelect(p.id)}
                               onDoubleClick={handleConnectClick}
                             >
+                              <ConnectionColorDot color={p.color_tag} />
                               <Server size={12} className={cn('shrink-0', isSel ? 'text-primary' : 'text-muted-foreground')} />
                               <span className="min-w-0 truncate">{p.name || 'Unnamed connection'}</span>
                               {isActive && (
@@ -906,6 +924,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                     onClick={() => handleSelect(p.id)}
                     onDoubleClick={handleConnectClick}
                   >
+                    <ConnectionColorDot color={p.color_tag} />
                     <Server size={12} className={cn('shrink-0', isSel ? 'text-primary' : 'text-muted-foreground')} />
                     <span className="min-w-0 truncate">{p.name || 'Unnamed connection'}</span>
                     {isActive && (
@@ -931,7 +950,10 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                       <Server size={18} className="text-primary" />
                     </div>
                     <div className="min-w-0">
-                      <h3 className="truncate text-base font-semibold text-foreground">{selectedProfile.name}</h3>
+                      <div className="flex items-center gap-2">
+                        <ConnectionColorDot color={selectedProfile.color_tag} className="h-2.5 w-2.5" />
+                        <h3 className="truncate text-base font-semibold text-foreground">{selectedProfile.name}</h3>
+                      </div>
                       <p className="text-ui-xs text-muted-foreground">Connection profile</p>
                     </div>
                   </div>
@@ -1121,6 +1143,69 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Label className="shrink-0 text-ui-xs">Color tag</Label>
+                <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Connection color tag">
+                  <button
+                    type="button"
+                    data-testid="color-swatch-none"
+                    title="No color"
+                    aria-label="No color"
+                    aria-pressed={!editorState.colorTag}
+                    className={cn(
+                      'flex h-5 w-5 items-center justify-center rounded-full border border-border text-ui-2xs text-muted-foreground transition-colors',
+                      !editorState.colorTag && 'ring-2 ring-primary ring-offset-1 ring-offset-background',
+                    )}
+                    onClick={() => setEditorState((prev) => ({ ...prev, colorTag: '' }))}
+                  >
+                    ∅
+                  </button>
+                  {CONNECTION_COLOR_PALETTE.map((swatch) => (
+                    <button
+                      key={swatch.id}
+                      type="button"
+                      data-testid={`color-swatch-${swatch.id}`}
+                      title={swatch.label}
+                      aria-label={swatch.label}
+                      aria-pressed={editorState.colorTag === swatch.value}
+                      className={cn(
+                        'h-5 w-5 rounded-full transition-[box-shadow]',
+                        editorState.colorTag === swatch.value && 'ring-2 ring-primary ring-offset-1 ring-offset-background',
+                      )}
+                      style={{ backgroundColor: swatch.value }}
+                      onClick={() => setEditorState((prev) => ({ ...prev, colorTag: swatch.value }))}
+                    />
+                  ))}
+                  <label
+                    className={cn(
+                      'relative inline-flex h-6 cursor-pointer items-center gap-1 rounded-md border border-dashed border-border px-1.5 text-ui-2xs text-muted-foreground transition-colors hover:border-primary/50 hover:bg-accent hover:text-foreground',
+                      editorState.colorTag
+                        && !isPresetConnectionColor(editorState.colorTag)
+                        && 'border-solid ring-2 ring-primary ring-offset-1 ring-offset-background',
+                    )}
+                    title="Pick a custom color"
+                  >
+                    <Pipette size={11} className="pointer-events-none shrink-0" aria-hidden="true" />
+                    <span className="pointer-events-none">Custom</span>
+                    {editorState.colorTag && !isPresetConnectionColor(editorState.colorTag) && (
+                      <span
+                        className="pointer-events-none h-2.5 w-2.5 shrink-0 rounded-full border border-border"
+                        style={{ backgroundColor: editorState.colorTag }}
+                        data-testid="color-picker-custom-preview"
+                      />
+                    )}
+                    <input
+                      type="color"
+                      data-testid="color-picker-custom"
+                      aria-label="Pick a custom color"
+                      value={colorInputValue(editorState.colorTag)}
+                      onChange={(e) => setEditorState((prev) => ({ ...prev, colorTag: e.target.value }))}
+                      className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                    />
+                  </label>
+                </div>
               </div>
 
               <div className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2">

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -445,6 +445,7 @@ describe('ConnectionManager Component', () => {
         name: 'Staging DB',
         uri: 'mongodb://staging:27017',
         ssh: null,
+        color_tag: null,
       });
       // The nested modal should be closed
       expect(screen.queryByText('New Connection')).not.toBeInTheDocument();
@@ -705,5 +706,147 @@ describe('ConnectionManager Component', () => {
     const connectBtn = screen.getByRole('button', { name: /already connected/i });
     expect(connectBtn).toBeInTheDocument();
     expect(connectBtn).toBeDisabled();
+  });
+
+  it('saves a color tag from the preset palette', async () => {
+    let savedProfile: any = null;
+    let profilesList: any[] = [];
+
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve(profilesList);
+      if (cmd === 'save_connection_profile') {
+        savedProfile = args.profile;
+        profilesList = [args.profile];
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <ConnectionManager
+        isOpen={true}
+        onClose={() => {}}
+        onConnect={() => {}}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'Prod' } });
+    await pickSelectOption('topology-select', /full uri string only/i);
+    fireEvent.change(screen.getByLabelText(/connection uri/i), { target: { value: 'mongodb://prod' } });
+    fireEvent.click(screen.getByTestId('color-swatch-blue'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedProfile).toMatchObject({
+        name: 'Prod',
+        uri: 'mongodb://prod',
+        color_tag: '#3b82f6',
+      });
+    });
+  });
+
+  it('saves a custom color from the color picker', async () => {
+    let savedProfile: any = null;
+    let profilesList: any[] = [];
+
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve(profilesList);
+      if (cmd === 'save_connection_profile') {
+        savedProfile = args.profile;
+        profilesList = [args.profile];
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <ConnectionManager
+        isOpen={true}
+        onClose={() => {}}
+        onConnect={() => {}}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'Custom' } });
+    await pickSelectOption('topology-select', /full uri string only/i);
+    fireEvent.change(screen.getByLabelText(/connection uri/i), { target: { value: 'mongodb://custom' } });
+    expect(screen.getByLabelText('Pick a custom color')).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('color-picker-custom'), { target: { value: '#a1b2c3' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedProfile).toMatchObject({
+        name: 'Custom',
+        uri: 'mongodb://custom',
+        color_tag: '#a1b2c3',
+      });
+    });
+  });
+
+  it('shows color dots in the profile list for tagged connections', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') {
+        return Promise.resolve([
+          { id: 'p1', name: 'Staging', uri: 'mongodb://staging', color_tag: '#22c55e' },
+          { id: 'p2', name: 'Prod', uri: 'mongodb://prod' },
+        ]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <ConnectionManager
+        isOpen={true}
+        onClose={() => {}}
+        onConnect={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(screen.getAllByText('Staging')[0]).toBeInTheDocument());
+    const dots = screen.getAllByTestId('connection-color-dot');
+    expect(dots.length).toBeGreaterThanOrEqual(1);
+    dots.forEach((dot) => {
+      expect(dot).toHaveStyle({ backgroundColor: 'rgb(34, 197, 94)' });
+    });
+  });
+
+  it('clears a saved color tag when none is selected', async () => {
+    let savedProfile: any = null;
+    const profilesList = [
+      { id: 'p1', name: 'Staging', uri: 'mongodb://staging', color_tag: '#22c55e' },
+    ];
+
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve(profilesList);
+      if (cmd === 'save_connection_profile') {
+        savedProfile = args.profile;
+        profilesList[0] = args.profile;
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <ConnectionManager
+        isOpen={true}
+        onClose={() => {}}
+        onConnect={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(screen.getAllByText('Staging')[0]).toBeInTheDocument());
+    fireEvent.click(screen.getAllByText('Staging')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+    fireEvent.click(screen.getByTestId('color-swatch-none'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedProfile).toMatchObject({
+        id: 'p1',
+        color_tag: null,
+      });
+    });
   });
 });

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -804,4 +804,31 @@ describe('Sidebar Component', () => {
       expect(onSelectCollection).toHaveBeenCalledWith('conn-new', 'sales_db', 'orders');
     });
   });
+
+  it('shows a color dot for tagged active connections', async () => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      if (cmd === 'list_all_saved_queries') return Promise.resolve([]);
+      if (cmd === 'list_databases') {
+        if (args.id === 'conn-1') return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Staging', uri: 'mongodb://staging', color_tag: '#3b82f6' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    expect(await screen.findByTitle('Connection color')).toBeInTheDocument();
+    expect(screen.getByText('Staging')).toBeInTheDocument();
+  });
 });

--- a/src/lib/__tests__/connectionColors.test.ts
+++ b/src/lib/__tests__/connectionColors.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import {
+  colorInputValue,
+  isPresetConnectionColor,
+  normalizeHexColor,
+} from '../connectionColors';
+
+describe('connectionColors', () => {
+  it('normalizes 6-digit and 3-digit hex colors', () => {
+    expect(normalizeHexColor('#A1B2C3')).toBe('#a1b2c3');
+    expect(normalizeHexColor('#f00')).toBe('#ff0000');
+    expect(normalizeHexColor('not-a-color')).toBeNull();
+  });
+
+  it('detects preset vs custom colors', () => {
+    expect(isPresetConnectionColor('#3b82f6')).toBe(true);
+    expect(isPresetConnectionColor('#a1b2c3')).toBe(false);
+  });
+
+  it('provides a valid color-input value', () => {
+    expect(colorInputValue()).toBe('#3b82f6');
+    expect(colorInputValue('#a1b2c3')).toBe('#a1b2c3');
+    expect(colorInputValue('#f00')).toBe('#ff0000');
+  });
+});

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -5,6 +5,6 @@ export interface ConnectionProfile {
   id: string;
   name: string;
   uri: string;
-  color_tag?: string;
+  color_tag?: string | null;
   ssh?: SshConfig | null;
 }

--- a/src/lib/connectionColors.ts
+++ b/src/lib/connectionColors.ts
@@ -1,0 +1,39 @@
+/** Preset connection color tags (#34). Hex values work in inline styles. */
+export const CONNECTION_COLOR_PALETTE = [
+  { id: 'red', value: '#ef4444', label: 'Red' },
+  { id: 'orange', value: '#f97316', label: 'Orange' },
+  { id: 'amber', value: '#eab308', label: 'Amber' },
+  { id: 'green', value: '#22c55e', label: 'Green' },
+  { id: 'blue', value: '#3b82f6', label: 'Blue' },
+  { id: 'violet', value: '#8b5cf6', label: 'Violet' },
+  { id: 'pink', value: '#ec4899', label: 'Pink' },
+  { id: 'slate', value: '#64748b', label: 'Slate' },
+] as const;
+
+export type ConnectionColorId = (typeof CONNECTION_COLOR_PALETTE)[number]['id'];
+
+/** Fallback shown in the native color picker when no tag is set. */
+export const CONNECTION_COLOR_PICKER_DEFAULT = '#3b82f6';
+
+export function normalizeHexColor(value: string): string | null {
+  const trimmed = value.trim();
+  if (/^#[0-9a-f]{6}$/i.test(trimmed)) return trimmed.toLowerCase();
+  const short = trimmed.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+  if (short) {
+    const [, r, g, b] = short;
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  return null;
+}
+
+export function isPresetConnectionColor(value: string): boolean {
+  const normalized = normalizeHexColor(value);
+  if (!normalized) return false;
+  return CONNECTION_COLOR_PALETTE.some((swatch) => swatch.value === normalized);
+}
+
+/** Value for `<input type="color">` — always `#rrggbb`. */
+export function colorInputValue(tag?: string | null): string {
+  if (!tag) return CONNECTION_COLOR_PICKER_DEFAULT;
+  return normalizeHexColor(tag) ?? CONNECTION_COLOR_PICKER_DEFAULT;
+}


### PR DESCRIPTION
## Summary

- Adds an 8-color preset palette picker in the connection editor (new/edit/duplicate)
- Persists `color_tag` on saved connection profiles; clearing the tag saves `null` for backward compatibility
- Shows a color dot in the connection manager profile list and detail header
- Sidebar already rendered color tags — no change needed there beyond test coverage

Fixes #34

## Test plan

- [x] `npm test -- src/components/__tests__/ConnectionManager.test.tsx`
- [x] `npm test -- src/components/__tests__/Sidebar.test.tsx`
- [x] `npx tsc --noEmit`
- [ ] Create/edit a connection, pick a color, save — dot appears in manager list
- [ ] Connect — colored stripe/dot shows in sidebar
- [ ] Clear color (∅ swatch) — returns to default appearance
- [ ] Existing profiles without `color_tag` unchanged