### PR TITLE
fix: run find query on Enter in builder fields

### DIFF
--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -1284,6 +1284,13 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     notify(`Cleared ${field} parameters`);
   };
 
+  const runQueryOnEnter = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleRun();
+    }
+  };
+
   const queryColClass = (invalid: boolean) =>
     cn(
       'flex min-w-0 flex-1 items-center border-r border-border bg-input/80 transition-colors last:border-r-0',
@@ -1779,6 +1786,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                       type="number"
                       value={skip}
                       onChange={(e) => setSkip(e.target.value)}
+                      onKeyDown={runQueryOnEnter}
                       placeholder="0"
                       min="0"
                       className="h-7 flex-1 min-w-0 border-0 bg-transparent px-2.5 font-mono text-[11.5px] shadow-none focus-visible:ring-0"
@@ -1796,6 +1804,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                       type="number"
                       value={limit}
                       onChange={(e) => setLimit(e.target.value)}
+                      onKeyDown={runQueryOnEnter}
                       placeholder="50"
                       min="1"
                       className="h-7 flex-1 min-w-0 border-0 bg-transparent px-2.5 font-mono text-[11.5px] shadow-none focus-visible:ring-0"

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -109,6 +109,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
     overflowWidgetsDomNode,
     tabSize: 2,
     quickSuggestions,
+    acceptSuggestionOnEnter: 'on' as const,
   };
 
   const editor = (
@@ -124,14 +125,23 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
         registerMqlensMonacoThemes(monaco);
         monaco.editor.setTheme(theme);
         registerMongoCompletionProvider(monaco);
+
+        // ⌘/Ctrl+Enter always runs; plain Enter is bound below for single-line fields.
         ed.onKeyDown((e) => {
-          if ((e.ctrlKey || e.metaKey) && e.keyCode === monaco.KeyCode.Enter) {
+          if (e.keyCode === monaco.KeyCode.Enter && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
             e.stopPropagation();
             onRunRef.current?.();
           }
         });
+
         if (singleLine) {
+          // Let Monaco accept suggestions on Enter when the widget is open; run only when closed.
+          ed.addCommand(
+            monaco.KeyCode.Enter,
+            () => onRunRef.current?.(),
+            '!suggestWidgetVisible && !renameInputVisible && !inSnippetMode',
+          );
           ed.onDidChangeModelContent(() => {
             const v = ed.getValue();
             if (v.includes('\n')) {

--- a/src/components/__tests__/QueryEditor.test.tsx
+++ b/src/components/__tests__/QueryEditor.test.tsx
@@ -1,17 +1,135 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 
+type KeyDownHandler = (e: {
+  keyCode: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  preventDefault: () => void;
+  stopPropagation: () => void;
+}) => void;
+
+const KeyCode = { Enter: 3 };
+let keyDownHandler: KeyDownHandler | undefined;
+let enterRunCommand: (() => void) | undefined;
+let enterRunWhen: string | undefined;
+
+vi.mock('../../lib/monacoMongo', () => ({
+  registerMongoCompletionProvider: vi.fn(),
+  setModelMeta: vi.fn(),
+  clearModelMeta: vi.fn(),
+}));
+
+vi.mock('../../lib/monacoAppTheme', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/monacoAppTheme')>();
+  return {
+    ...actual,
+    registerMqlensMonacoThemes: vi.fn(),
+    refreshMqlensMonacoTheme: vi.fn(),
+  };
+});
+
 vi.mock('@monaco-editor/react', () => ({
-  default: ({ value }: { value: string }) => <div data-testid="monaco" data-value={value} />,
+  default: ({
+    value,
+    onMount,
+  }: {
+    value: string;
+    onMount?: (ed: unknown, monaco: { KeyCode: typeof KeyCode; editor: { defineTheme: () => void; setTheme: () => void } }) => void;
+  }) => {
+    if (onMount) {
+      onMount(
+        {
+          onKeyDown: (handler: KeyDownHandler) => {
+            keyDownHandler = handler;
+          },
+          addCommand: (key: number, handler: () => void, when?: string) => {
+            if (key === KeyCode.Enter) {
+              enterRunCommand = handler;
+              enterRunWhen = when;
+            }
+            return 'run-on-enter';
+          },
+          onDidChangeModelContent: vi.fn(),
+          getValue: () => value,
+          setValue: vi.fn(),
+          getPosition: () => null,
+          setPosition: vi.fn(),
+          getModel: () => ({ uri: { toString: () => 'test://model' } }),
+          onDidDispose: vi.fn(),
+        },
+        {
+          KeyCode,
+          editor: { defineTheme: vi.fn(), setTheme: vi.fn() },
+        },
+      );
+    }
+    return <div data-testid="monaco" data-value={value} />;
+  },
 }));
 
 import { QueryEditor } from '../QueryEditor';
 
+function pressEnter(modifiers: Partial<{ ctrlKey: boolean; metaKey: boolean; shiftKey: boolean }> = {}) {
+  const preventDefault = vi.fn();
+  const stopPropagation = vi.fn();
+  keyDownHandler?.({
+    keyCode: KeyCode.Enter,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    preventDefault,
+    stopPropagation,
+    ...modifiers,
+  });
+  return { preventDefault, stopPropagation };
+}
+
 describe('QueryEditor', () => {
+  beforeEach(() => {
+    keyDownHandler = undefined;
+    enterRunCommand = undefined;
+    enterRunWhen = undefined;
+  });
+
   it('renders a Monaco editor with the given value', () => {
     const { getByTestId } = render(
       <QueryEditor surface="aggStage" value='{ "$match": {} }' onChange={() => {}} fields={['region']} schema={undefined} />,
     );
     expect(getByTestId('monaco').getAttribute('data-value')).toBe('{ "$match": {} }');
+  });
+
+  it('runs on Cmd/Ctrl+Enter in multi-line mode', () => {
+    const onRun = vi.fn();
+    render(
+      <QueryEditor surface="filter" value="{}" onChange={() => {}} fields={[]} onRun={onRun} />,
+    );
+    const { preventDefault } = pressEnter({ metaKey: true });
+    expect(onRun).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('does not run on plain Enter in multi-line mode', () => {
+    const onRun = vi.fn();
+    render(
+      <QueryEditor surface="filter" value="{}" onChange={() => {}} fields={[]} onRun={onRun} />,
+    );
+    pressEnter();
+    enterRunCommand?.();
+    expect(onRun).not.toHaveBeenCalled();
+    expect(enterRunCommand).toBeUndefined();
+  });
+
+  it('binds plain Enter to run only when suggestions are closed', () => {
+    const onRun = vi.fn();
+    render(
+      <QueryEditor singleLine surface="filter" value="{}" onChange={() => {}} fields={[]} onRun={onRun} />,
+    );
+    expect(enterRunWhen).toContain('!suggestWidgetVisible');
+    enterRunCommand?.();
+    expect(onRun).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -23,6 +23,25 @@ describe('getCompletions — filter', () => {
     const enums = items.filter((i) => i.kind === 'enum');
     expect(enums.map((e) => e.insertText)).toEqual(expect.arrayContaining(['"Free"', '"Team"']));
   });
+  it('does not double-quote enum values when already inside a quote', () => {
+    const schema = new Map([['workspaceId', { type: 'string', enumValues: ['default', 'personal'] }]]);
+    const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ "workspaceId": "', token: '', schema }));
+    const enums = items.filter((i) => i.kind === 'enum');
+    expect(enums.map((e) => e.insertText)).toEqual(expect.arrayContaining(['default"', 'personal"']));
+    expect(enums.map((e) => e.insertText)).not.toEqual(expect.arrayContaining(['"default"', '"personal"']));
+  });
+  it('does not add a closing quote when one is already ahead of the cursor', () => {
+    const schema = new Map([['workspaceId', { type: 'string', enumValues: ['default', 'personal'] }]]);
+    const items = getCompletions(base({
+      surface: 'filter',
+      textBeforeCursor: '{ "workspaceId": "',
+      textAfterCursor: '"',
+      token: '',
+      schema,
+    }));
+    const enums = items.filter((i) => i.kind === 'enum');
+    expect(enums.map((e) => e.insertText)).toEqual(expect.arrayContaining(['default', 'personal']));
+  });
   it('prefix-filters by token', () => {
     const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ reg', token: 'reg' }));
     expect(labels(items)).toContain('region');
@@ -444,6 +463,14 @@ describe('getCompletions — per-stage body editor (stageOperator)', () => {
   it('$lookup localField value offers field names as strings', () => {
     const items = getCompletions(stage('$lookup', '{ "localField": ', 'reg'));
     expect(items.find((i) => i.label === 'region')!.insertText).toBe('"region"');
+  });
+  it('$lookup localField value does not double-quote when already inside a quote', () => {
+    const items = getCompletions(stage('$lookup', '{ "localField": "', 'reg'));
+    expect(items.find((i) => i.label === 'region')!.insertText).toBe('region"');
+  });
+  it('$lookup localField value does not add a closing quote when one is ahead', () => {
+    const items = getCompletions(stage('$lookup', '{ "localField": "', 'reg', { textAfterCursor: '"' }));
+    expect(items.find((i) => i.label === 'region')!.insertText).toBe('region');
   });
   it('$unwind body suggests field path refs', () => {
     const items = getCompletions(stage('$unwind', '', '$reg'));

--- a/src/lib/monacoMongo.ts
+++ b/src/lib/monacoMongo.ts
@@ -57,9 +57,13 @@ export function registerMongoCompletionProvider(monaco: Monaco) {
         startLineNumber: position.lineNumber, startColumn: 1,
         endLineNumber: position.lineNumber, endColumn: position.column,
       });
+      const textAfterCursor: string = model.getValueInRange({
+        startLineNumber: position.lineNumber, startColumn: position.column,
+        endLineNumber: position.lineNumber, endColumn: model.getLineMaxColumn(position.lineNumber),
+      });
       const token = textBeforeCursor.match(/[\w$]*$/)?.[0] ?? '';
       const items = getCompletions({
-        surface: meta.surface, textBeforeCursor, token,
+        surface: meta.surface, textBeforeCursor, textAfterCursor, token,
         fields: meta.getFields(), schema: meta.getSchema(), collections: meta.getCollections?.(),
         stageOperator: meta.getStageOperator?.(),
       });

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -6,6 +6,7 @@ export interface FieldSchema { type?: string; enumValues?: string[]; }
 export interface CompletionCtx {
   surface: Surface;
   textBeforeCursor: string;
+  textAfterCursor?: string;
   token: string;
   fields: string[];
   schema?: Map<string, FieldSchema>;
@@ -262,13 +263,28 @@ function quoteForType(value: string, type?: string): string {
   return JSON.stringify(value);
 }
 
+// When the user already typed `"`, Monaco may auto-insert a closing `"` ahead of
+// the cursor — only add our own closer when one is not already there.
+function closeQuotedValue(ctx: CompletionCtx, value: string): string {
+  if (ctx.textAfterCursor?.trimStart().startsWith('"')) return value;
+  return `${value}"`;
+}
+
+function valueInsert(ctx: CompletionCtx, value: string, type?: string): string {
+  const unquoted = type === 'int' || type === 'long' || type === 'double' || type === 'decimal' || type === 'bool';
+  if (inQuote(ctx.textBeforeCursor)) {
+    return unquoted ? value : closeQuotedValue(ctx, value);
+  }
+  return quoteForType(value, type);
+}
+
 function enumItemsForLastField(ctx: CompletionCtx): CompletionItem[] {
   const field = lastFieldKey(ctx.textBeforeCursor);
   if (!field) return [];
   const fs = ctx.schema?.get(field);
   if (!fs?.enumValues?.length) return [];
   return fs.enumValues.map((v) => ({
-    label: v, kind: 'enum' as const, insertText: quoteForType(v, fs.type), detail: 'enum',
+    label: v, kind: 'enum' as const, insertText: valueInsert(ctx, v, fs.type), detail: 'enum',
   }));
 }
 
@@ -348,17 +364,24 @@ function keyScaffoldItems(ctx: CompletionCtx, list: EjsonType[], kind: Completio
   }));
 }
 
-// `"$field"` aggregation path references (for $group/$unwind/$sortByCount bodies).
 function fieldRefItems(ctx: CompletionCtx): CompletionItem[] {
   return ctx.fields.map((name) => ({
-    label: `$${name}`, kind: 'field' as const, insertText: `"$${name}"`, detail: 'field path',
+    label: `$${name}`, kind: 'field' as const,
+    insertText: inQuote(ctx.textBeforeCursor)
+      ? closeQuotedValue(ctx, `$${name}`)
+      : `"$${name}"`,
+    detail: 'field path',
   }));
 }
 
 // Field names as plain string values ($lookup localField/foreignField).
 function fieldStringItems(ctx: CompletionCtx): CompletionItem[] {
   return ctx.fields.map((name) => ({
-    label: name, kind: 'field' as const, insertText: `"${name}"`, detail: ctx.schema?.get(name)?.type,
+    label: name, kind: 'field' as const,
+    insertText: inQuote(ctx.textBeforeCursor)
+      ? closeQuotedValue(ctx, name)
+      : `"${name}"`,
+    detail: ctx.schema?.get(name)?.type,
   }));
 }
 


### PR DESCRIPTION
## Summary
- **Query / Projection / Sort** (single-line Monaco fields): plain **Enter** runs the query; **⌘/Ctrl+Enter** still works
- **Skip / Limit** number inputs: **Enter** runs the query
- Autocomplete suggestions still take priority when the suggest widget is open

Multi-line editors (aggregation stages) keep Enter for newlines; only **⌘/Ctrl+Enter** runs there.

## Test plan
- [x] `npm test -- --run src/components/__tests__/QueryEditor.test.tsx`
- [x] `npm test -- --run` (538 tests)
- [x] Manual: type in Query/Projection/Sort/Skip → Enter runs find query