### PR TITLE
fix: graceful updater offline behavior and connectivity feedback (#133)

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -19,6 +19,13 @@ import {
   type BiometricStatus,
 } from '../lib/vault';
 import { CHECK_UPDATE_EVENT } from './UpdatePrompt';
+import {
+  formatLastChecked,
+  readUpdateCheckSnapshot,
+  UPDATE_CHECK_STATE_EVENT,
+  updateCheckResultLabel,
+  type UpdateCheckSnapshot,
+} from '@/lib/updateCheckState';
 import { AppearanceSettings } from '@/components/theme/AppearanceSettings';
 import type { AppearanceSettings as AppearanceSettingsType } from '@/lib/themes/schema';
 import { Button } from '@/components/ui/button';
@@ -151,8 +158,17 @@ export const SettingsView: React.FC = () => {
   const [secMsg, setSecMsg] = useState('');
   const [bio, setBio] = useState<BiometricStatus | null>(null);
   const [bioBusy, setBioBusy] = useState(false);
+  const [updateCheck, setUpdateCheck] = useState<UpdateCheckSnapshot | null>(() =>
+    readUpdateCheckSnapshot(),
+  );
 
   const activeTab = SETTINGS_TABS.find((t) => t.id === tab) ?? SETTINGS_TABS[0];
+
+  useEffect(() => {
+    const sync = () => setUpdateCheck(readUpdateCheckSnapshot());
+    window.addEventListener(UPDATE_CHECK_STATE_EVENT, sync);
+    return () => window.removeEventListener(UPDATE_CHECK_STATE_EVENT, sync);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -336,7 +352,21 @@ export const SettingsView: React.FC = () => {
                 <CardTitle className="text-base">Manual check</CardTitle>
                 <CardDescription>Trigger an update check without restarting the app.</CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="space-y-4">
+                {updateCheck ? (
+                  <div className="space-y-1 text-sm" data-testid="update-last-checked">
+                    <p className="text-muted-foreground">
+                      Last checked: {formatLastChecked(updateCheck.checkedAt)}
+                    </p>
+                    <p className="text-foreground">
+                      Result: {updateCheckResultLabel(updateCheck.result)}
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground" data-testid="update-last-checked">
+                    No update check recorded yet.
+                  </p>
+                )}
                 <Button
                   type="button"
                   variant="outline"

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { relaunch } from '@tauri-apps/plugin-process';
-import { Download, X, RefreshCw, CheckCircle2, AlertTriangle, ArrowUpCircle } from 'lucide-react';
+import { Download, X, RefreshCw, CheckCircle2, AlertTriangle, ArrowUpCircle, WifiOff } from 'lucide-react';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { Button } from '@/components/ui/button';
 import {
@@ -14,6 +14,11 @@ import {
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import { useEscapeClose } from '../lib/useEscapeClose';
+import {
+  classifyUpdateCheckError,
+  updateCheckBackoffMs,
+  writeUpdateCheckSnapshot,
+} from '@/lib/updateCheckState';
 
 export const CHECK_UPDATE_EVENT = 'mqlens:check-update';
 
@@ -24,7 +29,14 @@ interface UpdateMeta {
   date: string | null;
 }
 
-type Phase = 'idle' | 'checking' | 'available' | 'downloading' | 'uptodate' | 'error';
+type Phase =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'downloading'
+  | 'uptodate'
+  | 'offline'
+  | 'check-failed';
 
 const renderInline = (text: string): React.ReactNode[] => {
   const out: React.ReactNode[] = [];
@@ -103,35 +115,89 @@ export const UpdatePrompt: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [pct, setPct] = useState(0);
   const [manual, setManual] = useState(false);
+  const retryAttemptRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const runCheck = useCallback(async (isManual: boolean) => {
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleAutoRetry = useCallback((attempt: number, runCheck: (isManual: boolean, retryAttempt?: number) => Promise<void>) => {
+    clearRetryTimer();
+    const delay = updateCheckBackoffMs(attempt);
+    retryTimerRef.current = setTimeout(() => {
+      void runCheck(false, attempt + 1);
+    }, delay);
+  }, [clearRetryTimer]);
+
+  const runCheck = useCallback(async (isManual: boolean, retryAttempt = 0) => {
+    clearRetryTimer();
     setManual(isManual);
     setError(null);
-    setPhase('checking');
+
+    if (isManual && typeof navigator !== 'undefined' && !navigator.onLine) {
+      writeUpdateCheckSnapshot({
+        checkedAt: new Date().toISOString(),
+        result: 'offline',
+      });
+      setPhase('offline');
+      return;
+    }
+
+    if (isManual) setPhase('checking');
+
     try {
       const channel = await currentChannel();
       const meta = await invoke<UpdateMeta | null>('update_check', { channel });
+      const checkedAt = new Date().toISOString();
+      retryAttemptRef.current = 0;
       if (meta) {
         setUpdate(meta);
         setPhase('available');
+        writeUpdateCheckSnapshot({ checkedAt, result: 'available' });
       } else {
+        writeUpdateCheckSnapshot({ checkedAt, result: 'uptodate' });
         setPhase(isManual ? 'uptodate' : 'idle');
       }
-    } catch (e: any) {
-      setError(String(e?.message || e));
-      setPhase(isManual ? 'error' : 'idle');
+    } catch (e: unknown) {
+      const detail = String((e as { message?: string })?.message || e);
+      const result = classifyUpdateCheckError(e);
+      writeUpdateCheckSnapshot({
+        checkedAt: new Date().toISOString(),
+        result,
+        detail,
+      });
+      if (isManual) {
+        setError(detail);
+        setPhase(result);
+      } else {
+        setPhase('idle');
+        if (result === 'offline') {
+          scheduleAutoRetry(retryAttempt, runCheck);
+        }
+      }
     }
-  }, []);
+  }, [clearRetryTimer, scheduleAutoRetry]);
 
   useEffect(() => {
     const t = setTimeout(() => void runCheck(false), 4000);
     const onManual = () => void runCheck(true);
+    const onOnline = () => {
+      retryAttemptRef.current = 0;
+      void runCheck(false);
+    };
     window.addEventListener(CHECK_UPDATE_EVENT, onManual);
+    window.addEventListener('online', onOnline);
     return () => {
       clearTimeout(t);
+      clearRetryTimer();
       window.removeEventListener(CHECK_UPDATE_EVENT, onManual);
+      window.removeEventListener('online', onOnline);
     };
-  }, [runCheck]);
+  }, [runCheck, clearRetryTimer]);
 
   const install = async () => {
     if (!update) return;
@@ -149,9 +215,9 @@ export const UpdatePrompt: React.FC = () => {
       const channel = await currentChannel();
       await invoke('update_install', { channel });
       await relaunch();
-    } catch (e: any) {
-      setError(String(e?.message || e));
-      setPhase('error');
+    } catch (e: unknown) {
+      setError(String((e as { message?: string })?.message || e));
+      setPhase('check-failed');
     } finally {
       unlisten?.();
     }
@@ -185,10 +251,22 @@ export const UpdatePrompt: React.FC = () => {
       </div>
     );
   }
-  if (phase === 'error') {
+  if (phase === 'offline') {
+    return (
+      <div className={cn(toastClassName, 'border-warning/30')} data-testid="update-toast">
+        <WifiOff size={14} className="text-warning" />
+        You’re offline. Connect to the internet and try again.
+        <Button type="button" variant="ghost" size="icon" className="ml-1 h-6 w-6" onClick={dismiss} aria-label="Dismiss">
+          <X size={12} />
+        </Button>
+      </div>
+    );
+  }
+  if (phase === 'check-failed') {
     return (
       <div className={cn(toastClassName, 'border-destructive/30 text-destructive')} data-testid="update-toast" title={error ?? undefined}>
-        <AlertTriangle size={14} /> Update check failed.
+        <AlertTriangle size={14} />
+        Couldn’t reach the update server. Try again later.
         <Button type="button" variant="ghost" size="icon" className="ml-1 h-6 w-6" onClick={dismiss} aria-label="Dismiss">
           <X size={12} />
         </Button>

--- a/src/components/__tests__/SettingsModal.test.tsx
+++ b/src/components/__tests__/SettingsModal.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { SettingsView } from '../SettingsModal';
+import { writeUpdateCheckSnapshot } from '../../lib/updateCheckState';
 
 const mockInvoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({
@@ -35,6 +36,7 @@ async function openTab(tabId: string) {
 describe('SettingsView Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     mockBiometricStatus.mockResolvedValue({ available: false, biometryType: 0, enrolled: false });
     mockInvoke.mockImplementation((cmd) => {
       if (cmd === 'load_app_settings') {
@@ -168,5 +170,16 @@ describe('SettingsView Component', () => {
     fireEvent.click(screen.getByRole('option', { name: /Claude Code/i }));
     expect(screen.getByTestId('local-command-input')).toBeInTheDocument();
     expect(await screen.findByTestId('agent-availability')).toHaveTextContent(/installed/i);
+  });
+
+  it('shows last update check status on the updates tab', async () => {
+    writeUpdateCheckSnapshot({
+      checkedAt: '2026-06-15T12:00:00.000Z',
+      result: 'offline',
+    });
+    renderSettings();
+    await openTab('settings-tab-updates');
+    expect(await screen.findByTestId('update-last-checked')).toHaveTextContent(/Offline/i);
+    expect(screen.getByTestId('update-last-checked')).toHaveTextContent(/Last checked:/i);
   });
 });

--- a/src/components/__tests__/UpdatePrompt.test.tsx
+++ b/src/components/__tests__/UpdatePrompt.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { readUpdateCheckSnapshot } from '../../lib/updateCheckState';
 
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => invokeMock(...a) }));
@@ -28,6 +29,12 @@ function routeInvoke(map: Record<string, unknown>) {
 beforeEach(() => {
   invokeMock.mockReset();
   mockRelaunch.mockClear();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
 });
 
 describe('UpdatePrompt', () => {
@@ -96,5 +103,33 @@ describe('UpdatePrompt', () => {
     fireEvent.click(await screen.findByTestId('update-later'));
     expect(screen.queryByTestId('update-dialog')).toBeNull();
     expect(installFn).not.toHaveBeenCalled();
+  });
+
+  it('shows an offline message on manual check when navigator is offline', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    routeInvoke({ update_check: null });
+    render(<UpdatePrompt />);
+    triggerManualCheck();
+    expect(await screen.findByTestId('update-toast')).toHaveTextContent(/offline/i);
+    expect(readUpdateCheckSnapshot()?.result).toBe('offline');
+  });
+
+  it('shows a server error message on manual check failure', async () => {
+    routeInvoke({ update_check: () => Promise.reject(new Error('invalid signature')) });
+    render(<UpdatePrompt />);
+    triggerManualCheck();
+    expect(await screen.findByTestId('update-toast')).toHaveTextContent(/update server/i);
+    expect(readUpdateCheckSnapshot()?.result).toBe('check-failed');
+  });
+
+  it('records offline on startup without showing a toast', async () => {
+    vi.useFakeTimers();
+    routeInvoke({ update_check: () => Promise.reject(new Error('network timeout')) });
+    render(<UpdatePrompt />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(readUpdateCheckSnapshot()?.result).toBe('offline');
+    expect(screen.queryByTestId('update-toast')).toBeNull();
   });
 });

--- a/src/lib/__tests__/updateCheckState.test.ts
+++ b/src/lib/__tests__/updateCheckState.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  classifyUpdateCheckError,
+  readUpdateCheckSnapshot,
+  updateCheckBackoffMs,
+  updateCheckResultLabel,
+  writeUpdateCheckSnapshot,
+} from '../updateCheckState';
+
+describe('updateCheckState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('classifies offline vs server errors', () => {
+    expect(classifyUpdateCheckError(new Error('network timeout'))).toBe('offline');
+    expect(classifyUpdateCheckError(new Error('invalid signature'))).toBe('check-failed');
+  });
+
+  it('persists and reads the last check snapshot', () => {
+    writeUpdateCheckSnapshot({
+      checkedAt: '2026-06-15T12:00:00.000Z',
+      result: 'uptodate',
+    });
+    expect(readUpdateCheckSnapshot()).toEqual({
+      checkedAt: '2026-06-15T12:00:00.000Z',
+      result: 'uptodate',
+    });
+  });
+
+  it('labels results for settings display', () => {
+    expect(updateCheckResultLabel('offline')).toBe('Offline');
+    expect(updateCheckResultLabel('check-failed')).toBe('Server error');
+  });
+
+  it('backs off exponentially up to five minutes', () => {
+    expect(updateCheckBackoffMs(0)).toBe(30_000);
+    expect(updateCheckBackoffMs(1)).toBe(60_000);
+    expect(updateCheckBackoffMs(4)).toBe(300_000);
+    expect(updateCheckBackoffMs(8)).toBe(300_000);
+  });
+});

--- a/src/lib/updateCheckState.ts
+++ b/src/lib/updateCheckState.ts
@@ -1,0 +1,84 @@
+export type UpdateCheckResultKind = 'uptodate' | 'available' | 'offline' | 'check-failed';
+
+export interface UpdateCheckSnapshot {
+  checkedAt: string;
+  result: UpdateCheckResultKind;
+  detail?: string;
+}
+
+export const UPDATE_CHECK_STATE_EVENT = 'mqlens:update-check-state-changed';
+
+const STORAGE_KEY = 'mqlens.update-check.snapshot';
+
+export function readUpdateCheckSnapshot(): UpdateCheckSnapshot | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as UpdateCheckSnapshot;
+    if (!parsed?.checkedAt || !parsed?.result) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeUpdateCheckSnapshot(snapshot: UpdateCheckSnapshot): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+  } catch {
+    /* ignore quota / private mode */
+  }
+  notifyUpdateCheckState();
+}
+
+export function notifyUpdateCheckState(): void {
+  window.dispatchEvent(new Event(UPDATE_CHECK_STATE_EVENT));
+}
+
+export function classifyUpdateCheckError(err: unknown): 'offline' | 'check-failed' {
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return 'offline';
+  }
+  const msg = String((err as { message?: string })?.message || err).toLowerCase();
+  const offlineHints = [
+    'network',
+    'failed to fetch',
+    'fetch failed',
+    'connection refused',
+    'offline',
+    'dns',
+    'timeout',
+    'timed out',
+    'enotfound',
+    'econnrefused',
+    'unreachable',
+    'no route to host',
+  ];
+  return offlineHints.some((hint) => msg.includes(hint)) ? 'offline' : 'check-failed';
+}
+
+export function updateCheckResultLabel(result: UpdateCheckResultKind): string {
+  switch (result) {
+    case 'uptodate':
+      return 'Up to date';
+    case 'available':
+      return 'Update available';
+    case 'offline':
+      return 'Offline';
+    case 'check-failed':
+      return 'Server error';
+  }
+}
+
+export function formatLastChecked(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+/** Exponential backoff for automatic retries when offline (30s → 5m cap). */
+export function updateCheckBackoffMs(attempt: number): number {
+  const base = 30_000;
+  const max = 300_000;
+  return Math.min(base * 2 ** attempt, max);
+}


### PR DESCRIPTION
## Summary
- Adds persisted update-check state (`localStorage`) with offline vs server-error classification and exponential backoff retries on startup when offline.
- `UpdatePrompt` distinguishes offline, server error, and up-to-date outcomes; startup failures stay silent (no toast spam) while manual checks show actionable messages.
- Settings → Updates shows last checked timestamp and result; listens for live updates after checks complete.

Closes #133

## Test plan
- [x] `npm test -- --run src/lib/__tests__/updateCheckState.test.ts`
- [x] `npm test -- --run src/components/__tests__/UpdatePrompt.test.tsx`
- [x] `npm test -- --run src/components/__tests__/SettingsModal.test.tsx`
- [x] `npx tsc --noEmit`
- [ ] Manual: launch offline → no error toast; Settings → Updates shows Offline + timestamp
- [ ] Manual: reconnect → auto retry; manual check shows appropriate toast when offline vs server error