### PR TITLE
Release v0.9.1: Query Enter + dependency patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mqlens",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mqlens",
-      "version": "0.7.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
@@ -58,7 +58,7 @@
         "@vitest/coverage-v8": "^4.1.7",
         "jsdom": "^29.1.1",
         "typescript": "~5.8.3",
-        "vite": "^7.0.4",
+        "vite": "^7.3.5",
         "vitest": "^4.1.7"
       }
     },
@@ -146,18 +146,18 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
+      "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
+        "@babel/generator": "^7.29.6",
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
+        "@babel/helpers": "^7.29.2",
+        "@babel/parser": "^7.29.3",
         "@babel/template": "^7.28.6",
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -177,14 +177,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -263,9 +263,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -273,9 +273,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -307,13 +307,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -399,14 +399,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3917,9 +3917,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -5464,9 +5464,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -67,11 +67,12 @@
     "@vitest/coverage-v8": "^4.1.7",
     "jsdom": "^29.1.1",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4",
+    "vite": "^7.3.5",
     "vitest": "^4.1.7"
   },
   "overrides": {
-    "dompurify": "3.4.0",
+    "dompurify": "3.4.10",
+    "@babel/core": "7.29.6",
     "esbuild": "0.28.1"
   }
 }

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -1284,6 +1284,13 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     notify(`Cleared ${field} parameters`);
   };
 
