### PR TITLE
test: fix flaky UpdatePrompt server-error assertion

### DIFF
--- a/src/components/__tests__/UpdatePrompt.test.tsx
+++ b/src/components/__tests__/UpdatePrompt.test.tsx
@@ -118,8 +118,8 @@ describe('UpdatePrompt', () => {
     routeInvoke({ update_check: () => Promise.reject(new Error('invalid signature')) });
     render(<UpdatePrompt />);
     triggerManualCheck();
-    expect(await screen.findByTestId('update-toast')).toHaveTextContent(/update server/i);
-    expect(readUpdateCheckSnapshot()?.result).toBe('check-failed');
+    expect(await screen.findByText(/update server/i)).toBeInTheDocument();
+    await waitFor(() => expect(readUpdateCheckSnapshot()?.result).toBe('check-failed'));
   });
 
   it('records offline on startup without showing a toast', async () => {


### PR DESCRIPTION
## Summary
- Fixes CI failure on release PR #148: `shows a server error message on manual check failure` was matching the transient checking toast before the error toast rendered on slower runners.

## Test plan
- [x] `npm test -- --run src/components/__tests__/UpdatePrompt.test.tsx` (5 consecutive runs)