### PR TITLE
feat: keyboard shortcuts reference in Settings (#132)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { CommandPalette, type PaletteAction } from './components/CommandPalette'
 import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import { DataGrid } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
-import { SettingsView } from './components/SettingsModal';
+import { SettingsView, type SettingsTabId } from './components/SettingsModal';
 import { IndexViewer } from './components/IndexViewer';
 import { IndexModal } from './components/IndexModal';
 import { MongoShell } from './components/MongoShell';
@@ -211,6 +211,7 @@ function Workspace() {
   const [activeConnections, setActiveConnections] = useState<ActiveConnection[]>([]);
   const [profilesRefreshKey, setProfilesRefreshKey] = useState(0);
   const [isConnectionModalOpen, setIsConnectionModalOpen] = useState(false);
+  const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTabId | undefined>();
 
   const addActiveConnection = (
     id: string,
@@ -546,7 +547,7 @@ function Workspace() {
     setActiveTabId(tabId);
   };
 
-  const handleOpenSettingsTab = () => {
+  const openSettingsTab = (section: SettingsTabId = 'appearance') => {
     const tabId = 'settings';
     const tabExists = tabs.some(t => t.id === tabId);
     if (!tabExists) {
@@ -562,8 +563,12 @@ function Workspace() {
         explainResult: null,
       }]);
     }
+    setSettingsInitialTab(section);
     setActiveTabId(tabId);
   };
+
+  const handleOpenSettingsTab = () => openSettingsTab('appearance');
+  const handleOpenShortcutsReference = () => openSettingsTab('shortcuts');
 
   const handleOpenExportTab = (sourceTab: QueryTab) => {
     if (sourceTab.type !== 'collection') return;
@@ -1749,12 +1754,13 @@ function Workspace() {
                 );
               })()}
               {activeTab && activeTab.type === 'settings' && (
-                <SettingsView />
+                <SettingsView initialTab={settingsInitialTab} />
               )}
               {activeTab && activeTab.type === 'quickstart' && (
                 <QuickStart
                   onConnect={() => setIsConnectionModalOpen(true)}
                   onOpenSettings={handleOpenSettingsTab}
+                  onOpenShortcuts={handleOpenShortcutsReference}
                   onQuickConnect={async (profile) => {
                     await handleQuickConnect(profile);
                   }}

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -4,6 +4,7 @@ import { open } from '@tauri-apps/plugin-dialog';
 import { useDialogs } from './dialogs/DialogProvider';
 import { PasswordInput } from './PasswordInput';
 import { useEscapeClose } from '../lib/useEscapeClose';
+import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 import {
   Plus, X, Server, Play, Edit3, Trash2, Check, AlertCircle, RefreshCw,
   Folder, FolderPlus, FolderOpen, Search, ChevronRight,
@@ -673,7 +674,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
   const handleImportUri = async () => {
     const uri = await prompt({
       title: 'Import Connection URI',
-      message: 'Paste a mongodb:// or mongodb+srv:// connection string. Protocol, hosts, auth, TLS, and topology are detected automatically. (⌘/Ctrl+Enter to import)',
+      message: `Paste a mongodb:// or mongodb+srv:// connection string. Protocol, hosts, auth, TLS, and topology are detected automatically. (${formatShortcut(shortcutById('submit-dialog')!)} to import)`,
       placeholder: 'mongodb://user:pass@host1:27017,host2:27017/?replicaSet=rs0&tls=true',
       confirmLabel: 'Import',
       multiline: true,

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/components/ui/resizable';
 import type { Layout } from 'react-resizable-panels';
 import { cn } from '@/lib/utils';
+import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 import {
   Play, 
   AlertCircle,
@@ -1357,7 +1358,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
               disabled={loading || explainLoading}
               size="sm"
               className="h-7 rounded-r-none px-2.5 text-[11px]"
-              title="Execute query (Ctrl/⌘ + Enter)"
+              title={`Execute query (${formatShortcut(shortcutById('run-query')!)})`}
             >
               <Play size={11} fill="currentColor" />
               Run

--- a/src/components/KeyboardShortcutsSettings.tsx
+++ b/src/components/KeyboardShortcutsSettings.tsx
@@ -1,0 +1,75 @@
+import React, { useMemo, useState } from 'react';
+import { Keyboard } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  filterKeyboardShortcuts,
+  formatShortcut,
+  groupKeyboardShortcuts,
+  SHORTCUT_GROUP_LABELS,
+  SHORTCUT_GROUP_ORDER,
+} from '@/lib/shortcuts';
+
+export const KeyboardShortcutsSettings: React.FC = () => {
+  const [filter, setFilter] = useState('');
+  const filtered = useMemo(() => filterKeyboardShortcuts(filter), [filter]);
+  const grouped = useMemo(() => groupKeyboardShortcuts(filtered), [filtered]);
+
+  return (
+    <Card className="max-w-3xl">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Keyboard className="h-4 w-4 text-primary" />
+          Keyboard shortcuts
+        </CardTitle>
+        <CardDescription>
+          Global shortcuts for navigation, queries, the sidebar, zoom, and the command palette.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Input
+          type="search"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Search shortcuts…"
+          data-testid="shortcuts-filter"
+          aria-label="Search keyboard shortcuts"
+        />
+
+        {filtered.length === 0 ? (
+          <p className="text-sm text-muted-foreground" data-testid="shortcuts-empty">
+            No shortcuts match your search.
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {SHORTCUT_GROUP_ORDER.map((group) => {
+              const items = grouped[group];
+              if (items.length === 0) return null;
+              return (
+                <section key={group} data-testid={`shortcuts-group-${group}`}>
+                  <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {SHORTCUT_GROUP_LABELS[group]}
+                  </h3>
+                  <ul className="divide-y divide-border rounded-lg border border-border">
+                    {items.map((shortcut) => (
+                      <li
+                        key={shortcut.id}
+                        className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+                        data-testid={`shortcut-row-${shortcut.id}`}
+                      >
+                        <span className="text-sm text-foreground">{shortcut.label}</span>
+                        <kbd className="shrink-0 rounded-md border border-border bg-muted px-2 py-1 font-mono text-[11px] text-foreground">
+                          {formatShortcut(shortcut)}
+                        </kbd>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -18,6 +18,7 @@ import { DataGrid } from './DataGrid';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
 import { useMonacoTheme } from '../lib/useMonacoTheme';
 import { registerMqlensMonacoThemes } from '../lib/monacoAppTheme';
+import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 
 type ShellTab = 'console' | 'viewer';
 
@@ -645,7 +646,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           <span className="text-xs font-semibold text-foreground">mongosh</span>
           <span className="font-mono text-[11px] text-muted-foreground">{connectionName} · {currentDb}</span>
           <span className="flex-1" />
-          <span className="font-mono text-[10px] text-muted-foreground">Ctrl/⌘↵</span>
+          <span className="font-mono text-[10px] text-muted-foreground">
+            {formatShortcut(shortcutById('run-query')!)}
+          </span>
           <Button size="sm" onClick={() => runRef.current()} disabled={running}>
             <Play size={11} />
             Run

--- a/src/components/QuickStart.tsx
+++ b/src/components/QuickStart.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import brandMark from '../assets/mqlens-mark.png';
 import type { ConnectionProfile } from '../lib/connection';
-import { primaryShortcutModifier } from '../lib/quickStartUtils';
+import { quickStartShortcutRows } from '../lib/shortcuts';
 import { ConnectionCard } from './ConnectionCard';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -27,6 +27,7 @@ import { Separator } from '@/components/ui/separator';
 interface QuickStartProps {
   onConnect: () => void;
   onOpenSettings: () => void;
+  onOpenShortcuts?: () => void;
   onQuickConnect: (profile: ConnectionProfile) => Promise<void>;
   onLoadSampleData: () => void;
   activeConnections: { profileId: string }[];
@@ -52,6 +53,7 @@ const QUICK_ACTIONS: {
 export const QuickStart: React.FC<QuickStartProps> = ({
   onConnect,
   onOpenSettings,
+  onOpenShortcuts,
   onQuickConnect,
   onLoadSampleData,
   activeConnections,
@@ -83,13 +85,7 @@ export const QuickStart: React.FC<QuickStartProps> = ({
   const isEmpty = sorted.length === 0;
   const activeIds = new Set(activeConnections.map((c) => c.profileId));
   const activeCount = sorted.filter((p) => activeIds.has(p.id)).length;
-  const modifier = primaryShortcutModifier();
-  const shortcuts = [
-    { keys: `${modifier} ↵`, label: 'Run the current query' },
-    { keys: `${modifier} F`, label: 'Search the sidebar tree' },
-    { keys: `${modifier} K`, label: 'Open command palette' },
-    { keys: `${modifier} + / −`, label: 'Zoom interface in or out' },
-  ] as const;
+  const shortcuts = quickStartShortcutRows();
 
   const handleQuickConnect = async (p: ConnectionProfile) => {
     setConnectingId(p.id);
@@ -303,14 +299,22 @@ export const QuickStart: React.FC<QuickStartProps> = ({
                   <CardTitle className="text-sm">Keyboard shortcuts</CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-col gap-3 pt-0">
-                  {shortcuts.map(({ keys, label }) => (
-                    <div key={keys} className="flex items-start gap-2.5 text-xs text-muted-foreground">
+                  {shortcuts.map(({ id, keys, label }) => (
+                    <div key={id} className="flex items-start gap-2.5 text-xs text-muted-foreground">
                       <kbd className="mt-0.5 shrink-0 rounded-md border border-border bg-muted px-2 py-0.5 font-mono text-[10px] text-foreground">
                         {keys}
                       </kbd>
                       <span className="min-w-0 flex-1 leading-snug">{label}</span>
                     </div>
                   ))}
+                  <button
+                    type="button"
+                    className="text-left text-xs font-medium text-primary hover:underline"
+                    data-testid="qs-view-all-shortcuts"
+                    onClick={onOpenShortcuts ?? onOpenSettings}
+                  >
+                    View all shortcuts in Settings
+                  </button>
                   <div className="flex items-start gap-2.5 text-xs text-muted-foreground">
                     <FolderOpen className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
                     <span className="min-w-0 flex-1 leading-snug">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import {
   ShieldCheck,
   ArrowUpCircle,
   Server,
+  Keyboard,
   type LucideIcon,
 } from 'lucide-react';
 import {
@@ -27,6 +28,7 @@ import {
   type UpdateCheckSnapshot,
 } from '@/lib/updateCheckState';
 import { AppearanceSettings } from '@/components/theme/AppearanceSettings';
+import { KeyboardShortcutsSettings } from '@/components/KeyboardShortcutsSettings';
 import type { AppearanceSettings as AppearanceSettingsType } from '@/lib/themes/schema';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -83,7 +85,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   antigravity: 'Antigravity (local)',
 };
 
-type SettingsTabId = 'appearance' | 'ai' | 'mcp' | 'mongosh' | 'updates' | 'security';
+type SettingsTabId = 'appearance' | 'ai' | 'mcp' | 'mongosh' | 'updates' | 'shortcuts' | 'security';
 
 const SETTINGS_TABS: {
   id: SettingsTabId;
@@ -126,6 +128,12 @@ const SETTINGS_TABS: {
     persistFooter: true,
   },
   {
+    id: 'shortcuts',
+    label: 'Shortcuts',
+    description: 'Keyboard shortcuts reference for the workspace.',
+    Icon: Keyboard,
+  },
+  {
     id: 'security',
     label: 'Security',
     description: 'Master password, biometrics, and vault recovery.',
@@ -133,8 +141,14 @@ const SETTINGS_TABS: {
   },
 ];
 
-export const SettingsView: React.FC = () => {
-  const [tab, setTab] = useState<SettingsTabId>('appearance');
+export type { SettingsTabId };
+
+export interface SettingsViewProps {
+  initialTab?: SettingsTabId;
+}
+
+export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab }) => {
+  const [tab, setTab] = useState<SettingsTabId>(initialTab ?? 'appearance');
   const [mongoshPath, setMongoshPath] = useState('');
   const [aiProvider, setAiProvider] = useState('anthropic');
   const [anthropicKey, setAnthropicKey] = useState('');
@@ -169,6 +183,10 @@ export const SettingsView: React.FC = () => {
     window.addEventListener(UPDATE_CHECK_STATE_EVENT, sync);
     return () => window.removeEventListener(UPDATE_CHECK_STATE_EVENT, sync);
   }, []);
+
+  useEffect(() => {
+    if (initialTab) setTab(initialTab);
+  }, [initialTab]);
 
   useEffect(() => {
     let cancelled = false;
@@ -599,6 +617,9 @@ export const SettingsView: React.FC = () => {
             </Card>
           </div>
         );
+
+      case 'shortcuts':
+        return <KeyboardShortcutsSettings />;
 
       case 'security':
         return (

--- a/src/components/__tests__/QuickStart.test.tsx
+++ b/src/components/__tests__/QuickStart.test.tsx
@@ -77,4 +77,12 @@ describe('QuickStart', () => {
     expect(await screen.findByText('Ctrl F')).toBeInTheDocument();
     platform.mockRestore();
   });
+
+  it('links to the full shortcuts reference', async () => {
+    invokeMock.mockResolvedValueOnce([]);
+    const onOpenShortcuts = vi.fn();
+    setup({ onOpenShortcuts });
+    fireEvent.click(await screen.findByTestId('qs-view-all-shortcuts'));
+    expect(onOpenShortcuts).toHaveBeenCalled();
+  });
 });

--- a/src/components/__tests__/SettingsModal.test.tsx
+++ b/src/components/__tests__/SettingsModal.test.tsx
@@ -182,4 +182,19 @@ describe('SettingsView Component', () => {
     expect(await screen.findByTestId('update-last-checked')).toHaveTextContent(/Offline/i);
     expect(screen.getByTestId('update-last-checked')).toHaveTextContent(/Last checked:/i);
   });
+
+  it('lists keyboard shortcuts with search on the shortcuts tab', async () => {
+    renderSettings();
+    await openTab('settings-tab-shortcuts');
+    expect(await screen.findByTestId('shortcuts-group-command-palette')).toBeInTheDocument();
+    expect(screen.getByTestId('shortcut-row-palette-open')).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('shortcuts-filter'), { target: { value: 'sidebar' } });
+    expect(screen.getByTestId('shortcut-row-sidebar-search')).toBeInTheDocument();
+    expect(screen.queryByTestId('shortcut-row-palette-open')).not.toBeInTheDocument();
+  });
+
+  it('opens the shortcuts tab when initialTab is shortcuts', async () => {
+    render(<SettingsView initialTab="shortcuts" />);
+    expect(await screen.findByTestId('shortcuts-group-zoom')).toBeInTheDocument();
+  });
 });

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -4,6 +4,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { formatShortcut, shortcutById } from "@/lib/shortcuts";
 
 interface StatusBarProps {
   cpu?: string;
@@ -52,7 +53,7 @@ export function StatusBar({
             </button>
           </TooltipTrigger>
           <TooltipContent side="top">
-            Reset zoom (⌘0 / Ctrl+0)
+            Reset zoom ({formatShortcut(shortcutById('zoom-reset')!)})
           </TooltipContent>
         </Tooltip>
       )}

--- a/src/components/theme/AppearanceSettings.tsx
+++ b/src/components/theme/AppearanceSettings.tsx
@@ -21,6 +21,7 @@ import {
   UI_ZOOM_MIN,
   UI_ZOOM_STEP,
 } from "@/lib/themes/ui-scale";
+import { formatZoomShortcutHint } from "@/lib/shortcuts";
 
 export function AppearanceSettings() {
   const {
@@ -159,7 +160,7 @@ export function AppearanceSettings() {
               onValueChange={([v]) => setUiZoom(clampUiZoom(v))}
             />
             <p className="text-[11px] text-muted-foreground">
-              Shortcut: ⌘ + / ⌘ − / ⌘ 0 to reset
+              Shortcut: {formatZoomShortcutHint()}
             </p>
           </div>
 

--- a/src/lib/__tests__/shortcuts.test.ts
+++ b/src/lib/__tests__/shortcuts.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterKeyboardShortcuts,
+  formatShortcut,
+  formatShortcutChord,
+  groupKeyboardShortcuts,
+  primaryShortcutModifier,
+  quickStartShortcutRows,
+  shortcutById,
+} from '../shortcuts';
+
+describe('shortcuts', () => {
+  it('uses platform-aware modifier labels', () => {
+    expect(primaryShortcutModifier('MacIntel')).toBe('⌘');
+    expect(primaryShortcutModifier('Win32')).toBe('Ctrl');
+    expect(formatShortcutChord({ mod: true, key: 'K' }, 'MacIntel')).toBe('⌘ K');
+    expect(formatShortcutChord({ mod: true, key: 'K' }, 'Win32')).toBe('Ctrl K');
+  });
+
+  it('formats known shortcuts for settings display', () => {
+    const run = shortcutById('run-query')!;
+    expect(formatShortcut(run, 'Win32')).toBe('Ctrl ↵');
+    expect(formatShortcut(shortcutById('palette-navigate')!, 'MacIntel')).toBe('↑ / ↓');
+  });
+
+  it('filters shortcuts by label, group, and keys', () => {
+    expect(filterKeyboardShortcuts('sidebar', undefined, 'Win32').map((s) => s.id)).toEqual([
+      'sidebar-search',
+    ]);
+    expect(filterKeyboardShortcuts('zoom', undefined, 'Win32').length).toBeGreaterThan(0);
+    expect(filterKeyboardShortcuts('nope', undefined, 'Win32')).toEqual([]);
+  });
+
+  it('groups shortcuts in stable section order', () => {
+    const grouped = groupKeyboardShortcuts(filterKeyboardShortcuts(''));
+    expect(grouped.navigation[0]?.id).toBe('close-dialog');
+    expect(grouped['command-palette'].some((s) => s.id === 'palette-open')).toBe(true);
+  });
+
+  it('builds quick start rows with combined zoom keys', () => {
+    const rows = quickStartShortcutRows('Win32');
+    expect(rows.find((r) => r.id === 'sidebar-search')?.keys).toBe('Ctrl F');
+    expect(rows.find((r) => r.id === 'zoom-in')?.keys).toBe('Ctrl + / Ctrl −');
+  });
+});

--- a/src/lib/quickStartUtils.ts
+++ b/src/lib/quickStartUtils.ts
@@ -8,9 +8,7 @@ export const AVATAR_PALETTE = [
   '#1f6f7a', // teal
 ] as const;
 
-export function primaryShortcutModifier(platform = navigator.platform): '⌘' | 'Ctrl' {
-  return /Mac|iPhone|iPad|iPod/i.test(platform) ? '⌘' : 'Ctrl';
-}
+export { primaryShortcutModifier } from './shortcuts';
 
 /** Host[:port] parsed from a mongodb URI, credentials stripped. '' if unparseable. */
 export function hostFromUri(uri: string): string {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,218 @@
+export type ShortcutGroup =
+  | 'navigation'
+  | 'query-editor'
+  | 'sidebar'
+  | 'zoom'
+  | 'command-palette';
+
+export const SHORTCUT_GROUP_LABELS: Record<ShortcutGroup, string> = {
+  navigation: 'Navigation',
+  'query-editor': 'Query editor',
+  sidebar: 'Sidebar',
+  zoom: 'Zoom',
+  'command-palette': 'Command palette',
+};
+
+export const SHORTCUT_GROUP_ORDER: ShortcutGroup[] = [
+  'navigation',
+  'query-editor',
+  'sidebar',
+  'zoom',
+  'command-palette',
+];
+
+export interface ShortcutChord {
+  mod?: boolean;
+  key: string;
+  shift?: boolean;
+}
+
+export interface KeyboardShortcut {
+  id: string;
+  group: ShortcutGroup;
+  label: string;
+  keywords?: string;
+  chords: ShortcutChord[];
+}
+
+export function isMacPlatform(platform = navigator.platform): boolean {
+  return /Mac|iPhone|iPad|iPod/i.test(platform);
+}
+
+export function primaryShortcutModifier(platform = navigator.platform): '⌘' | 'Ctrl' {
+  return isMacPlatform(platform) ? '⌘' : 'Ctrl';
+}
+
+const DISPLAY_KEYS: Record<string, string> = {
+  Enter: '↵',
+  Escape: 'esc',
+};
+
+function displayKey(key: string): string {
+  return DISPLAY_KEYS[key] ?? key;
+}
+
+export function formatShortcutChord(chord: ShortcutChord, platform = navigator.platform): string {
+  const mod = primaryShortcutModifier(platform);
+  const parts: string[] = [];
+  if (chord.mod) parts.push(mod);
+  if (chord.shift) parts.push('Shift');
+  parts.push(displayKey(chord.key));
+  return parts.join(' ');
+}
+
+export function formatShortcut(shortcut: KeyboardShortcut, platform = navigator.platform): string {
+  return shortcut.chords.map((chord) => formatShortcutChord(chord, platform)).join(' / ');
+}
+
+export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
+  {
+    id: 'close-dialog',
+    group: 'navigation',
+    label: 'Close the topmost dialog or modal',
+    chords: [{ key: 'Escape' }],
+    keywords: 'dismiss cancel overlay',
+  },
+  {
+    id: 'run-query',
+    group: 'query-editor',
+    label: 'Run the current query',
+    chords: [{ mod: true, key: 'Enter' }],
+    keywords: 'execute mongosh shell builder',
+  },
+  {
+    id: 'submit-dialog',
+    group: 'query-editor',
+    label: 'Submit a multi-line dialog (import URI, prompts)',
+    chords: [{ mod: true, key: 'Enter' }],
+    keywords: 'connection import prompt',
+  },
+  {
+    id: 'sidebar-search',
+    group: 'sidebar',
+    label: 'Focus sidebar tree search',
+    chords: [{ mod: true, key: 'F' }],
+    keywords: 'filter find tree',
+  },
+  {
+    id: 'zoom-in',
+    group: 'zoom',
+    label: 'Zoom interface in',
+    chords: [{ mod: true, key: '+' }],
+    keywords: 'magnify dpi scale',
+  },
+  {
+    id: 'zoom-out',
+    group: 'zoom',
+    label: 'Zoom interface out',
+    chords: [{ mod: true, key: '−' }],
+    keywords: 'shrink dpi scale',
+  },
+  {
+    id: 'zoom-reset',
+    group: 'zoom',
+    label: 'Reset interface zoom to 100%',
+    chords: [{ mod: true, key: '0' }],
+    keywords: 'default dpi scale status bar',
+  },
+  {
+    id: 'palette-open',
+    group: 'command-palette',
+    label: 'Open or close command palette',
+    chords: [{ mod: true, key: 'K' }],
+    keywords: 'search commands collections queries',
+  },
+  {
+    id: 'palette-navigate',
+    group: 'command-palette',
+    label: 'Navigate palette results',
+    chords: [{ key: '↑' }, { key: '↓' }],
+    keywords: 'arrow up down move',
+  },
+  {
+    id: 'palette-run',
+    group: 'command-palette',
+    label: 'Run the selected palette action',
+    chords: [{ key: 'Enter' }],
+    keywords: 'select execute',
+  },
+  {
+    id: 'palette-close',
+    group: 'command-palette',
+    label: 'Close command palette',
+    chords: [{ key: 'Escape' }],
+    keywords: 'dismiss cancel',
+  },
+];
+
+export const QUICK_START_SHORTCUT_IDS = [
+  'run-query',
+  'sidebar-search',
+  'palette-open',
+  'zoom-in',
+  'zoom-out',
+] as const;
+
+export function quickStartShortcutRows(platform = navigator.platform) {
+  const zoomIn = KEYBOARD_SHORTCUTS.find((s) => s.id === 'zoom-in')!;
+  const zoomOut = KEYBOARD_SHORTCUTS.find((s) => s.id === 'zoom-out')!;
+  const rows = QUICK_START_SHORTCUT_IDS.filter((id) => id !== 'zoom-out').map((id) => {
+    const shortcut = KEYBOARD_SHORTCUTS.find((s) => s.id === id)!;
+    if (id === 'zoom-in') {
+      return {
+        id,
+        keys: `${formatShortcutChord(zoomIn.chords[0], platform)} / ${formatShortcutChord(zoomOut.chords[0], platform)}`,
+        label: 'Zoom interface in or out',
+      };
+    }
+    return {
+      id,
+      keys: formatShortcut(shortcut, platform),
+      label: shortcut.label,
+    };
+  });
+  return rows;
+}
+
+export function formatZoomShortcutHint(platform = navigator.platform): string {
+  const zoomIn = shortcutById('zoom-in')!;
+  const zoomOut = shortcutById('zoom-out')!;
+  const zoomReset = shortcutById('zoom-reset')!;
+  return `${formatShortcutChord(zoomIn.chords[0], platform)} / ${formatShortcutChord(zoomOut.chords[0], platform)} / ${formatShortcutChord(zoomReset.chords[0], platform)} to reset`;
+}
+
+export function shortcutById(id: string): KeyboardShortcut | undefined {
+  return KEYBOARD_SHORTCUTS.find((s) => s.id === id);
+}
+
+export function filterKeyboardShortcuts(
+  query: string,
+  shortcuts: KeyboardShortcut[] = KEYBOARD_SHORTCUTS,
+  platform = navigator.platform,
+): KeyboardShortcut[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return shortcuts;
+  return shortcuts.filter((shortcut) => {
+    const haystack = [
+      shortcut.label,
+      shortcut.keywords ?? '',
+      SHORTCUT_GROUP_LABELS[shortcut.group],
+      formatShortcut(shortcut, platform),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
+export function groupKeyboardShortcuts(
+  shortcuts: KeyboardShortcut[],
+): Record<ShortcutGroup, KeyboardShortcut[]> {
+  const grouped = Object.fromEntries(
+    SHORTCUT_GROUP_ORDER.map((group) => [group, [] as KeyboardShortcut[]]),
+  ) as Record<ShortcutGroup, KeyboardShortcut[]>;
+  for (const shortcut of shortcuts) {
+    grouped[shortcut.group].push(shortcut);
+  }
+  return grouped;
+}


### PR DESCRIPTION
## Summary
- Adds `src/lib/shortcuts.ts` as the single source of truth for global shortcuts with platform-aware labels (⌘ on macOS, Ctrl elsewhere).
- New **Settings → Shortcuts** tab lists shortcuts grouped by Navigation, Query editor, Sidebar, Zoom, and Command palette, with search/filter.
- QuickStart keyboard card and existing tooltips (query run, zoom, connection import, status bar) now consume the shared definitions; QuickStart links to the full reference.

Closes #132

## Test plan
- [x] `npm test -- --run src/lib/__tests__/shortcuts.test.ts src/components/__tests__/QuickStart.test.tsx src/components/__tests__/SettingsModal.test.tsx`
- [x] `npx tsc --noEmit`
- [x] Manual: open Settings → Shortcuts, search for "zoom" / "palette"
- [x] Manual: QuickStart → "View all shortcuts in Settings" opens Shortcuts tab
- [x] Manual: verify ⌘ vs Ctrl labels on macOS vs Windows/Linux