+  const runQueryOnEnter = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleRun();
+    }
+  };
+
   const queryColClass = (invalid: boolean) =>
     cn(
       'flex min-w-0 flex-1 items-center border-r border-border bg-input/80 transition-colors last:border-r-0',
@@ -1779,6 +1786,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                       type="number"
                       value={skip}
                       onChange={(e) => setSkip(e.target.value)}
+                      onKeyDown={runQueryOnEnter}
                       placeholder="0"
                       min="0"
                       className="h-7 flex-1 min-w-0 border-0 bg-transparent px-2.5 font-mono text-[11.5px] shadow-none focus-visible:ring-0"
@@ -1796,6 +1804,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                       type="number"
                       value={limit}
                       onChange={(e) => setLimit(e.target.value)}
+                      onKeyDown={runQueryOnEnter}
                       placeholder="50"
                       min="1"
                       className="h-7 flex-1 min-w-0 border-0 bg-transparent px-2.5 font-mono text-[11.5px] shadow-none focus-visible:ring-0"

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -109,6 +109,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
     overflowWidgetsDomNode,
     tabSize: 2,
     quickSuggestions,
+    acceptSuggestionOnEnter: 'on' as const,
   };
 
   const editor = (
@@ -124,14 +125,23 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
         registerMqlensMonacoThemes(monaco);
         monaco.editor.setTheme(theme);
         registerMongoCompletionProvider(monaco);
+
+        // ⌘/Ctrl+Enter always runs; plain Enter is bound below for single-line fields.
         ed.onKeyDown((e) => {
-          if ((e.ctrlKey || e.metaKey) && e.keyCode === monaco.KeyCode.Enter) {
+          if (e.keyCode === monaco.KeyCode.Enter && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
             e.stopPropagation();
             onRunRef.current?.();
           }
         });
+
         if (singleLine) {
+          // Let Monaco accept suggestions on Enter when the widget is open; run only when closed.
+          ed.addCommand(
+            monaco.KeyCode.Enter,
+            () => onRunRef.current?.(),
+            '!suggestWidgetVisible && !renameInputVisible && !inSnippetMode',
+          );
           ed.onDidChangeModelContent(() => {
             const v = ed.getValue();
             if (v.includes('\n')) {

--- a/src/components/__tests__/QueryEditor.test.tsx
+++ b/src/components/__tests__/QueryEditor.test.tsx
@@ -1,17 +1,135 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 
+type KeyDownHandler = (e: {
+  keyCode: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  preventDefault: () => void;
+  stopPropagation: () => void;
+}) => void;
+
+const KeyCode = { Enter: 3 };
+let keyDownHandler: KeyDownHandler | undefined;
+let enterRunCommand: (() => void) | undefined;
+let enterRunWhen: string | undefined;
+
+vi.mock('../../lib/monacoMongo', () => ({
+  registerMongoCompletionProvider: vi.fn(),
+  setModelMeta: vi.fn(),
+  clearModelMeta: vi.fn(),
+}));
+
+vi.mock('../../lib/monacoAppTheme', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/monacoAppTheme')>();
+  return {
+    ...actual,
+    registerMqlensMonacoThemes: vi.fn(),
+    refreshMqlensMonacoTheme: vi.fn(),
+  };
+});
+
 vi.mock('@monaco-editor/react', () => ({
-  default: ({ value }: { value: string }) => <div data-testid="monaco" data-value={value} />,
+  default: ({
+    value,
+    onMount,
+  }: {
+    value: string;
+    onMount?: (ed: unknown, monaco: { KeyCode: typeof KeyCode; editor: { defineTheme: () => void; setTheme: () => void } }) => void;
+  }) => {
+    if (onMount) {
+      onMount(
+        {
+          onKeyDown: (handler: KeyDownHandler) => {
+            keyDownHandler = handler;
+          },
+          addCommand: (key: number, handler: () => void, when?: string) => {
+            if (key === KeyCode.Enter) {
+              enterRunCommand = handler;
+              enterRunWhen = when;
+            }
+            return 'run-on-enter';
+          },
+          onDidChangeModelContent: vi.fn(),
+          getValue: () => value,
+          setValue: vi.fn(),
+          getPosition: () => null,
+          setPosition: vi.fn(),
+          getModel: () => ({ uri: { toString: () => 'test://model' } }),
+          onDidDispose: vi.fn(),
+        },
+        {
+          KeyCode,
+          editor: { defineTheme: vi.fn(), setTheme: vi.fn() },
+        },
+      );
+    }
+    return <div data-testid="monaco" data-value={value} />;
+  },
 }));
 
 import { QueryEditor } from '../QueryEditor';
 
+function pressEnter(modifiers: Partial<{ ctrlKey: boolean; metaKey: boolean; shiftKey: boolean }> = {}) {
+  const preventDefault = vi.fn();
+  const stopPropagation = vi.fn();
+  keyDownHandler?.({
+    keyCode: KeyCode.Enter,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    preventDefault,
+    stopPropagation,
+    ...modifiers,
+  });
+  return { preventDefault, stopPropagation };
+}
+
 describe('QueryEditor', () => {
+  beforeEach(() => {
+    keyDownHandler = undefined;
+    enterRunCommand = undefined;
+    enterRunWhen = undefined;
+  });
+
   it('renders a Monaco editor with the given value', () => {
     const { getByTestId } = render(
       <QueryEditor surface="aggStage" value='{ "$match": {} }' onChange={() => {}} fields={['region']} schema={undefined} />,
     );
     expect(getByTestId('monaco').getAttribute('data-value')).toBe('{ "$match": {} }');
+  });
+
+  it('runs on Cmd/Ctrl+Enter in multi-line mode', () => {
+    const onRun = vi.fn();
+    render(
+      <QueryEditor surface="filter" value="{}" onChange={() => {}} fields={[]} onRun={onRun} />,
+    );
+    const { preventDefault } = pressEnter({ metaKey: true });
+    expect(onRun).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('does not run on plain Enter in multi-line mode', () => {
+    const onRun = vi.fn();
+    render(
+      <QueryEditor surface="filter" value="{}" onChange={() => {}} fields={[]} onRun={onRun} />,
+    );
+    pressEnter();
+    enterRunCommand?.();
+    expect(onRun).not.toHaveBeenCalled();
+    expect(enterRunCommand).toBeUndefined();
+  });
+
+  it('binds plain Enter to run only when suggestions are closed', () => {
+    const onRun = vi.fn();
+    render(
+      <QueryEditor singleLine surface="filter" value="{}" onChange={() => {}} fields={[]} onRun={onRun} />,
+    );
+    expect(enterRunWhen).toContain('!suggestWidgetVisible');
+    enterRunCommand?.();
+    expect(onRun).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -23,6 +23,25 @@ describe('getCompletions — filter', () => {
     const enums = items.filter((i) => i.kind === 'enum');
     expect(enums.map((e) => e.insertText)).toEqual(expect.arrayContaining(['"Free"', '"Team"']));
   });
+  it('does not double-quote enum values when already inside a quote', () => {
+    const schema = new Map([['workspaceId', { type: 'string', enumValues: ['default', 'personal'] }]]);
+    const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ "workspaceId": "', token: '', schema }));
+    const enums = items.filter((i) => i.kind === 'enum');
+    expect(enums.map((e) => e.insertText)).toEqual(expect.arrayContaining(['default"', 'personal"']));
+    expect(enums.map((e) => e.insertText)).not.toEqual(expect.arrayContaining(['"default"', '"personal"']));
+  });
+  it('does not add a closing quote when one is already ahead of the cursor', () => {
+    const schema = new Map([['workspaceId', { type: 'string', enumValues: ['default', 'personal'] }]]);
+    const items = getCompletions(base({
+      surface: 'filter',
+      textBeforeCursor: '{ "workspaceId": "',
+      textAfterCursor: '"',
+      token: '',
+      schema,
+    }));
+    const enums = items.filter((i) => i.kind === 'enum');
+    expect(enums.map((e) => e.insertText)).toEqual(expect.arrayContaining(['default', 'personal']));
+  });
   it('prefix-filters by token', () => {
     const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ reg', token: 'reg' }));
     expect(labels(items)).toContain('region');
@@ -444,6 +463,14 @@ describe('getCompletions — per-stage body editor (stageOperator)', () => {
   it('$lookup localField value offers field names as strings', () => {
     const items = getCompletions(stage('$lookup', '{ "localField": ', 'reg'));
     expect(items.find((i) => i.label === 'region')!.insertText).toBe('"region"');
+  });
+  it('$lookup localField value does not double-quote when already inside a quote', () => {
+    const items = getCompletions(stage('$lookup', '{ "localField": "', 'reg'));
+    expect(items.find((i) => i.label === 'region')!.insertText).toBe('region"');
+  });
+  it('$lookup localField value does not add a closing quote when one is ahead', () => {
+    const items = getCompletions(stage('$lookup', '{ "localField": "', 'reg', { textAfterCursor: '"' }));
+    expect(items.find((i) => i.label === 'region')!.insertText).toBe('region');
   });
   it('$unwind body suggests field path refs', () => {
     const items = getCompletions(stage('$unwind', '', '$reg'));

--- a/src/lib/monacoMongo.ts
+++ b/src/lib/monacoMongo.ts
@@ -57,9 +57,13 @@ export function registerMongoCompletionProvider(monaco: Monaco) {
         startLineNumber: position.lineNumber, startColumn: 1,
         endLineNumber: position.lineNumber, endColumn: position.column,
       });
+      const textAfterCursor: string = model.getValueInRange({
+        startLineNumber: position.lineNumber, startColumn: position.column,
+        endLineNumber: position.lineNumber, endColumn: model.getLineMaxColumn(position.lineNumber),
+      });
       const token = textBeforeCursor.match(/[\w$]*$/)?.[0] ?? '';
       const items = getCompletions({
-        surface: meta.surface, textBeforeCursor, token,
+        surface: meta.surface, textBeforeCursor, textAfterCursor, token,
         fields: meta.getFields(), schema: meta.getSchema(), collections: meta.getCollections?.(),
         stageOperator: meta.getStageOperator?.(),
       });

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -6,6 +6,7 @@ export interface FieldSchema { type?: string; enumValues?: string[]; }
 export interface CompletionCtx {
   surface: Surface;
   textBeforeCursor: string;
+  textAfterCursor?: string;
   token: string;
   fields: string[];
   schema?: Map<string, FieldSchema>;
@@ -262,13 +263,28 @@ function quoteForType(value: string, type?: string): string {
   return JSON.stringify(value);
 }
 
+// When the user already typed `"`, Monaco may auto-insert a closing `"` ahead of
+// the cursor — only add our own closer when one is not already there.
+function closeQuotedValue(ctx: CompletionCtx, value: string): string {
+  if (ctx.textAfterCursor?.trimStart().startsWith('"')) return value;
+  return `${value}"`;
+}
+
+function valueInsert(ctx: CompletionCtx, value: string, type?: string): string {
+  const unquoted = type === 'int' || type === 'long' || type === 'double' || type === 'decimal' || type === 'bool';
+  if (inQuote(ctx.textBeforeCursor)) {
+    return unquoted ? value : closeQuotedValue(ctx, value);
+  }
+  return quoteForType(value, type);
+}
+
 function enumItemsForLastField(ctx: CompletionCtx): CompletionItem[] {
   const field = lastFieldKey(ctx.textBeforeCursor);
   if (!field) return [];
   const fs = ctx.schema?.get(field);
   if (!fs?.enumValues?.length) return [];
   return fs.enumValues.map((v) => ({
-    label: v, kind: 'enum' as const, insertText: quoteForType(v, fs.type), detail: 'enum',
+    label: v, kind: 'enum' as const, insertText: valueInsert(ctx, v, fs.type), detail: 'enum',
   }));
 }
 
@@ -348,17 +364,24 @@ function keyScaffoldItems(ctx: CompletionCtx, list: EjsonType[], kind: Completio
   }));
 }
 
-// `"$field"` aggregation path references (for $group/$unwind/$sortByCount bodies).
 function fieldRefItems(ctx: CompletionCtx): CompletionItem[] {
   return ctx.fields.map((name) => ({
-    label: `$${name}`, kind: 'field' as const, insertText: `"$${name}"`, detail: 'field path',
+    label: `$${name}`, kind: 'field' as const,
+    insertText: inQuote(ctx.textBeforeCursor)
+      ? closeQuotedValue(ctx, `$${name}`)
+      : `"$${name}"`,
+    detail: 'field path',
   }));
 }
 
 // Field names as plain string values ($lookup localField/foreignField).
 function fieldStringItems(ctx: CompletionCtx): CompletionItem[] {
   return ctx.fields.map((name) => ({
-    label: name, kind: 'field' as const, insertText: `"${name}"`, detail: ctx.schema?.get(name)?.type,
+    label: name, kind: 'field' as const,
+    insertText: inQuote(ctx.textBeforeCursor)
+      ? closeQuotedValue(ctx, name)
+      : `"${name}"`,
+    detail: ctx.schema?.get(name)?.type,
   }));
 }
 


### PR DESCRIPTION
## Summary

Merges **dev** into **main** for the **v0.9.1** patch release — query builder keyboard UX and npm security patches since v0.9.0.

### Fixes
- **Enter runs find query** (#152) — Plain Enter executes the query from Query, Projection, Sort, Skip, and Limit when autocomplete is closed; Enter still accepts suggestions when the widget is open
- **Completion quote insertion** (#152) — Value completions no longer double-wrap quotes inside strings or add an extra closing quote when Monaco auto-closes ahead of the cursor

### Dependencies
- **npm advisories** (#151) — Patch dompurify, vite, and @babel/core

## Release mechanics

On merge, the **Release** workflow derives the next semver from conventional commits since `mqlens-v0.9.0` (expected **0.9.1** patch bump), commits the version bump to `main` with `[skip ci]`, and publishes `mqlens-v0.9.1` with signed updater assets.

## Test plan

- [x] CI passes on dev
- [x] Enter runs query from single-line builder fields when suggestions are closed
- [x] Enter accepts autocomplete suggestions when the widget is open
- [x] Accepting enum/string completions produces valid JSON (no `""default""`)
- [ ] Release workflow publishes `mqlens-v0.9.1` on merge