### PR TITLE
chore(deps): patch open Dependabot alerts for dompurify and undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mqlens",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mqlens",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
@@ -3917,9 +3917,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -5349,9 +5349,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "vitest": "^4.1.7"
   },
   "overrides": {
-    "dompurify": "3.4.10",
+    "dompurify": "3.4.11",
+    "undici": "7.28.0",
     "@babel/core": "7.29.6",
     "esbuild": "0.28.1"
   }


### PR DESCRIPTION
## Summary
- Bump `dompurify` override from `3.4.10` to `3.4.11` (Monaco Editor runtime transitive dependency)
- Add `undici@7.28.0` override (jsdom/Vitest dev transitive dependency)
- Resolves all 7 open Dependabot npm alerts on the repo

## Test plan
- [x] `npm install` completes successfully
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm test` — 565/568 tests pass (3 pre-existing flaky timeouts unrelated to this change)