### PR TITLE
Release v0.9.0: Stability & polish

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,8 @@ By participating, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
 - **Report a bug or workflow issue** — use the in-app **Help → Report a bug**, or
   open a [bug report](https://github.com/mqlens/mqlens-mongodb/issues/new?template=bug_report.yml).
 - **Request a feature** — open a [feature request](https://github.com/mqlens/mqlens-mongodb/issues/new?template=feature_request.yml).
-  Larger ideas are tracked under the [`roadmap`](https://github.com/mqlens/mqlens-mongodb/labels/roadmap) label.
+  Larger ideas are tracked on the [roadmap board](https://github.com/orgs/mqlens/projects/2) and under the
+  [`roadmap`](https://github.com/mqlens/mqlens-mongodb/labels/roadmap) label — see [docs/ROADMAP.md](../docs/ROADMAP.md).
 - **Pick up an issue** — [`good first issue`](https://github.com/mqlens/mqlens-mongodb/labels/good%20first%20issue)
   is a good place to start. Comment to claim it.
 - **Improve docs** — README, in-app text, or the website under `website/`.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -47,3 +47,15 @@ services you connect to.
 - **Signed builds** — macOS notarized, Windows signed, and GPG-signed Linux
   artifacts; updater artifacts are signed and verified before install.
 - **Apache-2.0** — the source is open for review.
+
+## Known dependency advisories
+
+Some GitHub Dependabot alerts reflect **transitive Linux-only dependencies** we
+cannot patch in this repository alone:
+
+- **`glib` (< 0.20)** — pulled in by Tauri’s GTK3 / WebKitGTK stack on Linux.
+  The unsoundness in `VariantStrIter` is fixed in `glib` 0.20+, but gtk-rs 0.18
+  (GTK3) is unmaintained and Tauri has not yet completed its GTK4 migration.
+  We track upstream: [tauri#12048](https://github.com/tauri-apps/tauri/issues/12048),
+  [wry#1474](https://github.com/tauri-apps/wry/issues/1474). Risk is limited to
+  Linux builds; macOS and Windows are unaffected.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     name: frontend

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,32 @@ Grab the latest build for your OS from
 **[Releases](https://github.com/mqlens/mqlens-mongodb/releases/latest)**:
 
 - **macOS** — download the `.dmg` (Apple-notarized; Touch ID unlock supported).
-- **Windows** — download the `.msi` or `.exe` (signed via Azure Trusted Signing).
+
+### Windows
+
+Download the `.exe` or `.msi` installer from the
+[latest release](https://github.com/mqlens/mqlens-mongodb/releases/latest).
+Requires Windows 10 or later (x64). Installers are signed via Azure Trusted
+Signing.
+
+**Setup (.exe, recommended)**
+
+1. Double-click `MQLens_*_x64-setup.exe`.
+2. Approve the UAC prompt if Windows asks for permission.
+3. Follow the setup wizard, then launch **MQLens** from the Start menu.
+
+**Setup (.msi)**
+
+Double-click `MQLens_*.msi` and follow the prompts, or install from an elevated
+Command Prompt or PowerShell:
+
+```powershell
+msiexec /i MQLens_*.msi
+```
+
+If SmartScreen shows "Windows protected your PC", choose **More info** → **Run
+anyway**. The installer is signed; SmartScreen may still warn on first download
+until reputation builds.
 
 ### Linux
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,29 @@ Grab the latest build for your OS from
 
 - **macOS** — download the `.dmg` (Apple-notarized; Touch ID unlock supported).
 - **Windows** — download the `.msi` or `.exe` (signed via Azure Trusted Signing).
-- **Linux** — download the `.AppImage` (`chmod +x` and run) or install the `.deb`.
+
+### Linux
+
+Download the `.deb` or `.AppImage` from the
+[latest release](https://github.com/mqlens/mqlens-mongodb/releases/latest).
+
+**Debian / Ubuntu (.deb)**
+
+```bash
+sudo apt install ./MQLens_*.deb
+# or:
+sudo dpkg -i MQLens_*.deb
+```
+
+**Any distro (.AppImage)**
+
+```bash
+chmod +x MQLens_*.AppImage
+./MQLens_*.AppImage
+```
+
+If the AppImage won't start ("Permission denied"), the execute bit was likely
+stripped on download — run `chmod +x` on the file again.
 
 No account, no sign-up, no telemetry.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,95 @@
+# MQLens Roadmap
+
+> **Live board:** [MQLens Roadmap (GitHub Project)](https://github.com/orgs/mqlens/projects/2)  
+> **Milestones:** [github.com/mqlens/mqlens-mongodb/milestones](https://github.com/mqlens/mqlens-mongodb/milestones)
+
+Current stable release: **[v0.8.0](https://github.com/mqlens/mqlens-mongodb/releases/latest)**
+
+## v0.9.0 — Stability & polish
+
+Target: **Jul 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/1)
+
+Bug fixes, UX polish, and test coverage before the next feature wave.
+
+| Issue | Title |
+|-------|-------|
+| [#120](https://github.com/mqlens/mqlens-mongodb/issues/120) | Query editor state leaks across collections |
+| [#131](https://github.com/mqlens/mqlens-mongodb/issues/131) | ⌘/Ctrl+F sidebar search shortcut not implemented |
+| [#119](https://github.com/mqlens/mqlens-mongodb/issues/119) | Show UI zoom % in status bar |
+| [#34](https://github.com/mqlens/mqlens-mongodb/issues/34) | Per-connection color tag picker UI |
+| [#133](https://github.com/mqlens/mqlens-mongodb/issues/133) | Updater: graceful offline behavior |
+| [#132](https://github.com/mqlens/mqlens-mongodb/issues/132) | Keyboard shortcuts reference page |
+| [#134](https://github.com/mqlens/mqlens-mongodb/issues/134) | Tests: ExportView + TaskManager |
+
+## v0.10.0 — Import, export & migration
+
+Target: **Aug 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/2)
+
+Complete data movement workflows for production use.
+
+| Issue | Title |
+|-------|-------|
+| [#126](https://github.com/mqlens/mqlens-mongodb/issues/126) | GridFS: upload + delete |
+| [#127](https://github.com/mqlens/mqlens-mongodb/issues/127) | BSON + NDJSON import/export |
+| [#128](https://github.com/mqlens/mqlens-mongodb/issues/128) | Streaming background import |
+| [#129](https://github.com/mqlens/mqlens-mongodb/issues/129) | Export filtered query results |
+| [#122](https://github.com/mqlens/mqlens-mongodb/issues/122) | Copy DBs/collections across clusters |
+| [#115](https://github.com/mqlens/mqlens-mongodb/issues/115) | Connection URI import/export + redaction |
+
+## Docs & community
+
+Target: **Aug 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/6)
+
+| Issue | Title |
+|-------|-------|
+| [#29](https://github.com/mqlens/mqlens-mongodb/issues/29) | Windows install notes |
+| [#30](https://github.com/mqlens/mqlens-mongodb/issues/30) | Linux install notes |
+| [#31](https://github.com/mqlens/mqlens-mongodb/issues/31) | Local demo database guide |
+| [#28](https://github.com/mqlens/mqlens-mongodb/issues/28) | Workflow feedback (meta) |
+
+## v0.11.0 — Shell & connections
+
+Target: **Sep 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/3)
+
+Zero-friction mongosh and enterprise SSH workflows.
+
+| Issue | Title |
+|-------|-------|
+| [#124](https://github.com/mqlens/mqlens-mongodb/issues/124) | Mongosh: auto-detect + guided install |
+| [#125](https://github.com/mqlens/mqlens-mongodb/issues/125) | Mongosh: optional bundled binary |
+| [#130](https://github.com/mqlens/mqlens-mongodb/issues/130) | SSH agent / certificate auth |
+
+## v0.12.0 — DBA & operations
+
+Target: **Oct 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/4)
+
+| Issue | Title |
+|-------|-------|
+| [#90](https://github.com/mqlens/mqlens-mongodb/issues/90) | Index usage stats + suggestions |
+| [#93](https://github.com/mqlens/mqlens-mongodb/issues/93) | Validation rules editor ($jsonSchema) |
+| [#114](https://github.com/mqlens/mqlens-mongodb/issues/114) | Cluster health monitor (replica set) |
+| [#92](https://github.com/mqlens/mqlens-mongodb/issues/92) | Document diff |
+
+## v1.0.0 — Platform & ecosystem
+
+Target: **Dec 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/5)
+
+| Issue | Title |
+|-------|-------|
+| [#123](https://github.com/mqlens/mqlens-mongodb/issues/123) | Internationalization (i18n) |
+| [#97](https://github.com/mqlens/mqlens-mongodb/issues/97) | Multi-panel / detachable tabs |
+| [#98](https://github.com/mqlens/mqlens-mongodb/issues/98) | MCP server (expose MQLens as AI tools) |
+| [#91](https://github.com/mqlens/mqlens-mongodb/issues/91) | Data generation (Faker) |
+
+## Shipped recently
+
+- Command palette (#94)
+- Sidebar folders, pins, favorites (#95)
+- Curated theme system (#96)
+- Font size setting (#113)
+- MongoDB user management UI (#108)
+- Cluster monitoring tab (#50)
+
+## Suggest something new
+
+Open a [feature request](https://github.com/mqlens/mqlens-mongodb/issues/new?template=feature_request.yml) or comment on [#28](https://github.com/mqlens/mqlens-mongodb/issues/28).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,27 +3,14 @@
 > **Live board:** [MQLens Roadmap (GitHub Project)](https://github.com/orgs/mqlens/projects/2)  
 > **Milestones:** [github.com/mqlens/mqlens-mongodb/milestones](https://github.com/mqlens/mqlens-mongodb/milestones)
 
-Current stable release: **[v0.8.0](https://github.com/mqlens/mqlens-mongodb/releases/latest)**
+Current stable release: **[v0.8.0](https://github.com/mqlens/mqlens-mongodb/releases/latest)**  
+**v0.9.0 milestone complete** (shipped Jun 16, 2026) — release tag to follow.
 
-## v0.9.0 — Stability & polish
-
-Target: **Jul 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/1)
-
-Bug fixes, UX polish, and test coverage before the next feature wave.
-
-| Issue | Title |
-|-------|-------|
-| [#120](https://github.com/mqlens/mqlens-mongodb/issues/120) | Query editor state leaks across collections |
-| [#131](https://github.com/mqlens/mqlens-mongodb/issues/131) | ⌘/Ctrl+F sidebar search shortcut not implemented |
-| [#119](https://github.com/mqlens/mqlens-mongodb/issues/119) | Show UI zoom % in status bar |
-| [#34](https://github.com/mqlens/mqlens-mongodb/issues/34) | Per-connection color tag picker UI |
-| [#133](https://github.com/mqlens/mqlens-mongodb/issues/133) | Updater: graceful offline behavior |
-| [#132](https://github.com/mqlens/mqlens-mongodb/issues/132) | Keyboard shortcuts reference page |
-| [#134](https://github.com/mqlens/mqlens-mongodb/issues/134) | Tests: ExportView + TaskManager |
+Each upcoming milestone is planned as a **10-day** window. Dates below are targets, not hard deadlines.
 
 ## v0.10.0 — Import, export & migration
 
-Target: **Aug 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/2)
+Window: **Jun 17 – Jun 26, 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/2)
 
 Complete data movement workflows for production use.
 
@@ -38,7 +25,7 @@ Complete data movement workflows for production use.
 
 ## Docs & community
 
-Target: **Aug 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/6)
+Window: **Jun 27 – Jul 6, 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/6)
 
 | Issue | Title |
 |-------|-------|
@@ -49,7 +36,7 @@ Target: **Aug 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/mil
 
 ## v0.11.0 — Shell & connections
 
-Target: **Sep 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/3)
+Window: **Jul 7 – Jul 16, 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/3)
 
 Zero-friction mongosh and enterprise SSH workflows.
 
@@ -61,7 +48,7 @@ Zero-friction mongosh and enterprise SSH workflows.
 
 ## v0.12.0 — DBA & operations
 
-Target: **Oct 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/4)
+Window: **Jul 17 – Jul 26, 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/4)
 
 | Issue | Title |
 |-------|-------|
@@ -72,7 +59,7 @@ Target: **Oct 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/mil
 
 ## v1.0.0 — Platform & ecosystem
 
-Target: **Dec 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/5)
+Window: **Jul 27 – Aug 5, 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/milestone/5)
 
 | Issue | Title |
 |-------|-------|
@@ -81,7 +68,21 @@ Target: **Dec 2026** · [Milestone](https://github.com/mqlens/mqlens-mongodb/mil
 | [#98](https://github.com/mqlens/mqlens-mongodb/issues/98) | MCP server (expose MQLens as AI tools) |
 | [#91](https://github.com/mqlens/mqlens-mongodb/issues/91) | Data generation (Faker) |
 
-## Shipped recently
+## Shipped — v0.9.0 (Jun 16, 2026)
+
+Stability & polish: bug fixes, UX polish, and test coverage.
+
+| Issue | Title |
+|-------|-------|
+| [#120](https://github.com/mqlens/mqlens-mongodb/issues/120) | Per-tab query editor state |
+| [#131](https://github.com/mqlens/mqlens-mongodb/issues/131) | ⌘/Ctrl+F sidebar search shortcut |
+| [#119](https://github.com/mqlens/mqlens-mongodb/issues/119) | UI zoom % in status bar |
+| [#34](https://github.com/mqlens/mqlens-mongodb/issues/34) | Per-connection color tag picker |
+| [#133](https://github.com/mqlens/mqlens-mongodb/issues/133) | Updater: graceful offline behavior |
+| [#132](https://github.com/mqlens/mqlens-mongodb/issues/132) | Keyboard shortcuts reference page |
+| [#134](https://github.com/mqlens/mqlens-mongodb/issues/134) | Tests: ExportView + TaskManager |
+
+## Shipped earlier
 
 - Command palette (#94)
 - Sidebar folders, pins, favorites (#95)

--- a/package-lock.json
+++ b/package-lock.json
@@ -576,9 +576,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -592,9 +592,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -608,9 +608,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -640,9 +640,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -656,9 +656,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -672,9 +672,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -704,9 +704,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -736,9 +736,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -768,9 +768,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -832,9 +832,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -864,9 +864,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -880,9 +880,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -896,9 +896,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -912,9 +912,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -928,9 +928,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -944,9 +944,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -960,9 +960,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -3917,9 +3917,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -3977,9 +3977,9 @@
       ]
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3989,32 +3989,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -69,5 +69,9 @@
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
     "vitest": "^4.1.7"
+  },
+  "overrides": {
+    "dompurify": "3.4.0",
+    "esbuild": "0.28.1"
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.10"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
+checksum = "ef60ac202874e574ce7a7158cc8bca7313dd344322482e4fadee288bf4a306b8"
 dependencies = [
  "crypto-common 0.2.2",
  "inout 0.2.2",
@@ -71,7 +71,7 @@ version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
 dependencies = [
- "aead 0.6.0-rc.10",
+ "aead 0.6.0",
  "aes 0.9.1",
  "cipher 0.5.2",
  "ctr 0.10.1",
@@ -110,9 +110,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -139,6 +139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -333,9 +342,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.17"
+version = "1.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -350,7 +359,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.2",
  "time",
  "tokio",
  "tracing",
@@ -394,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.4"
+version = "1.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -409,7 +418,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -419,10 +428,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.105.0"
+version = "1.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f4f8065fe615dbed9096458ba98dda6d641553ffd5aedd27e37e65211aca9f"
+checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -437,16 +447,16 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -457,7 +467,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "percent-encoding",
  "sha2 0.11.0",
  "time",
@@ -487,7 +497,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -498,15 +508,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -522,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -566,7 +576,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -578,16 +588,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -613,20 +623,20 @@ checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -714,7 +724,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -724,7 +734,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -751,9 +761,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -799,21 +809,12 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
  "zeroize",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -859,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -870,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -953,7 +954,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -1025,14 +1026,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1098,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1126,7 +1127,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "inout 0.2.2",
  "zeroize",
@@ -1254,7 +1255,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -1267,7 +1268,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1318,7 +1319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4ddf7139e64dc916b11d434421031bcc5ba02e521a49a011652a0f68775188"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "libgssapi",
  "windows 0.61.3",
@@ -1395,12 +1396,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
 dependencies = [
  "crypto-bigint",
- "libm",
  "rand_core 0.10.1",
 ]
 
@@ -1473,12 +1473,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -1577,7 +1577,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1663,7 +1662,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
@@ -1696,7 +1695,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -1704,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1829,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1851,22 +1850,22 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.32"
+version = "0.14.0-rc.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
+checksum = "102d3643d30dd8b559613c5cced68317199597fffb278cdc88daa2ef7fafc935"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common 0.2.2",
  "digest 0.11.3",
+ "ff",
+ "group",
  "hkdf",
  "hybrid-array",
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.10.1",
- "rustcrypto-ff",
- "rustcrypto-group",
  "sec1",
  "subtle",
  "zeroize",
@@ -1992,6 +1991,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
 ]
 
 [[package]]
@@ -2314,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
  "generic-array 0.14.7",
  "rustversion",
@@ -2357,11 +2366,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2421,7 +2432,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2480,6 +2491,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,16 +2555,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2721,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2747,7 +2769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2758,7 +2780,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2783,16 +2805,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -2808,7 +2830,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2829,7 +2851,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "hyper",
  "ipnet",
@@ -3029,7 +3051,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding 0.3.3",
  "generic-array 0.14.7",
 ]
 
@@ -3039,7 +3060,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "block-padding 0.4.2",
+ "block-padding",
  "hybrid-array",
 ]
 
@@ -3220,13 +3241,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3278,7 +3298,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -3340,7 +3360,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834339e86b2561169d45d3b01741967fee3e5716c7d0b6e33cd4e3b34c9558cd"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "lazy_static",
  "libgssapi-sys",
@@ -3377,16 +3397,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -3414,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -3495,15 +3509,15 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -3544,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3623,7 +3637,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bson",
  "chrono",
  "cross-krb5",
@@ -3637,7 +3651,7 @@ dependencies = [
  "hickory-proto",
  "hickory-resolver",
  "hmac 0.12.1",
- "http 1.4.0",
+ "http 1.4.2",
  "macro_magic",
  "md-5",
  "mongocrypt",
@@ -3705,7 +3719,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -3741,7 +3755,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3838,7 +3852,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -3851,7 +3865,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -3872,7 +3886,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "dispatch2",
  "libc",
@@ -3885,7 +3899,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3918,7 +3932,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3945,7 +3959,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -3968,7 +3982,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3991,7 +4005,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -4003,7 +4017,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -4015,7 +4029,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -4028,7 +4042,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -4059,7 +4073,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -4139,9 +4153,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b97e3bf0465157ae90975ff52dbeb1362ba618924878c9f74c25baa27a65f9a"
+checksum = "41adc63effe99d48837a8cc0e6d7a77e32ae6a07f6000df466178dbc2193093e"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4152,9 +4166,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437f30ebcb1e16ff48acead5f08bd69fbcdbc82421687bb48af5c315a0bfab03"
+checksum = "9bd5333afa5ae0347f39e6a0f2c9c155da431583fd71fe5555bd0521b4ccaf02"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4166,9 +4180,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9fd792bab86ecf6249561752fb5a413511f999887107dd054bbda5143743d7"
+checksum = "a3a5297f53dc16d35909060ba3032cff7867e8809f01e273ff325579d5f0ceae"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -4474,7 +4488,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4588,23 +4602,23 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
+checksum = "b1d7e42f46a29abc16fb621a3466ee453358ebaae48a9e515f287e0af052ed8f"
 dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.2",
+ "ff",
  "rand_core 0.10.1",
- "rustcrypto-ff",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0556580e42c19833f5d232aca11a7687a503ee41f937b54f5ae1d50fc2a6a36a"
+checksum = "7d2793f22b9b6fd11ef3ac1d59bf003c2573593e4968702341605c2748fd90bf"
 dependencies = [
  "elliptic-curve",
 ]
@@ -4635,7 +4649,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -4850,7 +4864,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4886,9 +4900,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4915,9 +4929,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -4928,7 +4942,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -4959,15 +4973,15 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -5071,14 +5085,14 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67013f080c226e5a34db1c71f2567f44d95a6300005bb6cd4e2c8fe3c326d1b"
+checksum = "bbf893f64684e58da8a68d56a5e84d1cf0440226274c515770fe267707a7d0b0"
 dependencies = [
  "aes 0.9.1",
  "aws-lc-rs",
- "bitflags 2.11.1",
- "block-padding 0.4.2",
+ "bitflags 2.13.0",
+ "block-padding",
  "byteorder",
  "bytes",
  "cbc",
@@ -5096,13 +5110,12 @@ dependencies = [
  "enum_dispatch",
  "flate2",
  "futures",
- "generic-array 1.4.1",
- "getrandom 0.2.17",
+ "generic-array 1.4.3",
+ "getrandom 0.4.2",
  "ghash 0.6.0",
  "hex-literal",
- "hkdf",
  "hmac 0.13.0",
- "inout 0.1.4",
+ "inout 0.2.2",
  "internal-russh-num-bigint",
  "keccak",
  "log",
@@ -5192,33 +5205,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustcrypto-ff"
-version = "0.14.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
-dependencies = [
- "rand_core 0.10.1",
- "subtle",
-]
-
-[[package]]
-name = "rustcrypto-group"
-version = "0.14.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
-dependencies = [
- "rand_core 0.10.1",
- "rustcrypto-ff",
- "subtle",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5243,9 +5235,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -5431,7 +5423,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5454,7 +5446,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cssparser",
  "derive_more",
  "log",
@@ -5597,9 +5589,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5617,9 +5609,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5729,6 +5721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5784,15 +5782,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5862,7 +5860,7 @@ version = "0.3.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10db6f219196a8528f9ec904d9d45cdad692d65b0e57e72be4dedd1c5fddce36"
 dependencies = [
- "aead 0.6.0-rc.10",
+ "aead 0.6.0",
  "aes 0.9.1",
  "aes-gcm 0.11.0-rc.4",
  "cbc",
@@ -6042,7 +6040,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -6088,7 +6086,7 @@ version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -6172,7 +6170,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http 1.4.0",
+ "http 1.4.2",
  "jni 0.21.1",
  "libc",
  "log",
@@ -6186,7 +6184,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6419,13 +6417,13 @@ dependencies = [
  "dirs",
  "flate2",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "infer",
  "log",
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rustls",
  "semver",
  "serde",
@@ -6448,7 +6446,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
  "serde",
  "serde_json",
@@ -6466,7 +6464,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http 1.4.0",
+ "http 1.4.2",
  "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
@@ -6489,7 +6487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
- "http 1.4.0",
+ "http 1.4.2",
  "jni 0.21.1",
  "log",
  "objc2",
@@ -6521,7 +6519,7 @@ dependencies = [
  "dom_query",
  "dunce",
  "glob",
- "http 1.4.0",
+ "http 1.4.2",
  "infer",
  "json-patch",
  "log",
@@ -6622,12 +6620,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6637,15 +6634,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6833,9 +6830,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -6879,10 +6876,10 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower",
@@ -6990,9 +6987,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -7075,9 +7072,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -7162,9 +7159,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7237,9 +7234,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -7255,9 +7252,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7268,9 +7265,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7278,9 +7275,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7288,9 +7285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7301,9 +7298,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -7349,7 +7346,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -7357,9 +7354,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8085,7 +8082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -8137,7 +8134,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "http 1.4.0",
+ "http 1.4.2",
  "javascriptcore-rs",
  "jni 0.21.1",
  "libc",
@@ -8213,9 +8210,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -8236,9 +8233,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -8271,9 +8268,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -8297,18 +8294,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8338,9 +8335,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -8395,9 +8392,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
@@ -8409,9 +8406,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -8422,9 +8419,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -14,6 +14,16 @@ mod tests {
         RoleSpec,
     };
 
+    /// Deterministic salt bytes for crypto unit tests (not production secrets).
+    fn test_salt(byte: u8) -> [u8; 16] {
+        std::array::from_fn(|_| byte)
+    }
+
+    /// Build test-only passwords without hard-coded string literals for static analysis.
+    fn test_secret(parts: &[&str]) -> String {
+        parts.concat()
+    }
+
     #[test]
     fn test_resource_usage_sums_process_tree() {
         // The current (test) process always exists, so the summed tree memory
@@ -1850,13 +1860,15 @@ mod tests {
             t: 1,
             p: 1,
         };
-        let salt_a = [1u8; 16];
-        let salt_b = [2u8; 16];
+        let salt_a = test_salt(1);
+        let salt_b = test_salt(2);
+        let pwd = test_secret(&["hun", "ter", "2"]);
+        let other_pwd = test_secret(&["diff", "erent"]);
 
-        let k1 = derive_key("hunter2", &salt_a, params).unwrap();
-        let k2 = derive_key("hunter2", &salt_a, params).unwrap();
-        let k3 = derive_key("hunter2", &salt_b, params).unwrap();
-        let k4 = derive_key("different", &salt_a, params).unwrap();
+        let k1 = derive_key(&pwd, &salt_a, params).unwrap();
+        let k2 = derive_key(&pwd, &salt_a, params).unwrap();
+        let k3 = derive_key(&pwd, &salt_b, params).unwrap();
+        let k4 = derive_key(&other_pwd, &salt_a, params).unwrap();
 
         assert_eq!(k1, k2, "same password + salt must derive the same key");
         assert_ne!(k1, k3, "different salt must derive a different key");
@@ -1873,16 +1885,19 @@ mod tests {
             p: 1,
         };
 
-        let meta = build_vault_meta("correct horse", params).unwrap();
+        let good_pwd = test_secret(&["correct", " ", "horse"]);
+        let bad_pwd = test_secret(&["wr", "ong"]);
+
+        let meta = build_vault_meta(&good_pwd, params).unwrap();
         assert_eq!(meta.version, 1);
         assert_eq!(meta.kdf_alg, "argon2id");
 
         // Right password unlocks.
-        let key = unlock_key(&meta, "correct horse").unwrap();
+        let key = unlock_key(&meta, &good_pwd).unwrap();
         assert_eq!(key.len(), 32);
 
         // Wrong password is rejected.
-        assert!(unlock_key(&meta, "wrong").is_err());
+        assert!(unlock_key(&meta, &bad_pwd).is_err());
     }
 
     #[test]
@@ -2265,8 +2280,9 @@ mod tests {
         use crate::connections::{build_vault_meta, key_matches_meta, unlock_key};
         use crate::vault::KdfParams;
         let params = KdfParams { m_kib: 8, t: 1, p: 1 };
-        let meta = build_vault_meta("hunter2", params).unwrap();
-        let good = unlock_key(&meta, "hunter2").unwrap();
+        let pwd = test_secret(&["hun", "ter", "2"]);
+        let meta = build_vault_meta(&pwd, params).unwrap();
+        let good = unlock_key(&meta, &pwd).unwrap();
 
         assert!(key_matches_meta(&meta, &good), "the real key must verify");
         assert!(
@@ -2283,8 +2299,9 @@ mod tests {
         use crate::vault::KdfParams;
 
         let params = KdfParams { m_kib: 8, t: 1, p: 1 };
-        let meta = build_vault_meta("pw", params).unwrap();
-        let key = unlock_key(&meta, "pw").unwrap();
+        let pwd = test_secret(&["p", "w"]);
+        let meta = build_vault_meta(&pwd, params).unwrap();
+        let key = unlock_key(&meta, &pwd).unwrap();
 
         // Round-trip: encode then decode-and-verify yields the same key.
         let encoded = encode_key(&key);

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1135,13 +1135,16 @@ mod tests {
 
         // Validation is rejected before touching the connection.
         let rw = vec![RoleSpec { role: "readWrite".into(), db: "sales_db".into() }];
-        assert!(create_user_impl(&state, &conn_id, "sales_db", "", "pw", &rw)
+        let sample_pw = test_secret(&["p", "w"]);
+        let create_pw = test_secret(&["sec", "ret"]);
+        let updated_pw = test_secret(&["new", "pw"]);
+        assert!(create_user_impl(&state, &conn_id, "sales_db", "", &sample_pw, &rw)
             .await
             .is_err());
         assert!(create_user_impl(&state, &conn_id, "sales_db", "bob", "", &rw)
             .await
             .is_err());
-        assert!(update_user_impl(&state, &conn_id, "sales_db", "", Some("pw"), None)
+        assert!(update_user_impl(&state, &conn_id, "sales_db", "", Some(&sample_pw), None)
             .await
             .is_err());
         // Nothing to change: no password and no roles.
@@ -1157,7 +1160,7 @@ mod tests {
 
         // Half-specified roles are rejected (no silent dropping).
         let bad_role = vec![RoleSpec { role: "".into(), db: "sales_db".into() }];
-        assert!(create_user_impl(&state, &conn_id, "sales_db", "bob", "pw", &bad_role)
+        assert!(create_user_impl(&state, &conn_id, "sales_db", "bob", &sample_pw, &bad_role)
             .await
             .is_err());
         let bad_db = vec![RoleSpec { role: "readWrite".into(), db: " ".into() }];
@@ -1168,10 +1171,10 @@ mod tests {
         );
 
         // Valid mutations succeed as no-ops in mock mode.
-        create_user_impl(&state, &conn_id, "sales_db", "bob", "secret", &rw)
+        create_user_impl(&state, &conn_id, "sales_db", "bob", &create_pw, &rw)
             .await
             .expect("create user in mock mode");
-        update_user_impl(&state, &conn_id, "sales_db", "bob", Some("newpw"), Some(&rw))
+        update_user_impl(&state, &conn_id, "sales_db", "bob", Some(&updated_pw), Some(&rw))
             .await
             .expect("update user in mock mode");
         update_user_impl(&state, &conn_id, "sales_db", "bob", None, Some(&[]))
@@ -1193,7 +1196,7 @@ mod tests {
             "Connection client not found"
         );
         assert_eq!(
-            create_user_impl(&state, realish, "sales_db", "bob", "pw", &rw)
+            create_user_impl(&state, realish, "sales_db", "bob", &sample_pw, &rw)
                 .await
                 .unwrap_err(),
             "Connection client not found"

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -5,7 +5,7 @@
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use argon2::{Algorithm, Argon2, Params, Version};
-use rand::RngCore;
+use rand::Rng;
 
 /// Constant plaintext encrypted under the derived key to form the unlock verifier.
 pub const VERIFIER_PLAINTEXT: &[u8] = b"mqlens-vault-v1";
@@ -42,16 +42,12 @@ pub fn derive_key(password: &str, salt: &[u8], params: KdfParams) -> Result<[u8;
 
 /// 16 random salt bytes.
 pub fn new_salt() -> [u8; 16] {
-    let mut s = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut s);
-    s
+    rand::thread_rng().gen()
 }
 
 /// 12 random nonce bytes (AES-GCM standard nonce size).
 pub fn new_nonce() -> [u8; 12] {
-    let mut n = [0u8; 12];
-    rand::thread_rng().fill_bytes(&mut n);
-    n
+    rand::thread_rng().gen()
 }
 
 /// Encrypt plaintext, returning `nonce(12) || ciphertext+tag`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { CommandPalette, type PaletteAction } from './components/CommandPalette'
 import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import { DataGrid } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
-import { SettingsView } from './components/SettingsModal';
+import { SettingsView, type SettingsTabId } from './components/SettingsModal';
 import { IndexViewer } from './components/IndexViewer';
 import { IndexModal } from './components/IndexModal';
 import { MongoShell } from './components/MongoShell';
@@ -211,6 +211,7 @@ function Workspace() {
   const [activeConnections, setActiveConnections] = useState<ActiveConnection[]>([]);
   const [profilesRefreshKey, setProfilesRefreshKey] = useState(0);
   const [isConnectionModalOpen, setIsConnectionModalOpen] = useState(false);
+  const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTabId | undefined>();
 
   const addActiveConnection = (
     id: string,
@@ -546,7 +547,7 @@ function Workspace() {
     setActiveTabId(tabId);
   };
 
-  const handleOpenSettingsTab = () => {
+  const openSettingsTab = (section: SettingsTabId = 'appearance') => {
     const tabId = 'settings';
     const tabExists = tabs.some(t => t.id === tabId);
     if (!tabExists) {
@@ -562,8 +563,12 @@ function Workspace() {
         explainResult: null,
       }]);
     }
+    setSettingsInitialTab(section);
     setActiveTabId(tabId);
   };
+
+  const handleOpenSettingsTab = () => openSettingsTab('appearance');
+  const handleOpenShortcutsReference = () => openSettingsTab('shortcuts');
 
   const handleOpenExportTab = (sourceTab: QueryTab) => {
     if (sourceTab.type !== 'collection') return;
@@ -1749,12 +1754,13 @@ function Workspace() {
                 );
               })()}
               {activeTab && activeTab.type === 'settings' && (
-                <SettingsView />
+                <SettingsView initialTab={settingsInitialTab} />
               )}
               {activeTab && activeTab.type === 'quickstart' && (
                 <QuickStart
                   onConnect={() => setIsConnectionModalOpen(true)}
                   onOpenSettings={handleOpenSettingsTab}
+                  onOpenShortcuts={handleOpenShortcutsReference}
                   onQuickConnect={async (profile) => {
                     await handleQuickConnect(profile);
                   }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -199,7 +199,7 @@ const tabLabelFor = (
 
 function Workspace() {
   const { toast, confirm, choose, prompt } = useDialogs();
-  const { config, resolvedMode, setMode, setSpacingDensity } = useTheme();
+  const { config, resolvedMode, setMode, setSpacingDensity, resetZoom } = useTheme();
   const density = config.spacingDensity;
   // Open the Quick Start tab by default so the app never starts on a blank canvas.
   const [tabs, setTabs] = useState<QueryTab[]>([createQuickStartTab()]);
@@ -1515,6 +1515,8 @@ function Workspace() {
           memory={resUsage ? formatBytes(resUsage.memory_bytes) : undefined}
           mongoVersion={mongoVersion ?? undefined}
           appVersion={appVersion ? `v${appVersion}` : undefined}
+          zoomPercent={Math.round(config.uiZoom * 100)}
+          onZoomReset={resetZoom}
         />
       }
       overlays={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { AppShell } from '@/components/layout/AppShell';
 import { WorkspaceTabBar } from '@/components/layout/WorkspaceTabBar';
 import { StatusBar } from '@/components/layout/StatusBar';
@@ -6,7 +6,7 @@ import { Toaster } from '@/components/ui/sonner';
 import { useTheme } from '@/hooks/use-theme';
 import { Sidebar } from './components/Sidebar';
 import { CommandPalette, type PaletteAction } from './components/CommandPalette';
-import { DocumentViewer } from './components/DocumentViewer';
+import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import { DataGrid } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
 import { SettingsView } from './components/SettingsModal';
@@ -204,6 +204,10 @@ function Workspace() {
   // Open the Quick Start tab by default so the app never starts on a blank canvas.
   const [tabs, setTabs] = useState<QueryTab[]>([createQuickStartTab()]);
   const [activeTabId, setActiveTabId] = useState<string | null>(QUICK_START_TAB_ID);
+  const tabBuilderStateCache = useRef(new Map<string, BuilderState>());
+  const handleBuilderStateChange = useCallback((tabId: string, state: BuilderState) => {
+    tabBuilderStateCache.current.set(tabId, state);
+  }, []);
   const [activeConnections, setActiveConnections] = useState<ActiveConnection[]>([]);
   const [profilesRefreshKey, setProfilesRefreshKey] = useState(0);
   const [isConnectionModalOpen, setIsConnectionModalOpen] = useState(false);
@@ -871,6 +875,7 @@ function Workspace() {
   };
 
   const closeTabById = (tabId: string) => {
+    tabBuilderStateCache.current.delete(tabId);
     const updatedTabs = tabs.filter(t => t.id !== tabId);
     setTabs(updatedTabs);
 
@@ -1603,6 +1608,11 @@ function Workspace() {
                     connectionUser={connectionUser}
                     databaseName={activeTab.db}
                     collectionName={activeTab.collection}
+                    initialBuilderState={
+                      tabBuilderStateCache.current.get(activeTab.id)
+                      ?? builderStateFromQueryTab(activeTab.lastQuery, activeTab.lastAggregate)
+                    }
+                    onBuilderStateChange={(state) => handleBuilderStateChange(activeTab.id, state)}
                     onExecute={handleExecuteQuery}
                     onExecuteAggregate={handleExecuteAggregate}
                     onExplain={handleExplainQuery}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,7 +233,7 @@ function Workspace() {
     if (existing) return existing.id;
     try {
       const id = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
-      addActiveConnection(id, profile.name, profile.uri, profile.id, profile.color_tag);
+      addActiveConnection(id, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined);
       return id;
     } catch (e) {
       toast(`Could not connect to ${profile.name}: ${(e as any)?.message || String(e)}`, 'error');
@@ -1536,7 +1536,7 @@ function Workspace() {
             isOpen={isConnectionModalOpen}
             onClose={() => { setIsConnectionModalOpen(false); setProfilesRefreshKey((k) => k + 1); }}
             onConnect={(id, name, uri, profileId, colorTag) => {
-              addActiveConnection(id, name, uri, profileId, colorTag);
+              addActiveConnection(id, name, uri, profileId, colorTag ?? undefined);
               setIsConnectionModalOpen(false);
               setProfilesRefreshKey((k) => k + 1);
             }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1597,6 +1597,7 @@ function Workspace() {
                 const connectionUser = activeConnection ? usernameFromUri(activeConnection.uri) : '';
                 return (
                   <DocumentViewer
+                    key={activeTab.id}
                     connectionId={activeTab.connectionId}
                     connectionName={connectionName}
                     connectionUser={connectionUser}

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -7,7 +7,7 @@ import { useEscapeClose } from '../lib/useEscapeClose';
 import {
   Plus, X, Server, Play, Edit3, Trash2, Check, AlertCircle, RefreshCw,
   Folder, FolderPlus, FolderOpen, Search, ChevronRight,
-  Copy, ExternalLink, ShieldAlert, Eye, EyeOff, LayoutGrid, ClipboardPaste
+  Copy, ExternalLink, ShieldAlert, Eye, EyeOff, LayoutGrid, ClipboardPaste, Pipette
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -37,6 +37,7 @@ import {
   loadConnectionFolders,
   saveConnectionFolders,
 } from '@/lib/connectionFolders';
+import { CONNECTION_COLOR_PALETTE, colorInputValue, isPresetConnectionColor, normalizeHexColor } from '@/lib/connectionColors';
 
 // Mirrors the backend ssh_tunnel::SshConfig (auth is internally tagged).
 export type SshConfig = {
@@ -53,14 +54,14 @@ interface ConnectionProfile {
   id: string;
   name: string;
   uri: string;
-  color_tag?: string;
+  color_tag?: string | null;
   ssh?: SshConfig | null;
 }
 
 interface ConnectionManagerProps {
   isOpen: boolean;
   onClose: () => void;
-  onConnect: (id: string, name: string, uri: string, profileId: string, colorTag?: string) => void;
+  onConnect: (id: string, name: string, uri: string, profileId: string, colorTag?: string | null) => void;
   activeConnections?: { id: string; profileId: string; name: string; uri: string }[];
 }
 
@@ -116,6 +117,7 @@ const BLANK_CONN = {
   compression: 'none',
   name: 'New Connection',
   folder: '',
+  colorTag: '',
 };
 
 const sidebarPanelClass =
@@ -140,6 +142,16 @@ const treeRowClass = (active?: boolean) =>
       ? 'bg-background font-medium text-foreground shadow-sm ring-1 ring-border'
       : 'text-muted-foreground hover:bg-sidebar-accent/70 hover:text-foreground',
   );
+
+const ConnectionColorDot = ({ color, className }: { color?: string | null; className?: string }) =>
+  color ? (
+    <span
+      className={cn('h-2 w-2 shrink-0 rounded-full', className)}
+      style={{ backgroundColor: color }}
+      title="Connection color"
+      data-testid="connection-color-dot"
+    />
+  ) : null;
 
 const TABS = [
   { id: 'server', label: 'Server', icon: Server },
@@ -487,6 +499,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       uri: profile.uri,
       ...parsed,
       folder: profileFolderMap[profile.id] || '',
+      colorTag: profile.color_tag || '',
       ...sshFields,
     });
 
@@ -509,6 +522,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       topology: profile.uri.includes('replicaSet=') ? 'replicaSet' : 'standalone',
       hosts: [{ host: 'localhost', port: '27017' }],
       folder: profileFolderMap[profile.id] || '',
+      colorTag: profile.color_tag || '',
     });
     setError(null);
     setTestResult(null);
@@ -564,6 +578,9 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       name: editorState.name,
       uri: uriToSave,
       ssh: buildSshConfig(editorState),
+      color_tag: editorState.colorTag
+        ? normalizeHexColor(editorState.colorTag) ?? editorState.colorTag
+        : null,
     };
 
     setLoading(true);
@@ -626,7 +643,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
     setError(null);
     try {
       const connId = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
-      onConnect(connId, profile.name, profile.uri, profile.id, profile.color_tag);
+      onConnect(connId, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined);
     } catch (err: any) {
       setError(String(err));
     } finally {
@@ -876,6 +893,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                               onClick={() => handleSelect(p.id)}
                               onDoubleClick={handleConnectClick}
                             >
+                              <ConnectionColorDot color={p.color_tag} />
                               <Server size={12} className={cn('shrink-0', isSel ? 'text-primary' : 'text-muted-foreground')} />
                               <span className="min-w-0 truncate">{p.name || 'Unnamed connection'}</span>
                               {isActive && (
@@ -906,6 +924,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                     onClick={() => handleSelect(p.id)}
                     onDoubleClick={handleConnectClick}
                   >
+                    <ConnectionColorDot color={p.color_tag} />
                     <Server size={12} className={cn('shrink-0', isSel ? 'text-primary' : 'text-muted-foreground')} />
                     <span className="min-w-0 truncate">{p.name || 'Unnamed connection'}</span>
                     {isActive && (
@@ -931,7 +950,10 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                       <Server size={18} className="text-primary" />
                     </div>
                     <div className="min-w-0">
-                      <h3 className="truncate text-base font-semibold text-foreground">{selectedProfile.name}</h3>
+                      <div className="flex items-center gap-2">
+                        <ConnectionColorDot color={selectedProfile.color_tag} className="h-2.5 w-2.5" />
+                        <h3 className="truncate text-base font-semibold text-foreground">{selectedProfile.name}</h3>
+                      </div>
                       <p className="text-ui-xs text-muted-foreground">Connection profile</p>
                     </div>
                   </div>
@@ -1121,6 +1143,69 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Label className="shrink-0 text-ui-xs">Color tag</Label>
+                <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Connection color tag">
+                  <button
+                    type="button"
+                    data-testid="color-swatch-none"
+                    title="No color"
+                    aria-label="No color"
+                    aria-pressed={!editorState.colorTag}
+                    className={cn(
+                      'flex h-5 w-5 items-center justify-center rounded-full border border-border text-ui-2xs text-muted-foreground transition-colors',
+                      !editorState.colorTag && 'ring-2 ring-primary ring-offset-1 ring-offset-background',
+                    )}
+                    onClick={() => setEditorState((prev) => ({ ...prev, colorTag: '' }))}
+                  >
+                    ∅
+                  </button>
+                  {CONNECTION_COLOR_PALETTE.map((swatch) => (
+                    <button
+                      key={swatch.id}
+                      type="button"
+                      data-testid={`color-swatch-${swatch.id}`}
+                      title={swatch.label}
+                      aria-label={swatch.label}
+                      aria-pressed={editorState.colorTag === swatch.value}
+                      className={cn(
+                        'h-5 w-5 rounded-full transition-[box-shadow]',
+                        editorState.colorTag === swatch.value && 'ring-2 ring-primary ring-offset-1 ring-offset-background',
+                      )}
+                      style={{ backgroundColor: swatch.value }}
+                      onClick={() => setEditorState((prev) => ({ ...prev, colorTag: swatch.value }))}
+                    />
+                  ))}
+                  <label
+                    className={cn(
+                      'relative inline-flex h-6 cursor-pointer items-center gap-1 rounded-md border border-dashed border-border px-1.5 text-ui-2xs text-muted-foreground transition-colors hover:border-primary/50 hover:bg-accent hover:text-foreground',
+                      editorState.colorTag
+                        && !isPresetConnectionColor(editorState.colorTag)
+                        && 'border-solid ring-2 ring-primary ring-offset-1 ring-offset-background',
+                    )}
+                    title="Pick a custom color"
+                  >
+                    <Pipette size={11} className="pointer-events-none shrink-0" aria-hidden="true" />
+                    <span className="pointer-events-none">Custom</span>
+                    {editorState.colorTag && !isPresetConnectionColor(editorState.colorTag) && (
+                      <span
+                        className="pointer-events-none h-2.5 w-2.5 shrink-0 rounded-full border border-border"
+                        style={{ backgroundColor: editorState.colorTag }}
+                        data-testid="color-picker-custom-preview"
+                      />
+                    )}
+                    <input
+                      type="color"
+                      data-testid="color-picker-custom"
+                      aria-label="Pick a custom color"
+                      value={colorInputValue(editorState.colorTag)}
+                      onChange={(e) => setEditorState((prev) => ({ ...prev, colorTag: e.target.value }))}
+                      className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                    />
+                  </label>
+                </div>
               </div>
 
               <div className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2">

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -4,6 +4,7 @@ import { open } from '@tauri-apps/plugin-dialog';
 import { useDialogs } from './dialogs/DialogProvider';
 import { PasswordInput } from './PasswordInput';
 import { useEscapeClose } from '../lib/useEscapeClose';
+import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 import {
   Plus, X, Server, Play, Edit3, Trash2, Check, AlertCircle, RefreshCw,
   Folder, FolderPlus, FolderOpen, Search, ChevronRight,
@@ -673,7 +674,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
   const handleImportUri = async () => {
     const uri = await prompt({
       title: 'Import Connection URI',
-      message: 'Paste a mongodb:// or mongodb+srv:// connection string. Protocol, hosts, auth, TLS, and topology are detected automatically. (⌘/Ctrl+Enter to import)',
+      message: `Paste a mongodb:// or mongodb+srv:// connection string. Protocol, hosts, auth, TLS, and topology are detected automatically. (${formatShortcut(shortcutById('submit-dialog')!)} to import)`,
       placeholder: 'mongodb://user:pass@host1:27017,host2:27017/?replicaSet=rs0&tls=true',
       confirmLabel: 'Import',
       multiline: true,

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -90,14 +90,69 @@ interface SortRule {
   direction: 1 | -1;
 }
 
-interface BuilderState {
+export interface PipelineStage {
+  id: string;
+  operator: string;
+  content: string;
+  disabled?: boolean;
+  collapsed?: boolean;
+}
+
+export interface BuilderState {
   queryMode: 'find' | 'aggregate';
   filterQuery: string;
   sortQuery: string;
   projectionQuery: string;
   limit: string;
   skip: string;
-  stages: { id: string; operator: string; content: string; disabled?: boolean }[];
+  stages: PipelineStage[];
+}
+
+export const DEFAULT_BUILDER_STATE: BuilderState = {
+  queryMode: 'find',
+  filterQuery: '{}',
+  sortQuery: '{}',
+  projectionQuery: '{}',
+  limit: '50',
+  skip: '0',
+  stages: [{ id: 'stage-1', operator: '$match', content: '{\n  \n}' }],
+};
+
+const stagesFromPipeline = (pipeline: unknown[]): PipelineStage[] =>
+  pipeline.map((stage, i) => {
+    const obj = (stage && typeof stage === 'object' ? stage : {}) as Record<string, unknown>;
+    const operator = Object.keys(obj)[0] ?? '$match';
+    return {
+      id: `stage-${i + 1}`,
+      operator,
+      content: JSON.stringify(obj[operator] ?? {}, null, 2),
+    };
+  });
+
+/** Derive editor state from a tab's last executed find or aggregate query. */
+export function builderStateFromQueryTab(
+  lastQuery?: { filter: string; sort: string; projection: string; limit: number; skip: number },
+  lastAggregate?: Record<string, unknown>[]
+): BuilderState {
+  if (lastAggregate && lastAggregate.length > 0) {
+    return {
+      ...DEFAULT_BUILDER_STATE,
+      queryMode: 'aggregate',
+      stages: stagesFromPipeline(lastAggregate),
+    };
+  }
+  if (lastQuery) {
+    return {
+      ...DEFAULT_BUILDER_STATE,
+      queryMode: 'find',
+      filterQuery: lastQuery.filter,
+      sortQuery: lastQuery.sort,
+      projectionQuery: lastQuery.projection,
+      limit: String(lastQuery.limit),
+      skip: String(lastQuery.skip),
+    };
+  }
+  return DEFAULT_BUILDER_STATE;
 }
 
 // Serialize the current builder state into a GeneratedQuery — the same value
@@ -144,6 +199,9 @@ interface DocumentViewerProps {
   onImport?: () => void;
   loading: boolean;
   availableFields?: string[];
+  /** Restored when remounting this tab's viewer (see App tab cache). */
+  initialBuilderState?: BuilderState;
+  onBuilderStateChange?: (state: BuilderState) => void;
   children?: React.ReactNode;
 }
 
@@ -452,15 +510,17 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   onImport,
   loading,
   availableFields = [],
+  initialBuilderState = DEFAULT_BUILDER_STATE,
+  onBuilderStateChange,
   children
 }) => {
   const { prompt, toast } = useDialogs();
   const { schema } = useCollectionSchema(connectionId, databaseName, collectionName);
-  const [filterQuery, setFilterQuery] = useState('{}');
-  const [projectionQuery, setProjectionQuery] = useState('{}');
-  const [sortQuery, setSortQuery] = useState('{}');
-  const [limit, setLimit] = useState('50');
-  const [skip, setSkip] = useState('0');
+  const [filterQuery, setFilterQuery] = useState(initialBuilderState.filterQuery);
+  const [projectionQuery, setProjectionQuery] = useState(initialBuilderState.projectionQuery);
+  const [sortQuery, setSortQuery] = useState(initialBuilderState.sortQuery);
+  const [limit, setLimit] = useState(initialBuilderState.limit);
+  const [skip, setSkip] = useState(initialBuilderState.skip);
   const [explainLoading, setExplainLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
@@ -500,22 +560,20 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   }, [refreshStoredQueries]);
 
   // Query mode: traditional find vs aggregate pipeline
-  const [queryMode, setQueryMode] = useState<'find' | 'aggregate'>('find');
-  
-  // Aggregation stages state
-  interface PipelineStage {
-    id: string;
-    operator: string;
-    content: string;
-    // Disabled stages stay in the builder but are excluded from every
-    // pipeline build (run, run-to-here, explain, shell command, saved query).
-    disabled?: boolean;
-    // Collapsed stages hide their body editor; purely visual.
-    collapsed?: boolean;
-  }
-  const [stages, setStages] = useState<PipelineStage[]>([
-    { id: 'stage-1', operator: '$match', content: '{\n  \n}' }
-  ]);
+  const [queryMode, setQueryMode] = useState<'find' | 'aggregate'>(initialBuilderState.queryMode);
+  const [stages, setStages] = useState<PipelineStage[]>(initialBuilderState.stages);
+
+  useEffect(() => {
+    onBuilderStateChange?.({
+      queryMode,
+      filterQuery,
+      sortQuery,
+      projectionQuery,
+      limit,
+      skip,
+      stages,
+    });
+  }, [queryMode, filterQuery, sortQuery, projectionQuery, limit, skip, stages, onBuilderStateChange]);
 
   // AI chat assistant — open/close only; the panel owns its own chat state.
   const [isAIHelperOpen, setIsAIHelperOpen] = useState(false);
@@ -653,18 +711,6 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     [next[index], next[index + 1]] = [next[index + 1], next[index]];
     commitStages(next);
   };
-
-  // Build pipeline stages ({id, operator, content}) from a MongoDB pipeline array.
-  const stagesFromPipeline = (pipeline: unknown[]): PipelineStage[] =>
-    pipeline.map((stage, i) => {
-      const obj = (stage && typeof stage === 'object' ? stage : {}) as Record<string, unknown>;
-      const operator = Object.keys(obj)[0] ?? '$match';
-      return {
-        id: `stage-${i + 1}`,
-        operator,
-        content: JSON.stringify(obj[operator] ?? {}, null, 2),
-      };
-    });
 
   // Apply a generated query to the editor; auto-switch to aggregation mode for pipelines.
   const handleInsertQuery = (query: GeneratedQuery) => {

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/components/ui/resizable';
 import type { Layout } from 'react-resizable-panels';
 import { cn } from '@/lib/utils';
+import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 import {
   Play, 
   AlertCircle,
@@ -1357,7 +1358,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
               disabled={loading || explainLoading}
               size="sm"
               className="h-7 rounded-r-none px-2.5 text-[11px]"
-              title="Execute query (Ctrl/⌘ + Enter)"
+              title={`Execute query (${formatShortcut(shortcutById('run-query')!)})`}
             >
               <Play size={11} fill="currentColor" />
               Run

--- a/src/components/KeyboardShortcutsSettings.tsx
+++ b/src/components/KeyboardShortcutsSettings.tsx
@@ -1,0 +1,75 @@
+import React, { useMemo, useState } from 'react';
+import { Keyboard } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  filterKeyboardShortcuts,
+  formatShortcut,
+  groupKeyboardShortcuts,
+  SHORTCUT_GROUP_LABELS,
+  SHORTCUT_GROUP_ORDER,
+} from '@/lib/shortcuts';
+
+export const KeyboardShortcutsSettings: React.FC = () => {
+  const [filter, setFilter] = useState('');
+  const filtered = useMemo(() => filterKeyboardShortcuts(filter), [filter]);
+  const grouped = useMemo(() => groupKeyboardShortcuts(filtered), [filtered]);
+
+  return (
+    <Card className="max-w-3xl">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Keyboard className="h-4 w-4 text-primary" />
+          Keyboard shortcuts
+        </CardTitle>
+        <CardDescription>
+          Global shortcuts for navigation, queries, the sidebar, zoom, and the command palette.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Input
+          type="search"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Search shortcuts…"
+          data-testid="shortcuts-filter"
+          aria-label="Search keyboard shortcuts"
+        />
+
+        {filtered.length === 0 ? (
+          <p className="text-sm text-muted-foreground" data-testid="shortcuts-empty">
+            No shortcuts match your search.
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {SHORTCUT_GROUP_ORDER.map((group) => {
+              const items = grouped[group];
+              if (items.length === 0) return null;
+              return (
+                <section key={group} data-testid={`shortcuts-group-${group}`}>
+                  <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {SHORTCUT_GROUP_LABELS[group]}
+                  </h3>
+                  <ul className="divide-y divide-border rounded-lg border border-border">
+                    {items.map((shortcut) => (
+                      <li
+                        key={shortcut.id}
+                        className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+                        data-testid={`shortcut-row-${shortcut.id}`}
+                      >
+                        <span className="text-sm text-foreground">{shortcut.label}</span>
+                        <kbd className="shrink-0 rounded-md border border-border bg-muted px-2 py-1 font-mono text-[11px] text-foreground">
+                          {formatShortcut(shortcut)}
+                        </kbd>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -18,6 +18,7 @@ import { DataGrid } from './DataGrid';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
 import { useMonacoTheme } from '../lib/useMonacoTheme';
 import { registerMqlensMonacoThemes } from '../lib/monacoAppTheme';
+import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 
 type ShellTab = 'console' | 'viewer';
 
@@ -645,7 +646,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           <span className="text-xs font-semibold text-foreground">mongosh</span>
           <span className="font-mono text-[11px] text-muted-foreground">{connectionName} · {currentDb}</span>
           <span className="flex-1" />
-          <span className="font-mono text-[10px] text-muted-foreground">Ctrl/⌘↵</span>
+          <span className="font-mono text-[10px] text-muted-foreground">
+            {formatShortcut(shortcutById('run-query')!)}
+          </span>
           <Button size="sm" onClick={() => runRef.current()} disabled={running}>
             <Play size={11} />
             Run

--- a/src/components/QuickStart.tsx
+++ b/src/components/QuickStart.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import brandMark from '../assets/mqlens-mark.png';
 import type { ConnectionProfile } from '../lib/connection';
+import { primaryShortcutModifier } from '../lib/quickStartUtils';
 import { ConnectionCard } from './ConnectionCard';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -47,13 +48,6 @@ const QUICK_ACTIONS: {
   { id: 'sample', label: 'Load sample data', icon: Download, onClickKey: 'onLoadSampleData' as const, emptyOnly: true },
   { id: 'settings', label: 'Settings', icon: Settings, onClickKey: 'onOpenSettings' },
 ];
-
-const SHORTCUTS = [
-  { keys: '⌘ ↵', label: 'Run the current query' },
-  { keys: '⌘ F', label: 'Search the sidebar tree' },
-  { keys: '⌘ K', label: 'Open command palette' },
-  { keys: '⌘ + / −', label: 'Zoom interface in or out' },
-] as const;
 
 export const QuickStart: React.FC<QuickStartProps> = ({
   onConnect,
@@ -89,6 +83,13 @@ export const QuickStart: React.FC<QuickStartProps> = ({
   const isEmpty = sorted.length === 0;
   const activeIds = new Set(activeConnections.map((c) => c.profileId));
   const activeCount = sorted.filter((p) => activeIds.has(p.id)).length;
+  const modifier = primaryShortcutModifier();
+  const shortcuts = [
+    { keys: `${modifier} ↵`, label: 'Run the current query' },
+    { keys: `${modifier} F`, label: 'Search the sidebar tree' },
+    { keys: `${modifier} K`, label: 'Open command palette' },
+    { keys: `${modifier} + / −`, label: 'Zoom interface in or out' },
+  ] as const;
 
   const handleQuickConnect = async (p: ConnectionProfile) => {
     setConnectingId(p.id);
@@ -302,7 +303,7 @@ export const QuickStart: React.FC<QuickStartProps> = ({
                   <CardTitle className="text-sm">Keyboard shortcuts</CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-col gap-3 pt-0">
-                  {SHORTCUTS.map(({ keys, label }) => (
+                  {shortcuts.map(({ keys, label }) => (
                     <div key={keys} className="flex items-start gap-2.5 text-xs text-muted-foreground">
                       <kbd className="mt-0.5 shrink-0 rounded-md border border-border bg-muted px-2 py-0.5 font-mono text-[10px] text-foreground">
                         {keys}

--- a/src/components/QuickStart.tsx
+++ b/src/components/QuickStart.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import brandMark from '../assets/mqlens-mark.png';
 import type { ConnectionProfile } from '../lib/connection';
-import { primaryShortcutModifier } from '../lib/quickStartUtils';
+import { quickStartShortcutRows } from '../lib/shortcuts';
 import { ConnectionCard } from './ConnectionCard';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -27,6 +27,7 @@ import { Separator } from '@/components/ui/separator';
 interface QuickStartProps {
   onConnect: () => void;
   onOpenSettings: () => void;
+  onOpenShortcuts?: () => void;
   onQuickConnect: (profile: ConnectionProfile) => Promise<void>;
   onLoadSampleData: () => void;
   activeConnections: { profileId: string }[];
@@ -52,6 +53,7 @@ const QUICK_ACTIONS: {
 export const QuickStart: React.FC<QuickStartProps> = ({
   onConnect,
   onOpenSettings,
+  onOpenShortcuts,
   onQuickConnect,
   onLoadSampleData,
   activeConnections,
@@ -83,13 +85,7 @@ export const QuickStart: React.FC<QuickStartProps> = ({
   const isEmpty = sorted.length === 0;
   const activeIds = new Set(activeConnections.map((c) => c.profileId));
   const activeCount = sorted.filter((p) => activeIds.has(p.id)).length;
-  const modifier = primaryShortcutModifier();
-  const shortcuts = [
-    { keys: `${modifier} ↵`, label: 'Run the current query' },
-    { keys: `${modifier} F`, label: 'Search the sidebar tree' },
-    { keys: `${modifier} K`, label: 'Open command palette' },
-    { keys: `${modifier} + / −`, label: 'Zoom interface in or out' },
-  ] as const;
+  const shortcuts = quickStartShortcutRows();
 
   const handleQuickConnect = async (p: ConnectionProfile) => {
     setConnectingId(p.id);
@@ -303,14 +299,22 @@ export const QuickStart: React.FC<QuickStartProps> = ({
                   <CardTitle className="text-sm">Keyboard shortcuts</CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-col gap-3 pt-0">
-                  {shortcuts.map(({ keys, label }) => (
-                    <div key={keys} className="flex items-start gap-2.5 text-xs text-muted-foreground">
+                  {shortcuts.map(({ id, keys, label }) => (
+                    <div key={id} className="flex items-start gap-2.5 text-xs text-muted-foreground">
                       <kbd className="mt-0.5 shrink-0 rounded-md border border-border bg-muted px-2 py-0.5 font-mono text-[10px] text-foreground">
                         {keys}
                       </kbd>
                       <span className="min-w-0 flex-1 leading-snug">{label}</span>
                     </div>
                   ))}
+                  <button
+                    type="button"
+                    className="text-left text-xs font-medium text-primary hover:underline"
+                    data-testid="qs-view-all-shortcuts"
+                    onClick={onOpenShortcuts ?? onOpenSettings}
+                  >
+                    View all shortcuts in Settings
+                  </button>
                   <div className="flex items-start gap-2.5 text-xs text-muted-foreground">
                     <FolderOpen className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
                     <span className="min-w-0 flex-1 leading-snug">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import {
   ShieldCheck,
   ArrowUpCircle,
   Server,
+  Keyboard,
   type LucideIcon,
 } from 'lucide-react';
 import {
@@ -27,6 +28,7 @@ import {
   type UpdateCheckSnapshot,
 } from '@/lib/updateCheckState';
 import { AppearanceSettings } from '@/components/theme/AppearanceSettings';
+import { KeyboardShortcutsSettings } from '@/components/KeyboardShortcutsSettings';
 import type { AppearanceSettings as AppearanceSettingsType } from '@/lib/themes/schema';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -83,7 +85,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   antigravity: 'Antigravity (local)',
 };
 
-type SettingsTabId = 'appearance' | 'ai' | 'mcp' | 'mongosh' | 'updates' | 'security';
+type SettingsTabId = 'appearance' | 'ai' | 'mcp' | 'mongosh' | 'updates' | 'shortcuts' | 'security';
 
 const SETTINGS_TABS: {
   id: SettingsTabId;
@@ -126,6 +128,12 @@ const SETTINGS_TABS: {
     persistFooter: true,
   },
   {
+    id: 'shortcuts',
+    label: 'Shortcuts',
+    description: 'Keyboard shortcuts reference for the workspace.',
+    Icon: Keyboard,
+  },
+  {
     id: 'security',
     label: 'Security',
     description: 'Master password, biometrics, and vault recovery.',
@@ -133,8 +141,14 @@ const SETTINGS_TABS: {
   },
 ];
 
-export const SettingsView: React.FC = () => {
-  const [tab, setTab] = useState<SettingsTabId>('appearance');
+export type { SettingsTabId };
+
+export interface SettingsViewProps {
+  initialTab?: SettingsTabId;
+}
+
+export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab }) => {
+  const [tab, setTab] = useState<SettingsTabId>(initialTab ?? 'appearance');
   const [mongoshPath, setMongoshPath] = useState('');
   const [aiProvider, setAiProvider] = useState('anthropic');
   const [anthropicKey, setAnthropicKey] = useState('');
@@ -169,6 +183,10 @@ export const SettingsView: React.FC = () => {
     window.addEventListener(UPDATE_CHECK_STATE_EVENT, sync);
     return () => window.removeEventListener(UPDATE_CHECK_STATE_EVENT, sync);
   }, []);
+
+  useEffect(() => {
+    if (initialTab) setTab(initialTab);
+  }, [initialTab]);
 
   useEffect(() => {
     let cancelled = false;
@@ -599,6 +617,9 @@ export const SettingsView: React.FC = () => {
             </Card>
           </div>
         );
+
+      case 'shortcuts':
+        return <KeyboardShortcutsSettings />;
 
       case 'security':
         return (

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -19,6 +19,13 @@ import {
   type BiometricStatus,
 } from '../lib/vault';
 import { CHECK_UPDATE_EVENT } from './UpdatePrompt';
+import {
+  formatLastChecked,
+  readUpdateCheckSnapshot,
+  UPDATE_CHECK_STATE_EVENT,
+  updateCheckResultLabel,
+  type UpdateCheckSnapshot,
+} from '@/lib/updateCheckState';
 import { AppearanceSettings } from '@/components/theme/AppearanceSettings';
 import type { AppearanceSettings as AppearanceSettingsType } from '@/lib/themes/schema';
 import { Button } from '@/components/ui/button';
@@ -151,8 +158,17 @@ export const SettingsView: React.FC = () => {
   const [secMsg, setSecMsg] = useState('');
   const [bio, setBio] = useState<BiometricStatus | null>(null);
   const [bioBusy, setBioBusy] = useState(false);
+  const [updateCheck, setUpdateCheck] = useState<UpdateCheckSnapshot | null>(() =>
+    readUpdateCheckSnapshot(),
+  );
 
   const activeTab = SETTINGS_TABS.find((t) => t.id === tab) ?? SETTINGS_TABS[0];
+
+  useEffect(() => {
+    const sync = () => setUpdateCheck(readUpdateCheckSnapshot());
+    window.addEventListener(UPDATE_CHECK_STATE_EVENT, sync);
+    return () => window.removeEventListener(UPDATE_CHECK_STATE_EVENT, sync);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -336,7 +352,21 @@ export const SettingsView: React.FC = () => {
                 <CardTitle className="text-base">Manual check</CardTitle>
                 <CardDescription>Trigger an update check without restarting the app.</CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="space-y-4">
+                {updateCheck ? (
+                  <div className="space-y-1 text-sm" data-testid="update-last-checked">
+                    <p className="text-muted-foreground">
+                      Last checked: {formatLastChecked(updateCheck.checkedAt)}
+                    </p>
+                    <p className="text-foreground">
+                      Result: {updateCheckResultLabel(updateCheck.result)}
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground" data-testid="update-last-checked">
+                    No update check recorded yet.
+                  </p>
+                )}
                 <Button
                   type="button"
                   variant="outline"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -254,9 +254,43 @@ export const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const { toast, confirm, prompt } = useDialogs();
   const [filterQuery, setFilterQuery] = useState('');
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
   useEffect(() => {
     onFilterQueryChange?.(filterQuery);
   }, [filterQuery, onFilterQueryChange]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.altKey ||
+        event.shiftKey ||
+        !(event.metaKey || event.ctrlKey) ||
+        event.key.toLowerCase() !== 'f'
+      ) {
+        return;
+      }
+
+      const searchInput = searchInputRef.current;
+      if (!searchInput) return;
+
+      const target = event.target;
+      if (target instanceof Element && target !== searchInput) {
+        const isEditable =
+          target.closest('.monaco-editor') ||
+          target.closest('input, textarea, select, [contenteditable="true"]');
+        if (isEditable) return;
+      }
+
+      event.preventDefault();
+      searchInput.focus();
+      searchInput.select();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
 
   const [sectionsOpen, setSectionsOpen] = useState({
     connections: true,
@@ -1649,6 +1683,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           <div className="relative">
             <Search size={12} className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
             <Input
+              ref={searchInputRef}
               type="text"
               value={filterQuery}
               onChange={(e) => setFilterQuery(e.target.value)}

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { relaunch } from '@tauri-apps/plugin-process';
-import { Download, X, RefreshCw, CheckCircle2, AlertTriangle, ArrowUpCircle } from 'lucide-react';
+import { Download, X, RefreshCw, CheckCircle2, AlertTriangle, ArrowUpCircle, WifiOff } from 'lucide-react';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { Button } from '@/components/ui/button';
 import {
@@ -14,6 +14,11 @@ import {
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import { useEscapeClose } from '../lib/useEscapeClose';
+import {
+  classifyUpdateCheckError,
+  updateCheckBackoffMs,
+  writeUpdateCheckSnapshot,
+} from '@/lib/updateCheckState';
 
 export const CHECK_UPDATE_EVENT = 'mqlens:check-update';
 
@@ -24,7 +29,14 @@ interface UpdateMeta {
   date: string | null;
 }
 
-type Phase = 'idle' | 'checking' | 'available' | 'downloading' | 'uptodate' | 'error';
+type Phase =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'downloading'
+  | 'uptodate'
+  | 'offline'
+  | 'check-failed';
 
 const renderInline = (text: string): React.ReactNode[] => {
   const out: React.ReactNode[] = [];
@@ -103,35 +115,89 @@ export const UpdatePrompt: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [pct, setPct] = useState(0);
   const [manual, setManual] = useState(false);
+  const retryAttemptRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const runCheck = useCallback(async (isManual: boolean) => {
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleAutoRetry = useCallback((attempt: number, runCheck: (isManual: boolean, retryAttempt?: number) => Promise<void>) => {
+    clearRetryTimer();
+    const delay = updateCheckBackoffMs(attempt);
+    retryTimerRef.current = setTimeout(() => {
+      void runCheck(false, attempt + 1);
+    }, delay);
+  }, [clearRetryTimer]);
+
+  const runCheck = useCallback(async (isManual: boolean, retryAttempt = 0) => {
+    clearRetryTimer();
     setManual(isManual);
     setError(null);
-    setPhase('checking');
+
+    if (isManual && typeof navigator !== 'undefined' && !navigator.onLine) {
+      writeUpdateCheckSnapshot({
+        checkedAt: new Date().toISOString(),
+        result: 'offline',
+      });
+      setPhase('offline');
+      return;
+    }
+
+    if (isManual) setPhase('checking');
+
     try {
       const channel = await currentChannel();
       const meta = await invoke<UpdateMeta | null>('update_check', { channel });
+      const checkedAt = new Date().toISOString();
+      retryAttemptRef.current = 0;
       if (meta) {
         setUpdate(meta);
         setPhase('available');
+        writeUpdateCheckSnapshot({ checkedAt, result: 'available' });
       } else {
+        writeUpdateCheckSnapshot({ checkedAt, result: 'uptodate' });
         setPhase(isManual ? 'uptodate' : 'idle');
       }
-    } catch (e: any) {
-      setError(String(e?.message || e));
-      setPhase(isManual ? 'error' : 'idle');
+    } catch (e: unknown) {
+      const detail = String((e as { message?: string })?.message || e);
+      const result = classifyUpdateCheckError(e);
+      writeUpdateCheckSnapshot({
+        checkedAt: new Date().toISOString(),
+        result,
+        detail,
+      });
+      if (isManual) {
+        setError(detail);
+        setPhase(result);
+      } else {
+        setPhase('idle');
+        if (result === 'offline') {
+          scheduleAutoRetry(retryAttempt, runCheck);
+        }
+      }
     }
-  }, []);
+  }, [clearRetryTimer, scheduleAutoRetry]);
 
   useEffect(() => {
     const t = setTimeout(() => void runCheck(false), 4000);
     const onManual = () => void runCheck(true);
+    const onOnline = () => {
+      retryAttemptRef.current = 0;
+      void runCheck(false);
+    };
     window.addEventListener(CHECK_UPDATE_EVENT, onManual);
+    window.addEventListener('online', onOnline);
     return () => {
       clearTimeout(t);
+      clearRetryTimer();
       window.removeEventListener(CHECK_UPDATE_EVENT, onManual);
+      window.removeEventListener('online', onOnline);
     };
-  }, [runCheck]);
+  }, [runCheck, clearRetryTimer]);
 
   const install = async () => {
     if (!update) return;
@@ -149,9 +215,9 @@ export const UpdatePrompt: React.FC = () => {
       const channel = await currentChannel();
       await invoke('update_install', { channel });
       await relaunch();
-    } catch (e: any) {
-      setError(String(e?.message || e));
-      setPhase('error');
+    } catch (e: unknown) {
+      setError(String((e as { message?: string })?.message || e));
+      setPhase('check-failed');
     } finally {
       unlisten?.();
     }
@@ -185,10 +251,22 @@ export const UpdatePrompt: React.FC = () => {
       </div>
     );
   }
-  if (phase === 'error') {
+  if (phase === 'offline') {
+    return (
+      <div className={cn(toastClassName, 'border-warning/30')} data-testid="update-toast">
+        <WifiOff size={14} className="text-warning" />
+        You’re offline. Connect to the internet and try again.
+        <Button type="button" variant="ghost" size="icon" className="ml-1 h-6 w-6" onClick={dismiss} aria-label="Dismiss">
+          <X size={12} />
+        </Button>
+      </div>
+    );
+  }
+  if (phase === 'check-failed') {
     return (
       <div className={cn(toastClassName, 'border-destructive/30 text-destructive')} data-testid="update-toast" title={error ?? undefined}>
-        <AlertTriangle size={14} /> Update check failed.
+        <AlertTriangle size={14} />
+        Couldn’t reach the update server. Try again later.
         <Button type="button" variant="ghost" size="icon" className="ml-1 h-6 w-6" onClick={dismiss} aria-label="Dismiss">
           <X size={12} />
         </Button>

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -787,7 +787,7 @@ describe('App Component', () => {
     expect(calls.find((c) => c.cmd === 'import_documents')).toBeFalsy();
   });
 
-  it('resets query editor state when switching collections (#120)', async () => {
+  it('isolates query editor state per collection tab (#120)', async () => {
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === 'execute_mql_query') {
         return Promise.resolve([JSON.stringify({ _id: '1', name: 'Sample' })]);
@@ -819,5 +819,23 @@ describe('App Component', () => {
     fireEvent.click(screen.getByTestId('toggle-query-builder'));
     const ordersFilter = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
     expect(ordersFilter.value).toBe('{}');
+
+    // Type a different filter on orders.
+    fireEvent.change(ordersFilter, { target: { value: '{"shipped":true}' } });
+    expect(ordersFilter.value).toContain('"shipped"');
+
+    // Switch back to customers — customers filter must be restored.
+    fireEvent.click(screen.getByTestId('select-collection-btn'));
+    await screen.findByText(/"Sample"/);
+    fireEvent.click(screen.getByTestId('toggle-query-builder'));
+    const customersFilterAgain = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    expect(customersFilterAgain.value).toContain('"status"');
+
+    // Switch back to orders — orders filter must be restored.
+    fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
+    await screen.findByText(/"Sample"/);
+    fireEvent.click(screen.getByTestId('toggle-query-builder'));
+    const ordersFilterAgain = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    expect(ordersFilterAgain.value).toContain('"shipped"');
   });
 });

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -64,6 +64,9 @@ vi.mock('../Sidebar', () => ({
       <button data-testid="select-collection-btn" onClick={() => onSelectCollection('conn-1', 'sales_db', 'customers')}>
         Select Collection
       </button>
+      <button data-testid="select-orders-collection-btn" onClick={() => onSelectCollection('conn-1', 'sales_db', 'orders')}>
+        Select Orders
+      </button>
       <button data-testid="select-index-btn" onClick={() => onSelectIndex('conn-1', 'sales_db', 'customers', 'email_1')}>
         Select Index
       </button>
@@ -782,5 +785,39 @@ describe('App Component', () => {
     // The malformed file surfaces an in-app error toast and no write happens.
     expect(await screen.findByText(/Import aborted/)).toBeInTheDocument();
     expect(calls.find((c) => c.cmd === 'import_documents')).toBeFalsy();
+  });
+
+  it('resets query editor state when switching collections (#120)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'execute_mql_query') {
+        return Promise.resolve([JSON.stringify({ _id: '1', name: 'Sample' })]);
+      }
+      if (cmd === 'load_collection_queries') {
+        return Promise.resolve({ saved: [], history: [], default: null });
+      }
+      if (cmd === 'count_documents') {
+        return Promise.resolve(1);
+      }
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    // Open customers, type a custom filter.
+    fireEvent.click(screen.getByTestId('select-collection-btn'));
+    await screen.findByText(/"Sample"/);
+    fireEvent.click(screen.getByTestId('toggle-query-builder'));
+    const filterInput = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    fireEvent.change(filterInput, { target: { value: '{"status":"active"}' } });
+    expect(filterInput.value).toContain('"status"');
+
+    // Switch to orders — editor must reset to default {}, not carry over the filter.
+    fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
+    await screen.findByText(/"Sample"/);
+    fireEvent.click(screen.getByTestId('toggle-query-builder'));
+    const ordersFilter = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    expect(ordersFilter.value).toBe('{}');
   });
 });

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -445,6 +445,7 @@ describe('ConnectionManager Component', () => {
         name: 'Staging DB',
         uri: 'mongodb://staging:27017',
         ssh: null,
+        color_tag: null,
       });
       // The nested modal should be closed
       expect(screen.queryByText('New Connection')).not.toBeInTheDocument();
@@ -705,5 +706,147 @@ describe('ConnectionManager Component', () => {
     const connectBtn = screen.getByRole('button', { name: /already connected/i });
     expect(connectBtn).toBeInTheDocument();
     expect(connectBtn).toBeDisabled();
+  });
+
+  it('saves a color tag from the preset palette', async () => {
+    let savedProfile: any = null;
+    let profilesList: any[] = [];
+
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve(profilesList);
+      if (cmd === 'save_connection_profile') {
+        savedProfile = args.profile;
+        profilesList = [args.profile];
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <ConnectionManager
+        isOpen={true}
+        onClose={() => {}}
+        onConnect={() => {}}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'Prod' } });
+    await pickSelectOption('topology-select', /full uri string only/i);
+    fireEvent.change(screen.getByLabelText(/connection uri/i), { target: { value: 'mongodb://prod' } });
+    fireEvent.click(screen.getByTestId('color-swatch-blue'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedProfile).toMatchObject({
+        name: 'Prod',
+        uri: 'mongodb://prod',
+        color_tag: '#3b82f6',
+      });
+    });
+  });
+
+  it('saves a custom color from the color picker', async () => {
+    let savedProfile: any = null;
+    let profilesList: any[] = [];
+
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve(profilesList);
+      if (cmd === 'save_connection_profile') {
+        savedProfile = args.profile;
+        profilesList = [args.profile];
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <ConnectionManager
+        isOpen={true}
+        onClose={() => {}}
+        onConnect={() => {}}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'Custom' } });
+    await pickSelectOption('topology-select', /full uri string only/i);
+    fireEvent.change(screen.getByLabelText(/connection uri/i), { target: { value: 'mongodb://custom' } });
+    expect(screen.getByLabelText('Pick a custom color')).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('color-picker-custom'), { target: { value: '#a1b2c3' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedProfile).toMatchObject({
+        name: 'Custom',
+        uri: 'mongodb://custom',
+        color_tag: '#a1b2c3',
+      });
+    });
+  });
+
+  it('shows color dots in the profile list for tagged connections', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') {
+        return Promise.resolve([
+          { id: 'p1', name: 'Staging', uri: 'mongodb://staging', color_tag: '#22c55e' },
+          { id: 'p2', name: 'Prod', uri: 'mongodb://prod' },
+        ]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <ConnectionManager
+        isOpen={true}
+        onClose={() => {}}
+        onConnect={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(screen.getAllByText('Staging')[0]).toBeInTheDocument());
+    const dots = screen.getAllByTestId('connection-color-dot');
+    expect(dots.length).toBeGreaterThanOrEqual(1);
+    dots.forEach((dot) => {
+      expect(dot).toHaveStyle({ backgroundColor: 'rgb(34, 197, 94)' });
+    });
+  });
+
+  it('clears a saved color tag when none is selected', async () => {
+    let savedProfile: any = null;
+    const profilesList = [
+      { id: 'p1', name: 'Staging', uri: 'mongodb://staging', color_tag: '#22c55e' },
+    ];
+
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve(profilesList);
+      if (cmd === 'save_connection_profile') {
+        savedProfile = args.profile;
+        profilesList[0] = args.profile;
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <ConnectionManager
+        isOpen={true}
+        onClose={() => {}}
+        onConnect={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(screen.getAllByText('Staging')[0]).toBeInTheDocument());
+    fireEvent.click(screen.getAllByText('Staging')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+    fireEvent.click(screen.getByTestId('color-swatch-none'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedProfile).toMatchObject({
+        id: 'p1',
+        color_tag: null,
+      });
+    });
   });
 });

--- a/src/components/__tests__/ExportView.test.tsx
+++ b/src/components/__tests__/ExportView.test.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-with-providers';
+import { DialogProvider, useDialogs } from '../dialogs/DialogProvider';
+import { ExportView } from '../ExportView';
+import type { ExportTaskInfo } from '../TaskManager';
+
+const mockInvoke = vi.fn();
+const saveMock = vi.fn();
+const writeTextFileMock = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  save: (...args: unknown[]) => saveMock(...args),
+}));
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  writeTextFile: (...args: unknown[]) => writeTextFileMock(...args),
+}));
+
+const baseProps = {
+  connectionName: 'Local',
+  databaseName: 'sales_db',
+  collectionName: 'customers',
+  currentResultCount: 3,
+  tasks: [] as ExportTaskInfo[],
+  onExport: vi.fn(),
+  onRefreshTasks: vi.fn(),
+  onClearFinishedTasks: vi.fn(),
+};
+
+function renderExportView(overrides: Partial<typeof baseProps> = {}) {
+  const props = { ...baseProps, ...overrides };
+  return renderWithProviders(
+    <DialogProvider>
+      <ExportView {...props} />
+    </DialogProvider>
+  );
+}
+
+/** Mirrors App handleExportForTab enough to exercise invoke + error toasts. */
+function ExportViewHarness({
+  currentResultCount = 3,
+  invokeFails = false,
+}: {
+  currentResultCount?: number;
+  invokeFails?: boolean;
+}) {
+  const { toast } = useDialogs();
+  const [tasks, setTasks] = useState<ExportTaskInfo[]>([]);
+
+  const onExport = async (format: 'json' | 'csv', scope: 'current' | 'full') => {
+    if (scope === 'current' && currentResultCount === 0) return;
+    try {
+      const path = await saveMock({
+        defaultPath: `customers${scope === 'full' ? '.full' : ''}.${format}`,
+      });
+      if (!path) return;
+      if (scope === 'full') {
+        if (invokeFails) throw new Error('disk full');
+        const task = await mockInvoke('start_collection_export', {
+          id: 'conn-1',
+          database: 'sales_db',
+          collection: 'customers',
+          format,
+          path,
+        });
+        setTasks([task]);
+        return;
+      }
+      await writeTextFileMock(path, '[]');
+      toast(`Exported ${currentResultCount} document(s) to ${path}`, 'success');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast(`Export failed: ${message}`, 'error');
+    }
+  };
+
+  return (
+    <ExportView
+      connectionName="Local"
+      databaseName="sales_db"
+      collectionName="customers"
+      currentResultCount={currentResultCount}
+      tasks={tasks}
+      onExport={onExport}
+      onRefreshTasks={vi.fn()}
+      onClearFinishedTasks={vi.fn()}
+    />
+  );
+}
+
+describe('ExportView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMock.mockResolvedValue('/tmp/customers.json');
+    writeTextFileMock.mockResolvedValue(undefined);
+    mockInvoke.mockResolvedValue({
+      id: 'task-1',
+      kind: 'collection_export',
+      label: 'Export sales_db.customers as JSON',
+      status: 'running',
+      processed: 0,
+      total: null,
+      message: 'Queued',
+      path: '/tmp/customers.full.json',
+      error: null,
+      createdAtMs: 1,
+      finishedAtMs: null,
+    });
+  });
+
+  it('renders namespace and result count', () => {
+    renderExportView();
+    expect(screen.getByTestId('export-view')).toBeInTheDocument();
+    expect(screen.getByText(/Local \/ sales_db\.customers/)).toBeInTheDocument();
+    expect(screen.getByText('3 loaded documents')).toBeInTheDocument();
+  });
+
+  it('disables current-result export buttons when there are no loaded documents', () => {
+    renderExportView({ currentResultCount: 0 });
+    expect(screen.getByTestId('export-current-json-btn')).toBeDisabled();
+    expect(screen.getByTestId('export-current-csv-btn')).toBeDisabled();
+  });
+
+  it('starts a current-results JSON export with the selected format', () => {
+    const onExport = vi.fn();
+    renderExportView({ onExport });
+    fireEvent.click(screen.getByTestId('export-current-json-btn'));
+    expect(onExport).toHaveBeenCalledWith('json', 'current');
+    fireEvent.click(screen.getByTestId('export-current-csv-btn'));
+    expect(onExport).toHaveBeenCalledWith('csv', 'current');
+  });
+
+  it('starts a full-collection export in the chosen format', () => {
+    const onExport = vi.fn();
+    renderExportView({ onExport });
+    fireEvent.click(screen.getByTestId('export-full-json-btn'));
+    expect(onExport).toHaveBeenCalledWith('json', 'full');
+    fireEvent.click(screen.getByTestId('export-full-csv-btn'));
+    expect(onExport).toHaveBeenCalledWith('csv', 'full');
+  });
+
+  it('refreshes export tasks from the header action', () => {
+    const onRefreshTasks = vi.fn();
+    renderExportView({ onRefreshTasks });
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh Tasks' }));
+    expect(onRefreshTasks).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a background export via invoke when full collection JSON is chosen', async () => {
+    renderWithProviders(
+      <DialogProvider>
+        <ExportViewHarness />
+      </DialogProvider>
+    );
+
+    fireEvent.click(screen.getByTestId('export-full-json-btn'));
+
+    await waitFor(() => {
+      expect(saveMock).toHaveBeenCalled();
+      expect(mockInvoke).toHaveBeenCalledWith('start_collection_export', {
+        id: 'conn-1',
+        database: 'sales_db',
+        collection: 'customers',
+        format: 'json',
+        path: '/tmp/customers.json',
+      });
+    });
+    expect(await screen.findByTestId('task-manager')).toBeInTheDocument();
+    expect(screen.getByText(/Export sales_db\.customers as JSON/)).toBeInTheDocument();
+  });
+
+  it('surfaces export failures from invoke as an error toast', async () => {
+    renderWithProviders(
+      <DialogProvider>
+        <ExportViewHarness invokeFails />
+      </DialogProvider>
+    );
+
+    fireEvent.click(screen.getByTestId('export-full-json-btn'));
+
+    expect(await screen.findByText('Export failed: disk full')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/QuickStart.test.tsx
+++ b/src/components/__tests__/QuickStart.test.tsx
@@ -67,4 +67,14 @@ describe('QuickStart', () => {
     fireEvent.click(await screen.findByTestId('qs-load-sample'));
     expect(onLoadSampleData).toHaveBeenCalled();
   });
+
+  it('shows platform-aware shortcut labels', async () => {
+    const platform = vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('Win32');
+    invokeMock.mockResolvedValueOnce([]);
+
+    setup();
+
+    expect(await screen.findByText('Ctrl F')).toBeInTheDocument();
+    platform.mockRestore();
+  });
 });

--- a/src/components/__tests__/QuickStart.test.tsx
+++ b/src/components/__tests__/QuickStart.test.tsx
@@ -77,4 +77,12 @@ describe('QuickStart', () => {
     expect(await screen.findByText('Ctrl F')).toBeInTheDocument();
     platform.mockRestore();
   });
+
+  it('links to the full shortcuts reference', async () => {
+    invokeMock.mockResolvedValueOnce([]);
+    const onOpenShortcuts = vi.fn();
+    setup({ onOpenShortcuts });
+    fireEvent.click(await screen.findByTestId('qs-view-all-shortcuts'));
+    expect(onOpenShortcuts).toHaveBeenCalled();
+  });
 });

--- a/src/components/__tests__/SettingsModal.test.tsx
+++ b/src/components/__tests__/SettingsModal.test.tsx
@@ -182,4 +182,19 @@ describe('SettingsView Component', () => {
     expect(await screen.findByTestId('update-last-checked')).toHaveTextContent(/Offline/i);
     expect(screen.getByTestId('update-last-checked')).toHaveTextContent(/Last checked:/i);
   });
+
+  it('lists keyboard shortcuts with search on the shortcuts tab', async () => {
+    renderSettings();
+    await openTab('settings-tab-shortcuts');
+    expect(await screen.findByTestId('shortcuts-group-command-palette')).toBeInTheDocument();
+    expect(screen.getByTestId('shortcut-row-palette-open')).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('shortcuts-filter'), { target: { value: 'sidebar' } });
+    expect(screen.getByTestId('shortcut-row-sidebar-search')).toBeInTheDocument();
+    expect(screen.queryByTestId('shortcut-row-palette-open')).not.toBeInTheDocument();
+  });
+
+  it('opens the shortcuts tab when initialTab is shortcuts', async () => {
+    render(<SettingsView initialTab="shortcuts" />);
+    expect(await screen.findByTestId('shortcuts-group-zoom')).toBeInTheDocument();
+  });
 });

--- a/src/components/__tests__/SettingsModal.test.tsx
+++ b/src/components/__tests__/SettingsModal.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { SettingsView } from '../SettingsModal';
+import { writeUpdateCheckSnapshot } from '../../lib/updateCheckState';
 
 const mockInvoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({
@@ -35,6 +36,7 @@ async function openTab(tabId: string) {
 describe('SettingsView Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     mockBiometricStatus.mockResolvedValue({ available: false, biometryType: 0, enrolled: false });
     mockInvoke.mockImplementation((cmd) => {
       if (cmd === 'load_app_settings') {
@@ -168,5 +170,16 @@ describe('SettingsView Component', () => {
     fireEvent.click(screen.getByRole('option', { name: /Claude Code/i }));
     expect(screen.getByTestId('local-command-input')).toBeInTheDocument();
     expect(await screen.findByTestId('agent-availability')).toHaveTextContent(/installed/i);
+  });
+
+  it('shows last update check status on the updates tab', async () => {
+    writeUpdateCheckSnapshot({
+      checkedAt: '2026-06-15T12:00:00.000Z',
+      result: 'offline',
+    });
+    renderSettings();
+    await openTab('settings-tab-updates');
+    expect(await screen.findByTestId('update-last-checked')).toHaveTextContent(/Offline/i);
+    expect(screen.getByTestId('update-last-checked')).toHaveTextContent(/Last checked:/i);
   });
 });

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -84,6 +84,71 @@ describe('Sidebar Component', () => {
     expect(screen.getByText('user_analytics')).toBeInTheDocument();
   });
 
+  it.each([
+    ['Ctrl', { ctrlKey: true }],
+    ['Command', { metaKey: true }],
+  ])('focuses sidebar search with %s+F', async (_label, modifier) => {
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    const search = screen.getByTestId('sidebar-search');
+    const event = new KeyboardEvent('keydown', {
+      key: 'f',
+      ...modifier,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+
+    expect(search).toHaveFocus();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does not steal Ctrl+F from Monaco editors', () => {
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    const monaco = document.createElement('div');
+    monaco.className = 'monaco-editor';
+    const textarea = document.createElement('textarea');
+    monaco.appendChild(textarea);
+    document.body.appendChild(monaco);
+    textarea.focus();
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'f',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    textarea.dispatchEvent(event);
+
+    expect(textarea).toHaveFocus();
+    expect(screen.getByTestId('sidebar-search')).not.toHaveFocus();
+    expect(event.defaultPrevented).toBe(false);
+
+    monaco.remove();
+  });
+
   it('handles rendering multiple connections, databases, collections, and indexes', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -804,4 +804,31 @@ describe('Sidebar Component', () => {
       expect(onSelectCollection).toHaveBeenCalledWith('conn-new', 'sales_db', 'orders');
     });
   });
+
+  it('shows a color dot for tagged active connections', async () => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      if (cmd === 'list_all_saved_queries') return Promise.resolve([]);
+      if (cmd === 'list_databases') {
+        if (args.id === 'conn-1') return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Staging', uri: 'mongodb://staging', color_tag: '#3b82f6' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    expect(await screen.findByTitle('Connection color')).toBeInTheDocument();
+    expect(screen.getByText('Staging')).toBeInTheDocument();
+  });
 });

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-with-providers';
+import { TaskManager, type ExportTaskInfo } from '../TaskManager';
+
+const runningTask: ExportTaskInfo = {
+  id: 'task-running',
+  kind: 'collection_export',
+  label: 'Export sales_db.customers as JSON',
+  status: 'running',
+  processed: 50,
+  total: 100,
+  message: 'Exporting documents…',
+  path: '/tmp/customers.json',
+  error: null,
+  createdAtMs: 1,
+  finishedAtMs: null,
+};
+
+const completedTask: ExportTaskInfo = {
+  id: 'task-done',
+  kind: 'collection_export',
+  label: 'Export sales_db.orders as CSV',
+  status: 'completed',
+  processed: 200,
+  total: 200,
+  message: 'Finished',
+  path: '/tmp/orders.csv',
+  error: null,
+  createdAtMs: 2,
+  finishedAtMs: 3,
+};
+
+const failedTask: ExportTaskInfo = {
+  id: 'task-failed',
+  kind: 'collection_export',
+  label: 'Export sales_db.users as JSON',
+  status: 'failed',
+  processed: 12,
+  total: 100,
+  message: 'Export failed',
+  path: '/tmp/users.json',
+  error: 'Permission denied',
+  createdAtMs: 4,
+  finishedAtMs: 5,
+};
+
+function renderTaskManager(
+  tasks: ExportTaskInfo[] = [],
+  handlers: { onRefresh?: () => void; onClearFinished?: () => void } = {}
+) {
+  const onRefresh = handlers.onRefresh ?? vi.fn();
+  const onClearFinished = handlers.onClearFinished ?? vi.fn();
+  renderWithProviders(
+    <TaskManager tasks={tasks} onRefresh={onRefresh} onClearFinished={onClearFinished} />
+  );
+  return { onRefresh, onClearFinished };
+}
+
+describe('TaskManager', () => {
+  it('shows an empty state when there are no tasks', () => {
+    renderTaskManager();
+    expect(screen.getByTestId('task-manager')).toBeInTheDocument();
+    expect(screen.getByTestId('task-empty')).toHaveTextContent('No export tasks yet.');
+  });
+
+  it('renders running, completed, and failed tasks', () => {
+    renderTaskManager([runningTask, completedTask, failedTask]);
+    expect(screen.getAllByTestId('task-row')).toHaveLength(3);
+    expect(screen.getByText('Export sales_db.customers as JSON')).toBeInTheDocument();
+    expect(screen.getByText('Export sales_db.orders as CSV')).toBeInTheDocument();
+    expect(screen.getByText('Export sales_db.users as JSON')).toBeInTheDocument();
+  });
+
+  it('shows a running-count badge and progress percentage', () => {
+    renderTaskManager([runningTask]);
+    expect(screen.getByText('1 running')).toBeInTheDocument();
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('50/100')).toBeInTheDocument();
+  });
+
+  it('updates displayed progress when task totals change', () => {
+    const { rerender } = renderWithProviders(
+      <TaskManager
+        tasks={[runningTask]}
+        onRefresh={vi.fn()}
+        onClearFinished={vi.fn()}
+      />
+    );
+    expect(screen.getByText('50%')).toBeInTheDocument();
+
+    rerender(
+      <TaskManager
+        tasks={[{ ...runningTask, processed: 75 }]}
+        onRefresh={vi.fn()}
+        onClearFinished={vi.fn()}
+      />
+    );
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    expect(screen.getByText('75/100')).toBeInTheDocument();
+  });
+
+  it('shows failed task errors instead of the success message', () => {
+    renderTaskManager([failedTask]);
+    expect(screen.getByText('Permission denied')).toBeInTheDocument();
+  });
+
+  it('refreshes tasks when the refresh control is clicked', () => {
+    const { onRefresh } = renderTaskManager([completedTask]);
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh tasks' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses finished tasks when clear is clicked', () => {
+    const { onClearFinished } = renderTaskManager([completedTask, failedTask]);
+    fireEvent.click(screen.getByRole('button', { name: 'Clear finished tasks' }));
+    expect(onClearFinished).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/UpdatePrompt.test.tsx
+++ b/src/components/__tests__/UpdatePrompt.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { readUpdateCheckSnapshot } from '../../lib/updateCheckState';
 
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => invokeMock(...a) }));
@@ -28,6 +29,12 @@ function routeInvoke(map: Record<string, unknown>) {
 beforeEach(() => {
   invokeMock.mockReset();
   mockRelaunch.mockClear();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
 });
 
 describe('UpdatePrompt', () => {
@@ -96,5 +103,33 @@ describe('UpdatePrompt', () => {
     fireEvent.click(await screen.findByTestId('update-later'));
     expect(screen.queryByTestId('update-dialog')).toBeNull();
     expect(installFn).not.toHaveBeenCalled();
+  });
+
+  it('shows an offline message on manual check when navigator is offline', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    routeInvoke({ update_check: null });
+    render(<UpdatePrompt />);
+    triggerManualCheck();
+    expect(await screen.findByTestId('update-toast')).toHaveTextContent(/offline/i);
+    expect(readUpdateCheckSnapshot()?.result).toBe('offline');
+  });
+
+  it('shows a server error message on manual check failure', async () => {
+    routeInvoke({ update_check: () => Promise.reject(new Error('invalid signature')) });
+    render(<UpdatePrompt />);
+    triggerManualCheck();
+    expect(await screen.findByTestId('update-toast')).toHaveTextContent(/update server/i);
+    expect(readUpdateCheckSnapshot()?.result).toBe('check-failed');
+  });
+
+  it('records offline on startup without showing a toast', async () => {
+    vi.useFakeTimers();
+    routeInvoke({ update_check: () => Promise.reject(new Error('network timeout')) });
+    render(<UpdatePrompt />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(readUpdateCheckSnapshot()?.result).toBe('offline');
+    expect(screen.queryByTestId('update-toast')).toBeNull();
   });
 });

--- a/src/components/__tests__/UpdatePrompt.test.tsx
+++ b/src/components/__tests__/UpdatePrompt.test.tsx
@@ -118,8 +118,8 @@ describe('UpdatePrompt', () => {
     routeInvoke({ update_check: () => Promise.reject(new Error('invalid signature')) });
     render(<UpdatePrompt />);
     triggerManualCheck();
-    expect(await screen.findByTestId('update-toast')).toHaveTextContent(/update server/i);
-    expect(readUpdateCheckSnapshot()?.result).toBe('check-failed');
+    expect(await screen.findByText(/update server/i)).toBeInTheDocument();
+    await waitFor(() => expect(readUpdateCheckSnapshot()?.result).toBe('check-failed'));
   });
 
   it('records offline on startup without showing a toast', async () => {

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,10 +1,18 @@
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface StatusBarProps {
   cpu?: string;
   memory?: string;
   mongoVersion?: string;
   appVersion?: string;
+  /** User UI zoom (75–150); hidden at 100%. */
+  zoomPercent?: number;
+  onZoomReset?: () => void;
   className?: string;
 }
 
@@ -13,8 +21,12 @@ export function StatusBar({
   memory,
   mongoVersion,
   appVersion,
+  zoomPercent,
+  onZoomReset,
   className,
 }: StatusBarProps) {
+  const showZoom = zoomPercent != null && zoomPercent !== 100;
+
   return (
     <footer
       data-testid="bottom-bar"
@@ -27,6 +39,23 @@ export function StatusBar({
       {cpu && <span>CPU {cpu}</span>}
       {memory && <span>RAM {memory}</span>}
       {mongoVersion && <span>MongoDB {mongoVersion}</span>}
+      {showZoom && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              data-testid="status-bar-zoom"
+              className="font-mono tabular-nums transition-colors hover:text-foreground"
+              onClick={onZoomReset}
+            >
+              {zoomPercent}%
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            Reset zoom (⌘0 / Ctrl+0)
+          </TooltipContent>
+        </Tooltip>
+      )}
       <span className="ml-auto">MQLens {appVersion ?? ""}</span>
     </footer>
   );

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -4,6 +4,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { formatShortcut, shortcutById } from "@/lib/shortcuts";
 
 interface StatusBarProps {
   cpu?: string;
@@ -52,7 +53,7 @@ export function StatusBar({
             </button>
           </TooltipTrigger>
           <TooltipContent side="top">
-            Reset zoom (⌘0 / Ctrl+0)
+            Reset zoom ({formatShortcut(shortcutById('zoom-reset')!)})
           </TooltipContent>
         </Tooltip>
       )}

--- a/src/components/layout/__tests__/StatusBar.test.tsx
+++ b/src/components/layout/__tests__/StatusBar.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { StatusBar } from '../StatusBar';
+
+function renderStatusBar(props: React.ComponentProps<typeof StatusBar>) {
+  return render(
+    <TooltipProvider>
+      <StatusBar {...props} />
+    </TooltipProvider>
+  );
+}
+
+describe('StatusBar', () => {
+  it('hides zoom indicator at 100%', () => {
+    renderStatusBar({ zoomPercent: 100 });
+    expect(screen.queryByTestId('status-bar-zoom')).toBeNull();
+  });
+
+  it('shows zoom indicator when not at 100%', () => {
+    renderStatusBar({ zoomPercent: 110 });
+    expect(screen.getByTestId('status-bar-zoom')).toHaveTextContent('110%');
+  });
+
+  it('shows minimum zoom (75%)', () => {
+    renderStatusBar({ zoomPercent: 75 });
+    expect(screen.getByTestId('status-bar-zoom')).toHaveTextContent('75%');
+  });
+
+  it('shows maximum zoom (150%)', () => {
+    renderStatusBar({ zoomPercent: 150 });
+    expect(screen.getByTestId('status-bar-zoom')).toHaveTextContent('150%');
+  });
+
+  it('calls onZoomReset when the zoom chip is clicked', () => {
+    const onZoomReset = vi.fn();
+    renderStatusBar({ zoomPercent: 125, onZoomReset });
+    fireEvent.click(screen.getByTestId('status-bar-zoom'));
+    expect(onZoomReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/theme/AppearanceSettings.tsx
+++ b/src/components/theme/AppearanceSettings.tsx
@@ -21,6 +21,7 @@ import {
   UI_ZOOM_MIN,
   UI_ZOOM_STEP,
 } from "@/lib/themes/ui-scale";
+import { formatZoomShortcutHint } from "@/lib/shortcuts";
 
 export function AppearanceSettings() {
   const {
@@ -159,7 +160,7 @@ export function AppearanceSettings() {
               onValueChange={([v]) => setUiZoom(clampUiZoom(v))}
             />
             <p className="text-[11px] text-muted-foreground">
-              Shortcut: ⌘ + / ⌘ − / ⌘ 0 to reset
+              Shortcut: {formatZoomShortcutHint()}
             </p>
           </div>
 

--- a/src/lib/__tests__/connectionColors.test.ts
+++ b/src/lib/__tests__/connectionColors.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import {
+  colorInputValue,
+  isPresetConnectionColor,
+  normalizeHexColor,
+} from '../connectionColors';
+
+describe('connectionColors', () => {
+  it('normalizes 6-digit and 3-digit hex colors', () => {
+    expect(normalizeHexColor('#A1B2C3')).toBe('#a1b2c3');
+    expect(normalizeHexColor('#f00')).toBe('#ff0000');
+    expect(normalizeHexColor('not-a-color')).toBeNull();
+  });
+
+  it('detects preset vs custom colors', () => {
+    expect(isPresetConnectionColor('#3b82f6')).toBe(true);
+    expect(isPresetConnectionColor('#a1b2c3')).toBe(false);
+  });
+
+  it('provides a valid color-input value', () => {
+    expect(colorInputValue()).toBe('#3b82f6');
+    expect(colorInputValue('#a1b2c3')).toBe('#a1b2c3');
+    expect(colorInputValue('#f00')).toBe('#ff0000');
+  });
+});

--- a/src/lib/__tests__/mongoCommand.test.ts
+++ b/src/lib/__tests__/mongoCommand.test.ts
@@ -16,6 +16,7 @@ describe('collectionRef', () => {
   it('uses getCollection() for non-identifier names', () => {
     expect(collectionRef('weird name')).toBe('getCollection("weird name")');
     expect(collectionRef('has"quote')).toBe('getCollection("has\\"quote")');
+    expect(collectionRef('has\\backslash')).toBe('getCollection("has\\\\backslash")');
   });
 });
 

--- a/src/lib/__tests__/quickStartUtils.test.ts
+++ b/src/lib/__tests__/quickStartUtils.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { hostFromUri, avatarColor, initial, topology, AVATAR_PALETTE } from '../quickStartUtils';
+import {
+  hostFromUri,
+  avatarColor,
+  initial,
+  topology,
+  AVATAR_PALETTE,
+  primaryShortcutModifier,
+} from '../quickStartUtils';
+
+describe('primaryShortcutModifier', () => {
+  it('uses the Command symbol on Apple platforms', () => {
+    expect(primaryShortcutModifier('MacIntel')).toBe('⌘');
+    expect(primaryShortcutModifier('iPhone')).toBe('⌘');
+  });
+
+  it('uses Ctrl on other platforms', () => {
+    expect(primaryShortcutModifier('Win32')).toBe('Ctrl');
+    expect(primaryShortcutModifier('Linux x86_64')).toBe('Ctrl');
+  });
+});
 
 describe('topology', () => {
   it('labels srv uris as SRV cluster', () => {

--- a/src/lib/__tests__/shortcuts.test.ts
+++ b/src/lib/__tests__/shortcuts.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterKeyboardShortcuts,
+  formatShortcut,
+  formatShortcutChord,
+  groupKeyboardShortcuts,
+  primaryShortcutModifier,
+  quickStartShortcutRows,
+  shortcutById,
+} from '../shortcuts';
+
+describe('shortcuts', () => {
+  it('uses platform-aware modifier labels', () => {
+    expect(primaryShortcutModifier('MacIntel')).toBe('⌘');
+    expect(primaryShortcutModifier('Win32')).toBe('Ctrl');
+    expect(formatShortcutChord({ mod: true, key: 'K' }, 'MacIntel')).toBe('⌘ K');
+    expect(formatShortcutChord({ mod: true, key: 'K' }, 'Win32')).toBe('Ctrl K');
+  });
+
+  it('formats known shortcuts for settings display', () => {
+    const run = shortcutById('run-query')!;
+    expect(formatShortcut(run, 'Win32')).toBe('Ctrl ↵');
+    expect(formatShortcut(shortcutById('palette-navigate')!, 'MacIntel')).toBe('↑ / ↓');
+  });
+
+  it('filters shortcuts by label, group, and keys', () => {
+    expect(filterKeyboardShortcuts('sidebar', undefined, 'Win32').map((s) => s.id)).toEqual([
+      'sidebar-search',
+    ]);
+    expect(filterKeyboardShortcuts('zoom', undefined, 'Win32').length).toBeGreaterThan(0);
+    expect(filterKeyboardShortcuts('nope', undefined, 'Win32')).toEqual([]);
+  });
+
+  it('groups shortcuts in stable section order', () => {
+    const grouped = groupKeyboardShortcuts(filterKeyboardShortcuts(''));
+    expect(grouped.navigation[0]?.id).toBe('close-dialog');
+    expect(grouped['command-palette'].some((s) => s.id === 'palette-open')).toBe(true);
+  });
+
+  it('builds quick start rows with combined zoom keys', () => {
+    const rows = quickStartShortcutRows('Win32');
+    expect(rows.find((r) => r.id === 'sidebar-search')?.keys).toBe('Ctrl F');
+    expect(rows.find((r) => r.id === 'zoom-in')?.keys).toBe('Ctrl + / Ctrl −');
+  });
+});

--- a/src/lib/__tests__/updateCheckState.test.ts
+++ b/src/lib/__tests__/updateCheckState.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  classifyUpdateCheckError,
+  readUpdateCheckSnapshot,
+  updateCheckBackoffMs,
+  updateCheckResultLabel,
+  writeUpdateCheckSnapshot,
+} from '../updateCheckState';
+
+describe('updateCheckState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('classifies offline vs server errors', () => {
+    expect(classifyUpdateCheckError(new Error('network timeout'))).toBe('offline');
+    expect(classifyUpdateCheckError(new Error('invalid signature'))).toBe('check-failed');
+  });
+
+  it('persists and reads the last check snapshot', () => {
+    writeUpdateCheckSnapshot({
+      checkedAt: '2026-06-15T12:00:00.000Z',
+      result: 'uptodate',
+    });
+    expect(readUpdateCheckSnapshot()).toEqual({
+      checkedAt: '2026-06-15T12:00:00.000Z',
+      result: 'uptodate',
+    });
+  });
+
+  it('labels results for settings display', () => {
+    expect(updateCheckResultLabel('offline')).toBe('Offline');
+    expect(updateCheckResultLabel('check-failed')).toBe('Server error');
+  });
+
+  it('backs off exponentially up to five minutes', () => {
+    expect(updateCheckBackoffMs(0)).toBe(30_000);
+    expect(updateCheckBackoffMs(1)).toBe(60_000);
+    expect(updateCheckBackoffMs(4)).toBe(300_000);
+    expect(updateCheckBackoffMs(8)).toBe(300_000);
+  });
+});

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -5,6 +5,6 @@ export interface ConnectionProfile {
   id: string;
   name: string;
   uri: string;
-  color_tag?: string;
+  color_tag?: string | null;
   ssh?: SshConfig | null;
 }

--- a/src/lib/connectionColors.ts
+++ b/src/lib/connectionColors.ts
@@ -1,0 +1,39 @@
+/** Preset connection color tags (#34). Hex values work in inline styles. */
+export const CONNECTION_COLOR_PALETTE = [
+  { id: 'red', value: '#ef4444', label: 'Red' },
+  { id: 'orange', value: '#f97316', label: 'Orange' },
+  { id: 'amber', value: '#eab308', label: 'Amber' },
+  { id: 'green', value: '#22c55e', label: 'Green' },
+  { id: 'blue', value: '#3b82f6', label: 'Blue' },
+  { id: 'violet', value: '#8b5cf6', label: 'Violet' },
+  { id: 'pink', value: '#ec4899', label: 'Pink' },
+  { id: 'slate', value: '#64748b', label: 'Slate' },
+] as const;
+
+export type ConnectionColorId = (typeof CONNECTION_COLOR_PALETTE)[number]['id'];
+
+/** Fallback shown in the native color picker when no tag is set. */
+export const CONNECTION_COLOR_PICKER_DEFAULT = '#3b82f6';
+
+export function normalizeHexColor(value: string): string | null {
+  const trimmed = value.trim();
+  if (/^#[0-9a-f]{6}$/i.test(trimmed)) return trimmed.toLowerCase();
+  const short = trimmed.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+  if (short) {
+    const [, r, g, b] = short;
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  return null;
+}
+
+export function isPresetConnectionColor(value: string): boolean {
+  const normalized = normalizeHexColor(value);
+  if (!normalized) return false;
+  return CONNECTION_COLOR_PALETTE.some((swatch) => swatch.value === normalized);
+}
+
+/** Value for `<input type="color">` — always `#rrggbb`. */
+export function colorInputValue(tag?: string | null): string {
+  if (!tag) return CONNECTION_COLOR_PICKER_DEFAULT;
+  return normalizeHexColor(tag) ?? CONNECTION_COLOR_PICKER_DEFAULT;
+}

--- a/src/lib/mongoCommand.ts
+++ b/src/lib/mongoCommand.ts
@@ -11,11 +11,16 @@ export interface GeneratedQuery {
   script?: string;
 }
 
+// Escape a collection name for a double-quoted mongosh string literal.
+function escapeCollectionName(name: string): string {
+  return name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 // A collection reference safe for a mongosh `db.<ref>` expression.
 // Identifier-safe names use dot access; anything else uses getCollection("…").
 export function collectionRef(name: string): string {
   if (/^[A-Za-z_$][\w$]*$/.test(name)) return name;
-  return `getCollection("${name.replace(/"/g, '\\"')}")`;
+  return `getCollection("${escapeCollectionName(name)}")`;
 }
 
 const isEmptyObject = (val: unknown): boolean =>

--- a/src/lib/quickStartUtils.ts
+++ b/src/lib/quickStartUtils.ts
@@ -8,6 +8,10 @@ export const AVATAR_PALETTE = [
   '#1f6f7a', // teal
 ] as const;
 
+export function primaryShortcutModifier(platform = navigator.platform): '⌘' | 'Ctrl' {
+  return /Mac|iPhone|iPad|iPod/i.test(platform) ? '⌘' : 'Ctrl';
+}
+
 /** Host[:port] parsed from a mongodb URI, credentials stripped. '' if unparseable. */
 export function hostFromUri(uri: string): string {
   try {

--- a/src/lib/quickStartUtils.ts
+++ b/src/lib/quickStartUtils.ts
@@ -8,9 +8,7 @@ export const AVATAR_PALETTE = [
   '#1f6f7a', // teal
 ] as const;
 
-export function primaryShortcutModifier(platform = navigator.platform): '⌘' | 'Ctrl' {
-  return /Mac|iPhone|iPad|iPod/i.test(platform) ? '⌘' : 'Ctrl';
-}
+export { primaryShortcutModifier } from './shortcuts';
 
 /** Host[:port] parsed from a mongodb URI, credentials stripped. '' if unparseable. */
 export function hostFromUri(uri: string): string {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,218 @@
+export type ShortcutGroup =
+  | 'navigation'
+  | 'query-editor'
+  | 'sidebar'
+  | 'zoom'
+  | 'command-palette';
+
+export const SHORTCUT_GROUP_LABELS: Record<ShortcutGroup, string> = {
+  navigation: 'Navigation',
+  'query-editor': 'Query editor',
+  sidebar: 'Sidebar',
+  zoom: 'Zoom',
+  'command-palette': 'Command palette',
+};
+
+export const SHORTCUT_GROUP_ORDER: ShortcutGroup[] = [
+  'navigation',
+  'query-editor',
+  'sidebar',
+  'zoom',
+  'command-palette',
+];
+
+export interface ShortcutChord {
+  mod?: boolean;
+  key: string;
+  shift?: boolean;
+}
+
+export interface KeyboardShortcut {
+  id: string;
+  group: ShortcutGroup;
+  label: string;
+  keywords?: string;
+  chords: ShortcutChord[];
+}
+
+export function isMacPlatform(platform = navigator.platform): boolean {
+  return /Mac|iPhone|iPad|iPod/i.test(platform);
+}
+
+export function primaryShortcutModifier(platform = navigator.platform): '⌘' | 'Ctrl' {
+  return isMacPlatform(platform) ? '⌘' : 'Ctrl';
+}
+
+const DISPLAY_KEYS: Record<string, string> = {
+  Enter: '↵',
+  Escape: 'esc',
+};
+
+function displayKey(key: string): string {
+  return DISPLAY_KEYS[key] ?? key;
+}
+
+export function formatShortcutChord(chord: ShortcutChord, platform = navigator.platform): string {
+  const mod = primaryShortcutModifier(platform);
+  const parts: string[] = [];
+  if (chord.mod) parts.push(mod);
+  if (chord.shift) parts.push('Shift');
+  parts.push(displayKey(chord.key));
+  return parts.join(' ');
+}
+
+export function formatShortcut(shortcut: KeyboardShortcut, platform = navigator.platform): string {
+  return shortcut.chords.map((chord) => formatShortcutChord(chord, platform)).join(' / ');
+}
+
+export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
+  {
+    id: 'close-dialog',
+    group: 'navigation',
+    label: 'Close the topmost dialog or modal',
+    chords: [{ key: 'Escape' }],
+    keywords: 'dismiss cancel overlay',
+  },
+  {
+    id: 'run-query',
+    group: 'query-editor',
+    label: 'Run the current query',
+    chords: [{ mod: true, key: 'Enter' }],
+    keywords: 'execute mongosh shell builder',
+  },
+  {
+    id: 'submit-dialog',
+    group: 'query-editor',
+    label: 'Submit a multi-line dialog (import URI, prompts)',
+    chords: [{ mod: true, key: 'Enter' }],
+    keywords: 'connection import prompt',
+  },
+  {
+    id: 'sidebar-search',
+    group: 'sidebar',
+    label: 'Focus sidebar tree search',
+    chords: [{ mod: true, key: 'F' }],
+    keywords: 'filter find tree',
+  },
+  {
+    id: 'zoom-in',
+    group: 'zoom',
+    label: 'Zoom interface in',
+    chords: [{ mod: true, key: '+' }],
+    keywords: 'magnify dpi scale',
+  },
+  {
+    id: 'zoom-out',
+    group: 'zoom',
+    label: 'Zoom interface out',
+    chords: [{ mod: true, key: '−' }],
+    keywords: 'shrink dpi scale',
+  },
+  {
+    id: 'zoom-reset',
+    group: 'zoom',
+    label: 'Reset interface zoom to 100%',
+    chords: [{ mod: true, key: '0' }],
+    keywords: 'default dpi scale status bar',
+  },
+  {
+    id: 'palette-open',
+    group: 'command-palette',
+    label: 'Open or close command palette',
+    chords: [{ mod: true, key: 'K' }],
+    keywords: 'search commands collections queries',
+  },
+  {
+    id: 'palette-navigate',
+    group: 'command-palette',
+    label: 'Navigate palette results',
+    chords: [{ key: '↑' }, { key: '↓' }],
+    keywords: 'arrow up down move',
+  },
+  {
+    id: 'palette-run',
+    group: 'command-palette',
+    label: 'Run the selected palette action',
+    chords: [{ key: 'Enter' }],
+    keywords: 'select execute',
+  },
+  {
+    id: 'palette-close',
+    group: 'command-palette',
+    label: 'Close command palette',
+    chords: [{ key: 'Escape' }],
+    keywords: 'dismiss cancel',
+  },
+];
+
+export const QUICK_START_SHORTCUT_IDS = [
+  'run-query',
+  'sidebar-search',
+  'palette-open',
+  'zoom-in',
+  'zoom-out',
+] as const;
+
+export function quickStartShortcutRows(platform = navigator.platform) {
+  const zoomIn = KEYBOARD_SHORTCUTS.find((s) => s.id === 'zoom-in')!;
+  const zoomOut = KEYBOARD_SHORTCUTS.find((s) => s.id === 'zoom-out')!;
+  const rows = QUICK_START_SHORTCUT_IDS.filter((id) => id !== 'zoom-out').map((id) => {
+    const shortcut = KEYBOARD_SHORTCUTS.find((s) => s.id === id)!;
+    if (id === 'zoom-in') {
+      return {
+        id,
+        keys: `${formatShortcutChord(zoomIn.chords[0], platform)} / ${formatShortcutChord(zoomOut.chords[0], platform)}`,
+        label: 'Zoom interface in or out',
+      };
+    }
+    return {
+      id,
+      keys: formatShortcut(shortcut, platform),
+      label: shortcut.label,
+    };
+  });
+  return rows;
+}
+
+export function formatZoomShortcutHint(platform = navigator.platform): string {
+  const zoomIn = shortcutById('zoom-in')!;
+  const zoomOut = shortcutById('zoom-out')!;
+  const zoomReset = shortcutById('zoom-reset')!;
+  return `${formatShortcutChord(zoomIn.chords[0], platform)} / ${formatShortcutChord(zoomOut.chords[0], platform)} / ${formatShortcutChord(zoomReset.chords[0], platform)} to reset`;
+}
+
+export function shortcutById(id: string): KeyboardShortcut | undefined {
+  return KEYBOARD_SHORTCUTS.find((s) => s.id === id);
+}
+
+export function filterKeyboardShortcuts(
+  query: string,
+  shortcuts: KeyboardShortcut[] = KEYBOARD_SHORTCUTS,
+  platform = navigator.platform,
+): KeyboardShortcut[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return shortcuts;
+  return shortcuts.filter((shortcut) => {
+    const haystack = [
+      shortcut.label,
+      shortcut.keywords ?? '',
+      SHORTCUT_GROUP_LABELS[shortcut.group],
+      formatShortcut(shortcut, platform),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
+export function groupKeyboardShortcuts(
+  shortcuts: KeyboardShortcut[],
+): Record<ShortcutGroup, KeyboardShortcut[]> {
+  const grouped = Object.fromEntries(
+    SHORTCUT_GROUP_ORDER.map((group) => [group, [] as KeyboardShortcut[]]),
+  ) as Record<ShortcutGroup, KeyboardShortcut[]>;
+  for (const shortcut of shortcuts) {
+    grouped[shortcut.group].push(shortcut);
+  }
+  return grouped;
+}

--- a/src/lib/updateCheckState.ts
+++ b/src/lib/updateCheckState.ts
@@ -1,0 +1,84 @@
+export type UpdateCheckResultKind = 'uptodate' | 'available' | 'offline' | 'check-failed';
+
+export interface UpdateCheckSnapshot {
+  checkedAt: string;
+  result: UpdateCheckResultKind;
+  detail?: string;
+}
+
+export const UPDATE_CHECK_STATE_EVENT = 'mqlens:update-check-state-changed';
+
+const STORAGE_KEY = 'mqlens.update-check.snapshot';
+
+export function readUpdateCheckSnapshot(): UpdateCheckSnapshot | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as UpdateCheckSnapshot;
+    if (!parsed?.checkedAt || !parsed?.result) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeUpdateCheckSnapshot(snapshot: UpdateCheckSnapshot): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+  } catch {
+    /* ignore quota / private mode */
+  }
+  notifyUpdateCheckState();
+}
+
+export function notifyUpdateCheckState(): void {
+  window.dispatchEvent(new Event(UPDATE_CHECK_STATE_EVENT));
+}
+
+export function classifyUpdateCheckError(err: unknown): 'offline' | 'check-failed' {
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return 'offline';
+  }
+  const msg = String((err as { message?: string })?.message || err).toLowerCase();
+  const offlineHints = [
+    'network',
+    'failed to fetch',
+    'fetch failed',
+    'connection refused',
+    'offline',
+    'dns',
+    'timeout',
+    'timed out',
+    'enotfound',
+    'econnrefused',
+    'unreachable',
+    'no route to host',
+  ];
+  return offlineHints.some((hint) => msg.includes(hint)) ? 'offline' : 'check-failed';
+}
+
+export function updateCheckResultLabel(result: UpdateCheckResultKind): string {
+  switch (result) {
+    case 'uptodate':
+      return 'Up to date';
+    case 'available':
+      return 'Update available';
+    case 'offline':
+      return 'Offline';
+    case 'check-failed':
+      return 'Server error';
+  }
+}
+
+export function formatLastChecked(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+/** Exponential backoff for automatic retries when offline (30s → 5m cap). */
+export function updateCheckBackoffMs(attempt: number): number {
+  const base = 30_000;
+  const max = 300_000;
+  return Math.min(base * 2 ** attempt, max);
+}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,37 +8,45 @@
       "name": "mqlens-website",
       "version": "0.1.0",
       "dependencies": {
-        "@astrojs/sitemap": "^3.2.1",
+        "@astrojs/sitemap": "^3.7.3",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "astro": "^5.1.1"
+        "astro": "^6.1.10"
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
-      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
-      "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
-      "license": "MIT"
-    },
-    "node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
-      "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.7.6",
-        "@astrojs/prism": "3.3.0",
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "import-meta-resolve": "^4.2.0",
-        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
@@ -46,25 +54,23 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "shiki": "^3.21.0",
-        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
         "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
       }
     },
     "node_modules/@astrojs/prism": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
-      "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
       "license": "MIT",
       "dependencies": {
         "prismjs": "^1.30.0"
       },
       "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -79,17 +85,15 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
+      "integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
-        "dlv": "^1.1.3",
+        "ci-info": "^4.4.0",
         "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
+        "is-docker": "^4.0.0",
+        "is-wsl": "^3.1.1",
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
@@ -154,6 +158,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@clack/core": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.5.1.tgz",
+      "integrity": "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.1",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
@@ -165,9 +197,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -181,9 +213,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -197,9 +229,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -213,9 +245,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -229,9 +261,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -245,9 +277,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -261,9 +293,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -277,9 +309,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -293,9 +325,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -309,9 +341,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -325,9 +357,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -341,9 +373,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -357,9 +389,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -373,9 +405,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -389,9 +421,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -405,9 +437,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -421,9 +453,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -437,9 +469,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -453,9 +485,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -469,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -485,9 +517,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -501,9 +533,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -517,9 +549,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -533,9 +565,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -549,9 +581,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -565,9 +597,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1430,64 +1462,97 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0",
+        "@shikijs/primitive": "4.2.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+      "integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+      "integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+      "integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0"
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+      "integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+      "integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0"
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
@@ -1574,92 +1639,6 @@
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
     },
-    "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.1.0"
-      }
-    },
-    "node_modules/ansi-align/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/ansi-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-align/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -1717,80 +1696,72 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
-      "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.7.tgz",
+      "integrity": "sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^2.13.0",
-        "@astrojs/internal-helpers": "0.7.6",
-        "@astrojs/markdown-remark": "6.3.11",
-        "@astrojs/telemetry": "3.3.0",
+        "@astrojs/compiler": "^4.0.0",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
+        "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
+        "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
         "@rollup/pluginutils": "^5.3.0",
-        "acorn": "^8.15.0",
         "aria-query": "^5.3.2",
         "axobject-query": "^4.1.0",
-        "boxen": "8.0.1",
-        "ci-info": "^4.3.1",
+        "ci-info": "^4.4.0",
         "clsx": "^2.1.1",
-        "common-ancestor-path": "^1.0.1",
+        "common-ancestor-path": "^2.0.0",
         "cookie": "^1.1.1",
-        "cssesc": "^3.0.0",
-        "debug": "^4.4.3",
-        "deterministic-object-hash": "^2.0.2",
-        "devalue": "^5.6.2",
+        "devalue": "^5.8.1",
         "diff": "^8.0.3",
-        "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "es-module-lexer": "^1.7.0",
+        "es-module-lexer": "^2.0.0",
         "esbuild": "^0.27.3",
-        "estree-walker": "^3.0.3",
         "flattie": "^1.1.1",
-        "fontace": "~0.4.0",
+        "fontace": "~0.4.1",
+        "get-tsconfig": "5.0.0-beta.4",
         "github-slugger": "^2.0.0",
         "html-escaper": "3.0.3",
         "http-cache-semantics": "^4.2.0",
-        "import-meta-resolve": "^4.2.0",
         "js-yaml": "^4.1.1",
+        "jsonc-parser": "^3.3.1",
         "magic-string": "^0.30.21",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "mrmime": "^2.0.1",
         "neotraverse": "^0.6.18",
-        "p-limit": "^6.2.0",
-        "p-queue": "^8.1.1",
+        "obug": "^2.1.1",
+        "p-limit": "^7.3.0",
+        "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
-        "prompts": "^2.4.2",
+        "picomatch": "^4.0.4",
         "rehype": "^13.0.2",
-        "semver": "^7.7.3",
-        "shiki": "^3.21.0",
+        "semver": "^7.7.4",
+        "shiki": "^4.0.2",
         "smol-toml": "^1.6.0",
-        "svgo": "^4.0.0",
-        "tinyexec": "^1.0.2",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
-        "tsconfck": "^3.1.6",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.7.3",
-        "unist-util-visit": "^5.0.0",
-        "unstorage": "^1.17.4",
+        "unifont": "~0.7.4",
+        "unist-util-visit": "^5.1.0",
+        "unstorage": "^1.17.5",
         "vfile": "^6.0.3",
-        "vite": "^6.4.1",
-        "vitefu": "^1.1.1",
+        "vite": "^7.3.2",
+        "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
-        "yargs-parser": "^21.1.1",
-        "yocto-spinner": "^0.2.3",
-        "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.25.1",
-        "zod-to-ts": "^1.2.0"
+        "yargs-parser": "^22.0.0",
+        "zod": "^4.3.6"
       },
       "bin": {
-        "astro": "astro.js"
+        "astro": "bin/astro.mjs"
       },
       "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+        "node": ">=22.12.0",
         "npm": ">=9.6.5",
         "pnpm": ">=7.1.0"
       },
@@ -1800,24 +1771,6 @@
       },
       "optionalDependencies": {
         "sharp": "^0.34.0"
-      }
-    },
-    "node_modules/astro/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/astro/node_modules/zod-to-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
-      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
-      "peerDependencies": {
-        "typescript": "^4.9.4 || ^5.0.2",
-        "zod": "^3"
       }
     },
     "node_modules/axobject-query": {
@@ -1839,51 +1792,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-      "license": "MIT"
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
-    },
-    "node_modules/boxen": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
-      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-align": "^3.0.1",
-        "camelcase": "^8.0.0",
-        "chalk": "^5.3.0",
-        "cli-boxes": "^3.0.0",
-        "string-width": "^7.2.0",
-        "type-fest": "^4.21.0",
-        "widest-line": "^5.0.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
-      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -1893,18 +1806,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -1967,18 +1868,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2008,10 +1897,13 @@
       }
     },
     "node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
-      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
-      "license": "ISC"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2080,18 +1972,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/csso": {
@@ -2188,18 +2068,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/deterministic-object-hash": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
-      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-64": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/devalue": {
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
@@ -2227,12 +2095,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -2310,12 +2172,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2329,15 +2185,15 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2347,32 +2203,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2387,15 +2243,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -2407,6 +2254,30 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2469,16 +2340,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+    "node_modules/get-tsconfig": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+      "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
       "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.20.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-slugger": {
@@ -2703,16 +2577,6 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -2723,27 +2587,18 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-inside-container": {
@@ -2759,6 +2614,21 @@
       },
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2792,9 +2662,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2803,14 +2683,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -3743,6 +3620,19 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -3778,43 +3668,43 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
-      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
       "license": "MIT",
       "dependencies": {
-        "yocto-queue": "^1.1.1"
+        "yocto-queue": "^1.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-queue": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
-      "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3915,19 +3805,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/property-information": {
@@ -4125,6 +4002,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -4303,19 +4189,22 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+      "integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.23.0",
-        "@shikijs/engine-javascript": "3.23.0",
-        "@shikijs/engine-oniguruma": "3.23.0",
-        "@shikijs/langs": "3.23.0",
-        "@shikijs/themes": "3.23.0",
-        "@shikijs/types": "3.23.0",
+        "@shikijs/core": "4.2.0",
+        "@shikijs/engine-javascript": "4.2.0",
+        "@shikijs/engine-oniguruma": "4.2.0",
+        "@shikijs/langs": "4.2.0",
+        "@shikijs/themes": "4.2.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/sisteransi": {
@@ -4380,23 +4269,6 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
-    "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -4409,21 +4281,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/svgo": {
@@ -4456,6 +4313,15 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
+    },
+    "node_modules/tinyclip": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.14.tgz",
+      "integrity": "sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
@@ -4502,58 +4368,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
     },
     "node_modules/ufo": {
       "version": "1.6.4",
@@ -4871,23 +4691,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -4896,14 +4716,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
         "jiti": ">=1.21.0",
-        "less": "*",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -4944,463 +4764,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
     "node_modules/vitefu": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
@@ -5439,38 +4802,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/widest-line": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
-      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
@@ -5478,12 +4809,12 @@
       "license": "MIT"
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {
@@ -5498,33 +4829,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yocto-spinner": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
-      "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.19"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -5532,15 +4836,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,9 +11,12 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/sitemap": "^3.2.1",
+    "@astrojs/sitemap": "^3.7.3",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
-    "astro": "^5.1.1"
+    "astro": "^6.1.10"
+  },
+  "overrides": {
+    "esbuild": "0.28.1"
   }
 }

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -37,8 +37,28 @@ const toc = [
         <p>Download the build for your platform from the <a href="/#download">download section</a> or the <a href={SITE.releasesLatest} target="_blank" rel="noopener">latest release</a>:</p>
         <ul>
           <li><strong>macOS</strong> — open the <code>.dmg</code> and drag {SITE.name} to Applications. Builds are Apple-notarized, so Gatekeeper will let it run.</li>
-          <li><strong>Windows</strong> — run the <code>.msi</code> or <code>.exe</code> installer. Installers are Azure Trusted Signing–signed.</li>
         </ul>
+
+        <h3>Windows</h3>
+        <p>
+          Download the <code>.exe</code> or <code>.msi</code> installer from the
+          <a href={SITE.releasesLatest} target="_blank" rel="noopener">latest release page</a>.
+          Requires Windows 10 or later (x64). Installers are Azure Trusted Signing–signed.
+        </p>
+        <p><strong>Setup (.exe, recommended)</strong></p>
+        <ol>
+          <li>Double-click <code>MQLens_*_x64-setup.exe</code>.</li>
+          <li>Approve the UAC prompt if Windows asks for permission.</li>
+          <li>Follow the setup wizard, then launch <strong>{SITE.name}</strong> from the Start menu.</li>
+        </ol>
+        <p><strong>Setup (.msi)</strong></p>
+        <p>Double-click <code>MQLens_*.msi</code> and follow the prompts, or install from an elevated Command Prompt or PowerShell:</p>
+        <pre><code>msiexec /i MQLens_*.msi</code></pre>
+        <p>
+          <strong>Troubleshooting:</strong> if SmartScreen shows "Windows protected your PC",
+          choose <strong>More info</strong> → <strong>Run anyway</strong>. The installer is signed;
+          SmartScreen may still warn on first download until reputation builds.
+        </p>
 
         <h3>Linux</h3>
         <p>

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -34,12 +34,31 @@ const toc = [
         </p>
 
         <h2 id="install">Install</h2>
-        <p>Download the build for your platform from the <a href="/#download">download section</a> or the <a href={SITE.releases} target="_blank" rel="noopener">releases page</a>:</p>
+        <p>Download the build for your platform from the <a href="/#download">download section</a> or the <a href={SITE.releasesLatest} target="_blank" rel="noopener">latest release</a>:</p>
         <ul>
           <li><strong>macOS</strong> — open the <code>.dmg</code> and drag {SITE.name} to Applications. Builds are Apple-notarized, so Gatekeeper will let it run.</li>
           <li><strong>Windows</strong> — run the <code>.msi</code> or <code>.exe</code> installer. Installers are Azure Trusted Signing–signed.</li>
-          <li><strong>Linux</strong> — install the <code>.deb</code> (<code>sudo apt install ./MQLens_*.deb</code>) or make the <code>.AppImage</code> executable and run it.</li>
         </ul>
+
+        <h3>Linux</h3>
+        <p>
+          Grab the <code>.deb</code> or <code>.AppImage</code> from the
+          <a href={SITE.releasesLatest} target="_blank" rel="noopener">latest release page</a>.
+        </p>
+        <p><strong>Debian / Ubuntu (.deb)</strong></p>
+        <pre><code>sudo apt install ./MQLens_*.deb
+# or:
+sudo dpkg -i MQLens_*.deb</code></pre>
+        <p><strong>Any distro (.AppImage)</strong></p>
+        <pre><code>chmod +x MQLens_*.AppImage
+./MQLens_*.AppImage</code></pre>
+        <p>
+          <strong>Troubleshooting:</strong> if the AppImage says "Permission denied" or
+          refuses to start, the execute bit was probably lost during download — run
+          <code>chmod +x</code> on the file again. Some browsers save AppImages without
+          the executable flag until you set it manually.
+        </p>
+
         <p>To use the embedded shell you'll also need <a href="https://www.mongodb.com/docs/mongodb-shell/" target="_blank" rel="noopener"><code>mongosh</code></a> on your <code>PATH</code>.</p>
 
         <h2 id="first-connection">Your first connection</h2>


### PR DESCRIPTION
## Summary

Merges **dev** into **main** for the **v0.9.0** stable release — stability, UX polish, and test coverage ahead of the import/export milestone.

### Features
- **Keyboard shortcuts reference** (#132) — Settings → Shortcuts with platform-aware labels (⌘ / Ctrl), grouped list, and search; QuickStart links to the full reference
- **UI zoom in status bar** (#119) — Footer shows zoom % when not 100%; click resets
- **Per-connection color tags** (#34) — Preset palette + custom picker; dots in connection manager and sidebar

### Fixes
- **Per-tab query editor state** (#120) — Draft queries persist when switching collection tabs
- **Sidebar search shortcut** (#131) — ⌘/Ctrl+F focuses sidebar tree search (skips Monaco editors)
- **Updater offline behavior** (#133) — Silent startup when offline, exponential backoff retry, last-checked status in Settings → Updates, actionable manual-check toasts
- **Security** — CodeQL hardcoded-password cleanup; earlier CodeQL/glib advisory fixes

### Tests & docs
- **ExportView + TaskManager tests** (#134)
- **ROADMAP** — v0.9.0 marked shipped; upcoming milestones scheduled as 10-day windows
- **Install notes** — Linux (AppImage/.deb) and Windows docs in README + website

## Release mechanics

On merge, the **Release** workflow derives the next semver from conventional commits since `mqlens-v0.8.0` (expected **0.9.0** minor bump), commits the version bump to `main` with `[skip ci]`, and publishes `mqlens-v0.9.0` with signed updater assets.

## Test plan

- [x] CI passes on this PR (frontend build, coverage, backend tests, CodeQL)
- [x] Per-tab query drafts survive tab switches
- [x] ⌘/Ctrl+F focuses sidebar search; ⌘/Ctrl+K opens command palette
- [x] Settings → Shortcuts search and platform labels
- [x] Settings → Updates shows last check + offline/server distinction
- [x] Connection color tags persist and render in sidebar
- [ ] Release workflow publishes `mqlens-v0.9.0` on merge