### PR TITLE
feat: copy databases and collections across clusters or between databases

### DIFF
--- a/src-tauri/src/db/copy.rs
+++ b/src-tauri/src/db/copy.rs
@@ -1,0 +1,794 @@
+//! Collection / database copy jobs (across clusters or between databases).
+
+use crate::limits::IMPORT_BATCH_SIZE;
+use crate::state::LockExt;
+use crate::{connection_is_mock, mock_db, require_real_client, AppState, CopyFailure, CopySummary, TaskInfo};
+use mongodb::bson::Document;
+use mongodb::Client;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConflictMode {
+    Skip,
+    Merge,
+    Overwrite,
+}
+
+impl ConflictMode {
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_lowercase().as_str() {
+            "skip" => Ok(ConflictMode::Skip),
+            "merge" => Ok(ConflictMode::Merge),
+            "overwrite" => Ok(ConflictMode::Overwrite),
+            other => Err(format!("Unknown conflict mode '{}'", other)),
+        }
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Parse an optional EJSON/MQL filter string into a BSON document.
+/// Empty / "{}" / None -> empty document (match all). Mirrors db/query.rs.
+fn parse_filter(filter: Option<&str>) -> Result<Document, String> {
+    let raw = filter.unwrap_or("").trim();
+    if raw.is_empty() || raw == "{}" {
+        return Ok(Document::new());
+    }
+    let val: serde_json::Value =
+        serde_json::from_str(raw).map_err(|e| format!("Invalid filter JSON: {}", e))?;
+    mongodb::bson::to_document(&val).map_err(|e| format!("Invalid filter: {}", e))
+}
+
+fn update_task<F>(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>, task_id: &str, update: F)
+where
+    F: FnOnce(&mut TaskInfo),
+{
+    if let Some(task) = tasks
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .get_mut(task_id)
+    {
+        update(task);
+    }
+}
+
+fn finish_copy_task(
+    tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>,
+    task_id: &str,
+    status: &str,
+    summary: CopySummary,
+) {
+    let processed = summary.documents_copied;
+    update_task(tasks, task_id, |task| {
+        task.status = status.to_string();
+        task.processed = processed;
+        task.message = match status {
+            "cancelled" => "Copy cancelled".to_string(),
+            _ => "Copy complete".to_string(),
+        };
+        task.summary = Some(summary);
+        task.finished_at_ms = Some(now_ms());
+    });
+    prune(tasks);
+}
+
+fn fail_task(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>, task_id: &str, err: String) {
+    update_task(tasks, task_id, |task| {
+        task.status = "failed".to_string();
+        task.message = "Copy failed".to_string();
+        task.error = Some(err);
+        task.finished_at_ms = Some(now_ms());
+    });
+    prune(tasks);
+}
+
+fn clear_cancel_flag(cancels: &Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>, task_id: &str) {
+    if let Ok(mut g) = cancels.lock() {
+        g.remove(task_id);
+    }
+}
+
+fn prune(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>) {
+    use crate::limits::MAX_TASK_HISTORY;
+    let mut guard = tasks.lock().unwrap_or_else(|p| p.into_inner());
+    if guard.len() <= MAX_TASK_HISTORY {
+        return;
+    }
+    let mut entries: Vec<(String, TaskInfo)> = guard.drain().collect();
+    entries.sort_by(|a, b| b.1.created_at_ms.cmp(&a.1.created_at_ms));
+    for (id, task) in entries.into_iter().take(MAX_TASK_HISTORY) {
+        guard.insert(id, task);
+    }
+}
+
+#[derive(Default)]
+pub struct CollectionCopyOutcome {
+    pub copied: u64,
+    pub skipped: u64,
+    pub indexes: u64,
+    pub was_skipped: bool, // true when Skip mode and target already existed
+}
+
+#[derive(serde::Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CopyTargetRef {
+    pub connection_id: String,
+    pub db: String,
+    pub collection: String,
+}
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CopyConflict {
+    pub connection_id: String,
+    pub db: String,
+    pub collection: String,
+    pub target_exists: bool,
+    pub target_doc_count: u64,
+}
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PreflightResult {
+    pub conflicts: Vec<CopyConflict>,
+    pub self_overwrite: bool,
+}
+
+/// Does `collection` exist in `db` on connection `id`? Works for mock + real.
+async fn collection_exists(state: &AppState, id: &str, db: &str, collection: &str) -> Result<bool, String> {
+    let names = crate::list_collections_impl(state, id, db).await?;
+    Ok(names.iter().any(|c| c.name == collection))
+}
+
+/// Count documents in a target collection (0 if it does not exist). Mock-aware.
+async fn target_doc_count(state: &AppState, id: &str, db: &str, collection: &str) -> Result<u64, String> {
+    if connection_is_mock(state, id)? {
+        return mock_db::count_mock_documents(db, collection, "{}").or(Ok(0));
+    }
+    let client = require_real_client(state, id)?;
+    let coll = client.database(db).collection::<Document>(collection);
+    coll.count_documents(Document::new())
+        .await
+        .map_err(|e| format!("Count failed: {}", e))
+}
+
+pub async fn preflight_copy_impl(
+    state: &AppState,
+    source_id: &str,
+    source_db: &str,
+    source_collections: Vec<String>,
+    targets: Vec<CopyTargetRef>,
+) -> Result<PreflightResult, String> {
+    let mut conflicts = Vec::new();
+    let mut self_overwrite = false;
+    for t in &targets {
+        // Self-overwrite only when a target lands on one of the SOURCE namespaces:
+        // same connection + same db + the target collection is itself a source
+        // collection. Rename-on-copy (orders → orders_backup) and copies to a
+        // different db on the same connection are legitimate and not flagged.
+        if t.connection_id == source_id
+            && t.db == source_db
+            && source_collections.contains(&t.collection)
+        {
+            self_overwrite = true;
+        }
+        let exists = collection_exists(state, &t.connection_id, &t.db, &t.collection).await?;
+        let count = if exists {
+            target_doc_count(state, &t.connection_id, &t.db, &t.collection).await?
+        } else {
+            0
+        };
+        conflicts.push(CopyConflict {
+            connection_id: t.connection_id.clone(),
+            db: t.db.clone(),
+            collection: t.collection.clone(),
+            target_exists: exists,
+            target_doc_count: count,
+        });
+    }
+    Ok(PreflightResult { conflicts, self_overwrite })
+}
+
+/// Copy one collection from source to target on the given clients.
+/// `update_progress(copied)` is called every batch with the running per-collection count.
+#[allow(clippy::too_many_arguments)]
+async fn copy_one_collection<F: FnMut(u64)>(
+    source: &Client,
+    target: &Client,
+    source_db: &str,
+    source_collection: &str,
+    target_db: &str,
+    target_collection: &str,
+    filter: &Document,
+    include_indexes: bool,
+    mode: ConflictMode,
+    cancel: &Arc<AtomicBool>,
+    mut update_progress: F,
+) -> Result<CollectionCopyOutcome, String> {
+    use futures::stream::StreamExt;
+
+    let src = source
+        .database(source_db)
+        .collection::<Document>(source_collection);
+    let tgt_db = target.database(target_db);
+    let tgt = tgt_db.collection::<Document>(target_collection);
+
+    // Conflict resolution against an existing target.
+    let target_existed = tgt_db
+        .list_collection_names()
+        .await
+        .map_err(|e| format!("Failed to inspect target: {}", e))?
+        .iter()
+        .any(|n| n == target_collection);
+    if target_existed {
+        match mode {
+            ConflictMode::Skip => {
+                return Ok(CollectionCopyOutcome { was_skipped: true, ..Default::default() });
+            }
+            ConflictMode::Overwrite => {
+                tgt.drop().await.map_err(|e| format!("Failed to drop target: {}", e))?;
+            }
+            ConflictMode::Merge => { /* keep existing; tolerate dup-key on insert */ }
+        }
+    }
+
+    let mut copied = 0u64;
+    let mut skipped = 0u64;
+    let mut cursor = src
+        .find(filter.clone())
+        .await
+        .map_err(|e| format!("Source query failed: {}", e))?;
+    let mut batch: Vec<Document> = Vec::with_capacity(IMPORT_BATCH_SIZE);
+
+    // Flush helper: attempt unordered insert_many on the batch slice; owns the
+    // retry path so the caller never loses the batch on a dup-key error.
+    // Caller pattern: flush(&tgt, &batch, ...).await?; batch.clear();
+    // The merge dup-key retry path is exercised via the demo smoke test;
+    // mock connections short-circuit before reaching this code.
+    async fn flush(
+        tgt: &mongodb::Collection<Document>,
+        batch: &[Document],
+        copied: &mut u64,
+        skipped: &mut u64,
+    ) -> Result<(), String> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let n = batch.len() as u64;
+        // Unordered insert; tolerate duplicate-key (merge onto existing _ids).
+        // Use to_vec() so the caller retains ownership of the original slice.
+        match tgt.insert_many(batch.to_vec()).ordered(false).await {
+            Ok(res) => {
+                *copied += res.inserted_ids.len() as u64;
+                *skipped += n - res.inserted_ids.len() as u64;
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("E11000") || msg.contains("duplicate key") {
+                    // Retry doc-by-doc so we get exact copied/skipped counts.
+                    // batch is still intact because we used to_vec() above.
+                    insert_individually(tgt, batch, copied, skipped).await?;
+                } else {
+                    return Err(format!("Insert into target failed: {}", msg));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    while let Some(result) = cursor.next().await {
+        if cancel.load(Ordering::SeqCst) {
+            return Ok(CollectionCopyOutcome { copied, skipped, indexes: 0, was_skipped: false });
+        }
+        let doc = result.map_err(|e| format!("Cursor read error: {}", e))?;
+        batch.push(doc);
+        if batch.len() >= IMPORT_BATCH_SIZE {
+            flush(&tgt, &batch, &mut copied, &mut skipped).await?;
+            batch.clear();
+            update_progress(copied);
+        }
+    }
+    // Final partial batch.
+    flush(&tgt, &batch, &mut copied, &mut skipped).await?;
+    batch.clear();
+    update_progress(copied);
+
+    let mut indexes = 0u64;
+    if include_indexes {
+        indexes = copy_indexes(source, source_db, source_collection, target, target_db, target_collection).await?;
+    }
+
+    Ok(CollectionCopyOutcome { copied, skipped, indexes, was_skipped: false })
+}
+
+/// Fallback path: insert one doc at a time, counting dup-key rows as skipped.
+async fn insert_individually(
+    tgt: &mongodb::Collection<Document>,
+    batch: &[Document],
+    copied: &mut u64,
+    skipped: &mut u64,
+) -> Result<(), String> {
+    for doc in batch {
+        match tgt.insert_one(doc.clone()).await {
+            Ok(_) => *copied += 1,
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("E11000") || msg.contains("duplicate key") {
+                    *skipped += 1;
+                } else {
+                    return Err(format!("Insert into target failed: {}", msg));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Recreate a view on the target from the source's view options (viewOn + pipeline).
+async fn copy_view(
+    source: &Client,
+    source_db: &str,
+    view_name: &str,
+    target: &Client,
+    target_db: &str,
+) -> Result<(), String> {
+    use futures::stream::StreamExt;
+    let filter = mongodb::bson::doc! { "name": view_name };
+    let mut cursor = source
+        .database(source_db)
+        .list_collections()
+        .filter(filter)
+        .await
+        .map_err(|e| format!("Failed to read view definition: {}", e))?;
+    let spec = cursor
+        .next()
+        .await
+        .ok_or_else(|| format!("View {} not found", view_name))?
+        .map_err(|e| format!("View read error: {}", e))?;
+    let opts = spec.options;
+    let view_on = opts.view_on.ok_or_else(|| "View has no viewOn".to_string())?;
+    let pipeline = opts.pipeline.unwrap_or_default();
+    target
+        .database(target_db)
+        .create_collection(view_name)
+        .view_on(view_on)
+        .pipeline(pipeline)
+        .await
+        .map_err(|e| format!("Failed to create view on target: {}", e))?;
+    Ok(())
+}
+
+/// Copy non-default indexes from source to target collection. Returns count created.
+async fn copy_indexes(
+    source: &Client,
+    source_db: &str,
+    source_collection: &str,
+    target: &Client,
+    target_db: &str,
+    target_collection: &str,
+) -> Result<u64, String> {
+    use futures::stream::StreamExt;
+    let src = source.database(source_db).collection::<Document>(source_collection);
+    let tgt = target.database(target_db).collection::<Document>(target_collection);
+    let mut cursor = src
+        .list_indexes()
+        .await
+        .map_err(|e| format!("Failed to list source indexes: {}", e))?;
+    let mut created = 0u64;
+    while let Some(result) = cursor.next().await {
+        let model = result.map_err(|e| format!("Index read error: {}", e))?;
+        let name = model.options.as_ref().and_then(|o| o.name.clone()).unwrap_or_default();
+        if name.is_empty() || name == "_id_" {
+            continue; // default index / unnamed index — skip
+        }
+        match tgt.create_index(model).await {
+            Ok(_) => created += 1,
+            Err(e) => {
+                // An equivalent index already on the target (common when merging into
+                // an existing collection) is not a failure — leave it and move on.
+                let msg = e.to_string();
+                if msg.contains("already exists")
+                    || msg.contains("IndexOptionsConflict")
+                    || msg.contains("IndexKeySpecsConflict")
+                {
+                    continue;
+                }
+                return Err(format!("Failed to create index on target: {}", msg));
+            }
+        }
+    }
+    Ok(created)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn start_collection_copy_impl(
+    state: &AppState,
+    source_id: &str,
+    source_db: &str,
+    source_collection: &str,
+    target_id: &str,
+    target_db: &str,
+    target_collection: &str,
+    filter: Option<String>,
+    include_indexes: bool,
+    conflict_mode: String,
+) -> Result<TaskInfo, String> {
+    let mode = ConflictMode::parse(&conflict_mode)?;
+    let filter_doc = parse_filter(filter.as_deref())?;
+
+    // Hard guard against self-overwrite (UI also blocks this).
+    if source_id == target_id && source_db == target_db && source_collection == target_collection {
+        return Err("Source and target are the same collection — copy would overwrite itself".to_string());
+    }
+
+    let source_is_mock = connection_is_mock(state, source_id)?;
+    let target_is_mock = connection_is_mock(state, target_id)?;
+
+    let task_id = Uuid::new_v4().to_string();
+    let task = TaskInfo {
+        id: task_id.clone(),
+        kind: "collection_copy".to_string(),
+        label: format!("Copy {}.{} → {}.{}", source_db, source_collection, target_db, target_collection),
+        status: "running".to_string(),
+        processed: 0,
+        total: None,
+        message: "Queued".to_string(),
+        path: None,
+        error: None,
+        created_at_ms: now_ms(),
+        finished_at_ms: None,
+        sub_label: None,
+        items_processed: None,
+        items_total: None,
+        summary: None,
+    };
+    state.tasks.lock_safe()?.insert(task_id.clone(), task.clone());
+    let cancel = state.register_cancel(&task_id);
+
+    // Mock path: simulate completion using mock doc counts, persist nothing.
+    if source_is_mock || target_is_mock {
+        let count = mock_db::count_mock_documents(source_db, source_collection, "{}").unwrap_or(0);
+        let tasks = state.tasks.clone();
+        let summary = CopySummary {
+            collections_copied: 1,
+            documents_copied: count,
+            ..Default::default()
+        };
+        finish_copy_task(&tasks, &task_id, "completed", summary);
+        state.clear_cancel(&task_id);
+        return Ok(task);
+    }
+
+    let source = require_real_client(state, source_id)?;
+    let target = require_real_client(state, target_id)?;
+    let tasks = state.tasks.clone();
+    let cancels = state.cancels.clone(); // Arc<Mutex<..>> — clone the Arc
+    let (sdb, scoll) = (source_db.to_string(), source_collection.to_string());
+    let (tdb, tcoll) = (target_db.to_string(), target_collection.to_string());
+    let task_id2 = task_id.clone();
+
+    tokio::spawn(async move {
+        // Count total for progress (best-effort).
+        if let Ok(total) = source.database(&sdb).collection::<Document>(&scoll)
+            .count_documents(filter_doc.clone()).await
+        {
+            update_task(&tasks, &task_id2, |t| t.total = Some(total));
+        }
+        update_task(&tasks, &task_id2, |t| t.message = "Copying documents".to_string());
+
+        let tasks_for_progress = tasks.clone();
+        let pid = task_id2.clone();
+        let result = copy_one_collection(
+            &source, &target, &sdb, &scoll, &tdb, &tcoll,
+            &filter_doc, include_indexes, mode, &cancel,
+            move |copied| update_task(&tasks_for_progress, &pid, |t| t.processed = copied),
+        ).await;
+
+        match result {
+            Ok(outcome) => {
+                let status = if cancel.load(Ordering::SeqCst) { "cancelled" } else { "completed" };
+                let summary = CopySummary {
+                    collections_copied: if outcome.was_skipped { 0 } else { 1 },
+                    documents_copied: outcome.copied,
+                    documents_skipped: outcome.skipped,
+                    indexes_created: outcome.indexes,
+                    skipped: if outcome.was_skipped { vec![tcoll.clone()] } else { vec![] },
+                    failed: vec![],
+                };
+                finish_copy_task(&tasks, &task_id2, status, summary);
+            }
+            Err(err) => fail_task(&tasks, &task_id2, err),
+        }
+        clear_cancel_flag(&cancels, &task_id2);
+    });
+
+    Ok(task)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn start_database_copy_impl(
+    state: &AppState,
+    source_id: &str,
+    source_db: &str,
+    target_id: &str,
+    target_db: &str,
+    collections: Option<Vec<String>>,
+    include_indexes: bool,
+    include_views: bool,
+    conflict_mode: String,
+) -> Result<TaskInfo, String> {
+    let mode = ConflictMode::parse(&conflict_mode)?;
+    if source_id == target_id && source_db == target_db {
+        return Err("Source and target database are the same — copy would overwrite itself".to_string());
+    }
+
+    // Resolve the collection set (and types) from the source.
+    let all = crate::list_collections_impl(state, source_id, source_db).await?;
+    let chosen: Vec<crate::CollectionInfo> = match &collections {
+        Some(names) => all.into_iter().filter(|c| names.contains(&c.name)).collect(),
+        None => all,
+    };
+
+    let task_id = Uuid::new_v4().to_string();
+    let task = TaskInfo {
+        id: task_id.clone(),
+        kind: "database_copy".to_string(),
+        label: format!("Copy database {} → {}", source_db, target_db),
+        status: "running".to_string(),
+        processed: 0,
+        total: None,
+        message: "Queued".to_string(),
+        path: None,
+        error: None,
+        created_at_ms: now_ms(),
+        finished_at_ms: None,
+        sub_label: None,
+        items_processed: Some(0),
+        items_total: Some(chosen.len() as u64),
+        summary: None,
+    };
+    state.tasks.lock_safe()?.insert(task_id.clone(), task.clone());
+    let cancel = state.register_cancel(&task_id);
+
+    // Mock path: simulate per-collection counts.
+    if connection_is_mock(state, source_id)? || connection_is_mock(state, target_id)? {
+        let tasks = state.tasks.clone();
+        let mut summary = CopySummary::default();
+        for c in &chosen {
+            let n = mock_db::count_mock_documents(source_db, &c.name, "{}").unwrap_or(0);
+            summary.collections_copied += 1;
+            summary.documents_copied += n;
+        }
+        finish_copy_task(&tasks, &task_id, "completed", summary);
+        state.clear_cancel(&task_id);
+        return Ok(task);
+    }
+
+    let source = require_real_client(state, source_id)?;
+    let target = require_real_client(state, target_id)?;
+    let tasks = state.tasks.clone();
+    let cancels = state.cancels.clone();
+    let (sdb, tdb) = (source_db.to_string(), target_db.to_string());
+    let task_id2 = task_id.clone();
+
+    tokio::spawn(async move {
+        let mut summary = CopySummary::default();
+        let mut overall = 0u64;
+        let total_items = chosen.len() as u64;
+
+        // Best-effort overall document total so the progress bar is determinate.
+        // Uses the O(1) metadata estimate; views/timeseries carry no copied docs.
+        let mut grand_total = 0u64;
+        for c in &chosen {
+            if c.collection_type == "view" || c.collection_type == "timeseries" {
+                continue;
+            }
+            if let Ok(n) = source
+                .database(&sdb)
+                .collection::<Document>(&c.name)
+                .estimated_document_count()
+                .await
+            {
+                grand_total += n;
+            }
+        }
+        update_task(&tasks, &task_id2, |t| t.total = Some(grand_total));
+
+        for (idx, c) in chosen.iter().enumerate() {
+            if cancel.load(Ordering::SeqCst) {
+                break;
+            }
+            update_task(&tasks, &task_id2, |t| {
+                t.items_processed = Some(idx as u64);
+                t.items_total = Some(total_items);
+                t.sub_label = Some(format!("{} ({}/{})", c.name, idx + 1, total_items));
+                t.message = format!("Copying {}", c.name);
+            });
+
+            if c.collection_type == "view" {
+                if include_views {
+                    match copy_view(&source, &sdb, &c.name, &target, &tdb).await {
+                        Ok(()) => summary.collections_copied += 1,
+                        Err(e) => summary.failed.push(CopyFailure { collection: c.name.clone(), error: e }),
+                    }
+                } else {
+                    summary.skipped.push(c.name.clone());
+                }
+                continue;
+            }
+            if c.collection_type == "timeseries" {
+                // Timeseries copy is out of scope; record as skipped, do not fail.
+                summary.skipped.push(format!("{} (timeseries)", c.name));
+                continue;
+            }
+
+            let base = overall;
+            let tasks_for_progress = tasks.clone();
+            let pid = task_id2.clone();
+            let outcome = copy_one_collection(
+                &source, &target, &sdb, &c.name, &tdb, &c.name,
+                &Document::new(), include_indexes, mode, &cancel,
+                move |copied| update_task(&tasks_for_progress, &pid, |t| t.processed = base + copied),
+            ).await;
+
+            match outcome {
+                Ok(o) if o.was_skipped => summary.skipped.push(c.name.clone()),
+                Ok(o) => {
+                    summary.collections_copied += 1;
+                    summary.documents_copied += o.copied;
+                    summary.documents_skipped += o.skipped;
+                    summary.indexes_created += o.indexes;
+                    overall += o.copied;
+                }
+                Err(e) => summary.failed.push(CopyFailure { collection: c.name.clone(), error: e }),
+            }
+        }
+
+        let status = if cancel.load(Ordering::SeqCst) { "cancelled" } else { "completed" };
+        update_task(&tasks, &task_id2, |t| t.items_processed = t.items_total);
+        finish_copy_task(&tasks, &task_id2, status, summary);
+        clear_cancel_flag(&cancels, &task_id2);
+    });
+
+    Ok(task)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conflict_mode_parses_known_values_and_rejects_others() {
+        assert_eq!(ConflictMode::parse("skip").unwrap(), ConflictMode::Skip);
+        assert_eq!(ConflictMode::parse(" Merge ").unwrap(), ConflictMode::Merge);
+        assert_eq!(ConflictMode::parse("OVERWRITE").unwrap(), ConflictMode::Overwrite);
+        assert!(ConflictMode::parse("bogus").is_err());
+    }
+
+    #[test]
+    fn parse_filter_handles_empty_and_json() {
+        assert_eq!(parse_filter(None).unwrap(), Document::new());
+        assert_eq!(parse_filter(Some("  ")).unwrap(), Document::new());
+        assert_eq!(parse_filter(Some("{}")).unwrap(), Document::new());
+        let d = parse_filter(Some("{\"a\": 1}")).unwrap();
+        // serde_json -> BSON serialises JSON integers as Int64
+        assert_eq!(d.get_i64("a").unwrap(), 1);
+        assert!(parse_filter(Some("{not json")).is_err());
+    }
+
+    fn mock_state(id: &str) -> AppState {
+        let state = AppState::new();
+        state.mocks.lock().unwrap().insert(id.to_string(), true);
+        state
+    }
+
+    #[tokio::test]
+    async fn preflight_flags_existing_mock_collection_and_self_overwrite() {
+        let state = mock_state("mockA");
+        // sales_db has a known mock collection "customers". Copying it onto itself
+        // (target collection is also a source collection) is a self-overwrite.
+        let targets = vec![CopyTargetRef {
+            connection_id: "mockA".into(),
+            db: "sales_db".into(),
+            collection: "customers".into(),
+        }];
+        let res = preflight_copy_impl(
+            &state, "mockA", "sales_db", vec!["customers".into()], targets,
+        )
+        .await
+        .unwrap();
+        assert!(res.self_overwrite, "copying a collection onto itself is self-overwrite");
+        assert_eq!(res.conflicts.len(), 1);
+        assert!(res.conflicts[0].target_exists);
+    }
+
+    #[tokio::test]
+    async fn preflight_allows_rename_on_copy_within_same_db() {
+        let state = mock_state("mockA");
+        // orders → orders_backup on the same connection+db is a valid rename-copy,
+        // NOT a self-overwrite, even though it stays in the source database.
+        let targets = vec![CopyTargetRef {
+            connection_id: "mockA".into(),
+            db: "sales_db".into(),
+            collection: "customers_backup".into(),
+        }];
+        let res = preflight_copy_impl(
+            &state, "mockA", "sales_db", vec!["customers".into()], targets,
+        )
+        .await
+        .unwrap();
+        assert!(!res.self_overwrite, "renaming to a new collection is not self-overwrite");
+        assert!(!res.conflicts[0].target_exists, "the backup name does not exist yet");
+    }
+
+    #[tokio::test]
+    async fn preflight_reports_missing_collection_as_no_conflict() {
+        let state = mock_state("mockA");
+        let targets = vec![CopyTargetRef {
+            connection_id: "mockA".into(),
+            db: "sales_db".into(),
+            collection: "does_not_exist".into(),
+        }];
+        let res = preflight_copy_impl(
+            &state, "mockA", "user_analytics", vec!["something".into()], targets,
+        )
+        .await
+        .unwrap();
+        assert!(!res.conflicts[0].target_exists);
+        assert!(!res.self_overwrite); // different db
+    }
+
+    #[tokio::test]
+    async fn mock_collection_copy_completes_with_summary() {
+        let state = AppState::new();
+        state.mocks.lock().unwrap().insert("src".to_string(), true);
+        state.mocks.lock().unwrap().insert("dst".to_string(), true);
+        let task = start_collection_copy_impl(
+            &state, "src", "sales_db", "customers",
+            "dst", "sales_db", "customers_copy",
+            None, true, "merge".into(),
+        ).await.unwrap();
+        let tasks = state.tasks.lock().unwrap();
+        let stored = tasks.get(&task.id).unwrap();
+        assert_eq!(stored.status, "completed");
+        let summary = stored.summary.as_ref().unwrap();
+        assert_eq!(summary.collections_copied, 1);
+    }
+
+    #[tokio::test]
+    async fn mock_database_copy_summarizes_all_collections() {
+        let state = AppState::new();
+        state.mocks.lock().unwrap().insert("src".to_string(), true);
+        state.mocks.lock().unwrap().insert("dst".to_string(), true);
+        let task = start_database_copy_impl(
+            &state, "src", "sales_db", "dst", "sales_db_copy",
+            None, true, true, "overwrite".into(),
+        ).await.unwrap();
+        let tasks = state.tasks.lock().unwrap();
+        let s = tasks.get(&task.id).unwrap().summary.as_ref().unwrap();
+        // sales_db mock has customers, transactions, products -> 3 collections.
+        assert_eq!(s.collections_copied, 3);
+    }
+
+    #[tokio::test]
+    async fn self_overwrite_is_rejected() {
+        let state = AppState::new();
+        state.mocks.lock().unwrap().insert("c".to_string(), true);
+        let result = start_collection_copy_impl(
+            &state, "c", "sales_db", "customers",
+            "c", "sales_db", "customers",
+            None, false, "overwrite".into(),
+        ).await;
+        let err = result.err().expect("expected an Err but got Ok");
+        assert!(err.contains("overwrite itself"), "unexpected error: {}", err);
+    }
+}

--- a/src-tauri/src/db/export.rs
+++ b/src-tauri/src/db/export.rs
@@ -382,6 +382,10 @@ pub async fn start_collection_export_impl(
         error: None,
         created_at_ms: now_ms(),
         finished_at_ms: None,
+        sub_label: None,
+        items_processed: None,
+        items_total: None,
+        summary: None,
     };
     state
         .tasks

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,6 +1,7 @@
 //! Database-operation modules (split out of lib.rs).
 
 pub mod aggregate;
+pub mod copy;
 pub mod ddl;
 pub mod documents;
 pub mod export;

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -16,8 +16,9 @@ mod integration {
         drop_database_impl, execute_aggregate_impl, execute_mql_query_impl,
         explain_aggregate_query_impl, explain_mql_query_impl, get_mongodb_version_impl,
         import_documents_impl, insert_document_impl, list_collections_impl, list_databases_impl,
-        list_gridfs_files_impl, list_indexes_impl, rename_collection_impl, rename_database_impl,
-        start_collection_export_impl, update_document_impl, update_many_impl, AppState,
+        list_gridfs_files_impl, list_indexes_impl, preflight_copy_impl, rename_collection_impl,
+        rename_database_impl, start_collection_copy_impl, start_collection_export_impl,
+        start_database_copy_impl, update_document_impl, update_many_impl, AppState, CopyTargetRef,
     };
     use mongodb::bson::{doc, Document};
 
@@ -655,6 +656,142 @@ mod integration {
             "nested fields should be reported with dotted paths"
         );
 
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_copy_collection_real_conflict_modes() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        seed(
+            &state,
+            &id,
+            &db,
+            "orders",
+            vec![
+                doc! { "_id": 1, "amount": 10 },
+                doc! { "_id": 2, "amount": 20 },
+                doc! { "_id": 3, "amount": 30 },
+                doc! { "_id": 4, "amount": 40 },
+                doc! { "_id": 5, "amount": 50 },
+            ],
+        )
+        .await;
+        // A non-default index so copy_indexes has something to recreate.
+        create_index_impl(&state, &id, &db, "orders", "amount_1", r#"{"amount":1}"#, false, false)
+            .await
+            .expect("source index");
+
+        // 1) Merge copy into a fresh target collection (same connection, copies docs + index).
+        let task = start_collection_copy_impl(
+            &state, &id, &db, "orders", &id, &db, "orders_copy", None, true, "merge".into(),
+        )
+        .await
+        .expect("start collection copy");
+        let done = wait_for_task(&state, &task.id).await;
+        assert_eq!(done.status, "completed");
+        let s = done.summary.as_ref().unwrap();
+        assert_eq!(s.documents_copied, 5);
+        assert!(s.indexes_created >= 1, "non-_id index should be recreated");
+        let copied = count_documents_impl(&state, &id, &db, "orders_copy", "{}").await.unwrap();
+        assert_eq!(copied, 5);
+
+        // 2) Preflight now sees the existing target with its doc count (real count path).
+        let pf = preflight_copy_impl(
+            &state, &id, &db, vec!["orders".into()],
+            vec![CopyTargetRef { connection_id: id.clone(), db: db.clone(), collection: "orders_copy".into() }],
+        )
+        .await
+        .expect("preflight");
+        assert!(pf.conflicts[0].target_exists);
+        assert_eq!(pf.conflicts[0].target_doc_count, 5);
+
+        // 3) Skip mode against the existing target leaves it untouched and reports a skip.
+        let skip_task = start_collection_copy_impl(
+            &state, &id, &db, "orders", &id, &db, "orders_copy", None, false, "skip".into(),
+        )
+        .await
+        .expect("skip copy");
+        let skip_done = wait_for_task(&state, &skip_task.id).await;
+        let skip_s = skip_done.summary.as_ref().unwrap();
+        assert_eq!(skip_s.collections_copied, 0);
+        assert!(skip_s.skipped.iter().any(|n| n == "orders_copy"));
+
+        // 4) Merge against a fully-duplicate target exercises the dup-key retry → all skipped.
+        let merge_task = start_collection_copy_impl(
+            &state, &id, &db, "orders", &id, &db, "orders_copy", None, false, "merge".into(),
+        )
+        .await
+        .expect("merge copy");
+        let merge_done = wait_for_task(&state, &merge_task.id).await;
+        let merge_s = merge_done.summary.as_ref().unwrap();
+        assert_eq!(merge_s.documents_copied, 0);
+        assert_eq!(merge_s.documents_skipped, 5, "all five _ids already exist");
+
+        // 5) Overwrite drops and replaces the target.
+        let ow_task = start_collection_copy_impl(
+            &state, &id, &db, "orders", &id, &db, "orders_copy", None, false, "overwrite".into(),
+        )
+        .await
+        .expect("overwrite copy");
+        let ow_done = wait_for_task(&state, &ow_task.id).await;
+        assert_eq!(ow_done.summary.as_ref().unwrap().documents_copied, 5);
+
+        // 6) Filtered copy carries only the matching documents.
+        let filt_task = start_collection_copy_impl(
+            &state, &id, &db, "orders", &id, &db, "orders_big",
+            Some(r#"{"amount":{"$gte":30}}"#.into()), false, "merge".into(),
+        )
+        .await
+        .expect("filtered copy");
+        let filt_done = wait_for_task(&state, &filt_task.id).await;
+        assert_eq!(filt_done.summary.as_ref().unwrap().documents_copied, 3);
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    #[tokio::test]
+    async fn it_copy_database_real_with_view() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+        seed(
+            &state,
+            &id,
+            &db,
+            "items",
+            vec![doc! { "_id": 1, "qty": 2 }, doc! { "_id": 2, "qty": 8 }],
+        )
+        .await;
+        create_index_impl(&state, &id, &db, "items", "qty_1", r#"{"qty":1}"#, false, false)
+            .await
+            .expect("source index");
+        create_view_impl(&state, &id, &db, "big_items", "items", r#"[{"$match":{"qty":{"$gte":5}}}]"#)
+            .await
+            .expect("source view");
+
+        let target = format!("{}_copy", db);
+        let task = start_database_copy_impl(
+            &state, &id, &db, &id, &target, None, true, true, "merge".into(),
+        )
+        .await
+        .expect("start database copy");
+        let done = wait_for_task(&state, &task.id).await;
+        assert_eq!(done.status, "completed");
+        let s = done.summary.as_ref().unwrap();
+        // The base collection plus the recreated view.
+        assert_eq!(s.collections_copied, 2);
+        assert_eq!(s.documents_copied, 2);
+
+        // The target db has the collection (with data + index) and the view.
+        let cols = list_collections_impl(&state, &id, &target).await.unwrap();
+        assert!(cols.iter().any(|c| c.name == "items" && c.collection_type == "collection"));
+        assert!(cols.iter().any(|c| c.name == "big_items" && c.collection_type == "view"));
+        let idxs = list_indexes_impl(&state, &id, &target, "items").await.unwrap();
+        assert!(idxs.iter().any(|i| i.name == "qty_1"), "index should be recreated on target");
+
+        let _ = client_of(&state, &id).database(&target).drop().await;
         cleanup(&state, &id, &db).await;
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ pub use db::users::{
     MongoUser, RoleInfo, RoleSpec,
 };
 pub use db::version::get_mongodb_version_impl;
+pub use db::copy::{preflight_copy_impl, start_collection_copy_impl, start_database_copy_impl, CopyTargetRef};
 pub use biometric::{decode_and_verify_key, encode_key, BiometricStatus};
 pub use state::{AppState, LockExt};
 pub use window::target_window_size;
@@ -175,6 +176,24 @@ pub struct AgentDetection {
     pub version: String,
 }
 
+#[derive(Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CopyFailure {
+    pub collection: String,
+    pub error: String,
+}
+
+#[derive(Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CopySummary {
+    pub collections_copied: u64,
+    pub documents_copied: u64,
+    pub documents_skipped: u64,
+    pub indexes_created: u64,
+    pub skipped: Vec<String>,
+    pub failed: Vec<CopyFailure>,
+}
+
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskInfo {
@@ -189,6 +208,14 @@ pub struct TaskInfo {
     pub error: Option<String>,
     pub created_at_ms: u64,
     pub finished_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sub_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub items_processed: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub items_total: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<CopySummary>,
 }
 
 /// Probe each local agent's binary with `--version` (short, blocking). NotFound -> not available.
@@ -928,6 +955,66 @@ async fn clear_finished_export_tasks(
 }
 
 #[tauri::command]
+async fn cancel_task(state: tauri::State<'_, AppState>, id: String) -> Result<(), String> {
+    if state.request_cancel(&id) {
+        Ok(())
+    } else {
+        Err("Task is not running or cannot be cancelled".to_string())
+    }
+}
+
+#[tauri::command]
+async fn preflight_copy(
+    state: tauri::State<'_, AppState>,
+    source_id: String,
+    source_db: String,
+    source_collections: Vec<String>,
+    targets: Vec<CopyTargetRef>,
+) -> Result<db::copy::PreflightResult, String> {
+    preflight_copy_impl(&state, &source_id, &source_db, source_collections, targets).await
+}
+
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+async fn start_collection_copy(
+    state: tauri::State<'_, AppState>,
+    source_id: String,
+    source_db: String,
+    source_collection: String,
+    target_id: String,
+    target_db: String,
+    target_collection: String,
+    filter: Option<String>,
+    include_indexes: bool,
+    conflict_mode: String,
+) -> Result<TaskInfo, String> {
+    start_collection_copy_impl(
+        &state, &source_id, &source_db, &source_collection,
+        &target_id, &target_db, &target_collection,
+        filter, include_indexes, conflict_mode,
+    ).await
+}
+
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+async fn start_database_copy(
+    state: tauri::State<'_, AppState>,
+    source_id: String,
+    source_db: String,
+    target_id: String,
+    target_db: String,
+    collections: Option<Vec<String>>,
+    include_indexes: bool,
+    include_views: bool,
+    conflict_mode: String,
+) -> Result<TaskInfo, String> {
+    start_database_copy_impl(
+        &state, &source_id, &source_db, &target_id, &target_db,
+        collections, include_indexes, include_views, conflict_mode,
+    ).await
+}
+
+#[tauri::command]
 async fn execute_aggregate(
     state: tauri::State<'_, AppState>,
     id: String,
@@ -1419,6 +1506,10 @@ pub fn run() {
             start_collection_export,
             list_export_tasks,
             clear_finished_export_tasks,
+            cancel_task,
+            preflight_copy,
+            start_collection_copy,
+            start_database_copy,
             create_collection,
             create_view,
             drop_collection,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3,6 +3,7 @@
 use crate::{ssh_tunnel, IndexInfo, MongoshSession, TaskInfo};
 use mongodb::Client;
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -22,6 +23,8 @@ pub struct AppState {
     pub mock_indexes: Mutex<HashMap<String, Vec<IndexInfo>>>,
     pub mongosh_sessions: Mutex<HashMap<String, Arc<MongoshSession>>>,
     pub tasks: Arc<Mutex<HashMap<String, TaskInfo>>>,
+    /// Per-task cancel flags for cancellable copy tasks (copy-only).
+    pub cancels: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
     // Live SSH tunnels keyed by connection id; dropped on disconnect to tear down.
     pub ssh_tunnels: Mutex<HashMap<String, ssh_tunnel::SshTunnel>>,
     // Persisted across polls so CPU usage can be sampled as a delta.
@@ -41,6 +44,7 @@ impl AppState {
             mock_indexes: Mutex::new(HashMap::new()),
             mongosh_sessions: Mutex::new(HashMap::new()),
             tasks: Arc::new(Mutex::new(HashMap::new())),
+            cancels: Arc::new(Mutex::new(HashMap::new())),
             ssh_tunnels: Mutex::new(HashMap::new()),
             sys: Mutex::new(sysinfo::System::new()),
             resource_pids: Mutex::new(Vec::new()),
@@ -52,5 +56,50 @@ impl AppState {
     /// The in-memory vault key, or an error if the vault is locked.
     pub fn require_key(&self) -> Result<[u8; 32], String> {
         self.vault_key.lock_safe()?.ok_or_else(|| "vault is locked".to_string())
+    }
+
+    /// Create (or reset) a cancel flag for a task and return a clone to poll.
+    pub fn register_cancel(&self, task_id: &str) -> Arc<AtomicBool> {
+        let flag = Arc::new(AtomicBool::new(false));
+        if let Ok(mut guard) = self.cancels.lock() {
+            guard.insert(task_id.to_string(), flag.clone());
+        }
+        flag
+    }
+
+    /// Request cancellation of a task. Returns true if the task was known.
+    pub fn request_cancel(&self, task_id: &str) -> bool {
+        match self.cancels.lock() {
+            Ok(guard) => match guard.get(task_id) {
+                Some(flag) => {
+                    flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                    true
+                }
+                None => false,
+            },
+            Err(_) => false,
+        }
+    }
+
+    /// Drop a finished task's cancel flag.
+    pub fn clear_cancel(&self, task_id: &str) {
+        if let Ok(mut guard) = self.cancels.lock() {
+            guard.remove(task_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_and_request_cancel_flips_the_flag() {
+        let state = AppState::new();
+        let flag = state.register_cancel("task-1");
+        assert!(!flag.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(state.request_cancel("task-1")); // known task -> true
+        assert!(flag.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(!state.request_cancel("missing")); // unknown task -> false
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,12 +16,13 @@ import { MongoShell } from './components/MongoShell';
 import { QuickStart } from './components/QuickStart';
 import { DocumentEditModal } from './components/DocumentEditModal';
 import { ExportView } from './components/ExportView';
+import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
 import { CreateViewView } from './components/CreateViewView';
 import { GridFsView } from './components/GridFsView';
 import { MonitoringView } from './components/MonitoringView';
 import { UserManagementView } from './components/UserManagementView';
-import { type ExportTaskInfo } from './components/TaskManager';
+import { TaskManager, type ExportTaskInfo } from './components/TaskManager';
 import { VaultGate } from './components/VaultGate';
 import { UpdatePrompt } from './components/UpdatePrompt';
 import { DialogProvider, useDialogs } from './components/dialogs/DialogProvider';
@@ -38,12 +39,12 @@ import { toJson, toCsv, parseJson, parseCsv } from './lib/dataTransfer';
 import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
-import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Table2, Eye, HardDrive, Activity, Copy, Users } from 'lucide-react';
+import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 interface QueryTab {
   id: string;
-  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users';
+  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users';
   connectionId: string;
   db: string;
   collection: string;
@@ -138,6 +139,20 @@ const createQuickStartTab = (): QueryTab => ({
   explainResult: null,
 });
 
+const TASKS_TAB_ID = 'tasks';
+
+const createTasksTab = (): QueryTab => ({
+  id: TASKS_TAB_ID,
+  type: 'tasks',
+  connectionId: '',
+  db: '',
+  collection: '',
+  results: [],
+  loading: false,
+  error: null,
+  explainResult: null,
+});
+
 const tabIconFor = (tab: QueryTab, isActive: boolean): React.ReactNode => {
   const className = isActive ? 'text-primary' : 'text-muted-foreground';
   const size = 11;
@@ -152,6 +167,8 @@ const tabIconFor = (tab: QueryTab, isActive: boolean): React.ReactNode => {
       return <Rocket size={size} className={className} />;
     case 'export':
       return <Download size={size} className={className} />;
+    case 'tasks':
+      return <ListChecks size={size} className={className} />;
     case 'schema':
       return <Table2 size={size} className={className} />;
     case 'create-view':
@@ -182,6 +199,8 @@ const tabLabelFor = (
       return 'Quick Start';
     case 'export':
       return `Export: ${tab.collection}`;
+    case 'tasks':
+      return 'Tasks';
     case 'schema':
       return `Schema: ${tab.collection}`;
     case 'create-view':
@@ -336,6 +355,69 @@ function Workspace() {
       setExportTasks(tasks);
     } catch {
       /* ignore */
+    }
+  };
+
+  type CopySource = { connectionId: string; db: string; collections: string[] };
+  const [copyDialog, setCopyDialog] = useState<
+    { source: CopySource; target?: { connectionId: string; db?: string } } | null
+  >(null);
+  // In-app clipboard for the Copy → Paste-here flow.
+  const [copyClipboard, setCopyClipboard] = useState<CopySource | null>(null);
+
+  // Destination to refresh in the sidebar after a copy starts (and periodically
+  // while it runs), so newly-copied databases/collections show up live.
+  const [copyRefresh, setCopyRefresh] = useState<
+    { connectionId: string; db?: string; expand: boolean } | null
+  >(null);
+  const [copyRefreshNonce, setCopyRefreshNonce] = useState(0);
+  const triggerCopyRefresh = React.useCallback(
+    (target: { connectionId: string; db?: string }, expand: boolean) => {
+      setCopyRefresh({ ...target, expand });
+      setCopyRefreshNonce((n) => n + 1);
+    },
+    []
+  );
+
+  // While a copy task is running, periodically re-refresh its destination so
+  // collections that trickle in during a long copy stay visible. `expand: false`
+  // keeps reloading collections without re-opening a db the user has collapsed.
+  const copyRunning = exportTasks.some(
+    (t) => (t.kind === 'collection_copy' || t.kind === 'database_copy') && t.status === 'running'
+  );
+  const refreshConnId = copyRefresh?.connectionId;
+  const refreshDb = copyRefresh?.db;
+  useEffect(() => {
+    if (!copyRunning || !refreshConnId) return;
+    const id = setInterval(() => {
+      setCopyRefresh((prev) => (prev ? { ...prev, expand: false } : prev));
+      setCopyRefreshNonce((n) => n + 1);
+    }, 4000);
+    return () => clearInterval(id);
+  }, [copyRunning, refreshConnId, refreshDb]);
+
+  const handleCopyCollections = (connectionId: string, db: string, collections: string[]) =>
+    setCopyDialog({ source: { connectionId, db, collections } });
+  const handleCopyDatabase = (connectionId: string, db: string) =>
+    setCopyDialog({ source: { connectionId, db, collections: [] } });
+
+  // Copy → clipboard (no dialog); Paste-here opens the dialog pre-filled with that target.
+  const handleCopyToClipboard = (connectionId: string, db: string, collections: string[]) => {
+    setCopyClipboard({ connectionId, db, collections });
+    const what = collections.length === 0 ? `database ${db}` : `${collections.length} collection(s)`;
+    toast(`Copied ${what} — right-click a target and choose “Paste here”.`, 'success');
+  };
+  const handlePasteInto = (connectionId: string, db?: string) => {
+    if (!copyClipboard) return;
+    setCopyDialog({ source: copyClipboard, target: { connectionId, db } });
+  };
+
+  const handleCancelTask = async (taskId: string) => {
+    try {
+      await invoke('cancel_task', { id: taskId });
+      await loadExportTasks();
+    } catch (err: any) {
+      toast(`Could not cancel: ${err?.message || err}`, 'error');
     }
   };
 
@@ -569,6 +651,13 @@ function Workspace() {
 
   const handleOpenSettingsTab = () => openSettingsTab('appearance');
   const handleOpenShortcutsReference = () => openSettingsTab('shortcuts');
+
+  const handleOpenTasksTab = () => {
+    if (!tabs.some(t => t.id === TASKS_TAB_ID)) {
+      setTabs(prev => [...prev, createTasksTab()]);
+    }
+    setActiveTabId(TASKS_TAB_ID);
+  };
 
   const handleOpenExportTab = (sourceTab: QueryTab) => {
     if (sourceTab.type !== 'collection') return;
@@ -1173,6 +1262,7 @@ function Workspace() {
           path,
         });
         setExportTasks((prev) => [task, ...prev.filter((t) => t.id !== task.id)]);
+        handleOpenTasksTab();
         await loadExportTasks();
         return;
       }
@@ -1500,6 +1590,13 @@ function Workspace() {
             });
           }}
           onOpenSettings={handleOpenSettingsTab}
+          onCopyCollections={handleCopyCollections}
+          onCopyDatabase={handleCopyDatabase}
+          onCopyToClipboard={handleCopyToClipboard}
+          onPasteInto={handlePasteInto}
+          canPaste={!!copyClipboard}
+          refreshTarget={copyRefresh}
+          refreshTargetNonce={copyRefreshNonce}
         />
       }
       sidebarWidth={sidebarWidth}
@@ -1522,6 +1619,8 @@ function Workspace() {
           appVersion={appVersion ? `v${appVersion}` : undefined}
           zoomPercent={Math.round(config.uiZoom * 100)}
           onZoomReset={resetZoom}
+          onOpenTasks={handleOpenTasksTab}
+          runningTasks={exportTasks.filter((t) => t.status === 'running').length}
         />
       }
       overlays={
@@ -1571,6 +1670,63 @@ function Workspace() {
           />
 
           <UpdatePrompt />
+
+          {copyDialog && (
+            <CopyToDialog
+              open={!!copyDialog}
+              onOpenChange={(o) => !o && setCopyDialog(null)}
+              source={copyDialog.source}
+              presetTargetId={copyDialog.target?.connectionId}
+              presetTargetDb={copyDialog.target?.db}
+              activeConnections={activeConnections.map((c) => ({ id: c.id, name: c.name, uri: c.uri }))}
+              listDatabases={(id) => invoke<string[]>('list_databases', { id })}
+              listCollections={(id, db) =>
+                invoke<{ name: string }[]>('list_collections', { id, db }).then((cs) => cs.map((c) => c.name))
+              }
+              preflight={(req) =>
+                invoke('preflight_copy', {
+                  sourceId: req.sourceId,
+                  sourceDb: req.sourceDb,
+                  sourceCollections: req.sourceCollections,
+                  targets: req.targets,
+                })
+              }
+              onConfirm={async (req) => {
+                handleOpenTasksTab();
+                // Surface the destination right away and expand it; the periodic
+                // effect keeps it fresh while the copy runs.
+                triggerCopyRefresh({ connectionId: req.targetId, db: req.targetDb }, true);
+                let task: ExportTaskInfo;
+                if (req.type === 'database') {
+                  task = await invoke<ExportTaskInfo>('start_database_copy', {
+                    sourceId: req.sourceId, sourceDb: req.sourceDb,
+                    targetId: req.targetId, targetDb: req.targetDb,
+                    collections: req.collections, includeIndexes: req.includeIndexes,
+                    includeViews: req.includeViews, conflictMode: req.conflictMode,
+                  });
+                } else if (req.type === 'collections') {
+                  // Copy each selected collection as its own task (same target db, same name).
+                  const tasks = await Promise.all(req.collections.map((name) =>
+                    invoke<ExportTaskInfo>('start_collection_copy', {
+                      sourceId: req.sourceId, sourceDb: req.sourceDb, sourceCollection: name,
+                      targetId: req.targetId, targetDb: req.targetDb, targetCollection: name,
+                      filter: null, includeIndexes: req.includeIndexes, conflictMode: req.conflictMode,
+                    })));
+                  setExportTasks((prev) => [...tasks, ...prev.filter((t) => !tasks.some((n) => n.id === t.id))]);
+                  await loadExportTasks();
+                  return;
+                } else {
+                  task = await invoke<ExportTaskInfo>('start_collection_copy', {
+                    sourceId: req.sourceId, sourceDb: req.sourceDb, sourceCollection: req.sourceCollection,
+                    targetId: req.targetId, targetDb: req.targetDb, targetCollection: req.targetCollection,
+                    filter: req.filter ?? null, includeIndexes: req.includeIndexes, conflictMode: req.conflictMode,
+                  });
+                }
+                setExportTasks((prev) => [task, ...prev.filter((t) => t.id !== task.id)]);
+                await loadExportTasks();
+              }}
+            />
+          )}
         </>
       }
     >
@@ -1729,13 +1885,28 @@ function Workspace() {
                     databaseName={activeTab.db}
                     collectionName={activeTab.collection}
                     currentResultCount={sourceTab?.results.length || 0}
-                    tasks={exportTasks}
                     onExport={(format, scope) => handleExportForTab(sourceTab || activeTab, format, scope)}
-                    onRefreshTasks={loadExportTasks}
-                    onClearFinishedTasks={handleClearFinishedTasks}
+                    onOpenTasks={handleOpenTasksTab}
                   />
                 );
               })()}
+              {activeTab && activeTab.type === 'tasks' && (
+                <div className="flex h-full flex-col overflow-auto p-4" data-testid="tasks-view">
+                  <header className="mb-3">
+                    <h2 className="text-sm font-semibold text-foreground">Tasks</h2>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      Background copy and export jobs.
+                    </p>
+                  </header>
+                  <TaskManager
+                    tasks={exportTasks}
+                    onRefresh={loadExportTasks}
+                    onClearFinished={handleClearFinishedTasks}
+                    onCancel={handleCancelTask}
+                    variant="embedded"
+                  />
+                </div>
+              )}
               {activeTab && activeTab.type === 'shell' && (() => {
                 const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
                 const connectionName = activeConnection ? activeConnection.name : activeTab.connectionId;

--- a/src/components/CopyToDialog.tsx
+++ b/src/components/CopyToDialog.tsx
@@ -1,0 +1,536 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type CopyRequest =
+  | {
+      type: 'collection';
+      sourceId: string;
+      sourceDb: string;
+      sourceCollection: string;
+      targetId: string;
+      targetDb: string;
+      targetCollection: string;
+      filter?: string;
+      includeIndexes: boolean;
+      conflictMode: 'skip' | 'merge' | 'overwrite';
+    }
+  | {
+      type: 'collections';
+      sourceId: string;
+      sourceDb: string;
+      collections: string[];
+      targetId: string;
+      targetDb: string;
+      includeIndexes: boolean;
+      conflictMode: 'skip' | 'merge' | 'overwrite';
+    }
+  | {
+      type: 'database';
+      sourceId: string;
+      sourceDb: string;
+      targetId: string;
+      targetDb: string;
+      collections: string[] | null;
+      includeIndexes: boolean;
+      includeViews: boolean;
+      conflictMode: 'skip' | 'merge' | 'overwrite';
+    };
+
+export interface PreflightRequest {
+  sourceId: string;
+  sourceDb: string;
+  /** Source collection names — used to flag a true self-overwrite (target lands on a source). */
+  sourceCollections: string[];
+  targets: { connectionId: string; db: string; collection: string }[];
+}
+
+export interface PreflightResult {
+  conflicts: { db: string; collection: string; targetExists: boolean; targetDocCount: number }[];
+  selfOverwrite: boolean;
+}
+
+export interface CopyToDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  source: {
+    connectionId: string;
+    db: string;
+    collections: string[];
+  };
+  activeConnections: { id: string; name: string; uri: string }[];
+  listDatabases: (connectionId: string) => Promise<string[]>;
+  listCollections: (connectionId: string, db: string) => Promise<string[]>;
+  preflight: (req: PreflightRequest) => Promise<PreflightResult>;
+  onConfirm: (req: CopyRequest) => Promise<void>;
+  /** Pre-selected target (e.g. from a "Paste here" action). Falls back to the first connection / source db. */
+  presetTargetId?: string;
+  presetTargetDb?: string;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const CopyToDialog: React.FC<CopyToDialogProps> = ({
+  open,
+  onOpenChange,
+  source,
+  activeConnections,
+  listDatabases,
+  listCollections,
+  preflight,
+  onConfirm,
+  presetTargetId,
+  presetTargetDb,
+}) => {
+  // Derive mode from source.collections.length
+  const mode: 'database' | 'collection' | 'collections' =
+    source.collections.length === 0
+      ? 'database'
+      : source.collections.length === 1
+      ? 'collection'
+      : 'collections';
+
+  // ─── State ─────────────────────────────────────────────────────────────────
+
+  const resolvedDefaultTargetId = presetTargetId || activeConnections[0]?.id || '';
+
+  const [targetId, setTargetId] = useState(resolvedDefaultTargetId);
+  const [databases, setDatabases] = useState<string[]>([]);
+  const [dbsLoaded, setDbsLoaded] = useState(false);
+  const [targetDb, setTargetDb] = useState(presetTargetDb || source.db);
+  const [isNewDb, setIsNewDb] = useState(false);
+  const [newDbName, setNewDbName] = useState('');
+  const [targetCollection, setTargetCollection] = useState(
+    mode === 'collection' ? source.collections[0] : ''
+  );
+  const [includeIndexes, setIncludeIndexes] = useState(true);
+  const [includeViews, setIncludeViews] = useState(true);
+  const [filter, setFilter] = useState('');
+  const [conflictMode, setConflictMode] = useState<'skip' | 'merge' | 'overwrite'>('merge');
+  const [overwriteConfirmed, setOverwriteConfirmed] = useState(false);
+  const [preflightResult, setPreflightResult] = useState<PreflightResult | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  // The actual source collections — known up front for collection(s) mode, fetched
+  // for database mode. Used both to build preflight targets and to flag self-overwrite.
+  const [sourceCollections, setSourceCollections] = useState<string[]>(
+    mode === 'database' ? [] : source.collections
+  );
+
+  // ─── Effects ───────────────────────────────────────────────────────────────
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setTargetId(resolvedDefaultTargetId);
+      setTargetDb(presetTargetDb || source.db);
+      setIsNewDb(false);
+      setNewDbName('');
+      setTargetCollection(mode === 'collection' ? source.collections[0] : '');
+      setIncludeIndexes(true);
+      setIncludeViews(true);
+      setFilter('');
+      setConflictMode('merge');
+      setOverwriteConfirmed(false);
+      setPreflightResult(null);
+      setDbsLoaded(false);
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Load databases when targetId changes
+  useEffect(() => {
+    if (!targetId) return;
+    let cancelled = false;
+    setDbsLoaded(false);
+    listDatabases(targetId)
+      .then((dbs) => {
+        if (cancelled) return;
+        setDatabases(dbs);
+        setDbsLoaded(true);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDatabases([]);
+        setDbsLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [targetId, listDatabases]);
+
+  // Once the target's databases are known, if the chosen name isn't among them
+  // (e.g. a pasted/pre-filled db that doesn't exist on this connection), switch
+  // to the "new database" input so the name stays visible and will be created.
+  useEffect(() => {
+    if (!dbsLoaded || isNewDb || !targetDb) return;
+    if (!databases.includes(targetDb)) {
+      setIsNewDb(true);
+      setNewDbName(targetDb);
+      setTargetDb('');
+    }
+  }, [dbsLoaded, databases, isNewDb, targetDb]);
+
+  // Resolve the source collection set: known for collection(s) mode; fetched from
+  // the source database for a whole-database copy so preflight checks real targets.
+  useEffect(() => {
+    if (!open) return;
+    if (mode === 'database') {
+      let cancelled = false;
+      listCollections(source.connectionId, source.db)
+        .then((cols) => {
+          if (!cancelled) setSourceCollections(cols);
+        })
+        .catch(() => {
+          if (!cancelled) setSourceCollections([]);
+        });
+      return () => {
+        cancelled = true;
+      };
+    }
+    setSourceCollections(source.collections);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, mode, source.connectionId, source.db]);
+
+  // Run preflight when target is known
+  useEffect(() => {
+    const effectiveDb = isNewDb ? newDbName.trim() : targetDb.trim();
+    if (!targetId || !effectiveDb) {
+      setPreflightResult(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    // One target per real collection being copied. Database mode uses the fetched
+    // source collections so existing target collections surface the conflict UI.
+    const targets =
+      mode === 'collection'
+        ? targetCollection.trim()
+          ? [{ connectionId: targetId, db: effectiveDb, collection: targetCollection.trim() }]
+          : []
+        : (mode === 'collections' ? source.collections : sourceCollections).map((c) => ({
+            connectionId: targetId,
+            db: effectiveDb,
+            collection: c,
+          }));
+
+    if (targets.length === 0) {
+      setPreflightResult(null);
+      return;
+    }
+
+    preflight({ sourceId: source.connectionId, sourceDb: source.db, sourceCollections, targets })
+      .then((result) => {
+        if (!cancelled) setPreflightResult(result);
+      })
+      .catch(() => {
+        if (!cancelled) setPreflightResult(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [targetId, targetDb, isNewDb, newDbName, targetCollection, mode, source, sourceCollections, preflight]);
+
+  // ─── Gating logic ──────────────────────────────────────────────────────────
+
+  const effectiveDb = isNewDb ? newDbName.trim() : targetDb.trim();
+  const hasConflicts = preflightResult?.conflicts.some((c) => c.targetExists) ?? false;
+  const needsOverwriteConfirm = conflictMode === 'overwrite' && hasConflicts;
+  const startDisabled =
+    !!preflightResult?.selfOverwrite ||
+    !targetId ||
+    !effectiveDb ||
+    (mode === 'collection' && !targetCollection.trim()) ||
+    (needsOverwriteConfirm && !overwriteConfirmed) ||
+    isSubmitting;
+
+  // ─── Handlers ──────────────────────────────────────────────────────────────
+
+  const handleTargetIdChange = (val: string) => {
+    setTargetId(val);
+    setTargetDb(source.db);
+    setIsNewDb(false);
+    setNewDbName('');
+  };
+
+  const handleTargetDbChange = (val: string) => {
+    if (val === '__new__') {
+      setIsNewDb(true);
+      setTargetDb('');
+    } else {
+      setIsNewDb(false);
+      setTargetDb(val);
+    }
+  };
+
+  const handleStart = async () => {
+    if (startDisabled) return;
+    setIsSubmitting(true);
+    try {
+      const db = effectiveDb;
+      let req: CopyRequest;
+      if (mode === 'collection') {
+        req = {
+          type: 'collection',
+          sourceId: source.connectionId,
+          sourceDb: source.db,
+          sourceCollection: source.collections[0],
+          targetId,
+          targetDb: db,
+          targetCollection: targetCollection.trim(),
+          filter: filter.trim() || undefined,
+          includeIndexes,
+          conflictMode,
+        };
+      } else if (mode === 'collections') {
+        req = {
+          type: 'collections',
+          sourceId: source.connectionId,
+          sourceDb: source.db,
+          collections: source.collections,
+          targetId,
+          targetDb: db,
+          includeIndexes,
+          conflictMode,
+        };
+      } else {
+        req = {
+          type: 'database',
+          sourceId: source.connectionId,
+          sourceDb: source.db,
+          targetId,
+          targetDb: db,
+          collections: null,
+          includeIndexes,
+          includeViews,
+          conflictMode,
+        };
+      }
+      await onConfirm(req);
+      onOpenChange(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  const modeLabel =
+    mode === 'collection'
+      ? `collection "${source.collections[0]}"`
+      : mode === 'collections'
+      ? `${source.collections.length} collections`
+      : `database "${source.db}"`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Copy {modeLabel}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          {/* Target connection */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="target-connection">Target connection</Label>
+            <Select value={targetId} onValueChange={handleTargetIdChange}>
+              <SelectTrigger id="target-connection">
+                <SelectValue placeholder="Select connection…" />
+              </SelectTrigger>
+              <SelectContent>
+                {activeConnections.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Target database */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="target-database">Target database</Label>
+            {isNewDb ? (
+              <>
+                <Input
+                  id="target-database"
+                  placeholder="New database name…"
+                  value={newDbName}
+                  onChange={(e) => setNewDbName(e.target.value)}
+                  autoFocus
+                />
+                {newDbName.trim() && !databases.includes(newDbName.trim()) && (
+                  <p className="text-xs text-muted-foreground">
+                    Doesn't exist on the target — it will be created.
+                  </p>
+                )}
+              </>
+            ) : (
+              <Select value={targetDb} onValueChange={handleTargetDbChange}>
+                <SelectTrigger id="target-database">
+                  <SelectValue placeholder="Select database…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {databases.map((db) => (
+                    <SelectItem key={db} value={db}>
+                      {db}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="__new__">➕ New database…</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+
+          {/* Target collection (single-collection mode only) */}
+          {mode === 'collection' && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="target-collection">Target collection</Label>
+              <Input
+                id="target-collection"
+                value={targetCollection}
+                onChange={(e) => setTargetCollection(e.target.value)}
+                placeholder="Collection name…"
+              />
+            </div>
+          )}
+
+          {/* Single-collection filter */}
+          {mode === 'collection' && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="filter-input">Filter (EJSON, optional)</Label>
+              <Input
+                id="filter-input"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder='{"status": "active"}'
+              />
+            </div>
+          )}
+
+          {/* Options */}
+          <div className="flex flex-col gap-2">
+            <Label>Options</Label>
+            <div className="flex flex-col gap-2">
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={includeIndexes}
+                  onChange={(e) => setIncludeIndexes(e.target.checked)}
+                  id="include-indexes"
+                />
+                Include indexes
+              </label>
+              {mode === 'database' && (
+                <label className="flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={includeViews}
+                    onChange={(e) => setIncludeViews(e.target.checked)}
+                    id="include-views"
+                  />
+                  Include views
+                </label>
+              )}
+            </div>
+          </div>
+
+          {/* Conflict resolution — always rendered but only visible when there are conflicts */}
+          {hasConflicts && (
+            <div className="flex flex-col gap-2">
+              <Label>Conflict resolution</Label>
+              <div className="flex flex-col gap-2">
+                <label className="flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="conflictMode"
+                    value="skip"
+                    checked={conflictMode === 'skip'}
+                    onChange={() => {
+                      setConflictMode('skip');
+                      setOverwriteConfirmed(false);
+                    }}
+                  />
+                  Skip — leave existing target documents untouched
+                </label>
+                <label className="flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="conflictMode"
+                    value="merge"
+                    checked={conflictMode === 'merge'}
+                    onChange={() => {
+                      setConflictMode('merge');
+                      setOverwriteConfirmed(false);
+                    }}
+                  />
+                  Merge — keep existing documents, add new ones (duplicate _ids skipped)
+                </label>
+                <label className="flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="conflictMode"
+                    id="conflict-overwrite"
+                    value="overwrite"
+                    checked={conflictMode === 'overwrite'}
+                    onChange={() => {
+                      setConflictMode('overwrite');
+                      setOverwriteConfirmed(false);
+                    }}
+                  />
+                  Overwrite — drop and replace the target collection(s)
+                </label>
+              </div>
+
+              {/* Destructive confirm — shown when Overwrite selected */}
+              {conflictMode === 'overwrite' && (
+                <label className="mt-1 flex cursor-pointer items-center gap-2 text-sm text-destructive">
+                  <input
+                    type="checkbox"
+                    id="overwrite-confirm"
+                    checked={overwriteConfirmed}
+                    onChange={(e) => setOverwriteConfirmed(e.target.checked)}
+                  />
+                  I understand this replaces the target collection(s)
+                </label>
+              )}
+            </div>
+          )}
+
+          {/* Self-overwrite warning */}
+          {preflightResult?.selfOverwrite && (
+            <p className="text-sm text-destructive">
+              Source and target are the same collection — copy is not allowed.
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleStart} disabled={startDisabled}>
+            Start copy
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/ExportView.tsx
+++ b/src/components/ExportView.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
-import { Download, FileJson, FileSpreadsheet, RefreshCw } from 'lucide-react';
+import { Download, FileJson, FileSpreadsheet, ListChecks } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { TaskManager, type ExportTaskInfo } from './TaskManager';
 
 interface ExportViewProps {
   connectionName: string;
   databaseName: string;
   collectionName: string;
   currentResultCount: number;
-  tasks: ExportTaskInfo[];
   onExport: (format: 'json' | 'csv', scope: 'current' | 'full') => void;
-  onRefreshTasks: () => void;
-  onClearFinishedTasks: () => void;
+  /** Open the dedicated Tasks tab where background jobs (incl. full exports) appear. */
+  onOpenTasks?: () => void;
 }
 
 export const ExportView: React.FC<ExportViewProps> = ({
@@ -20,10 +18,8 @@ export const ExportView: React.FC<ExportViewProps> = ({
   databaseName,
   collectionName,
   currentResultCount,
-  tasks,
   onExport,
-  onRefreshTasks,
-  onClearFinishedTasks,
+  onOpenTasks,
 }) => {
   const hasCurrentResults = currentResultCount > 0;
 
@@ -36,9 +32,9 @@ export const ExportView: React.FC<ExportViewProps> = ({
             {connectionName} / {databaseName}.{collectionName}
           </p>
         </div>
-        <Button type="button" variant="outline" size="sm" onClick={onRefreshTasks}>
-          <RefreshCw size={12} />
-          Refresh Tasks
+        <Button type="button" variant="outline" size="sm" onClick={onOpenTasks}>
+          <ListChecks size={12} />
+          View Tasks
         </Button>
       </header>
 
@@ -110,12 +106,13 @@ export const ExportView: React.FC<ExportViewProps> = ({
         </Card>
       </div>
 
-      <TaskManager
-        tasks={tasks}
-        onRefresh={onRefreshTasks}
-        onClearFinished={onClearFinishedTasks}
-        variant="embedded"
-      />
+      <p className="mt-4 text-xs text-muted-foreground">
+        Full-collection exports run in the background. Track their progress in the{' '}
+        <button type="button" className="underline hover:text-foreground" onClick={onOpenTasks}>
+          Tasks
+        </button>{' '}
+        tab.
+      </p>
     </div>
   );
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { useDialogs } from './dialogs/DialogProvider';
 import { fuzzyMatch } from '../lib/fuzzyMatch';
+import { type CollectionSelection, emptySelection, toggleCollection, selectionScope } from '@/lib/collectionSelection';
 import {
   type FolderNode,
   FOLDERS_CHANGED_EVENT,
@@ -86,6 +87,8 @@ import {
   X,
   Pin,
   Heart,
+  Copy,
+  ClipboardPaste,
 } from 'lucide-react';
 
 const REPO_URL = 'https://github.com/mqlens/mqlens-mongodb';
@@ -152,6 +155,22 @@ interface SidebarProps {
   collectionMutationTrigger?: number;
   onConnectProfile?: (profile: ConnectionProfile) => Promise<string | null> | string | null;
   profilesRefreshKey?: number;
+  onCopyCollections?: (connectionId: string, db: string, collections: string[]) => void;
+  onCopyDatabase?: (connectionId: string, db: string) => void;
+  /** Copy source to the in-app clipboard (collections=[] means whole database). */
+  onCopyToClipboard?: (connectionId: string, db: string, collections: string[]) => void;
+  /** Paste the clipboard into a target (db omitted = paste onto a connection). */
+  onPasteInto?: (connectionId: string, db?: string) => void;
+  /** Whether the clipboard currently holds something to paste. */
+  canPaste?: boolean;
+  /**
+   * Destination to refresh after a copy starts (and periodically while it runs),
+   * so newly-copied databases/collections appear. `expand` auto-opens the target
+   * db (only on copy start, so a manual collapse mid-copy is respected).
+   */
+  refreshTarget?: { connectionId: string; db?: string; expand: boolean } | null;
+  /** Bumped by the parent to fire a refresh of `refreshTarget`. */
+  refreshTargetNonce?: number;
 }
 
 const treeRowClass = (active?: boolean) =>
@@ -251,6 +270,13 @@ export const Sidebar: React.FC<SidebarProps> = ({
   collectionMutationTrigger,
   onConnectProfile,
   profilesRefreshKey = 0,
+  onCopyCollections,
+  onCopyDatabase,
+  onCopyToClipboard,
+  onPasteInto,
+  canPaste,
+  refreshTarget,
+  refreshTargetNonce,
 }) => {
   const { toast, confirm, prompt } = useDialogs();
   const [filterQuery, setFilterQuery] = useState('');
@@ -308,6 +334,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const [expandedCollectionsFolders, setExpandedCollectionsFolders] = useState<{ [connectionDbFolderKey: string]: boolean }>({});
   const [expandedCollections, setExpandedCollections] = useState<{ [connectionDbCollKey: string]: boolean }>({});
   const [expandedIndexesFolders, setExpandedIndexesFolders] = useState<{ [connectionDbCollKey: string]: boolean }>({});
+
+  const [selection, setSelection] = useState<CollectionSelection>(emptySelection());
 
   const [pinnedItems, setPinnedItems] = useState<PinnedItem[]>(() => loadPinnedCollections());
   const [favoriteItems, setFavoriteItems] = useState<FavoriteItem[]>(() => loadFavoriteItems());
@@ -579,6 +607,23 @@ export const Sidebar: React.FC<SidebarProps> = ({
       });
     }
   }, [collectionMutationTrigger]);
+
+  // Refresh a copy destination when the parent bumps the nonce — on copy start
+  // and periodically while it runs — so new databases/collections appear live.
+  useEffect(() => {
+    if (!refreshTargetNonce || !refreshTarget) return;
+    const { connectionId, db, expand } = refreshTarget;
+    loadDatabases(connectionId);
+    if (db) {
+      const key = `${connectionId}/${db}`;
+      if (expand) {
+        setExpandedDbs((prev) => ({ ...prev, [key]: true }));
+        setExpandedCollectionsFolders((prev) => ({ ...prev, [`${key}/collections`]: true }));
+      }
+      handleRefreshDb(connectionId, db);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshTargetNonce]);
 
   const loadDatabases = async (connectionId: string) => {
     try {
@@ -1006,6 +1051,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }
   };
 
+  const selectedNamesFor = (connId: string, dbName: string, collName: string): string[] => {
+    const scope = selectionScope(connId, dbName);
+    if (selection.scope === scope && selection.names.has(collName)) {
+      return [...selection.names];
+    }
+    return [collName];
+  };
+
   const renderCollectionNode = (connId: string, dbName: string, collName: string) => {
     const collKey = `${connId}/${dbName}/${collName}`;
     const isCollExpanded = expandedCollections[collKey];
@@ -1015,17 +1068,24 @@ export const Sidebar: React.FC<SidebarProps> = ({
       activeCollection?.db === dbName &&
       activeCollection?.collection === collName &&
       !activeCollection?.indexName;
+    const isSelected = selection.scope === selectionScope(connId, dbName) && selection.names.has(collName);
 
     return (
       <div key={collName}>
         <ContextMenu>
           <ContextMenuTrigger asChild>
             <div
-              onClick={() => {
-                onSelectCollection(connId, dbName, collName);
-                toggleCollectionNode(connId, dbName, collName);
+              onClick={(e) => {
+                if (e.metaKey || e.ctrlKey) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setSelection((s) => toggleCollection(s, connId, dbName, collName));
+                } else {
+                  onSelectCollection(connId, dbName, collName);
+                  toggleCollectionNode(connId, dbName, collName);
+                }
               }}
-              className={treeRowClass(isActive)}
+              className={cn(treeRowClass(isActive), isSelected && 'bg-accent')}
             >
               <ChevronRight
                 size={10}
@@ -1116,6 +1176,19 @@ export const Sidebar: React.FC<SidebarProps> = ({
             <ContextMenuItem className={ctxItemClass} onClick={() => onAnalyzeSchema?.(connId, dbName, collName)}>
               <Table2 />
               <span>Analyze Schema</span>
+            </ContextMenuItem>
+            <ContextMenuItem
+              className={ctxItemClass}
+              onClick={() => onCopyToClipboard?.(connId, dbName, selectedNamesFor(connId, dbName, collName))}
+            >
+              <Copy />
+              <span>Copy</span>
+            </ContextMenuItem>
+            <ContextMenuItem
+              className={ctxItemClass}
+              onClick={() => onCopyCollections?.(connId, dbName, selectedNamesFor(connId, dbName, collName))}
+            >
+              Copy to…
             </ContextMenuItem>
             <ContextMenuItem
               className={ctxItemClass}
@@ -1305,6 +1378,19 @@ export const Sidebar: React.FC<SidebarProps> = ({
                       className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100"
                       onClick={(e) => {
                         e.stopPropagation();
+                        loadDatabases(conn.id);
+                      }}
+                      title="Refresh Databases"
+                      aria-label="Refresh databases"
+                    >
+                      <RefreshCw className="size-3" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
                         onDisconnect(conn.id);
                       }}
                       title="Disconnect Connection"
@@ -1319,6 +1405,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     <Plus />
                     <span>Add Database</span>
                   </ContextMenuItem>
+                  <ContextMenuItem className={ctxItemClass} onClick={() => loadDatabases(conn.id)}>
+                    <RefreshCw />
+                    <span>Refresh Databases</span>
+                  </ContextMenuItem>
+                  {canPaste && (
+                    <ContextMenuItem className={ctxItemClass} onClick={() => onPasteInto?.(conn.id)}>
+                      <ClipboardPaste />
+                      <span>Paste here</span>
+                    </ContextMenuItem>
+                  )}
                   <ContextMenuItem
                     className={ctxItemClass}
                     data-testid={`ctx-pin-conn-${conn.id}`}
@@ -1485,6 +1581,19 @@ export const Sidebar: React.FC<SidebarProps> = ({
                               <Eye />
                               <span>Create View</span>
                             </ContextMenuItem>
+                            <ContextMenuItem className={ctxItemClass} onClick={() => onCopyToClipboard?.(conn.id, dbName, [])}>
+                              <Copy />
+                              <span>Copy database</span>
+                            </ContextMenuItem>
+                            <ContextMenuItem className={ctxItemClass} onClick={() => onCopyDatabase?.(conn.id, dbName)}>
+                              Copy database to…
+                            </ContextMenuItem>
+                            {canPaste && (
+                              <ContextMenuItem className={ctxItemClass} onClick={() => onPasteInto?.(conn.id, dbName)}>
+                                <ClipboardPaste />
+                                <span>Paste here</span>
+                              </ContextMenuItem>
+                            )}
                             <ContextMenuItem
                               className={ctxItemClass}
                               onClick={() => onOpenShell?.(conn.id, dbName, undefined, 'show collections')}

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,16 +1,25 @@
 import React from 'react';
-import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, Trash2 } from 'lucide-react';
+import { AlertTriangle, Ban, CheckCircle2, Loader2, RefreshCw, Trash2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 
+export interface CopySummaryInfo {
+  collectionsCopied: number;
+  documentsCopied: number;
+  documentsSkipped: number;
+  indexesCreated: number;
+  skipped: string[];
+  failed: { collection: string; error: string }[];
+}
+
 export interface ExportTaskInfo {
   id: string;
   kind: string;
   label: string;
-  status: 'running' | 'completed' | 'failed' | string;
+  status: 'running' | 'completed' | 'failed' | 'cancelled' | string;
   processed: number;
   total?: number | null;
   message: string;
@@ -18,12 +27,17 @@ export interface ExportTaskInfo {
   error?: string | null;
   createdAtMs: number;
   finishedAtMs?: number | null;
+  subLabel?: string | null;
+  itemsProcessed?: number | null;
+  itemsTotal?: number | null;
+  summary?: CopySummaryInfo | null;
 }
 
 interface TaskManagerProps {
   tasks: ExportTaskInfo[];
   onRefresh: () => void;
   onClearFinished: () => void;
+  onCancel?: (taskId: string) => void;
   variant?: 'floating' | 'embedded';
 }
 
@@ -36,6 +50,7 @@ export const TaskManager: React.FC<TaskManagerProps> = ({
   tasks,
   onRefresh,
   onClearFinished,
+  onCancel,
   variant = 'floating',
 }) => {
   const running = tasks.filter((task) => task.status === 'running').length;
@@ -90,13 +105,17 @@ export const TaskManager: React.FC<TaskManagerProps> = ({
           <div className="flex flex-col">
             {tasks.length === 0 && (
               <div className="px-3 py-6 text-center text-xs text-muted-foreground" data-testid="task-empty">
-                No export tasks yet.
+                No background tasks yet.
               </div>
             )}
             {tasks.map((task) => {
               const percent = taskPercent(task);
               const isRunning = task.status === 'running';
               const isFailed = task.status === 'failed';
+              const isCancelled = task.status === 'cancelled';
+              // Only copy tasks support cancellation; exports cannot be cancelled.
+              const isCancellable =
+                task.kind === 'collection_copy' || task.kind === 'database_copy';
               return (
                 <div
                   key={task.id}
@@ -108,7 +127,8 @@ export const TaskManager: React.FC<TaskManagerProps> = ({
                       'mt-0.5 flex-shrink-0',
                       isRunning && 'text-primary',
                       isFailed && 'text-destructive',
-                      !isRunning && !isFailed && 'text-success'
+                      isCancelled && 'text-muted-foreground',
+                      !isRunning && !isFailed && !isCancelled && 'text-success'
                     )}
                     aria-hidden="true"
                   >
@@ -116,6 +136,8 @@ export const TaskManager: React.FC<TaskManagerProps> = ({
                       <Loader2 size={13} className="animate-spin" />
                     ) : isFailed ? (
                       <AlertTriangle size={13} />
+                    ) : isCancelled ? (
+                      <Ban size={13} />
                     ) : (
                       <CheckCircle2 size={13} />
                     )}
@@ -141,15 +163,52 @@ export const TaskManager: React.FC<TaskManagerProps> = ({
                       <div
                         className={cn(
                           'h-full rounded-full transition-all',
-                          isFailed ? 'bg-destructive' : isRunning ? 'bg-primary' : 'bg-success'
+                          isFailed ? 'bg-destructive' : isRunning ? 'bg-primary' : isCancelled ? 'bg-muted-foreground' : 'bg-success'
                         )}
-                        style={{ width: `${percent ?? (isRunning ? 18 : 100)}%` }}
+                        style={{ width: `${percent ?? (isRunning ? 18 : isCancelled ? 0 : 100)}%` }}
                       />
                     </div>
                     {task.path && (
                       <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground" title={task.path}>
                         {task.path}
                       </div>
+                    )}
+                    {task.subLabel && (
+                      <div className="mt-0.5 truncate text-[10px] text-muted-foreground" title={task.subLabel}>
+                        {task.subLabel}
+                        {task.itemsTotal ? ` · ${task.itemsProcessed ?? 0}/${task.itemsTotal} collections` : ''}
+                      </div>
+                    )}
+                    {task.summary && (
+                      <div
+                        className="mt-1 text-[10px] text-muted-foreground"
+                        title={
+                          [
+                            ...(task.summary.failed.length > 0
+                              ? task.summary.failed.map((f) => `${f.collection}: ${f.error}`)
+                              : []),
+                            ...(task.summary.skipped.length > 0
+                              ? [`Skipped: ${task.summary.skipped.join(', ')}`]
+                              : []),
+                          ].join('\n') || undefined
+                        }
+                      >
+                        {task.summary.documentsCopied} copied
+                        {task.summary.documentsSkipped > 0 && `, ${task.summary.documentsSkipped} skipped`}
+                        {task.summary.indexesCreated > 0 && `, ${task.summary.indexesCreated} indexes`}
+                        {task.summary.failed.length > 0 && (
+                          <span className="text-destructive"> · {task.summary.failed.length} failed</span>
+                        )}
+                      </div>
+                    )}
+                    {isRunning && isCancellable && onCancel && (
+                      <button
+                        type="button"
+                        className="mt-1 text-[10px] text-destructive hover:underline"
+                        onClick={() => onCancel(task.id)}
+                      >
+                        Cancel
+                      </button>
                     )}
                   </div>
                 </div>

--- a/src/components/__tests__/CopyToDialog.test.tsx
+++ b/src/components/__tests__/CopyToDialog.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { CopyToDialog } from '../CopyToDialog';
+
+const baseProps = {
+  open: true,
+  onOpenChange: () => {},
+  activeConnections: [{ id: 'c1', name: 'Local', uri: 'mongodb://x' }],
+  listDatabases: vi.fn(async () => ['app', 'other']),
+  listCollections: vi.fn(async () => ['orders']),
+  preflight: vi.fn(async () => ({ conflicts: [], selfOverwrite: false })),
+};
+
+describe('CopyToDialog', () => {
+  it('defaults the target collection name to the source name', async () => {
+    render(<CopyToDialog {...baseProps}
+      source={{ connectionId: 'c1', db: 'app', collections: ['orders'] }}
+      onConfirm={vi.fn(async () => {})} />);
+    const input = await screen.findByLabelText(/target collection/i) as HTMLInputElement;
+    expect(input.value).toBe('orders');
+  });
+
+  it('disables Start when preflight reports self-overwrite', async () => {
+    render(<CopyToDialog {...baseProps}
+      preflight={vi.fn(async () => ({ conflicts: [], selfOverwrite: true }))}
+      source={{ connectionId: 'c1', db: 'app', collections: ['orders'] }}
+      onConfirm={vi.fn(async () => {})} />);
+    await waitFor(() => {
+      expect((screen.getByRole('button', { name: /start copy/i }) as HTMLButtonElement).disabled).toBe(true);
+    });
+  });
+
+  it('treats a pre-filled db that is missing on the target as a new database', async () => {
+    // Paste a database whose name does not exist on the chosen target connection.
+    render(<CopyToDialog {...baseProps}
+      listDatabases={vi.fn(async () => ['app', 'other'])}
+      source={{ connectionId: 'c1', db: 'cidaas-management-test', collections: [] }}
+      presetTargetId="c1"
+      presetTargetDb="cidaas-management-test"
+      onConfirm={vi.fn(async () => {})} />);
+    // It should fall into the "new database" input pre-filled with the pasted name…
+    const input = await screen.findByPlaceholderText(/new database name/i) as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe('cidaas-management-test'));
+    // …and explain that it will be created.
+    expect(screen.getByText(/will be created/i)).toBeInTheDocument();
+  });
+
+  it('requires Overwrite confirmation before Start enables', async () => {
+    const onConfirm = vi.fn(async () => {});
+    render(<CopyToDialog {...baseProps}
+      preflight={vi.fn(async () => ({ conflicts: [{ db: 'app', collection: 'orders', targetExists: true, targetDocCount: 3 }], selfOverwrite: false }))}
+      source={{ connectionId: 'c1', db: 'app', collections: ['orders'] }}
+      onConfirm={onConfirm} />);
+    fireEvent.click(await screen.findByLabelText(/overwrite/i));
+    const start = screen.getByRole('button', { name: /start copy/i }) as HTMLButtonElement;
+    expect(start.disabled).toBe(true); // confirm checkbox not yet checked
+    fireEvent.click(screen.getByLabelText(/i understand/i));
+    await waitFor(() => expect(start.disabled).toBe(false));
+  });
+});

--- a/src/components/__tests__/ExportView.test.tsx
+++ b/src/components/__tests__/ExportView.test.tsx
@@ -1,10 +1,8 @@
-import { useState } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../test/render-with-providers';
 import { DialogProvider, useDialogs } from '../dialogs/DialogProvider';
 import { ExportView } from '../ExportView';
-import type { ExportTaskInfo } from '../TaskManager';
 
 const mockInvoke = vi.fn();
 const saveMock = vi.fn();
@@ -27,10 +25,8 @@ const baseProps = {
   databaseName: 'sales_db',
   collectionName: 'customers',
   currentResultCount: 3,
-  tasks: [] as ExportTaskInfo[],
   onExport: vi.fn(),
-  onRefreshTasks: vi.fn(),
-  onClearFinishedTasks: vi.fn(),
+  onOpenTasks: vi.fn(),
 };
 
 function renderExportView(overrides: Partial<typeof baseProps> = {}) {
@@ -51,7 +47,6 @@ function ExportViewHarness({
   invokeFails?: boolean;
 }) {
   const { toast } = useDialogs();
-  const [tasks, setTasks] = useState<ExportTaskInfo[]>([]);
 
   const onExport = async (format: 'json' | 'csv', scope: 'current' | 'full') => {
     if (scope === 'current' && currentResultCount === 0) return;
@@ -62,14 +57,13 @@ function ExportViewHarness({
       if (!path) return;
       if (scope === 'full') {
         if (invokeFails) throw new Error('disk full');
-        const task = await mockInvoke('start_collection_export', {
+        await mockInvoke('start_collection_export', {
           id: 'conn-1',
           database: 'sales_db',
           collection: 'customers',
           format,
           path,
         });
-        setTasks([task]);
         return;
       }
       await writeTextFileMock(path, '[]');
@@ -86,10 +80,8 @@ function ExportViewHarness({
       databaseName="sales_db"
       collectionName="customers"
       currentResultCount={currentResultCount}
-      tasks={tasks}
       onExport={onExport}
-      onRefreshTasks={vi.fn()}
-      onClearFinishedTasks={vi.fn()}
+      onOpenTasks={vi.fn()}
     />
   );
 }
@@ -145,11 +137,11 @@ describe('ExportView', () => {
     expect(onExport).toHaveBeenCalledWith('csv', 'full');
   });
 
-  it('refreshes export tasks from the header action', () => {
-    const onRefreshTasks = vi.fn();
-    renderExportView({ onRefreshTasks });
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh Tasks' }));
-    expect(onRefreshTasks).toHaveBeenCalledTimes(1);
+  it('opens the Tasks tab from the header action', () => {
+    const onOpenTasks = vi.fn();
+    renderExportView({ onOpenTasks });
+    fireEvent.click(screen.getByRole('button', { name: 'View Tasks' }));
+    expect(onOpenTasks).toHaveBeenCalledTimes(1);
   });
 
   it('starts a background export via invoke when full collection JSON is chosen', async () => {
@@ -171,8 +163,6 @@ describe('ExportView', () => {
         path: '/tmp/customers.json',
       });
     });
-    expect(await screen.findByTestId('task-manager')).toBeInTheDocument();
-    expect(screen.getByText(/Export sales_db\.customers as JSON/)).toBeInTheDocument();
   });
 
   it('surfaces export failures from invoke as an error toast', async () => {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -291,6 +291,42 @@ describe('Sidebar Component', () => {
     expect(orders10.compareDocumentPosition(zeta)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
+  it('refreshes and expands a copy destination when the refresh nonce bumps', async () => {
+    let collections: { name: string; type: string }[] = [];
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      if (cmd === 'list_all_saved_queries') return Promise.resolve([]);
+      if (cmd === 'list_databases') return Promise.resolve(['shop']);
+      if (cmd === 'list_collections' && args.db === 'shop') return Promise.resolve(collections);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    const sidebar = (nonce: number) => (
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        refreshTarget={{ connectionId: 'conn-1', db: 'shop', expand: true }}
+        refreshTargetNonce={nonce}
+      />
+    );
+
+    const { rerender } = render(sidebar(0));
+    await screen.findByText('shop');
+
+    // The copy lands a new collection; bumping the nonce surfaces it without any
+    // manual expansion, because the destination db + Collections folder auto-open.
+    collections = [{ name: 'copied_orders', type: 'collection' }];
+    rerender(<DialogProvider>{sidebar(1)}</DialogProvider>);
+
+    expect(await screen.findByText('copied_orders')).toBeInTheDocument();
+  });
+
   it('applies custom width inline style if width prop is provided', () => {
     const { container } = render(
       <Sidebar

--- a/src/components/__tests__/TaskManager.copy.test.tsx
+++ b/src/components/__tests__/TaskManager.copy.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TaskManager, type ExportTaskInfo } from '../TaskManager';
+
+const copyTask: ExportTaskInfo = {
+  id: 't1', kind: 'collection_copy', label: 'Copy a.b → c.d',
+  status: 'completed', processed: 5, total: 5, message: 'Copy complete',
+  createdAtMs: 1, summary: {
+    collectionsCopied: 1, documentsCopied: 5, documentsSkipped: 2,
+    indexesCreated: 1, skipped: [], failed: [],
+  },
+};
+
+describe('TaskManager copy tasks', () => {
+  it('renders a copy summary on completion', () => {
+    render(<TaskManager tasks={[copyTask]} onRefresh={() => {}} onClearFinished={() => {}} />);
+    expect(screen.getByText(/5 copied/i)).toBeTruthy();
+    expect(screen.getByText(/2 skipped/i)).toBeTruthy();
+  });
+
+  it('shows a Cancel button for running copy tasks and calls onCancel', () => {
+    const onCancel = vi.fn();
+    const running: ExportTaskInfo = { ...copyTask, status: 'running', summary: undefined };
+    render(<TaskManager tasks={[running]} onRefresh={() => {}} onClearFinished={() => {}} onCancel={onCancel} />);
+    screen.getByRole('button', { name: /cancel/i }).click();
+    expect(onCancel).toHaveBeenCalledWith('t1');
+  });
+
+  it('renders cancelled task as muted/neutral, not as success', () => {
+    const cancelled: ExportTaskInfo = {
+      ...copyTask, status: 'cancelled', processed: 3, total: 5, message: 'Copy cancelled', summary: undefined,
+    };
+    const { container } = render(
+      <TaskManager tasks={[cancelled]} onRefresh={() => {}} onClearFinished={() => {}} />
+    );
+    // The icon wrapper div (aria-hidden="true") must carry text-muted-foreground, NOT text-success.
+    // There are multiple aria-hidden elements (SVG icons inside), so we target the div wrapper
+    // by looking for the one that is a div element.
+    const iconWrappers = Array.from(container.querySelectorAll('div[aria-hidden="true"]'));
+    expect(iconWrappers.length).toBeGreaterThan(0);
+    const iconDiv = iconWrappers[0];
+    expect(iconDiv.className).toContain('text-muted-foreground');
+    expect(iconDiv.className).not.toContain('text-success');
+    // Progress bar fill must carry bg-muted-foreground, NOT bg-success
+    const bar = container.querySelector('.bg-muted-foreground');
+    expect(bar).toBeTruthy();
+    expect(container.querySelector('.bg-success')).toBeNull();
+    // No Cancel button shown for a cancelled task
+    expect(screen.queryByRole('button', { name: /cancel/i })).toBeNull();
+  });
+
+  it('shows failure tooltip on summary block when failures present', () => {
+    const withFailures: ExportTaskInfo = {
+      ...copyTask,
+      summary: {
+        collectionsCopied: 1, documentsCopied: 3, documentsSkipped: 0,
+        indexesCreated: 0, skipped: [],
+        failed: [{ collection: 'orders', error: 'timeout' }],
+      },
+    };
+    const { container } = render(
+      <TaskManager tasks={[withFailures]} onRefresh={() => {}} onClearFinished={() => {}} />
+    );
+    // Find all elements with title; filter out the toolbar buttons (Refresh / Clear)
+    const titled = Array.from(container.querySelectorAll('[title]')).filter(
+      (el) => el.tagName.toLowerCase() !== 'button' && el.tagName.toLowerCase() !== 'span'
+    );
+    const summaryDiv = titled.find((el) => el.getAttribute('title')?.includes('orders: timeout'));
+    expect(summaryDiv).toBeTruthy();
+    expect(summaryDiv?.getAttribute('title')).toContain('orders: timeout');
+  });
+});

--- a/src/components/__tests__/TaskManager.test.tsx
+++ b/src/components/__tests__/TaskManager.test.tsx
@@ -61,7 +61,7 @@ describe('TaskManager', () => {
   it('shows an empty state when there are no tasks', () => {
     renderTaskManager();
     expect(screen.getByTestId('task-manager')).toBeInTheDocument();
-    expect(screen.getByTestId('task-empty')).toHaveTextContent('No export tasks yet.');
+    expect(screen.getByTestId('task-empty')).toHaveTextContent('No background tasks yet.');
   });
 
   it('renders running, completed, and failed tasks', () => {

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { ListChecks } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   Tooltip,
@@ -14,6 +15,10 @@ interface StatusBarProps {
   /** User UI zoom (75–150); hidden at 100%. */
   zoomPercent?: number;
   onZoomReset?: () => void;
+  /** Open the dedicated Tasks tab. */
+  onOpenTasks?: () => void;
+  /** Number of currently-running background tasks, shown as a badge. */
+  runningTasks?: number;
   className?: string;
 }
 
@@ -24,6 +29,8 @@ export function StatusBar({
   appVersion,
   zoomPercent,
   onZoomReset,
+  onOpenTasks,
+  runningTasks = 0,
   className,
 }: StatusBarProps) {
   const showZoom = zoomPercent != null && zoomPercent !== 100;
@@ -57,7 +64,30 @@ export function StatusBar({
           </TooltipContent>
         </Tooltip>
       )}
-      <span className="ml-auto">MQLens {appVersion ?? ""}</span>
+      {onOpenTasks && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              data-testid="status-bar-tasks"
+              className="ml-auto flex items-center gap-1 transition-colors hover:text-foreground"
+              onClick={onOpenTasks}
+            >
+              <ListChecks size={12} />
+              <span>Tasks</span>
+              {runningTasks > 0 && (
+                <span className="rounded-full bg-primary px-1.5 text-[10px] font-medium tabular-nums text-primary-foreground">
+                  {runningTasks}
+                </span>
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            {runningTasks > 0 ? `${runningTasks} running task(s)` : "Background tasks"}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      <span className={onOpenTasks ? "" : "ml-auto"}>MQLens {appVersion ?? ""}</span>
     </footer>
   );
 }

--- a/src/lib/__tests__/collectionSelection.test.ts
+++ b/src/lib/__tests__/collectionSelection.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { emptySelection, toggleCollection } from '../collectionSelection';
+
+describe('collection selection', () => {
+  it('toggles names within a scope', () => {
+    let s = toggleCollection(emptySelection(), 'c1', 'app', 'orders');
+    expect([...s.names]).toEqual(['orders']);
+    s = toggleCollection(s, 'c1', 'app', 'users');
+    expect(s.names.has('orders') && s.names.has('users')).toBe(true);
+    s = toggleCollection(s, 'c1', 'app', 'orders');
+    expect(s.names.has('orders')).toBe(false);
+  });
+
+  it('clears selection when switching to a different db scope', () => {
+    let s = toggleCollection(emptySelection(), 'c1', 'app', 'orders');
+    s = toggleCollection(s, 'c1', 'other', 'logs');
+    expect([...s.names]).toEqual(['logs']);
+  });
+});

--- a/src/lib/collectionSelection.ts
+++ b/src/lib/collectionSelection.ts
@@ -1,0 +1,26 @@
+// Tracks multi-selected collections scoped to a single connection+db.
+export interface CollectionSelection {
+  scope: string | null; // `${connectionId}::${db}` or null when empty
+  names: Set<string>;
+}
+
+export const emptySelection = (): CollectionSelection => ({ scope: null, names: new Set() });
+
+export const selectionScope = (connectionId: string, db: string) => `${connectionId}::${db}`;
+
+/** Toggle membership; switching scope clears the previous selection. */
+export const toggleCollection = (
+  sel: CollectionSelection,
+  connectionId: string,
+  db: string,
+  name: string,
+): CollectionSelection => {
+  const scope = selectionScope(connectionId, db);
+  if (sel.scope !== scope) {
+    return { scope, names: new Set([name]) };
+  }
+  const names = new Set(sel.names);
+  if (names.has(name)) names.delete(name);
+  else names.add(name);
+  return { scope: names.size ? scope : null, names };
+};


### PR DESCRIPTION
Implements #122 — a guided **Copy to…** flow to move a collection, a multi-selected set of collections, or a whole database to any other connected cluster or database (cross-cluster over the same TLS/SSH/proxy/auth as existing connections, and works in mock/demo mode).

## What's included

**Copy engine (Rust)**
- Per-collection document copy with **Skip / Merge / Overwrite** conflict modes, optional indexes, optional views, and an optional EJSON filter.
- Duplicate-key retry, continue-on-error, and a per-collection summary (copied / skipped / failed).
- Cancellation via a copy-only cancel registry.
- Preflight detects target conflicts and blocks self-overwrite.

**UI**
- `CopyToDialog`: pick target connection/database (create a new database inline), rename the target collection, choose options, and resolve conflicts. A pasted database name that doesn't exist on the target is created.
- **Copy → Paste-here** clipboard flow opens the dialog pre-filled with the chosen target.
- Dedicated **Tasks** tab (reachable from a status-bar button) shows copy/export progress, summaries, and cancel.
- Sidebar: collection multi-select, a connection refresh button, and **auto-refresh of the copy destination** while a copy runs so new collections appear live.

## Testing
- `npx tsc --noEmit` clean
- `npx vitest run` — 553 frontend tests pass
- `npm run build` succeeds

Closes #122