### PR TITLE
feat: complete GridFS upload, delete, and bucket management

### DIFF
--- a/src-tauri/src/db/gridfs.rs
+++ b/src-tauri/src/db/gridfs.rs
@@ -249,8 +249,13 @@ pub async fn upload_gridfs_file_impl(
         .await
         .map_err(|e| format!("Failed to finalize GridFS upload: {}", e))?;
 
+    // Best-effort: the file is already durably stored, so a failure to stamp the
+    // contentType must not surface as an upload failure. Worst case the file simply
+    // lacks a contentType.
     if let Some(ct) = resolved_content_type.as_deref() {
-        set_gridfs_content_type(&client, database, bucket, &file_bson_id, ct).await?;
+        if let Err(e) = set_gridfs_content_type(&client, database, bucket, &file_bson_id, ct).await {
+            eprintln!("warning: GridFS upload succeeded but content type was not set: {}", e);
+        }
     }
 
     let file_id = file_bson_id.into_relaxed_extjson().to_string();

--- a/src-tauri/src/db/gridfs.rs
+++ b/src-tauri/src/db/gridfs.rs
@@ -1,10 +1,11 @@
-//! GridFS browsing (M7): list files in a bucket and download them to disk.
+//! GridFS browsing (M7): list, upload, download, and delete files in a bucket.
 
-use crate::limits::{GRIDFS_STREAM_BUF, MAX_GRIDFS_LIST};
+use crate::limits::{GRIDFS_STREAM_BUF, MAX_GRIDFS_LIST, MAX_GRIDFS_UPLOAD_BYTES};
 use crate::{connection_is_mock, require_real_client, AppState};
 use serde::Serialize;
+use std::path::Path;
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct GridFsFileInfo {
     pub id: String, // Extended-JSON of the file's _id
     pub filename: String,
@@ -12,6 +13,74 @@ pub struct GridFsFileInfo {
     pub chunk_size_bytes: u32,
     pub upload_date: String,
     pub content_type: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct GridFsTransferProgress {
+    pub transferred: u64,
+    pub total: u64,
+}
+
+fn gridfs_bucket(
+    client: &mongodb::Client,
+    database: &str,
+    bucket: &str,
+) -> mongodb::gridfs::GridFsBucket {
+    client.database(database).gridfs_bucket(
+        mongodb::options::GridFsBucketOptions::builder()
+            .bucket_name(bucket.to_string())
+            .build(),
+    )
+}
+
+fn guess_content_type(filename: &str) -> Option<&'static str> {
+    let ext = Path::new(filename)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_lowercase())?;
+    match ext.as_str() {
+        "pdf" => Some("application/pdf"),
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        "svg" => Some("image/svg+xml"),
+        "json" => Some("application/json"),
+        "txt" => Some("text/plain"),
+        "html" | "htm" => Some("text/html"),
+        "css" => Some("text/css"),
+        "js" => Some("text/javascript"),
+        "csv" => Some("text/csv"),
+        "xml" => Some("application/xml"),
+        "zip" => Some("application/zip"),
+        "gz" => Some("application/gzip"),
+        "mp4" => Some("video/mp4"),
+        "webm" => Some("video/webm"),
+        "mp3" => Some("audio/mpeg"),
+        "wav" => Some("audio/wav"),
+        "wasm" => Some("application/wasm"),
+        _ => None,
+    }
+}
+
+async fn set_gridfs_content_type(
+    client: &mongodb::Client,
+    database: &str,
+    bucket: &str,
+    file_id: &mongodb::bson::Bson,
+    content_type: &str,
+) -> Result<(), String> {
+    let files_coll = format!("{}.files", bucket);
+    let coll = client
+        .database(database)
+        .collection::<mongodb::bson::Document>(&files_coll);
+    coll.update_one(
+        mongodb::bson::doc! { "_id": file_id },
+        mongodb::bson::doc! { "$set": { "contentType": content_type } },
+    )
+    .await
+    .map_err(|e| format!("Failed to set GridFS content type: {}", e))?;
+    Ok(())
 }
 
 pub async fn list_gridfs_files_impl(
@@ -70,6 +139,147 @@ pub async fn list_gridfs_files_impl(
     serde_json::to_string(&files).map_err(|e| format!("Serialization error: {}", e))
 }
 
+pub async fn upload_gridfs_file_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    bucket: &str,
+    source_path: &str,
+    filename: Option<&str>,
+    metadata_json: Option<&str>,
+    content_type: Option<&str>,
+    on_progress: Option<&(dyn Fn(GridFsTransferProgress) + Send + Sync)>,
+) -> Result<String, String> {
+    if connection_is_mock(state, id)? {
+        return Err("GridFS is not supported on mock connections".to_string());
+    }
+
+    let metadata = match metadata_json {
+        Some(json) if !json.trim().is_empty() => {
+            let value: serde_json::Value =
+                serde_json::from_str(json).map_err(|e| format!("Invalid metadata JSON: {}", e))?;
+            let bson = mongodb::bson::Bson::try_from(value)
+                .map_err(|e| format!("Invalid metadata document: {}", e))?;
+            match bson {
+                mongodb::bson::Bson::Document(doc) => Some(doc),
+                _ => return Err("Metadata must be a JSON object".to_string()),
+            }
+        }
+        _ => None,
+    };
+
+    let path = Path::new(source_path);
+    if !path.is_file() {
+        return Err(format!("Source file not found: {}", source_path));
+    }
+
+    let file_meta = tokio::fs::metadata(source_path)
+        .await
+        .map_err(|e| format!("Failed to read source file metadata: {}", e))?;
+    let total = file_meta.len();
+    if total > MAX_GRIDFS_UPLOAD_BYTES {
+        return Err(format!(
+            "File exceeds the maximum GridFS upload size ({} bytes)",
+            MAX_GRIDFS_UPLOAD_BYTES
+        ));
+    }
+
+    let upload_name = filename
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            path.file_name()
+                .and_then(|n| n.to_str())
+                .map(|s| s.to_string())
+        })
+        .ok_or_else(|| "Could not determine a filename for upload".to_string())?;
+    let resolved_content_type = content_type
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.to_string())
+        .or_else(|| guess_content_type(&upload_name).map(|s| s.to_string()));
+
+    let client = require_real_client(state, id)?;
+    let bucket_obj = gridfs_bucket(&client, database, bucket);
+
+    let mut upload_builder = bucket_obj.open_upload_stream(&upload_name);
+    if let Some(meta) = metadata {
+        upload_builder = upload_builder.metadata(meta);
+    }
+    let mut upload = upload_builder
+        .await
+        .map_err(|e| format!("Failed to open GridFS upload: {}", e))?;
+
+    use futures::AsyncWriteExt;
+    use tokio::io::AsyncReadExt;
+
+    let mut file = tokio::fs::File::open(source_path)
+        .await
+        .map_err(|e| format!("Failed to open source file: {}", e))?;
+    let mut buf = vec![0u8; GRIDFS_STREAM_BUF];
+    let mut transferred = 0u64;
+    if let Some(cb) = on_progress {
+        cb(GridFsTransferProgress {
+            transferred: 0,
+            total,
+        });
+    }
+    loop {
+        let n = file
+            .read(&mut buf)
+            .await
+            .map_err(|e| format!("Failed to read source file: {}", e))?;
+        if n == 0 {
+            break;
+        }
+        upload
+            .write_all(&buf[..n])
+            .await
+            .map_err(|e| format!("GridFS write error: {}", e))?;
+        transferred += n as u64;
+        if let Some(cb) = on_progress {
+            cb(GridFsTransferProgress {
+                transferred,
+                total,
+            });
+        }
+    }
+    let file_bson_id = upload.id().clone();
+    upload
+        .close()
+        .await
+        .map_err(|e| format!("Failed to finalize GridFS upload: {}", e))?;
+
+    if let Some(ct) = resolved_content_type.as_deref() {
+        set_gridfs_content_type(&client, database, bucket, &file_bson_id, ct).await?;
+    }
+
+    let file_id = file_bson_id.into_relaxed_extjson().to_string();
+    Ok(file_id)
+}
+
+pub async fn delete_gridfs_file_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    bucket: &str,
+    file_id_json: &str,
+) -> Result<(), String> {
+    if connection_is_mock(state, id)? {
+        return Err("GridFS is not supported on mock connections".to_string());
+    }
+    let id_value: serde_json::Value =
+        serde_json::from_str(file_id_json).map_err(|e| format!("Invalid file id JSON: {}", e))?;
+    let file_id = mongodb::bson::Bson::try_from(id_value)
+        .map_err(|e| format!("Invalid file id: {}", e))?;
+
+    let client = require_real_client(state, id)?;
+    let bucket_obj = gridfs_bucket(&client, database, bucket);
+    bucket_obj
+        .delete(file_id)
+        .await
+        .map_err(|e| format!("Failed to delete GridFS file: {}", e))
+}
+
 pub async fn download_gridfs_file_impl(
     state: &AppState,
     id: &str,
@@ -77,6 +287,8 @@ pub async fn download_gridfs_file_impl(
     bucket: &str,
     file_id_json: &str,
     dest_path: &str,
+    total_bytes: Option<u64>,
+    on_progress: Option<&(dyn Fn(GridFsTransferProgress) + Send + Sync)>,
 ) -> Result<u64, String> {
     if connection_is_mock(state, id)? {
         return Err("GridFS is not supported on mock connections".to_string());
@@ -88,11 +300,7 @@ pub async fn download_gridfs_file_impl(
         .map_err(|e| format!("Invalid file id: {}", e))?;
 
     let client = require_real_client(state, id)?;
-    let bucket_obj = client.database(database).gridfs_bucket(
-        mongodb::options::GridFsBucketOptions::builder()
-            .bucket_name(bucket.to_string())
-            .build(),
-    );
+    let bucket_obj = gridfs_bucket(&client, database, bucket);
     let mut stream = bucket_obj
         .open_download_stream(file_id)
         .await
@@ -101,11 +309,19 @@ pub async fn download_gridfs_file_impl(
     use futures::AsyncReadExt;
     use tokio::io::AsyncWriteExt;
 
+    let total = total_bytes.unwrap_or(0);
+    if let Some(cb) = on_progress {
+        cb(GridFsTransferProgress {
+            transferred: 0,
+            total,
+        });
+    }
+
     let mut file = tokio::fs::File::create(dest_path)
         .await
         .map_err(|e| format!("Failed to create file: {}", e))?;
     let mut buf = vec![0u8; GRIDFS_STREAM_BUF];
-    let mut total = 0u64;
+    let mut transferred = 0u64;
     loop {
         let n = stream
             .read(&mut buf)
@@ -117,10 +333,16 @@ pub async fn download_gridfs_file_impl(
         file.write_all(&buf[..n])
             .await
             .map_err(|e| format!("Failed to write file: {}", e))?;
-        total += n as u64;
+        transferred += n as u64;
+        if let Some(cb) = on_progress {
+            cb(GridFsTransferProgress {
+                transferred,
+                total,
+            });
+        }
     }
     file.flush()
         .await
         .map_err(|e| format!("Failed to flush file: {}", e))?;
-    Ok(total)
+    Ok(transferred)
 }

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -12,12 +12,13 @@ mod integration {
     use crate::{
         analyze_schema_impl, connect_db_impl, count_documents_impl, create_collection_impl,
         create_index_impl, create_view_impl, delete_document_impl, delete_index_impl,
-        delete_many_impl, disconnect_db_impl, download_gridfs_file_impl, drop_collection_impl,
-        drop_database_impl, execute_aggregate_impl, execute_mql_query_impl,
+        delete_many_impl, delete_gridfs_file_impl, disconnect_db_impl, download_gridfs_file_impl,
+        drop_collection_impl, drop_database_impl, execute_aggregate_impl, execute_mql_query_impl,
         explain_aggregate_query_impl, explain_mql_query_impl, get_mongodb_version_impl,
         import_documents_impl, insert_document_impl, list_collections_impl, list_databases_impl,
         list_gridfs_files_impl, list_indexes_impl, rename_collection_impl, rename_database_impl,
-        start_collection_export_impl, update_document_impl, update_many_impl, AppState,
+        start_collection_export_impl, update_document_impl, update_many_impl,
+        upload_gridfs_file_impl, AppState,
     };
     use mongodb::bson::{doc, Document};
 
@@ -569,22 +570,31 @@ mod integration {
     }
 
     #[tokio::test]
-    async fn it_gridfs_list_and_download_real() {
+    async fn it_gridfs_list_upload_download_and_delete_real() {
         use futures::AsyncWriteExt;
         let Some((state, id, db)) = connect().await else {
             return;
         };
 
-        // Upload a file into the "uploads" GridFS bucket via the driver.
-        let bucket = client_of(&state, &id).database(&db).gridfs_bucket(
-            mongodb::options::GridFsBucketOptions::builder()
-                .bucket_name("uploads".to_string())
-                .build(),
-        );
+        let src = std::env::temp_dir().join(format!("mqlens-it-gridfs-src-{}.txt", uuid::Uuid::new_v4().simple()));
         let payload = b"hello gridfs integration".to_vec();
-        let mut upload = bucket.open_upload_stream("greeting.txt").await.unwrap();
-        upload.write_all(&payload).await.unwrap();
-        upload.close().await.unwrap();
+        std::fs::write(&src, &payload).expect("write temp upload source");
+        let src_str = src.to_string_lossy().to_string();
+
+        let uploaded_id = upload_gridfs_file_impl(
+            &state,
+            &id,
+            &db,
+            "uploads",
+            &src_str,
+            Some("greeting.txt"),
+            Some(r#"{"source":"integration-test"}"#),
+            None,
+            None,
+        )
+        .await
+        .expect("upload gridfs");
+        assert!(!uploaded_id.is_empty());
 
         // list_gridfs_files_impl returns JSON of files; find ours.
         let listed = list_gridfs_files_impl(&state, &id, &db, "uploads")
@@ -597,8 +607,7 @@ mod integration {
             .find(|f| f["filename"] == "greeting.txt")
             .expect("uploaded file listed");
         assert_eq!(entry["length"].as_u64().unwrap(), payload.len() as u64);
-        // `id` is already the file _id rendered as extended JSON (e.g. {"$oid":"..."}),
-        // which is exactly what download_gridfs_file_impl expects — pass it through as-is.
+        assert_eq!(entry["content_type"].as_str(), Some("text/plain"));
         let file_id_json = entry["id"].as_str().expect("gridfs id is a json string").to_string();
 
         // Download it back to disk and verify the bytes.
@@ -611,6 +620,8 @@ mod integration {
             "uploads",
             &file_id_json,
             &dest_str,
+            Some(payload.len() as u64),
+            None,
         )
         .await
         .unwrap_or_else(|e| panic!("download gridfs (id={file_id_json}): {e}"));
@@ -619,6 +630,23 @@ mod integration {
         assert_eq!(got, payload);
         let _ = std::fs::remove_file(&dest);
 
+        delete_gridfs_file_impl(&state, &id, &db, "uploads", &file_id_json)
+            .await
+            .expect("delete gridfs");
+        let listed_after = list_gridfs_files_impl(&state, &id, &db, "uploads")
+            .await
+            .expect("list after delete");
+        let after: serde_json::Value = serde_json::from_str(&listed_after).unwrap();
+        assert!(
+            !after
+                .as_array()
+                .expect("files array")
+                .iter()
+                .any(|f| f["filename"] == "greeting.txt"),
+            "deleted file should no longer be listed"
+        );
+
+        let _ = std::fs::remove_file(&src);
         cleanup(&state, &id, &db).await;
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,7 +33,10 @@ pub use db::documents::{
     json_to_bson_document, update_document_impl, update_many_impl, ImportResult,
 };
 pub use db::export::start_collection_export_impl;
-pub use db::gridfs::{download_gridfs_file_impl, list_gridfs_files_impl, GridFsFileInfo};
+pub use db::gridfs::{
+    delete_gridfs_file_impl, download_gridfs_file_impl, list_gridfs_files_impl,
+    upload_gridfs_file_impl, GridFsFileInfo, GridFsTransferProgress,
+};
 pub use db::metadata::{
     create_index_impl, delete_index_impl, list_collections_impl, list_databases_impl,
     list_indexes_impl,
@@ -1129,8 +1132,63 @@ async fn download_gridfs_file(
     bucket: String,
     file_id: String,
     dest_path: String,
+    total_bytes: Option<u64>,
+    on_progress: tauri::ipc::Channel<GridFsTransferProgress>,
 ) -> Result<u64, String> {
-    download_gridfs_file_impl(&state, &id, &database, &bucket, &file_id, &dest_path).await
+    let emit = |update: GridFsTransferProgress| {
+        let _ = on_progress.send(update);
+    };
+    download_gridfs_file_impl(
+        &state,
+        &id,
+        &database,
+        &bucket,
+        &file_id,
+        &dest_path,
+        total_bytes,
+        Some(&emit),
+    )
+    .await
+}
+
+#[tauri::command]
+async fn upload_gridfs_file(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+    bucket: String,
+    source_path: String,
+    filename: Option<String>,
+    metadata_json: Option<String>,
+    content_type: Option<String>,
+    on_progress: tauri::ipc::Channel<GridFsTransferProgress>,
+) -> Result<String, String> {
+    let emit = |update: GridFsTransferProgress| {
+        let _ = on_progress.send(update);
+    };
+    upload_gridfs_file_impl(
+        &state,
+        &id,
+        &database,
+        &bucket,
+        &source_path,
+        filename.as_deref(),
+        metadata_json.as_deref(),
+        content_type.as_deref(),
+        Some(&emit),
+    )
+    .await
+}
+
+#[tauri::command]
+async fn delete_gridfs_file(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+    bucket: String,
+    file_id: String,
+) -> Result<(), String> {
+    delete_gridfs_file_impl(&state, &id, &database, &bucket, &file_id).await
 }
 
 #[tauri::command]
@@ -1410,6 +1468,8 @@ pub fn run() {
             update_many,
             list_gridfs_files,
             download_gridfs_file,
+            upload_gridfs_file,
+            delete_gridfs_file,
             insert_document,
             import_documents,
             update_document,

--- a/src-tauri/src/limits.rs
+++ b/src-tauri/src/limits.rs
@@ -14,6 +14,8 @@ pub const MAX_IMPORT_DOCS: usize = 10_000;
 pub const GRIDFS_STREAM_BUF: usize = 64 * 1024;
 /// Maximum GridFS file metadata entries listed at once.
 pub const MAX_GRIDFS_LIST: i64 = 500;
+/// Maximum single-file GridFS upload size (streamed; not loaded whole-file into RAM).
+pub const MAX_GRIDFS_UPLOAD_BYTES: u64 = 512 * 1024 * 1024;
 /// Maximum documents sampled for schema inference.
 pub const MAX_SCHEMA_SAMPLE: i64 = 1_000;
 /// Mongosh output caps per command.

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3,11 +3,13 @@ mod tests {
     use crate::AppState;
     use crate::{
         connect_db_impl, count_documents_impl, create_collection_impl, create_index_impl,
-        delete_document_impl, disconnect_db_impl, download_gridfs_file_impl, drop_collection_impl,
+        delete_document_impl, delete_gridfs_file_impl, disconnect_db_impl,
+        download_gridfs_file_impl, drop_collection_impl,
         drop_database_impl, execute_aggregate_impl, execute_mql_query_impl, explain_mql_query_impl,
         import_documents_impl, insert_document_impl, json_to_bson_document, list_collections_impl,
         list_databases_impl, list_gridfs_files_impl, list_indexes_impl, rename_collection_impl,
         rename_database_impl, start_collection_export_impl, update_document_impl,
+        upload_gridfs_file_impl,
     };
     use crate::{
         create_user_impl, drop_user_impl, list_roles_impl, list_users_impl, update_user_impl,
@@ -928,11 +930,43 @@ mod tests {
             "uploads",
             r#"{"$oid":"507f1f77bcf86cd799439011"}"#,
             "/tmp/out.bin",
+            None,
+            None,
         )
         .await;
         assert!(
             dl.unwrap_err().contains("not supported on mock"),
             "GridFS download on a mock connection should be rejected"
+        );
+
+        let up = upload_gridfs_file_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "uploads",
+            "/tmp/in.bin",
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(
+            up.unwrap_err().contains("not supported on mock"),
+            "GridFS upload on a mock connection should be rejected"
+        );
+
+        let del = delete_gridfs_file_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "uploads",
+            r#"{"$oid":"507f1f77bcf86cd799439011"}"#,
+        )
+        .await;
+        assert!(
+            del.unwrap_err().contains("not supported on mock"),
+            "GridFS delete on a mock connection should be rejected"
         );
     }
 
@@ -942,10 +976,30 @@ mod tests {
         let id = "realish-gridfs";
         state.mocks.lock().unwrap().insert(id.to_string(), false);
 
-        let bad_id = download_gridfs_file_impl(&state, id, "db", "fs", "{", "/tmp/file.bin")
+        let bad_id = download_gridfs_file_impl(&state, id, "db", "fs", "{", "/tmp/file.bin", None, None)
             .await
             .unwrap_err();
         assert!(bad_id.contains("Invalid file id JSON"));
+
+        let bad_upload_meta = upload_gridfs_file_impl(
+            &state,
+            id,
+            "db",
+            "fs",
+            "/tmp/missing.bin",
+            None,
+            Some("{"),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(bad_upload_meta.contains("Invalid metadata JSON"));
+
+        let bad_delete = delete_gridfs_file_impl(&state, id, "db", "fs", "{")
+            .await
+            .unwrap_err();
+        assert!(bad_delete.contains("Invalid file id JSON"));
 
         let missing_client = list_gridfs_files_impl(&state, id, "db", "fs")
             .await

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1703,6 +1703,7 @@ function Workspace() {
                   connectionId={activeTab.connectionId}
                   databaseName={activeTab.db}
                   bucket={activeTab.collection}
+                  onNamespaceMutated={() => setCollectionMutationTrigger((prev) => prev + 1)}
                 />
               )}
               {activeTab && activeTab.type === 'monitoring' && (

--- a/src/components/GridFsView.tsx
+++ b/src/components/GridFsView.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { invoke } from '@tauri-apps/api/core';
-import { save } from '@tauri-apps/plugin-dialog';
-import { HardDrive, Loader2, AlertCircle, Download } from 'lucide-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { invoke, Channel } from '@tauri-apps/api/core';
+import { open, save } from '@tauri-apps/plugin-dialog';
+import { HardDrive, Loader2, AlertCircle, Download, Upload, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { formatBytes } from '../lib/format';
+import { gridfsMetadataForUpload, validateGridfsMetadataJson } from '../lib/gridfsUpload';
 import { useDialogs } from './dialogs/DialogProvider';
 
 interface GridFsFile {
@@ -16,56 +17,236 @@ interface GridFsFile {
   content_type?: string | null;
 }
 
+interface GridFsTransferProgress {
+  transferred: number;
+  total: number;
+}
+
 interface GridFsViewProps {
   connectionId: string;
   databaseName: string;
   bucket: string;
+  onNamespaceMutated?: () => void;
 }
 
-export const GridFsView: React.FC<GridFsViewProps> = ({ connectionId, databaseName, bucket }) => {
-  const { toast } = useDialogs();
+type TransferState = {
+  kind: 'upload' | 'download';
+  label: string;
+  transferred: number;
+  total: number;
+} | null;
+
+function basename(path: string): string {
+  const parts = path.split(/[/\\]/);
+  return parts[parts.length - 1] || path;
+}
+
+export const GridFsView: React.FC<GridFsViewProps> = ({
+  connectionId,
+  databaseName,
+  bucket,
+  onNamespaceMutated = () => {},
+}) => {
+  const { toast, confirm, prompt, choose } = useDialogs();
   const [files, setFiles] = useState<GridFsFile[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [transfer, setTransfer] = useState<TransferState>(null);
+  const [dragActive, setDragActive] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadFiles = useCallback(async () => {
     setLoading(true);
     setError(null);
-    (async () => {
+    try {
+      const json = await invoke<string>('list_gridfs_files', {
+        id: connectionId,
+        database: databaseName,
+        bucket,
+      });
+      setFiles(JSON.parse(json) as GridFsFile[]);
+    } catch (err: any) {
+      setError(String(err?.message || err));
+    } finally {
+      setLoading(false);
+    }
+  }, [connectionId, databaseName, bucket]);
+
+  useEffect(() => {
+    void loadFiles();
+  }, [loadFiles]);
+
+  const makeProgressChannel = (kind: 'upload' | 'download', label: string) => {
+    const channel = new Channel<GridFsTransferProgress>();
+    channel.onmessage = (update) => {
+      setTransfer({
+        kind,
+        label,
+        transferred: update.transferred,
+        total: update.total,
+      });
+    };
+    return channel;
+  };
+
+  const resolveUploadMetadata = async (batchLabel: string): Promise<string | null> => {
+    const choice = await choose({
+      title: 'GridFS metadata',
+      message: `${batchLabel}: add optional metadata?`,
+      choices: [
+        { value: 'skip', label: 'Skip metadata' },
+        { value: 'add', label: 'Add metadata JSON' },
+      ],
+    });
+    if (choice !== 'add') return null;
+
+    const raw = await prompt({
+      title: 'GridFS metadata',
+      message: 'Metadata JSON object (stored on the file document):',
+      defaultValue: '{\n  \n}',
+      multiline: true,
+      validate: validateGridfsMetadataJson,
+    });
+    if (raw === null) return null;
+    return gridfsMetadataForUpload(raw);
+  };
+
+  const resolveUploadFilename = async (
+    sourcePath: string,
+    index: number,
+    total: number,
+  ): Promise<string | null> => {
+    const defaultName = basename(sourcePath);
+    const title = total > 1 ? `Upload file ${index + 1} of ${total}` : 'Upload to GridFS';
+    const message =
+      total > 1
+        ? `Filename in the bucket for ${defaultName}:`
+        : 'Filename in the bucket:';
+    return prompt({
+      title,
+      message,
+      defaultValue: defaultName,
+      validate: (v) => (v.trim() ? null : 'Filename is required'),
+    });
+  };
+
+  const uploadPaths = async (paths: string[]) => {
+    if (paths.length === 0 || transfer) return;
+
+    const planned: { sourcePath: string; filename: string }[] = [];
+    for (let i = 0; i < paths.length; i += 1) {
+      const sourcePath = paths[i];
+      const filename = await resolveUploadFilename(sourcePath, i, paths.length);
+      if (!filename?.trim()) return;
+      planned.push({ sourcePath, filename: filename.trim() });
+    }
+
+    const metadataJson = await resolveUploadMetadata(
+      paths.length > 1 ? 'These files' : 'This file',
+    );
+
+    let uploadedAny = false;
+    for (const { sourcePath, filename } of planned) {
+      const channel = makeProgressChannel('upload', filename);
       try {
-        const json = await invoke<string>('list_gridfs_files', {
+        await invoke('upload_gridfs_file', {
           id: connectionId,
           database: databaseName,
           bucket,
+          sourcePath,
+          filename,
+          metadataJson,
+          contentType: null,
+          onProgress: channel,
         });
-        if (cancelled) return;
-        setFiles(JSON.parse(json) as GridFsFile[]);
+        uploadedAny = true;
+        toast(`Uploaded ${filename}`, 'success');
       } catch (err: any) {
-        if (!cancelled) setError(String(err?.message || err));
+        toast(`Upload failed: ${err?.message || err}`, 'error');
+        break;
       } finally {
-        if (!cancelled) setLoading(false);
+        setTransfer(null);
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [connectionId, databaseName, bucket]);
+    }
+    await loadFiles();
+    if (uploadedAny) {
+      onNamespaceMutated();
+    }
+  };
+
+  const handleUploadClick = async () => {
+    try {
+      const selected = await open({ multiple: true });
+      if (!selected) return;
+      const paths = Array.isArray(selected) ? selected : [selected];
+      await uploadPaths(paths.filter((p): p is string => typeof p === 'string'));
+    } catch (err: any) {
+      toast(`Upload failed: ${err?.message || err}`, 'error');
+    }
+  };
+
+  const handleDrop = async (event: React.DragEvent) => {
+    event.preventDefault();
+    setDragActive(false);
+    const paths = Array.from(event.dataTransfer.files)
+      .map((f) => (f as File & { path?: string }).path)
+      .filter((p): p is string => typeof p === 'string' && p.length > 0);
+    if (paths.length === 0) {
+      toast('Drag-and-drop is available in the desktop app.', 'error');
+      return;
+    }
+    await uploadPaths(paths);
+  };
 
   const handleDownload = async (file: GridFsFile) => {
+    if (transfer) return;
     try {
       const destPath = await save({ defaultPath: file.filename });
       if (!destPath) return;
-      await invoke('download_gridfs_file', {
+      const channel = makeProgressChannel('download', file.filename);
+      try {
+        await invoke('download_gridfs_file', {
+          id: connectionId,
+          database: databaseName,
+          bucket,
+          fileId: file.id,
+          destPath,
+          totalBytes: file.length,
+          onProgress: channel,
+        });
+        toast(`Downloaded ${file.filename}`, 'success');
+      } finally {
+        setTransfer(null);
+      }
+    } catch (err: any) {
+      toast(`Download failed: ${err?.message || err}`, 'error');
+      setTransfer(null);
+    }
+  };
+
+  const handleDelete = async (file: GridFsFile) => {
+    if (transfer) return;
+    if (
+      !(await confirm({
+        title: 'Delete GridFS file',
+        message: `Delete "${file.filename}" from ${databaseName}.${bucket}? This cannot be undone.`,
+        confirmLabel: 'Delete',
+        destructive: true,
+      }))
+    ) {
+      return;
+    }
+    try {
+      await invoke('delete_gridfs_file', {
         id: connectionId,
         database: databaseName,
         bucket,
         fileId: file.id,
-        destPath,
       });
-      toast(`Downloaded ${file.filename}`, 'success');
+      toast(`Deleted ${file.filename}`, 'success');
+      await loadFiles();
+      onNamespaceMutated();
     } catch (err: any) {
-      toast(`Download failed: ${err?.message || err}`, 'error');
+      toast(`Delete failed: ${err?.message || err}`, 'error');
     }
   };
 
@@ -89,8 +270,29 @@ export const GridFsView: React.FC<GridFsViewProps> = ({ connectionId, databaseNa
     );
   }
 
+  const transferPct =
+    transfer && transfer.total > 0
+      ? Math.min(100, Math.round((transfer.transferred / transfer.total) * 100))
+      : null;
+
   return (
-    <div className="flex h-full flex-col overflow-hidden" data-testid="gridfs-view">
+    <div
+      className="relative flex h-full flex-col overflow-hidden"
+      data-testid="gridfs-view"
+      onDragEnter={(e) => {
+        e.preventDefault();
+        setDragActive(true);
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragActive(true);
+      }}
+      onDragLeave={(e) => {
+        e.preventDefault();
+        if (e.currentTarget === e.target) setDragActive(false);
+      }}
+      onDrop={handleDrop}
+    >
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
           <HardDrive size={14} className="text-success" />
@@ -98,16 +300,76 @@ export const GridFsView: React.FC<GridFsViewProps> = ({ connectionId, databaseNa
             GridFS: {databaseName}.{bucket}
           </span>
         </div>
-        <span className="font-mono text-[11px] text-muted-foreground">{files.length} file(s)</span>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] text-muted-foreground">{files.length} file(s)</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 text-[11px]"
+            data-testid="gridfs-upload-btn"
+            disabled={!!transfer}
+            onClick={() => void handleUploadClick()}
+          >
+            <Upload size={12} />
+            Upload
+          </Button>
+        </div>
       </div>
 
+      {transfer && (
+        <div className="border-b border-border bg-muted/30 px-4 py-2" data-testid="gridfs-transfer-progress">
+          <div className="mb-1 flex items-center justify-between text-[11px] text-muted-foreground">
+            <span>
+              {transfer.kind === 'upload' ? 'Uploading' : 'Downloading'} {transfer.label}
+            </span>
+            <span className="font-mono tabular-nums">
+              {formatBytes(transfer.transferred)}
+              {transfer.total > 0 ? ` / ${formatBytes(transfer.total)}` : ''}
+              {transferPct !== null ? ` (${transferPct}%)` : ''}
+            </span>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full bg-primary transition-[width] duration-150 ease-out"
+              style={{ width: `${transferPct ?? (transfer.transferred > 0 ? 8 : 0)}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {dragActive && (
+        <div
+          className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/70 backdrop-blur-[1px]"
+          data-testid="gridfs-drop-overlay"
+        >
+          <div className="rounded-md border border-dashed border-primary px-6 py-4 text-sm text-primary">
+            Drop files to upload
+          </div>
+        </div>
+      )}
+
       {files.length === 0 ? (
-        <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+        <div
+          className="flex h-full flex-col items-center justify-center gap-3 p-6 text-sm text-muted-foreground"
+          data-testid="gridfs-empty-state"
+        >
           <HardDrive size={20} />
-          No files in this bucket.
+          <span>No files in this bucket.</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8"
+            disabled={!!transfer}
+            onClick={() => void handleUploadClick()}
+          >
+            <Upload size={12} />
+            Upload files
+          </Button>
         </div>
       ) : (
-        <ScrollArea className="flex-1">
+        <ScrollArea className="relative flex-1">
           <table className="w-full border-collapse text-xs">
             <thead className="sticky top-0 bg-muted/80 backdrop-blur-sm">
               <tr className="text-left text-muted-foreground">
@@ -123,6 +385,10 @@ export const GridFsView: React.FC<GridFsViewProps> = ({ connectionId, databaseNa
                 <tr
                   key={file.id}
                   className="border-t border-border hover:bg-accent/50"
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    void handleDelete(file);
+                  }}
                 >
                   <td className="px-4 py-1.5 font-mono text-foreground">{file.filename}</td>
                   <td className="px-4 py-1.5 tabular-nums">{formatBytes(file.length)}</td>
@@ -133,17 +399,32 @@ export const GridFsView: React.FC<GridFsViewProps> = ({ connectionId, databaseNa
                     {formatBytes(file.chunk_size_bytes)}
                   </td>
                   <td className="px-4 py-1.5">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-7 text-[11px]"
-                      data-testid="gridfs-download-btn"
-                      onClick={() => handleDownload(file)}
-                    >
-                      <Download size={12} />
-                      Download
-                    </Button>
+                    <div className="flex items-center gap-1.5">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-[11px]"
+                        data-testid="gridfs-download-btn"
+                        disabled={!!transfer}
+                        onClick={() => void handleDownload(file)}
+                      >
+                        <Download size={12} />
+                        Download
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-[11px] text-destructive hover:text-destructive"
+                        data-testid="gridfs-delete-btn"
+                        disabled={!!transfer}
+                        onClick={() => void handleDelete(file)}
+                      >
+                        <Trash2 size={12} />
+                        Delete
+                      </Button>
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/src/components/GridFsView.tsx
+++ b/src/components/GridFsView.tsx
@@ -52,7 +52,6 @@ export const GridFsView: React.FC<GridFsViewProps> = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [transfer, setTransfer] = useState<TransferState>(null);
-  const [dragActive, setDragActive] = useState(false);
 
   const loadFiles = useCallback(async () => {
     setLoading(true);
@@ -145,6 +144,7 @@ export const GridFsView: React.FC<GridFsViewProps> = ({
     );
 
     let uploadedAny = false;
+    const failed: string[] = [];
     for (const { sourcePath, filename } of planned) {
       const channel = makeProgressChannel('upload', filename);
       try {
@@ -161,11 +161,16 @@ export const GridFsView: React.FC<GridFsViewProps> = ({
         uploadedAny = true;
         toast(`Uploaded ${filename}`, 'success');
       } catch (err: any) {
-        toast(`Upload failed: ${err?.message || err}`, 'error');
-        break;
+        // Don't abort the batch — keep uploading the remaining files and
+        // report which ones failed at the end.
+        failed.push(filename);
+        toast(`Upload failed for ${filename}: ${err?.message || err}`, 'error');
       } finally {
         setTransfer(null);
       }
+    }
+    if (failed.length > 1) {
+      toast(`${failed.length} files failed to upload.`, 'error');
     }
     await loadFiles();
     if (uploadedAny) {
@@ -182,19 +187,6 @@ export const GridFsView: React.FC<GridFsViewProps> = ({
     } catch (err: any) {
       toast(`Upload failed: ${err?.message || err}`, 'error');
     }
-  };
-
-  const handleDrop = async (event: React.DragEvent) => {
-    event.preventDefault();
-    setDragActive(false);
-    const paths = Array.from(event.dataTransfer.files)
-      .map((f) => (f as File & { path?: string }).path)
-      .filter((p): p is string => typeof p === 'string' && p.length > 0);
-    if (paths.length === 0) {
-      toast('Drag-and-drop is available in the desktop app.', 'error');
-      return;
-    }
-    await uploadPaths(paths);
   };
 
   const handleDownload = async (file: GridFsFile) => {
@@ -276,23 +268,7 @@ export const GridFsView: React.FC<GridFsViewProps> = ({
       : null;
 
   return (
-    <div
-      className="relative flex h-full flex-col overflow-hidden"
-      data-testid="gridfs-view"
-      onDragEnter={(e) => {
-        e.preventDefault();
-        setDragActive(true);
-      }}
-      onDragOver={(e) => {
-        e.preventDefault();
-        setDragActive(true);
-      }}
-      onDragLeave={(e) => {
-        e.preventDefault();
-        if (e.currentTarget === e.target) setDragActive(false);
-      }}
-      onDrop={handleDrop}
-    >
+    <div className="relative flex h-full flex-col overflow-hidden" data-testid="gridfs-view">
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
           <HardDrive size={14} className="text-success" />
@@ -338,17 +314,6 @@ export const GridFsView: React.FC<GridFsViewProps> = ({
         </div>
       )}
 
-      {dragActive && (
-        <div
-          className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/70 backdrop-blur-[1px]"
-          data-testid="gridfs-drop-overlay"
-        >
-          <div className="rounded-md border border-dashed border-primary px-6 py-4 text-sm text-primary">
-            Drop files to upload
-          </div>
-        </div>
-      )}
-
       {files.length === 0 ? (
         <div
           className="flex h-full flex-col items-center justify-center gap-3 p-6 text-sm text-muted-foreground"
@@ -385,10 +350,6 @@ export const GridFsView: React.FC<GridFsViewProps> = ({
                 <tr
                   key={file.id}
                   className="border-t border-border hover:bg-accent/50"
-                  onContextMenu={(e) => {
-                    e.preventDefault();
-                    void handleDelete(file);
-                  }}
                 >
                   <td className="px-4 py-1.5 font-mono text-foreground">{file.filename}</td>
                   <td className="px-4 py-1.5 tabular-nums">{formatBytes(file.length)}</td>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -114,6 +114,17 @@ export interface IndexInfo {
 const compareCollectionNames = (a: string, b: string) =>
   a.localeCompare(b, undefined, { sensitivity: 'base', numeric: true });
 
+const validateGridfsBucketName = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return 'Bucket name is required';
+  if (trimmed.includes('.')) return 'Bucket name cannot contain "."';
+  if (trimmed.startsWith('system')) return 'Bucket name cannot start with "system"';
+  if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+    return 'Use letters, numbers, underscore, or hyphen only';
+  }
+  return null;
+};
+
 interface ConnectionProfile {
   id: string;
   name: string;
@@ -719,6 +730,18 @@ export const Sidebar: React.FC<SidebarProps> = ({
     } catch (err) {
       toast(`Failed to create collection: ${err}`, 'error');
     }
+  };
+
+  const handleOpenGridfsBucket = async (connectionId: string, dbName: string) => {
+    const name = await prompt({
+      title: 'Open GridFS bucket',
+      message: 'Bucket name (collections are created on first upload):',
+      defaultValue: 'fs',
+      placeholder: 'fs',
+      validate: validateGridfsBucketName,
+    });
+    if (!name) return;
+    onOpenGridfs?.(connectionId, dbName, name.trim());
   };
 
   const handleDropCollection = async (connectionId: string, dbName: string, collName: string) => {
@@ -1487,6 +1510,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
                             </ContextMenuItem>
                             <ContextMenuItem
                               className={ctxItemClass}
+                              data-testid={`ctx-add-gridfs-bucket-${conn.id}-${dbName}`}
+                              onClick={() => void handleOpenGridfsBucket(conn.id, dbName)}
+                            >
+                              <Archive />
+                              <span>Open GridFS Bucket</span>
+                            </ContextMenuItem>
+                            <ContextMenuItem
+                              className={ctxItemClass}
                               onClick={() => onOpenShell?.(conn.id, dbName, undefined, 'show collections')}
                             >
                               <Terminal />
@@ -1571,6 +1602,20 @@ export const Sidebar: React.FC<SidebarProps> = ({
                               <Badge variant="secondary" className="h-4 px-1 text-[9px] font-normal" data-testid="gridfs-count">
                                 ({gridfsBuckets.length})
                               </Badge>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                className="ml-auto h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
+                                data-testid={`gridfs-new-bucket-${conn.id}-${dbName}`}
+                                title="Open GridFS bucket"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  void handleOpenGridfsBucket(conn.id, dbName);
+                                }}
+                              >
+                                <Plus size={11} />
+                              </Button>
                             </div>
                             {isGridfsExpanded && (
                               <div className="ml-3 border-l border-border/50 pl-1">
@@ -1586,9 +1631,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                     </span>
                                   </div>
                                 ))}
-                                {gridfsBuckets.length === 0 && (
-                                  <div className="py-0.5 pl-6 text-[10px] italic text-muted-foreground">Empty</div>
-                                )}
+                                <div
+                                  className={cn(treeRowClass(), 'text-[10px] text-primary')}
+                                  data-testid={`gridfs-open-bucket-${conn.id}-${dbName}`}
+                                  onClick={() => void handleOpenGridfsBucket(conn.id, dbName)}
+                                >
+                                  <Plus size={11} className="ml-3.5 shrink-0" />
+                                  <span>New bucket…</span>
+                                </div>
                               </div>
                             )}
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1514,7 +1514,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                               onClick={() => void handleOpenGridfsBucket(conn.id, dbName)}
                             >
                               <Archive />
-                              <span>Open GridFS Bucket</span>
+                              <span>New Bucket</span>
                             </ContextMenuItem>
                             <ContextMenuItem
                               className={ctxItemClass}
@@ -1552,115 +1552,193 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
                         {isDbExpanded && (
                           <div className="ml-3 border-l border-border/50 pl-1">
-                            <div className={treeRowClass()} onClick={() => toggleCollectionsFolder(conn.id, dbName)}>
-                              <ChevronRight
-                                size={10}
-                                className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isFolderExpanded && 'rotate-90')}
-                              />
-                              <Folder size={11} className="shrink-0 text-amber-500" />
-                              <span className="text-muted-foreground">Collections</span>
-                              <Badge variant="secondary" className="h-4 px-1 text-[9px] font-normal" data-testid="collections-count">
-                                ({regularColls.length})
-                              </Badge>
-                            </div>
-                            {isFolderExpanded && (
-                              <div className="ml-3 border-l border-border/50 pl-1">
-                                {regularColls.map((collName) => renderCollectionNode(conn.id, dbName, collName))}
-                                {regularColls.length === 0 && (
-                                  <div className="py-0.5 pl-6 text-[10px] italic text-muted-foreground">Empty</div>
-                                )}
-                              </div>
-                            )}
-
-                            <div className={treeRowClass()} onClick={() => toggleVirtualFolder(`${dbKey}/views`)}>
-                              <ChevronRight
-                                size={10}
-                                className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isViewsExpanded && 'rotate-90')}
-                              />
-                              <Eye size={11} className="shrink-0 text-amber-500" />
-                              <span className="text-muted-foreground">Views</span>
-                              <Badge variant="secondary" className="h-4 px-1 text-[9px] font-normal" data-testid="views-count">
-                                ({views.length})
-                              </Badge>
-                            </div>
-                            {isViewsExpanded && (
-                              <div className="ml-3 border-l border-border/50 pl-1">
-                                {views.map((viewName) => renderCollectionNode(conn.id, dbName, viewName))}
-                                {views.length === 0 && (
-                                  <div className="py-0.5 pl-6 text-[10px] italic text-muted-foreground">Empty</div>
-                                )}
-                              </div>
-                            )}
-
-                            <div className={treeRowClass()} onClick={() => toggleVirtualFolder(`${dbKey}/gridfs`)}>
-                              <ChevronRight
-                                size={10}
-                                className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isGridfsExpanded && 'rotate-90')}
-                              />
-                              <Archive size={11} className="shrink-0 text-amber-500" />
-                              <span className="text-muted-foreground">GridFS Buckets</span>
-                              <Badge variant="secondary" className="h-4 px-1 text-[9px] font-normal" data-testid="gridfs-count">
-                                ({gridfsBuckets.length})
-                              </Badge>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="ml-auto h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
-                                data-testid={`gridfs-new-bucket-${conn.id}-${dbName}`}
-                                title="Open GridFS bucket"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  void handleOpenGridfsBucket(conn.id, dbName);
-                                }}
-                              >
-                                <Plus size={11} />
-                              </Button>
-                            </div>
-                            {isGridfsExpanded && (
-                              <div className="ml-3 border-l border-border/50 pl-1">
-                                {gridfsBuckets.map((bucket) => (
-                                  <div
-                                    key={bucket}
-                                    className={treeRowClass()}
-                                    onClick={() => onOpenGridfs?.(conn.id, dbName, bucket)}
-                                  >
-                                    <Archive size={11} className="ml-3.5 shrink-0 text-emerald-500" />
-                                    <span className="min-w-0 truncate" title={bucket}>
-                                      {bucket}
-                                    </span>
+                            <ContextMenu>
+                              <ContextMenuTrigger asChild>
+                                <div>
+                                  <div className={treeRowClass()} onClick={() => toggleCollectionsFolder(conn.id, dbName)}>
+                                    <ChevronRight
+                                      size={10}
+                                      className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isFolderExpanded && 'rotate-90')}
+                                    />
+                                    <Folder size={11} className="shrink-0 text-amber-500" />
+                                    <span className="text-muted-foreground">Collections</span>
+                                    <Badge variant="secondary" className="h-4 px-1 text-[9px] font-normal" data-testid="collections-count">
+                                      ({regularColls.length})
+                                    </Badge>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="icon"
+                                      className="ml-auto h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
+                                      data-testid={`collections-new-${conn.id}-${dbName}`}
+                                      title="New collection"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        void handleAddCollection(conn.id, dbName);
+                                      }}
+                                    >
+                                      <Plus size={11} />
+                                    </Button>
                                   </div>
-                                ))}
-                                <div
-                                  className={cn(treeRowClass(), 'text-[10px] text-primary')}
-                                  data-testid={`gridfs-open-bucket-${conn.id}-${dbName}`}
+                                  {isFolderExpanded && (
+                                    <div className="ml-3 border-l border-border/50 pl-1">
+                                      {regularColls.map((collName) => renderCollectionNode(conn.id, dbName, collName))}
+                                      {regularColls.length === 0 && (
+                                        <div className="py-0.5 pl-6 text-[10px] italic text-muted-foreground">Empty</div>
+                                      )}
+                                    </div>
+                                  )}
+                                </div>
+                              </ContextMenuTrigger>
+                              <ContextMenuContent>
+                                <ContextMenuItem
+                                  className={ctxItemClass}
+                                  data-testid={`ctx-collections-new-${conn.id}-${dbName}`}
+                                  onClick={() => void handleAddCollection(conn.id, dbName)}
+                                >
+                                  <Plus />
+                                  <span>New Collection</span>
+                                </ContextMenuItem>
+                              </ContextMenuContent>
+                            </ContextMenu>
+
+                            <ContextMenu>
+                              <ContextMenuTrigger asChild>
+                                <div>
+                                  <div className={treeRowClass()} onClick={() => toggleVirtualFolder(`${dbKey}/views`)}>
+                                    <ChevronRight
+                                      size={10}
+                                      className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isViewsExpanded && 'rotate-90')}
+                                    />
+                                    <Eye size={11} className="shrink-0 text-amber-500" />
+                                    <span className="text-muted-foreground">Views</span>
+                                    <Badge variant="secondary" className="h-4 px-1 text-[9px] font-normal" data-testid="views-count">
+                                      ({views.length})
+                                    </Badge>
+                                  </div>
+                                  {isViewsExpanded && (
+                                    <div className="ml-3 border-l border-border/50 pl-1">
+                                      {views.map((viewName) => renderCollectionNode(conn.id, dbName, viewName))}
+                                      {views.length === 0 && (
+                                        <div className="py-0.5 pl-6 text-[10px] italic text-muted-foreground">Empty</div>
+                                      )}
+                                    </div>
+                                  )}
+                                </div>
+                              </ContextMenuTrigger>
+                              <ContextMenuContent>
+                                <ContextMenuItem
+                                  className={ctxItemClass}
+                                  data-testid={`ctx-views-create-${conn.id}-${dbName}`}
+                                  onClick={() => onCreateView?.(conn.id, dbName)}
+                                >
+                                  <Eye />
+                                  <span>Create View</span>
+                                </ContextMenuItem>
+                              </ContextMenuContent>
+                            </ContextMenu>
+
+                            <ContextMenu>
+                              <ContextMenuTrigger asChild>
+                                <div>
+                                  <div className={treeRowClass()} onClick={() => toggleVirtualFolder(`${dbKey}/gridfs`)}>
+                                    <ChevronRight
+                                      size={10}
+                                      className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isGridfsExpanded && 'rotate-90')}
+                                    />
+                                    <Archive size={11} className="shrink-0 text-amber-500" />
+                                    <span className="text-muted-foreground">GridFS Buckets</span>
+                                    <Badge variant="secondary" className="h-4 px-1 text-[9px] font-normal" data-testid="gridfs-count">
+                                      ({gridfsBuckets.length})
+                                    </Badge>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="icon"
+                                      className="ml-auto h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
+                                      data-testid={`gridfs-new-bucket-${conn.id}-${dbName}`}
+                                      title="New bucket"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        void handleOpenGridfsBucket(conn.id, dbName);
+                                      }}
+                                    >
+                                      <Plus size={11} />
+                                    </Button>
+                                  </div>
+                                  {isGridfsExpanded && (
+                                    <div className="ml-3 border-l border-border/50 pl-1">
+                                      {gridfsBuckets.map((bucket) => (
+                                        <div
+                                          key={bucket}
+                                          className={treeRowClass()}
+                                          onClick={() => onOpenGridfs?.(conn.id, dbName, bucket)}
+                                        >
+                                          <Archive size={11} className="ml-3.5 shrink-0 text-emerald-500" />
+                                          <span className="min-w-0 truncate" title={bucket}>
+                                            {bucket}
+                                          </span>
+                                        </div>
+                                      ))}
+                                      <div
+                                        className={cn(treeRowClass(), 'text-[10px] text-primary')}
+                                        data-testid={`gridfs-open-bucket-${conn.id}-${dbName}`}
+                                        onClick={() => void handleOpenGridfsBucket(conn.id, dbName)}
+                                      >
+                                        <Plus size={11} className="ml-3.5 shrink-0" />
+                                        <span>New bucket…</span>
+                                      </div>
+                                    </div>
+                                  )}
+                                </div>
+                              </ContextMenuTrigger>
+                              <ContextMenuContent>
+                                <ContextMenuItem
+                                  className={ctxItemClass}
+                                  data-testid={`ctx-gridfs-new-bucket-${conn.id}-${dbName}`}
                                   onClick={() => void handleOpenGridfsBucket(conn.id, dbName)}
                                 >
-                                  <Plus size={11} className="ml-3.5 shrink-0" />
-                                  <span>New bucket…</span>
-                                </div>
-                              </div>
-                            )}
+                                  <Plus />
+                                  <span>New Bucket</span>
+                                </ContextMenuItem>
+                              </ContextMenuContent>
+                            </ContextMenu>
 
-                            <div className={treeRowClass()} onClick={() => toggleVirtualFolder(`${dbKey}/system`)}>
-                              <ChevronRight
-                                size={10}
-                                className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isSystemExpanded && 'rotate-90')}
-                              />
-                              <Cog size={11} className="shrink-0 text-amber-500" />
-                              <span className="text-muted-foreground">System</span>
-                              <Badge variant="secondary" className="h-4 px-1 text-[9px] font-normal" data-testid="system-count">
-                                ({systemColls.length})
-                              </Badge>
-                            </div>
-                            {isSystemExpanded && (
-                              <div className="ml-3 border-l border-border/50 pl-1">
-                                {systemColls.map((collName) => renderCollectionNode(conn.id, dbName, collName))}
-                                {systemColls.length === 0 && (
-                                  <div className="py-0.5 pl-6 text-[10px] italic text-muted-foreground">Empty</div>
-                                )}
-                              </div>
-                            )}
+                            <ContextMenu>
+                              <ContextMenuTrigger asChild>
+                                <div>
+                                  <div className={treeRowClass()} onClick={() => toggleVirtualFolder(`${dbKey}/system`)}>
+                                    <ChevronRight
+                                      size={10}
+                                      className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isSystemExpanded && 'rotate-90')}
+                                    />
+                                    <Cog size={11} className="shrink-0 text-amber-500" />
+                                    <span className="text-muted-foreground">System</span>
+                                    <Badge variant="secondary" className="h-4 px-1 text-[9px] font-normal" data-testid="system-count">
+                                      ({systemColls.length})
+                                    </Badge>
+                                  </div>
+                                  {isSystemExpanded && (
+                                    <div className="ml-3 border-l border-border/50 pl-1">
+                                      {systemColls.map((collName) => renderCollectionNode(conn.id, dbName, collName))}
+                                      {systemColls.length === 0 && (
+                                        <div className="py-0.5 pl-6 text-[10px] italic text-muted-foreground">Empty</div>
+                                      )}
+                                    </div>
+                                  )}
+                                </div>
+                              </ContextMenuTrigger>
+                              <ContextMenuContent>
+                                <ContextMenuItem
+                                  className={ctxItemClass}
+                                  data-testid={`ctx-system-refresh-${conn.id}-${dbName}`}
+                                  onClick={() => void handleRefreshDb(conn.id, dbName)}
+                                >
+                                  <RefreshCw />
+                                  <span>Refresh Database</span>
+                                </ContextMenuItem>
+                              </ContextMenuContent>
+                            </ContextMenu>
                           </div>
                         )}
                       </div>

--- a/src/components/__tests__/GridFsView.test.tsx
+++ b/src/components/__tests__/GridFsView.test.tsx
@@ -4,20 +4,40 @@ import { GridFsView } from '../GridFsView';
 
 const mockInvoke = vi.fn();
 const mockSave = vi.fn();
+const mockOpen = vi.fn();
+const mockConfirm = vi.fn();
+const mockPrompt = vi.fn();
+const mockChoose = vi.fn();
+const mockToast = vi.fn();
+
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: any[]) => mockInvoke(...args),
-}));
-vi.mock('@tauri-apps/plugin-dialog', () => ({
-  save: (...args: any[]) => mockSave(...args),
+  Channel: class {
+    onmessage: ((update: any) => void) | null = null;
+  },
 }));
 
-// GridFsView consumes the in-app dialog system for toasts.
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  save: (...args: any[]) => mockSave(...args),
+  open: (...args: any[]) => mockOpen(...args),
+}));
+
 vi.mock('../dialogs/DialogProvider', () => ({
-  useDialogs: () => ({ toast: vi.fn(), confirm: vi.fn(), prompt: vi.fn(), choose: vi.fn() }),
+  useDialogs: () => ({
+    toast: mockToast,
+    confirm: mockConfirm,
+    prompt: mockPrompt,
+    choose: mockChoose,
+  }),
 }));
 
 describe('GridFsView (M7 — GridFS browsing)', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfirm.mockResolvedValue(true);
+    mockChoose.mockResolvedValue('skip');
+    mockPrompt.mockImplementation(async ({ defaultValue }: { defaultValue?: string }) => defaultValue ?? 'file.bin');
+  });
 
   const files = [
     { id: '{"$oid":"aaa"}', filename: 'report.pdf', length: 2048, chunk_size_bytes: 261120, upload_date: '2026-01-02T10:00:00Z', content_type: 'application/pdf' },
@@ -30,7 +50,6 @@ describe('GridFsView (M7 — GridFS browsing)', () => {
 
     expect(await screen.findByText('report.pdf')).toBeInTheDocument();
     expect(screen.getByText('photo.jpg')).toBeInTheDocument();
-    // 1048576 bytes -> "1 MB" (formatBytes); 2048 -> "2 KB"
     expect(screen.getByText(/1 MB/)).toBeInTheDocument();
     expect(mockInvoke).toHaveBeenCalledWith('list_gridfs_files', {
       id: 'c1',
@@ -50,13 +69,15 @@ describe('GridFsView (M7 — GridFS browsing)', () => {
     fireEvent.click(screen.getAllByTestId('gridfs-download-btn')[0]);
 
     await waitFor(() =>
-      expect(mockInvoke).toHaveBeenCalledWith('download_gridfs_file', {
+      expect(mockInvoke).toHaveBeenCalledWith('download_gridfs_file', expect.objectContaining({
         id: 'c1',
         database: 'shop',
         bucket: 'uploads',
         fileId: '{"$oid":"aaa"}',
         destPath: '/home/me/report.pdf',
-      })
+        totalBytes: 2048,
+        onProgress: expect.any(Object),
+      }))
     );
   });
 
@@ -70,6 +91,91 @@ describe('GridFsView (M7 — GridFS browsing)', () => {
 
     await waitFor(() => expect(mockSave).toHaveBeenCalled());
     expect(mockInvoke).not.toHaveBeenCalledWith('download_gridfs_file', expect.anything());
+  });
+
+  it('uploads a file selected from the open dialog', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_gridfs_files') return Promise.resolve(JSON.stringify(files));
+      if (cmd === 'upload_gridfs_file') return Promise.resolve('{"$oid":"new"}');
+      return Promise.resolve(undefined);
+    });
+    mockOpen.mockResolvedValue('/tmp/report.pdf');
+
+    render(<GridFsView connectionId="c1" databaseName="shop" bucket="uploads" />);
+    await screen.findByText('report.pdf');
+    fireEvent.click(screen.getByTestId('gridfs-upload-btn'));
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('upload_gridfs_file', expect.objectContaining({
+        id: 'c1',
+        database: 'shop',
+        bucket: 'uploads',
+        sourcePath: '/tmp/report.pdf',
+        filename: 'report.pdf',
+        metadataJson: null,
+        contentType: null,
+        onProgress: expect.any(Object),
+      }))
+    );
+    expect(mockToast).toHaveBeenCalledWith('Uploaded report.pdf', 'success');
+  });
+
+  it('uploads with optional metadata JSON', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_gridfs_files') return Promise.resolve(JSON.stringify(files));
+      if (cmd === 'upload_gridfs_file') return Promise.resolve('{"$oid":"new"}');
+      return Promise.resolve(undefined);
+    });
+    mockOpen.mockResolvedValue('/tmp/report.pdf');
+    mockChoose.mockResolvedValue('add');
+    mockPrompt
+      .mockResolvedValueOnce('report.pdf')
+      .mockResolvedValueOnce('{"source":"manual"}');
+
+    render(<GridFsView connectionId="c1" databaseName="shop" bucket="uploads" />);
+    await screen.findByText('report.pdf');
+    fireEvent.click(screen.getByTestId('gridfs-upload-btn'));
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('upload_gridfs_file', expect.objectContaining({
+        metadataJson: '{"source":"manual"}',
+      }))
+    );
+  });
+
+  it('deletes a file after confirmation', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_gridfs_files') return Promise.resolve(JSON.stringify(files));
+      if (cmd === 'delete_gridfs_file') return Promise.resolve(undefined);
+      return Promise.resolve(undefined);
+    });
+
+    render(<GridFsView connectionId="c1" databaseName="shop" bucket="uploads" />);
+    await screen.findByText('report.pdf');
+    fireEvent.click(screen.getAllByTestId('gridfs-delete-btn')[0]);
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('delete_gridfs_file', {
+        id: 'c1',
+        database: 'shop',
+        bucket: 'uploads',
+        fileId: '{"$oid":"aaa"}',
+      })
+    );
+    expect(mockConfirm).toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith('Deleted report.pdf', 'success');
+  });
+
+  it('does not delete when confirmation is cancelled', async () => {
+    mockConfirm.mockResolvedValue(false);
+    mockInvoke.mockResolvedValue(JSON.stringify(files));
+    render(<GridFsView connectionId="c1" databaseName="shop" bucket="uploads" />);
+
+    await screen.findByText('report.pdf');
+    fireEvent.click(screen.getAllByTestId('gridfs-delete-btn')[0]);
+
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalled());
+    expect(mockInvoke).not.toHaveBeenCalledWith('delete_gridfs_file', expect.anything());
   });
 
   it('shows an error state when listing fails', async () => {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -831,4 +831,40 @@ describe('Sidebar Component', () => {
     expect(await screen.findByTitle('Connection color')).toBeInTheDocument();
     expect(screen.getByText('Staging')).toBeInTheDocument();
   });
+
+  it('opens a new GridFS bucket from the sidebar when none exist', async () => {
+    const onOpenGridfs = vi.fn();
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'list_databases') {
+        if (args.id === 'conn-1') return Promise.resolve(['demo']);
+      }
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Local', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onOpenGridfs={onOpenGridfs}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('demo'));
+    fireEvent.click(await screen.findByText('GridFS Buckets'));
+
+    fireEvent.click(screen.getByTestId('gridfs-open-bucket-conn-1-demo'));
+    const input = await screen.findByTestId('dialog-input');
+    fireEvent.change(input, { target: { value: 'uploads' } });
+    fireEvent.click(screen.getByTestId('dialog-confirm'));
+
+    await waitFor(() => {
+      expect(onOpenGridfs).toHaveBeenCalledWith('conn-1', 'demo', 'uploads');
+    });
+  });
 });

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -867,4 +867,125 @@ describe('Sidebar Component', () => {
       expect(onOpenGridfs).toHaveBeenCalledWith('conn-1', 'demo', 'uploads');
     });
   });
+
+  it('shows New Bucket on GridFS Buckets context menu, not empty-space items', async () => {
+    const onOpenGridfs = vi.fn();
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'list_databases') {
+        if (args.id === 'conn-1') return Promise.resolve(['demo']);
+      }
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Local', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onOpenGridfs={onOpenGridfs}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('demo'));
+    const gridfsRow = await screen.findByText('GridFS Buckets');
+    fireEvent.contextMenu(gridfsRow);
+
+    expect(screen.getByText('New Bucket')).toBeInTheDocument();
+    expect(screen.queryByText('New Connection')).toBeNull();
+    expect(screen.queryByText('Settings')).toBeNull();
+  });
+
+  it('shows New Collection on Collections context menu, not empty-space items', async () => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'list_databases') {
+        if (args.id === 'conn-1') return Promise.resolve(['demo']);
+      }
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Local', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('demo'));
+    fireEvent.contextMenu(await screen.findByText('Collections'));
+
+    expect(screen.getByText('New Collection')).toBeInTheDocument();
+    expect(screen.queryByText('New Connection')).toBeNull();
+    expect(screen.queryByText('Settings')).toBeNull();
+  });
+
+  it('shows Create View on Views context menu, not empty-space items', async () => {
+    const onCreateView = vi.fn();
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'list_databases') {
+        if (args.id === 'conn-1') return Promise.resolve(['demo']);
+      }
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Local', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onCreateView={onCreateView}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('demo'));
+    fireEvent.contextMenu(await screen.findByText('Views'));
+
+    expect(screen.getByText('Create View')).toBeInTheDocument();
+    expect(screen.queryByText('New Connection')).toBeNull();
+    expect(screen.queryByText('Settings')).toBeNull();
+  });
+
+  it('shows Refresh Database on System context menu, not empty-space items', async () => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'list_databases') {
+        if (args.id === 'conn-1') return Promise.resolve(['demo']);
+      }
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Local', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('demo'));
+    fireEvent.contextMenu(await screen.findByText('System'));
+
+    expect(screen.getByText('Refresh Database')).toBeInTheDocument();
+    expect(screen.queryByText('New Connection')).toBeNull();
+    expect(screen.queryByText('Settings')).toBeNull();
+  });
 });

--- a/src/lib/__tests__/gridfsUpload.test.ts
+++ b/src/lib/__tests__/gridfsUpload.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { gridfsMetadataForUpload, validateGridfsMetadataJson } from '../gridfsUpload';
+
+describe('gridfsUpload helpers', () => {
+  it('allows empty metadata', () => {
+    expect(validateGridfsMetadataJson('')).toBeNull();
+    expect(validateGridfsMetadataJson('   ')).toBeNull();
+    expect(gridfsMetadataForUpload('')).toBeNull();
+    expect(gridfsMetadataForUpload('  ')).toBeNull();
+  });
+
+  it('accepts a JSON object', () => {
+    expect(validateGridfsMetadataJson('{"source":"test"}')).toBeNull();
+    expect(gridfsMetadataForUpload('{"source":"test"}')).toBe('{"source":"test"}');
+  });
+
+  it('rejects non-object JSON', () => {
+    expect(validateGridfsMetadataJson('[]')).toMatch(/object/i);
+    expect(validateGridfsMetadataJson('null')).toMatch(/object/i);
+    expect(validateGridfsMetadataJson('{"')).toMatch(/json/i);
+  });
+});

--- a/src/lib/gridfsUpload.ts
+++ b/src/lib/gridfsUpload.ts
@@ -1,0 +1,20 @@
+/** Validate optional GridFS metadata JSON (empty string is allowed). */
+export function validateGridfsMetadataJson(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return 'Metadata must be a JSON object';
+    }
+    return null;
+  } catch {
+    return 'Invalid JSON';
+  }
+}
+
+/** Normalize optional metadata for the upload IPC call. */
+export function gridfsMetadataForUpload(raw: string | null | undefined): string | null {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : null;
+}


### PR DESCRIPTION
## Summary
- Add streamed `upload_gridfs_file` and `delete_gridfs_file` Tauri commands with progress channels and a 512MB upload cap
- Extend `GridFsView` with multi-file upload, per-file filename prompts, optional metadata JSON, drag-and-drop, delete with confirmation, and upload/download progress
- Let users open new GridFS buckets from the sidebar when none exist yet; refresh the tree after upload/delete
- Infer `contentType` from file extension on upload

Fixes #126

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml gridfs`
- [x] `npm test -- src/components/__tests__/GridFsView.test.tsx src/lib/__tests__/gridfsUpload.test.ts`
- [x] `npm test -- src/components/__tests__/Sidebar.test.tsx -t GridFS`
- [x] `npx tsc --noEmit`
- [ ] Open empty database → GridFS Buckets → New bucket… → upload file → bucket appears in sidebar
- [ ] Upload with metadata JSON; delete file with confirmation
- [ ] Verify upload/download progress bar for a large file