### PR TITLE
feat: BSON and NDJSON file import and export

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1428,6 +1428,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6212,6 +6233,7 @@ dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",
  "base64 0.22.1",
+ "csv",
  "futures",
  "mongodb",
  "rand 0.8.6",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+csv = "1"
 mongodb = { version = "3.0.0", features = ["aws-auth", "gssapi-auth"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -3,18 +3,98 @@
 use crate::limits::{IMPORT_BATCH_SIZE, MAX_IMPORT_DOCS};
 use crate::{connection_is_mock, require_real_client, AppState};
 
-// Parse a JSON string into a BSON Document, interpreting MongoDB Extended JSON
-// (e.g. {"$oid": "..."} -> ObjectId, {"$date": ...} -> DateTime) so that writes
+use mongodb::bson::Document;
+
+// Convert a parsed JSON value into a BSON Document, interpreting MongoDB Extended
+// JSON (e.g. {"$oid": "..."} -> ObjectId, {"$date": ...} -> DateTime) so that writes
 // match documents by their real _id type rather than a literal sub-document.
-pub fn json_to_bson_document(s: &str) -> Result<mongodb::bson::Document, String> {
-    let value: serde_json::Value =
-        serde_json::from_str(s).map_err(|e| format!("Invalid JSON: {}", e))?;
+fn value_to_bson_document(value: serde_json::Value) -> Result<Document, String> {
     let bson = mongodb::bson::Bson::try_from(value)
         .map_err(|e| format!("Invalid BSON/Extended JSON: {}", e))?;
     match bson {
         mongodb::bson::Bson::Document(doc) => Ok(doc),
         _ => Err("Expected a JSON object (e.g. { \"field\": value })".to_string()),
     }
+}
+
+// Parse a JSON string into a BSON Document, interpreting MongoDB Extended JSON.
+pub fn json_to_bson_document(s: &str) -> Result<Document, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(s).map_err(|e| format!("Invalid JSON: {}", e))?;
+    value_to_bson_document(value)
+}
+
+/// Parse a JSON array of documents (`[{…}, {…}]`) — the JSON-array import format.
+pub fn parse_json_array_docs(text: &str) -> Result<Vec<Document>, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(text).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let arr = match value {
+        serde_json::Value::Array(arr) => arr,
+        _ => return Err("Expected a JSON array of documents".to_string()),
+    };
+    arr.into_iter().map(value_to_bson_document).collect()
+}
+
+/// Parse newline-delimited JSON (NDJSON/JSONL): one Extended JSON document per line.
+/// Blank and whitespace-only lines are tolerated (incl. a trailing newline).
+pub fn parse_ndjson_docs(text: &str) -> Result<Vec<Document>, String> {
+    let mut docs = Vec::new();
+    for (idx, line) in text.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let doc =
+            json_to_bson_document(line).map_err(|e| format!("NDJSON line {}: {}", idx + 1, e))?;
+        docs.push(doc);
+    }
+    Ok(docs)
+}
+
+/// Parse concatenated BSON documents (mongoexport's `.bson` on-disk format).
+pub fn parse_bson_docs(bytes: &[u8]) -> Result<Vec<Document>, String> {
+    use std::io::Cursor;
+    let total = bytes.len() as u64;
+    let mut cursor = Cursor::new(bytes);
+    let mut docs = Vec::new();
+    while cursor.position() < total {
+        let doc = Document::from_reader(&mut cursor).map_err(|e| format!("Invalid BSON: {}", e))?;
+        docs.push(doc);
+    }
+    Ok(docs)
+}
+
+/// Parse CSV text into documents. The first row is the header; each cell is revived
+/// to its JSON value when parseable (number/bool/object/array), else kept as a string.
+pub fn parse_csv_docs(text: &str) -> Result<Vec<Document>, String> {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(text.as_bytes());
+    let headers: Vec<String> = reader
+        .headers()
+        .map_err(|e| format!("Invalid CSV header: {}", e))?
+        .iter()
+        .map(|h| h.to_string())
+        .collect();
+    let mut docs = Vec::new();
+    for (idx, record) in reader.records().enumerate() {
+        let record = record.map_err(|e| format!("Invalid CSV row {}: {}", idx + 2, e))?;
+        let mut map = serde_json::Map::with_capacity(headers.len());
+        for (col, header) in headers.iter().enumerate() {
+            let cell = record.get(col).unwrap_or("");
+            map.insert(header.clone(), revive_csv_cell(cell));
+        }
+        docs.push(value_to_bson_document(serde_json::Value::Object(map))?);
+    }
+    Ok(docs)
+}
+
+/// A CSV cell becomes its JSON value when parseable, otherwise the raw string
+/// (matching the frontend importer's `parseCell`).
+fn revive_csv_cell(cell: &str) -> serde_json::Value {
+    if cell.is_empty() {
+        return serde_json::Value::String(String::new());
+    }
+    serde_json::from_str(cell).unwrap_or_else(|_| serde_json::Value::String(cell.to_string()))
 }
 
 pub async fn delete_document_impl(
@@ -163,19 +243,60 @@ pub async fn import_documents_impl(
     docs: Vec<serde_json::Value>,
     mode: &str,
 ) -> Result<ImportResult, String> {
-    if docs.len() > MAX_IMPORT_DOCS {
+    // Convert all docs up front; a bad doc fails the whole import before writing.
+    let mut bson_docs: Vec<Document> = Vec::with_capacity(docs.len());
+    for value in docs {
+        bson_docs.push(value_to_bson_document(value)?);
+    }
+    finalize_import(state, id, database, collection, bson_docs, mode).await
+}
+
+/// Import a collection from a file on disk, parsing by `format`
+/// (`json` | `ndjson` | `bson` | `csv`). This is the source of truth for
+/// file-based import — binary BSON cannot ride the JSON-value IPC path.
+pub async fn import_collection_file_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    path: &str,
+    format: &str,
+    mode: &str,
+) -> Result<ImportResult, String> {
+    let bson_docs = match format.trim().to_lowercase().as_str() {
+        "json" => parse_json_array_docs(&read_text(path)?)?,
+        "ndjson" | "jsonl" => parse_ndjson_docs(&read_text(path)?)?,
+        "csv" => parse_csv_docs(&read_text(path)?)?,
+        "bson" => parse_bson_docs(&read_bytes(path)?)?,
+        other => return Err(format!("Unsupported import format: {}", other)),
+    };
+    finalize_import(state, id, database, collection, bson_docs, mode).await
+}
+
+fn read_text(path: &str) -> Result<String, String> {
+    std::fs::read_to_string(path).map_err(|e| format!("Failed to read import file: {}", e))
+}
+
+fn read_bytes(path: &str) -> Result<Vec<u8>, String> {
+    std::fs::read(path).map_err(|e| format!("Failed to read import file: {}", e))
+}
+
+/// Enforce the batch cap, short-circuit mock connections (validate only), then
+/// write the documents to the live collection under the duplicate-handling mode.
+async fn finalize_import(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    bson_docs: Vec<Document>,
+    mode: &str,
+) -> Result<ImportResult, String> {
+    if bson_docs.len() > MAX_IMPORT_DOCS {
         return Err(format!(
             "Import too large ({} documents). Maximum per batch is {} — split the file or use collection export/import on disk.",
-            docs.len(),
+            bson_docs.len(),
             MAX_IMPORT_DOCS
         ));
-    }
-
-    // Convert all docs up front; a bad doc fails the whole import before writing.
-    let mut bson_docs: Vec<mongodb::bson::Document> = Vec::with_capacity(docs.len());
-    for value in &docs {
-        let s = serde_json::to_string(value).map_err(|e| format!("Invalid document: {}", e))?;
-        bson_docs.push(json_to_bson_document(&s)?);
     }
 
     if connection_is_mock(state, id)? {
@@ -195,10 +316,17 @@ pub async fn import_documents_impl(
     }
 
     let client = require_real_client(state, id)?;
-    let coll = client
-        .database(database)
-        .collection::<mongodb::bson::Document>(collection);
+    let coll = client.database(database).collection::<Document>(collection);
+    write_imported_docs(&coll, bson_docs, mode).await
+}
 
+/// Write already-converted BSON documents to a live collection under the
+/// duplicate-handling mode. Shared by the JSON-value and file import paths.
+async fn write_imported_docs(
+    coll: &mongodb::Collection<Document>,
+    bson_docs: Vec<Document>,
+    mode: &str,
+) -> Result<ImportResult, String> {
     // Collect the set of incoming _ids that already exist in the collection,
     // keyed by their stringified BSON (same rendering on both sides). Used by
     // skip (partition) and abort (pre-check) so we never rely on bulk-write
@@ -249,7 +377,7 @@ pub async fn import_documents_impl(
             // Existing _ids get replaced (counts as updated); everything else is
             // inserted. This is an upsert-by-_id without relying on the driver's
             // option setters, which vary across versions.
-            let existing = existing_ids(&coll, &bson_docs).await?;
+            let existing = existing_ids(coll, &bson_docs).await?;
             let mut inserted = 0u64;
             let mut updated = 0u64;
             for doc in bson_docs {
@@ -278,7 +406,7 @@ pub async fn import_documents_impl(
         }
         "abort" => {
             // Any incoming _id already present -> abort, write nothing.
-            let existing = existing_ids(&coll, &bson_docs).await?;
+            let existing = existing_ids(coll, &bson_docs).await?;
             if !existing.is_empty() {
                 return Err(format!(
                     "Import aborted: {} document(s) already exist",
@@ -286,7 +414,7 @@ pub async fn import_documents_impl(
                 ));
             }
             let total = bson_docs.len() as u64;
-            insert_many_batched(&coll, bson_docs).await?;
+            insert_many_batched(coll, bson_docs).await?;
             Ok(ImportResult {
                 inserted: total,
                 updated: 0,
@@ -296,7 +424,7 @@ pub async fn import_documents_impl(
         _ => {
             // "skip" (default): insert only docs whose _id does not already exist;
             // count existing ones as skipped. Docs without an _id always insert.
-            let existing = existing_ids(&coll, &bson_docs).await?;
+            let existing = existing_ids(coll, &bson_docs).await?;
             let total = bson_docs.len() as u64;
             let to_insert: Vec<mongodb::bson::Document> = bson_docs
                 .into_iter()
@@ -307,7 +435,7 @@ pub async fn import_documents_impl(
                 .collect();
             let inserted = to_insert.len() as u64;
             if !to_insert.is_empty() {
-                insert_many_batched(&coll, to_insert).await?;
+                insert_many_batched(coll, to_insert).await?;
             }
             Ok(ImportResult {
                 inserted,

--- a/src-tauri/src/db/export.rs
+++ b/src-tauri/src/db/export.rs
@@ -223,6 +223,31 @@ async fn export_mock_to_file(
         file.write_all(b"\n]\n")
             .await
             .map_err(|e| format!("Failed to write export file: {}", e))?;
+    } else if format == "ndjson" {
+        for (idx, doc) in docs.iter().enumerate() {
+            file.write_all(doc.as_bytes())
+                .await
+                .map_err(|e| format!("Failed to write export file: {}", e))?;
+            file.write_all(b"\n")
+                .await
+                .map_err(|e| format!("Failed to write export file: {}", e))?;
+            let processed = idx as u64 + 1;
+            update_task(&tasks, &task_id, |task| {
+                task.processed = processed;
+            });
+        }
+    } else if format == "bson" {
+        for (idx, doc) in docs.iter().enumerate() {
+            let bytes = mongodb::bson::to_vec(&crate::json_to_bson_document(doc)?)
+                .map_err(|e| format!("BSON serialization error: {}", e))?;
+            file.write_all(&bytes)
+                .await
+                .map_err(|e| format!("Failed to write export file: {}", e))?;
+            let processed = idx as u64 + 1;
+            update_task(&tasks, &task_id, |task| {
+                task.processed = processed;
+            });
+        }
     } else {
         let values: Vec<serde_json::Value> = docs
             .iter()
@@ -339,6 +364,61 @@ async fn export_real_to_file(
             task.processed = processed;
         });
         Ok(processed)
+    } else if format == "ndjson" {
+        // One relaxed-EJSON document per line — the same per-doc value as the JSON
+        // array path, so it round-trips identically.
+        update_task(&tasks, &task_id, |task| {
+            task.message = "Writing NDJSON".to_string();
+        });
+        let mut cursor = open_export_cursor(&coll, &source).await?;
+        let mut processed = 0u64;
+        while let Some(result) = cursor.next().await {
+            let doc = result.map_err(|e| format!("Cursor read error: {}", e))?;
+            let json_val = bson_doc_to_json_value(&doc)?;
+            let json = serde_json::to_string(&json_val)
+                .map_err(|e| format!("JSON serialization error: {}", e))?;
+            file.write_all(json.as_bytes())
+                .await
+                .map_err(|e| format!("Failed to write export file: {}", e))?;
+            file.write_all(b"\n")
+                .await
+                .map_err(|e| format!("Failed to write export file: {}", e))?;
+            processed += 1;
+            if processed == total || processed % 100 == 0 {
+                update_task(&tasks, &task_id, |task| {
+                    task.processed = processed;
+                });
+            }
+        }
+        update_task(&tasks, &task_id, |task| {
+            task.processed = processed;
+        });
+        Ok(processed)
+    } else if format == "bson" {
+        // Concatenated raw BSON — mongoexport's binary format, fully type-preserving.
+        update_task(&tasks, &task_id, |task| {
+            task.message = "Writing BSON".to_string();
+        });
+        let mut cursor = open_export_cursor(&coll, &source).await?;
+        let mut processed = 0u64;
+        while let Some(result) = cursor.next().await {
+            let doc = result.map_err(|e| format!("Cursor read error: {}", e))?;
+            let bytes = mongodb::bson::to_vec(&doc)
+                .map_err(|e| format!("BSON serialization error: {}", e))?;
+            file.write_all(&bytes)
+                .await
+                .map_err(|e| format!("Failed to write export file: {}", e))?;
+            processed += 1;
+            if processed == total || processed % 100 == 0 {
+                update_task(&tasks, &task_id, |task| {
+                    task.processed = processed;
+                });
+            }
+        }
+        update_task(&tasks, &task_id, |task| {
+            task.processed = processed;
+        });
+        Ok(processed)
     } else {
         update_task(&tasks, &task_id, |task| {
             task.message = "Scanning CSV fields".to_string();
@@ -415,8 +495,8 @@ async fn export_real_to_file(
 /// Normalize + validate the format and path shared by both export entry points.
 fn validate_format_and_path(format: &str, path: &str) -> Result<String, String> {
     let format = format.trim().to_lowercase();
-    if format != "json" && format != "csv" {
-        return Err("Export format must be json or csv".to_string());
+    if !matches!(format.as_str(), "json" | "csv" | "bson" | "ndjson") {
+        return Err("Export format must be json, ndjson, bson, or csv".to_string());
     }
     if path.trim().is_empty() {
         return Err("Export path is required".to_string());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,8 +29,9 @@ pub use db::ddl::{
     rename_collection_impl, rename_database_impl, DatabaseRenameResult,
 };
 pub use db::documents::{
-    delete_document_impl, delete_many_impl, import_documents_impl, insert_document_impl,
-    json_to_bson_document, update_document_impl, update_many_impl, ImportResult,
+    delete_document_impl, delete_many_impl, import_collection_file_impl, import_documents_impl,
+    insert_document_impl, json_to_bson_document, parse_bson_docs, parse_csv_docs,
+    parse_json_array_docs, parse_ndjson_docs, update_document_impl, update_many_impl, ImportResult,
 };
 pub use db::export::{start_collection_export_impl, start_filtered_export_impl};
 pub use db::gridfs::{
@@ -1319,15 +1320,16 @@ async fn insert_document(
 }
 
 #[tauri::command]
-async fn import_documents(
+async fn import_collection_file(
     state: tauri::State<'_, AppState>,
     id: String,
     database: String,
     collection: String,
-    docs: Vec<serde_json::Value>,
+    path: String,
+    format: String,
     mode: String,
 ) -> Result<ImportResult, String> {
-    import_documents_impl(&state, &id, &database, &collection, docs, &mode).await
+    import_collection_file_impl(&state, &id, &database, &collection, &path, &format, &mode).await
 }
 
 #[tauri::command]
@@ -1587,7 +1589,7 @@ pub fn run() {
             upload_gridfs_file,
             delete_gridfs_file,
             insert_document,
-            import_documents,
+            import_collection_file,
             update_document,
             execute_mql_query,
             execute_aggregate,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -6,10 +6,11 @@ mod tests {
         delete_document_impl, delete_gridfs_file_impl, disconnect_db_impl,
         download_gridfs_file_impl, drop_collection_impl,
         drop_database_impl, execute_aggregate_impl, execute_mql_query_impl, explain_mql_query_impl,
-        import_documents_impl, insert_document_impl, json_to_bson_document, list_collections_impl,
-        list_databases_impl, list_gridfs_files_impl, list_indexes_impl, rename_collection_impl,
-        rename_database_impl, start_collection_export_impl, start_filtered_export_impl,
-        update_document_impl, upload_gridfs_file_impl,
+        import_collection_file_impl, import_documents_impl, insert_document_impl,
+        json_to_bson_document, list_collections_impl, list_databases_impl, list_gridfs_files_impl,
+        list_indexes_impl, parse_bson_docs, parse_csv_docs, parse_json_array_docs, parse_ndjson_docs,
+        rename_collection_impl, rename_database_impl, start_collection_export_impl,
+        start_filtered_export_impl, update_document_impl, upload_gridfs_file_impl,
     };
     use crate::{
         create_user_impl, drop_user_impl, list_roles_impl, list_users_impl, update_user_impl,
@@ -233,6 +234,81 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// Drive an export task to completion (or timeout) and return the finished TaskInfo.
+    async fn await_export(state: &AppState, task_id: &str) -> crate::TaskInfo {
+        for _ in 0..50 {
+            let status = state
+                .tasks
+                .lock()
+                .unwrap()
+                .get(task_id)
+                .map(|t| t.status.clone())
+                .unwrap();
+            if status != "running" {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        state.tasks.lock().unwrap().get(task_id).cloned().unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_mock_full_collection_export_task_writes_ndjson() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        let path = temp_import_path("ndjson");
+        let path_str = path.to_string_lossy().to_string();
+        let task = start_collection_export_impl(
+            &state, &conn_id, "sales_db", "customers", "ndjson", &path_str,
+        )
+        .await
+        .expect("start ndjson export");
+        let finished = await_export(&state, &task.id).await;
+        assert_eq!(finished.status, "completed");
+        assert_eq!(finished.processed, 3);
+
+        let text = std::fs::read_to_string(&path).expect("ndjson file");
+        // One document per line, no array brackets, and it round-trips back to 3 docs.
+        let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(lines.len(), 3);
+        assert!(!text.contains('['));
+        let docs = parse_ndjson_docs(&text).expect("re-parse ndjson");
+        assert_eq!(docs.len(), 3);
+        assert!(text.contains("Alice Smith"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn test_mock_full_collection_export_task_writes_bson() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        let path = temp_import_path("bson");
+        let path_str = path.to_string_lossy().to_string();
+        let task = start_collection_export_impl(
+            &state, &conn_id, "sales_db", "customers", "bson", &path_str,
+        )
+        .await
+        .expect("start bson export");
+        let finished = await_export(&state, &task.id).await;
+        assert_eq!(finished.status, "completed");
+        assert_eq!(finished.processed, 3);
+
+        // The on-disk bytes are concatenated BSON and parse back to 3 documents.
+        let bytes = std::fs::read(&path).expect("bson file");
+        let docs = parse_bson_docs(&bytes).expect("re-parse bson");
+        assert_eq!(docs.len(), 3);
+        let names: Vec<String> = docs
+            .iter()
+            .filter_map(|d| d.get_str("name").ok().map(|s| s.to_string()))
+            .collect();
+        assert!(names.iter().any(|n| n == "Alice Smith"));
+        let _ = std::fs::remove_file(&path);
+    }
+
     #[tokio::test]
     async fn test_mock_filtered_export_writes_only_matching_subset() {
         let state = AppState::new();
@@ -328,7 +404,7 @@ mod tests {
         .await
         .err()
         .expect("invalid export format should error");
-        assert_eq!(invalid_format, "Export format must be json or csv");
+        assert_eq!(invalid_format, "Export format must be json, ndjson, bson, or csv");
 
         let missing_path = start_filtered_export_impl(
             &state, "missing", "db", "coll", "json", "   ", "{}", "{}", "{}", "",
@@ -368,7 +444,7 @@ mod tests {
                 .await
                 .err()
                 .expect("invalid export format should error");
-        assert_eq!(invalid_format, "Export format must be json or csv");
+        assert_eq!(invalid_format, "Export format must be json, ndjson, bson, or csv");
 
         let missing_path =
             start_collection_export_impl(&state, "missing", "db", "coll", "json", "   ")
@@ -2500,5 +2576,174 @@ mod tests {
         // Correct length but a key that doesn't match this vault.
         let wrong = base64::engine::general_purpose::STANDARD.encode([0u8; 32]);
         assert!(decode_and_verify_key(&meta, &wrong).is_err());
+    }
+
+    // ── Import file parsers (issue #127: BSON / NDJSON / JSON / CSV) ───────
+
+    fn temp_import_path(ext: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "mqlens-import-test-{}-{}.{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            ext
+        ))
+    }
+
+    #[test]
+    fn test_parse_json_array_docs() {
+        let docs =
+            parse_json_array_docs(r#"[{"_id": 1, "name": "Ada"}, {"_id": 2, "name": "Bob"}]"#)
+                .expect("parse json array");
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].get_str("name").unwrap(), "Ada");
+        assert_eq!(docs[1].get_i32("_id").unwrap(), 2);
+    }
+
+    #[test]
+    fn test_parse_json_array_docs_rejects_non_array() {
+        assert!(parse_json_array_docs(r#"{"_id": 1}"#).is_err());
+    }
+
+    #[test]
+    fn test_parse_ndjson_docs_skips_blank_lines() {
+        // One doc per line, blank lines (incl. trailing newline) tolerated.
+        let text = "{\"_id\": 1, \"name\": \"Ada\"}\n\n{\"_id\": 2, \"name\": \"Bob\"}\n";
+        let docs = parse_ndjson_docs(text).expect("parse ndjson");
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].get_str("name").unwrap(), "Ada");
+        assert_eq!(docs[1].get_str("name").unwrap(), "Bob");
+    }
+
+    #[test]
+    fn test_parse_ndjson_docs_interprets_extended_json() {
+        // An $oid wrapper must revive to a real ObjectId, not a sub-document.
+        let oid = mongodb::bson::oid::ObjectId::new();
+        let line = format!("{{\"_id\": {{\"$oid\": \"{}\"}}}}", oid.to_hex());
+        let docs = parse_ndjson_docs(&line).expect("parse ndjson ejson");
+        assert_eq!(docs[0].get_object_id("_id").unwrap(), oid);
+    }
+
+    #[test]
+    fn test_parse_bson_docs_roundtrip_preserves_types() {
+        use mongodb::bson::{doc, oid::ObjectId, DateTime, Decimal128};
+        use std::str::FromStr;
+        let oid = ObjectId::new();
+        let when = DateTime::from_millis(1_700_000_000_000);
+        let dec = Decimal128::from_str("123.45").unwrap();
+        let original = doc! { "_id": oid, "when": when, "amount": dec, "name": "Ada" };
+        // Two concatenated BSON documents, mongoexport's on-disk format.
+        let mut bytes = mongodb::bson::to_vec(&original).expect("serialize bson");
+        bytes.extend(mongodb::bson::to_vec(&doc! { "_id": 2, "name": "Bob" }).unwrap());
+
+        let docs = parse_bson_docs(&bytes).expect("parse bson");
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].get_object_id("_id").unwrap(), oid);
+        assert_eq!(docs[0].get_datetime("when").unwrap(), &when);
+        assert_eq!(
+            docs[0].get("amount"),
+            Some(&mongodb::bson::Bson::Decimal128(dec))
+        );
+        assert_eq!(docs[1].get_str("name").unwrap(), "Bob");
+    }
+
+    #[test]
+    fn test_parse_bson_docs_empty_input() {
+        assert_eq!(parse_bson_docs(&[]).expect("empty bson").len(), 0);
+    }
+
+    #[test]
+    fn test_parse_csv_docs_revives_cell_values() {
+        // Numbers/bools/objects parse as JSON; bare text stays a string.
+        let text = "_id,name,active,tags\n1,Ada,true,\"[1,2]\"\n2,Bob,false,plain";
+        let docs = parse_csv_docs(text).expect("parse csv");
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].get_i32("_id").unwrap(), 1);
+        assert_eq!(docs[0].get_str("name").unwrap(), "Ada");
+        assert!(docs[0].get_bool("active").unwrap());
+        assert_eq!(
+            docs[0].get_array("tags").unwrap(),
+            &vec![mongodb::bson::Bson::Int32(1), mongodb::bson::Bson::Int32(2)]
+        );
+        assert_eq!(docs[1].get_str("tags").unwrap(), "plain");
+    }
+
+    #[tokio::test]
+    async fn test_mock_import_collection_file_ndjson() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        let path = temp_import_path("ndjson");
+        std::fs::write(
+            &path,
+            "{\"_id\": 1, \"name\": \"Ada\"}\n{\"_id\": 2, \"name\": \"Bob\"}\n",
+        )
+        .unwrap();
+
+        let res = import_collection_file_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            &path.to_string_lossy(),
+            "ndjson",
+            "skip",
+        )
+        .await
+        .expect("ndjson import validates on mock");
+        assert_eq!(res.inserted, 2);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn test_mock_import_collection_file_bson() {
+        use mongodb::bson::doc;
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        let path = temp_import_path("bson");
+        let mut bytes = mongodb::bson::to_vec(&doc! { "_id": 1, "name": "Ada" }).unwrap();
+        bytes.extend(mongodb::bson::to_vec(&doc! { "_id": 2, "name": "Bob" }).unwrap());
+        std::fs::write(&path, &bytes).unwrap();
+
+        let res = import_collection_file_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            &path.to_string_lossy(),
+            "bson",
+            "skip",
+        )
+        .await
+        .expect("bson import validates on mock");
+        assert_eq!(res.inserted, 2);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn test_import_collection_file_rejects_unknown_format() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        let path = temp_import_path("txt");
+        std::fs::write(&path, "nope").unwrap();
+        let res = import_collection_file_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            &path.to_string_lossy(),
+            "yaml",
+            "skip",
+        )
+        .await;
+        assert!(res.is_err(), "unknown import format must error");
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,8 +34,9 @@ import { clearNamespaceIndex, loadNamespaceIndex, matchesNamespaceScope } from '
 import { CHECK_UPDATE_EVENT } from './components/UpdatePrompt';
 import type { ConnectionProfile } from './lib/connection';
 import { save, open } from '@tauri-apps/plugin-dialog';
-import { writeTextFile, readTextFile } from '@tauri-apps/plugin-fs';
-import { toJson, toCsv, parseJson, parseCsv } from './lib/dataTransfer';
+import { writeTextFile, writeFile } from '@tauri-apps/plugin-fs';
+import { BSON, EJSON } from 'bson';
+import { toJson, toCsv, toNdjson } from './lib/dataTransfer';
 import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
@@ -1241,7 +1242,7 @@ function Workspace() {
 
   const handleExportForTab = async (
     targetTab: QueryTab | null,
-    format: 'json' | 'csv',
+    format: 'json' | 'csv' | 'bson' | 'ndjson',
     scope: 'current' | 'full' | 'filtered' = 'current',
     query?: FilteredExportQuery
   ) => {
@@ -1254,9 +1255,11 @@ function Workspace() {
     }
     try {
       const suffix = scope === 'full' ? '.full' : scope === 'filtered' ? '.filtered' : '';
+      // NDJSON conventionally uses the .jsonl extension; the rest match the format.
+      const ext = format === 'ndjson' ? 'jsonl' : format;
       const path = await save({
-        defaultPath: `${targetTab.collection}${suffix}.${format}`,
-        filters: [{ name: format.toUpperCase(), extensions: [format] }],
+        defaultPath: `${targetTab.collection}${suffix}.${ext}`,
+        filters: [{ name: format.toUpperCase(), extensions: [ext] }],
       });
       if (!path) return; // cancelled
       if (scope === 'full') {
@@ -1291,8 +1294,23 @@ function Workspace() {
         return;
       }
 
-      const content = format === 'json' ? toJson(docs) : toCsv(docs);
-      await writeTextFile(path, content);
+      if (format === 'bson') {
+        // Revive relaxed-EJSON grid objects to real BSON types, then concatenate
+        // each serialized document (mongoexport's binary format).
+        const chunks = docs.map((d) => BSON.serialize(EJSON.parse(JSON.stringify(d))));
+        const total = chunks.reduce((n, c) => n + c.length, 0);
+        const bytes = new Uint8Array(total);
+        let offset = 0;
+        for (const chunk of chunks) {
+          bytes.set(chunk, offset);
+          offset += chunk.length;
+        }
+        await writeFile(path, bytes);
+      } else {
+        const content =
+          format === 'json' ? toJson(docs) : format === 'ndjson' ? toNdjson(docs) : toCsv(docs);
+        await writeTextFile(path, content);
+      }
       toast(`Exported ${docs.length} document(s) to ${path}`, 'success');
     } catch (err: any) {
       toast(`Export failed: ${err?.message || err}`, 'error');
@@ -1329,30 +1347,28 @@ function Workspace() {
     };
   };
 
+  // Map a chosen import file to its backend format by extension.
+  const importFormatForPath = (path: string): 'json' | 'ndjson' | 'csv' | 'bson' => {
+    const lower = path.toLowerCase();
+    if (lower.endsWith('.bson')) return 'bson';
+    if (lower.endsWith('.csv')) return 'csv';
+    if (lower.endsWith('.jsonl') || lower.endsWith('.ndjson')) return 'ndjson';
+    return 'json';
+  };
+
   const handleImport = async () => {
     if (!activeTab || activeTab.type !== 'collection') return;
     try {
       const path = await open({
         multiple: false,
-        filters: [{ name: 'Data', extensions: ['json', 'csv'] }],
+        filters: [{ name: 'Data', extensions: ['json', 'jsonl', 'ndjson', 'csv', 'bson'] }],
       });
       if (!path || typeof path !== 'string') return; // cancelled
-      const text = await readTextFile(path);
-      // Parse by extension; a malformed file aborts before any write.
-      let docs: Record<string, any>[];
-      try {
-        docs = path.toLowerCase().endsWith('.csv') ? parseCsv(text) : parseJson(text);
-      } catch (parseErr: any) {
-        toast(`Import aborted — could not parse file: ${parseErr?.message || parseErr}`, 'error');
-        return;
-      }
-      if (docs.length === 0) {
-        toast('Nothing to import: the file has no documents.', 'error');
-        return;
-      }
-      // Choose the duplicate-handling mode.
+      const format = importFormatForPath(path);
+      // Choose the duplicate-handling mode. The backend parses the file (binary
+      // BSON cannot be read in the browser), so a malformed file fails there.
       const mode = await choose({
-        title: `Import ${docs.length} document(s)`,
+        title: 'Import documents',
         message: 'How should existing documents with the same _id be handled?',
         choices: [
           { value: 'skip', label: 'Skip duplicates (insert new only)' },
@@ -1362,12 +1378,13 @@ function Workspace() {
       });
       if (!mode) return; // cancelled
       const res = await invoke<{ inserted: number; updated: number; skipped: number }>(
-        'import_documents',
+        'import_collection_file',
         {
           id: activeTab.connectionId,
           database: activeTab.db,
           collection: activeTab.collection,
-          docs,
+          path,
+          format,
           mode,
         }
       );

--- a/src/components/ExportView.tsx
+++ b/src/components/ExportView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Download, FileJson, FileSpreadsheet, Filter, ListChecks, Hash } from 'lucide-react';
+import { Download, Filter, ListChecks, Hash } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
@@ -7,6 +7,9 @@ import { cn } from '@/lib/utils';
 import { QueryEditor } from './QueryEditor';
 import { FindQueryBar } from './FindQueryBar';
 import { useCollectionSchema } from '../lib/useCollectionSchema';
+
+/** File formats the export view can produce. */
+export type ExportFormat = 'json' | 'ndjson' | 'bson' | 'csv';
 
 /** The edited query the user chose to export from the Filtered card. */
 export type FilteredExportQuery =
@@ -36,7 +39,7 @@ interface ExportViewProps {
   /** Seeds the editable Filtered card from the source tab's active query. */
   filtered?: FilteredExportSeed;
   onExport: (
-    format: 'json' | 'csv',
+    format: ExportFormat,
     scope: 'current' | 'full' | 'filtered',
     query?: FilteredExportQuery
   ) => void;
@@ -80,6 +83,14 @@ const editorShell = (valid: boolean) =>
     valid ? 'border-input' : 'border-destructive focus-within:ring-destructive'
   );
 
+/** The four file formats every export scope can produce. */
+const EXPORT_FORMATS: { value: ExportFormat; label: string }[] = [
+  { value: 'json', label: 'JSON' },
+  { value: 'ndjson', label: 'NDJSON' },
+  { value: 'bson', label: 'BSON' },
+  { value: 'csv', label: 'CSV' },
+];
+
 export const ExportView: React.FC<ExportViewProps> = ({
   connectionId,
   connectionName,
@@ -105,6 +116,7 @@ export const ExportView: React.FC<ExportViewProps> = ({
   const [count, setCount] = React.useState<number | null | undefined>(filtered?.matchCount);
   const [counting, setCounting] = React.useState(false);
   const [countError, setCountError] = React.useState<string | null>(null);
+  const [format, setFormat] = React.useState<ExportFormat>('json');
 
   const filterCheck = checkJsonObject(filter);
   const sortCheck = checkJsonObject(sort);
@@ -155,6 +167,26 @@ export const ExportView: React.FC<ExportViewProps> = ({
         </Button>
       </header>
 
+      <div className="mb-4 flex items-center gap-2" data-testid="export-format-picker">
+        <Label className="text-xs text-muted-foreground">Format</Label>
+        <div className="inline-flex rounded-md border border-border p-0.5">
+          {EXPORT_FORMATS.map((f) => (
+            <Button
+              key={f.value}
+              type="button"
+              size="sm"
+              variant={format === f.value ? 'default' : 'ghost'}
+              aria-pressed={format === f.value}
+              className="h-7 px-2.5"
+              onClick={() => setFormat(f.value)}
+              data-testid={`export-format-${f.value}`}
+            >
+              {f.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
       <div className="grid gap-4 sm:grid-cols-2">
         <Card>
           <CardHeader className="pb-2">
@@ -172,22 +204,11 @@ export const ExportView: React.FC<ExportViewProps> = ({
               variant="outline"
               size="sm"
               disabled={!hasCurrentResults}
-              onClick={() => onExport('json', 'current')}
-              data-testid="export-current-json-btn"
+              onClick={() => onExport(format, 'current')}
+              data-testid="export-current-btn"
             >
-              <FileJson size={13} />
-              JSON
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={!hasCurrentResults}
-              onClick={() => onExport('csv', 'current')}
-              data-testid="export-current-csv-btn"
-            >
-              <FileSpreadsheet size={13} />
-              CSV
+              <Download size={13} />
+              Export {format.toUpperCase()}
             </Button>
           </CardContent>
         </Card>
@@ -204,20 +225,11 @@ export const ExportView: React.FC<ExportViewProps> = ({
             <Button
               type="button"
               size="sm"
-              onClick={() => onExport('json', 'full')}
-              data-testid="export-full-json-btn"
+              onClick={() => onExport(format, 'full')}
+              data-testid="export-full-btn"
             >
-              <FileJson size={13} />
-              JSON
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              onClick={() => onExport('csv', 'full')}
-              data-testid="export-full-csv-btn"
-            >
-              <FileSpreadsheet size={13} />
-              CSV
+              <Download size={13} />
+              Export {format.toUpperCase()}
             </Button>
           </CardContent>
         </Card>
@@ -296,21 +308,11 @@ export const ExportView: React.FC<ExportViewProps> = ({
               type="button"
               size="sm"
               disabled={!canExportFiltered}
-              onClick={() => onExport('json', 'filtered', buildQuery())}
-              data-testid="export-filtered-json-btn"
+              onClick={() => onExport(format, 'filtered', buildQuery())}
+              data-testid="export-filtered-btn"
             >
-              <FileJson size={13} />
-              JSON
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              disabled={!canExportFiltered}
-              onClick={() => onExport('csv', 'filtered', buildQuery())}
-              data-testid="export-filtered-csv-btn"
-            >
-              <FileSpreadsheet size={13} />
-              CSV
+              <Download size={13} />
+              Export {format.toUpperCase()}
             </Button>
           </div>
         </CardContent>

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -47,14 +47,14 @@ vi.mock('@tauri-apps/api/path', () => ({
 const saveMock = vi.fn();
 const openMock = vi.fn();
 const writeTextFileMock = vi.fn();
-const readTextFileMock = vi.fn();
+const writeFileMock = vi.fn();
 vi.mock('@tauri-apps/plugin-dialog', () => ({
   save: (...a: any[]) => saveMock(...a),
   open: (...a: any[]) => openMock(...a),
 }));
 vi.mock('@tauri-apps/plugin-fs', () => ({
   writeTextFile: (...a: any[]) => writeTextFileMock(...a),
-  readTextFile: (...a: any[]) => readTextFileMock(...a),
+  writeFile: (...a: any[]) => writeFileMock(...a),
 }));
 
 // Mock Sidebar component
@@ -568,7 +568,7 @@ describe('App Component', () => {
     expect(await screen.findByText(/"VIP Vic"/)).toBeInTheDocument();
   });
 
-  it('imports documents from a JSON file via import_documents (H5)', async () => {
+  it('imports documents from a file via import_collection_file (H5)', async () => {
     const calls: any[] = [];
     mockInvoke.mockImplementation((cmd: string, args: any) => {
       calls.push({ cmd, args });
@@ -578,13 +578,13 @@ describe('App Component', () => {
       if (cmd === 'load_collection_queries') {
         return Promise.resolve({ saved: [], history: [], default: null });
       }
-      if (cmd === 'import_documents') {
+      if (cmd === 'import_collection_file') {
         return Promise.resolve({ inserted: 2, updated: 0, skipped: 0 });
       }
       return Promise.resolve([]);
     });
-    openMock.mockResolvedValue('/tmp/data.json');
-    readTextFileMock.mockResolvedValue('[{"name":"Ada"},{"name":"Bob"}]');
+    // The backend parses the file from disk; the frontend only forwards path + format.
+    openMock.mockResolvedValue('/tmp/data.jsonl');
 
     const { fireEvent, waitFor } = await import('@testing-library/react');
     renderWithProviders(<App />);
@@ -599,14 +599,15 @@ describe('App Component', () => {
     fireEvent.click(await screen.findByTestId('dialog-choice-skip'));
 
     await waitFor(() => {
-      const imp = calls.find((c) => c.cmd === 'import_documents');
+      const imp = calls.find((c) => c.cmd === 'import_collection_file');
       expect(imp).toBeTruthy();
       expect(imp.args).toMatchObject({
         database: 'sales_db',
         collection: 'customers',
+        path: '/tmp/data.jsonl',
+        format: 'ndjson',
         mode: 'skip',
       });
-      expect(imp.args.docs).toEqual([{ name: 'Ada' }, { name: 'Bob' }]);
     });
   });
 
@@ -654,7 +655,7 @@ describe('App Component', () => {
 
     fireEvent.click(screen.getByTestId('export-btn'));
     expect(await screen.findByTestId('export-view')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('export-full-json-btn'));
+    fireEvent.click(screen.getByTestId('export-full-btn'));
 
     await waitFor(() => {
       const exp = calls.find((c) => c.cmd === 'start_collection_export');
@@ -758,20 +759,21 @@ describe('App Component', () => {
     expect(countAfter).toBe(1);
   });
 
-  it('aborts import on a malformed file without calling the backend (H5)', async () => {
-    const calls: any[] = [];
-    mockInvoke.mockImplementation((cmd: string, args: any) => {
-      calls.push({ cmd, args });
+  it('surfaces a malformed-file backend error as an import error toast (H5)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === 'execute_mql_query') {
         return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
       }
       if (cmd === 'load_collection_queries') {
         return Promise.resolve({ saved: [], history: [], default: null });
       }
+      if (cmd === 'import_collection_file') {
+        // The backend parses the file and rejects on malformed input.
+        return Promise.reject('Invalid JSON: expected value at line 1');
+      }
       return Promise.resolve([]);
     });
     openMock.mockResolvedValue('/tmp/bad.json');
-    readTextFileMock.mockResolvedValue('{not valid json');
 
     const { fireEvent } = await import('@testing-library/react');
     renderWithProviders(<App />);
@@ -781,10 +783,9 @@ describe('App Component', () => {
     expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('import-btn'));
-
-    // The malformed file surfaces an in-app error toast and no write happens.
-    expect(await screen.findByText(/Import aborted/)).toBeInTheDocument();
-    expect(calls.find((c) => c.cmd === 'import_documents')).toBeFalsy();
+    // Pick a duplicate-handling mode, then the backend reports the parse failure.
+    fireEvent.click(await screen.findByTestId('dialog-choice-skip'));
+    expect(await screen.findByText(/Import failed/)).toBeInTheDocument();
   });
 
   it('isolates query editor state per collection tab (#120)', async () => {

--- a/src/components/__tests__/ExportView.test.tsx
+++ b/src/components/__tests__/ExportView.test.tsx
@@ -62,6 +62,8 @@ function renderExportView(
   );
 }
 
+type ExportFormat = 'json' | 'csv' | 'bson' | 'ndjson';
+
 /** Mirrors App handleExportForTab enough to exercise invoke + error toasts. */
 function ExportViewHarness({
   currentResultCount = 3,
@@ -73,7 +75,7 @@ function ExportViewHarness({
   const { toast } = useDialogs();
 
   const onExport = async (
-    format: 'json' | 'csv',
+    format: ExportFormat,
     scope: 'current' | 'full' | 'filtered'
   ) => {
     if (scope === 'current' && currentResultCount === 0) return;
@@ -140,36 +142,46 @@ describe('ExportView', () => {
     expect(screen.getByText('3 loaded documents')).toBeInTheDocument();
   });
 
-  it('disables current-result export buttons when there are no loaded documents', () => {
+  it('offers all four formats in the picker', () => {
+    renderExportView();
+    for (const fmt of ['json', 'ndjson', 'bson', 'csv'] as const) {
+      expect(screen.getByTestId(`export-format-${fmt}`)).toBeInTheDocument();
+    }
+  });
+
+  it('disables the current-result export button when there are no loaded documents', () => {
     renderExportView({ currentResultCount: 0 });
-    expect(screen.getByTestId('export-current-json-btn')).toBeDisabled();
-    expect(screen.getByTestId('export-current-csv-btn')).toBeDisabled();
+    expect(screen.getByTestId('export-current-btn')).toBeDisabled();
   });
 
-  it('starts a current-results JSON export with the selected format', () => {
+  it('exports current results in the default (JSON) format', () => {
     const onExport = vi.fn();
     renderExportView({ onExport });
-    fireEvent.click(screen.getByTestId('export-current-json-btn'));
+    fireEvent.click(screen.getByTestId('export-current-btn'));
     expect(onExport).toHaveBeenCalledWith('json', 'current');
-    fireEvent.click(screen.getByTestId('export-current-csv-btn'));
-    expect(onExport).toHaveBeenCalledWith('csv', 'current');
   });
 
-  it('starts a full-collection export in the chosen format', () => {
+  it('exports current results in the selected format', () => {
     const onExport = vi.fn();
     renderExportView({ onExport });
-    fireEvent.click(screen.getByTestId('export-full-json-btn'));
-    expect(onExport).toHaveBeenCalledWith('json', 'full');
-    fireEvent.click(screen.getByTestId('export-full-csv-btn'));
-    expect(onExport).toHaveBeenCalledWith('csv', 'full');
+    fireEvent.click(screen.getByTestId('export-format-ndjson'));
+    fireEvent.click(screen.getByTestId('export-current-btn'));
+    expect(onExport).toHaveBeenCalledWith('ndjson', 'current');
+  });
+
+  it('exports the full collection in the selected format', () => {
+    const onExport = vi.fn();
+    renderExportView({ onExport });
+    fireEvent.click(screen.getByTestId('export-format-bson'));
+    fireEvent.click(screen.getByTestId('export-full-btn'));
+    expect(onExport).toHaveBeenCalledWith('bson', 'full');
   });
 
   it('seeds the filter editor and keeps filtered export enabled by default', () => {
     renderExportView({ filtered: { kind: 'find', filter: '{}', matchCount: null } });
     const input = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
     expect(input.value).toBe('{}');
-    expect(screen.getByTestId('export-filtered-json-btn')).not.toBeDisabled();
-    expect(screen.getByTestId('export-filtered-csv-btn')).not.toBeDisabled();
+    expect(screen.getByTestId('export-filtered-btn')).not.toBeDisabled();
   });
 
   it('seeds from the active find query and exports the edited query', () => {
@@ -189,7 +201,7 @@ describe('ExportView', () => {
     expect(screen.getByText('1,234 matching documents')).toBeInTheDocument();
 
     fireEvent.change(filterInput, { target: { value: '{"tier":"silver"}' } });
-    fireEvent.click(screen.getByTestId('export-filtered-json-btn'));
+    fireEvent.click(screen.getByTestId('export-filtered-btn'));
     expect(onExport).toHaveBeenCalledWith('json', 'filtered', {
       kind: 'find',
       filter: '{"tier":"silver"}',
@@ -203,8 +215,7 @@ describe('ExportView', () => {
     fireEvent.change(screen.getByTestId('query-filter-input'), {
       target: { value: '{bad' },
     });
-    expect(screen.getByTestId('export-filtered-json-btn')).toBeDisabled();
-    expect(screen.getByTestId('export-filtered-csv-btn')).toBeDisabled();
+    expect(screen.getByTestId('export-filtered-btn')).toBeDisabled();
     expect(screen.getAllByText('Invalid JSON').length).toBeGreaterThan(0);
   });
 
@@ -250,7 +261,8 @@ describe('ExportView', () => {
     expect(pipelineInput.value).toContain('$match');
 
     fireEvent.change(pipelineInput, { target: { value: '[{"$limit":5}]' } });
-    fireEvent.click(screen.getByTestId('export-filtered-csv-btn'));
+    fireEvent.click(screen.getByTestId('export-format-csv'));
+    fireEvent.click(screen.getByTestId('export-filtered-btn'));
     expect(onExport).toHaveBeenCalledWith('csv', 'filtered', {
       kind: 'aggregate',
       pipeline: '[{"$limit":5}]',
@@ -264,14 +276,14 @@ describe('ExportView', () => {
     expect(onOpenTasks).toHaveBeenCalledTimes(1);
   });
 
-  it('starts a background export via invoke when full collection JSON is chosen', async () => {
+  it('starts a background export via invoke when full collection is chosen', async () => {
     renderWithProviders(
       <DialogProvider>
         <ExportViewHarness />
       </DialogProvider>
     );
 
-    fireEvent.click(screen.getByTestId('export-full-json-btn'));
+    fireEvent.click(screen.getByTestId('export-full-btn'));
 
     await waitFor(() => {
       expect(saveMock).toHaveBeenCalled();
@@ -292,7 +304,7 @@ describe('ExportView', () => {
       </DialogProvider>
     );
 
-    fireEvent.click(screen.getByTestId('export-full-json-btn'));
+    fireEvent.click(screen.getByTestId('export-full-btn'));
 
     expect(await screen.findByText('Export failed: disk full')).toBeInTheDocument();
   });

--- a/src/lib/__tests__/dataTransfer.test.ts
+++ b/src/lib/__tests__/dataTransfer.test.ts
@@ -1,10 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { toJson, toCsv, parseJson, parseCsv } from '../dataTransfer';
+import { toJson, toCsv, toNdjson } from '../dataTransfer';
 
 describe('toJson', () => {
   it('pretty-prints an array of documents', () => {
     const out = toJson([{ a: 1 }, { b: 2 }]);
     expect(out).toBe('[\n  {\n    "a": 1\n  },\n  {\n    "b": 2\n  }\n]');
+  });
+});
+
+describe('toNdjson', () => {
+  it('writes one compact JSON document per line, no array brackets', () => {
+    const out = toNdjson([{ a: 1 }, { b: 2 }]);
+    expect(out).toBe('{"a":1}\n{"b":2}');
+  });
+
+  it('preserves Extended JSON wrappers verbatim (relaxed EJSON round-trips)', () => {
+    const out = toNdjson([{ _id: { $oid: 'abc' } }]);
+    expect(out).toBe('{"_id":{"$oid":"abc"}}');
+  });
+
+  it('returns an empty string for no documents', () => {
+    expect(toNdjson([])).toBe('');
   });
 });
 
@@ -31,45 +47,5 @@ describe('toCsv', () => {
   it('renders null/missing as empty cells', () => {
     const out = toCsv([{ a: 1, b: null }, { a: 2 }]);
     expect(out).toBe('a,b\n1,\n2,');
-  });
-});
-
-describe('parseJson', () => {
-  it('parses a JSON array of documents', () => {
-    expect(parseJson('[{"a":1},{"b":2}]')).toEqual([{ a: 1 }, { b: 2 }]);
-  });
-
-  it('throws on a non-array', () => {
-    expect(() => parseJson('{"a":1}')).toThrow(/array/i);
-  });
-
-  it('throws on invalid JSON', () => {
-    expect(() => parseJson('{bad')).toThrow();
-  });
-});
-
-describe('parseCsv', () => {
-  it('maps the header row to fields and coerces cell types', () => {
-    const rows = parseCsv('a,b,c\n1,true,hi');
-    expect(rows).toEqual([{ a: 1, b: true, c: 'hi' }]);
-  });
-
-  it('parses JSON-object cells back into objects', () => {
-    const rows = parseCsv('_id,addr\n1,"{""city"":""NY""}"');
-    expect(rows).toEqual([{ _id: 1, addr: { city: 'NY' } }]);
-  });
-
-  it('throws when a row has the wrong column count', () => {
-    expect(() => parseCsv('a,b\n1,2,3')).toThrow(/column/i);
-  });
-
-  it('round-trips flat docs through toCsv', () => {
-    const docs = [{ a: 1, b: 'x,y' }, { a: 2, b: 'z' }];
-    expect(parseCsv(toCsv(docs))).toEqual(docs);
-  });
-
-  it('parses quoted cells containing newlines', () => {
-    const docs = [{ a: 'line1\nline2', b: 'ok' }];
-    expect(parseCsv(toCsv(docs))).toEqual(docs);
   });
 });

--- a/src/lib/dataTransfer.ts
+++ b/src/lib/dataTransfer.ts
@@ -1,10 +1,17 @@
-// Pure serialize/parse helpers for exporting/importing the result grid.
+// Pure serialize helpers for exporting the result grid (JSON / NDJSON / CSV).
 // No I/O — file access happens in the caller via the Tauri dialog/fs plugins.
+// File import parsing lives in the Rust backend (import_collection_file).
 
 type Doc = Record<string, unknown>;
 
 export function toJson(docs: Doc[]): string {
   return JSON.stringify(docs, null, 2);
+}
+
+// Newline-delimited JSON (NDJSON/JSONL): one compact document per line, no array
+// brackets. Documents are already relaxed-EJSON objects, so this round-trips.
+export function toNdjson(docs: Doc[]): string {
+  return docs.map((doc) => JSON.stringify(doc)).join('\n');
 }
 
 // Quote a CSV field when it contains a comma, double-quote, or newline.
@@ -35,82 +42,3 @@ export function toCsv(docs: Doc[]): string {
   return [header, ...rows].join('\n');
 }
 
-export function parseJson(text: string): Doc[] {
-  const value = JSON.parse(text);
-  if (!Array.isArray(value)) {
-    throw new Error('Expected a JSON array of documents');
-  }
-  return value as Doc[];
-}
-
-// Split CSV text into rows/fields, honoring quoting/escaping ("" -> ") and
-// newlines inside quoted cells.
-function splitCsvRows(text: string): string[][] {
-  const rows: string[][] = [];
-  let row: string[] = [];
-  let cur = '';
-  let inQuotes = false;
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    if (inQuotes) {
-      if (ch === '"') {
-        if (text[i + 1] === '"') {
-          cur += '"';
-          i++;
-        } else {
-          inQuotes = false;
-        }
-      } else {
-        cur += ch;
-      }
-    } else if (ch === '"') {
-      inQuotes = true;
-    } else if (ch === ',') {
-      row.push(cur);
-      cur = '';
-    } else if (ch === '\n' || ch === '\r') {
-      row.push(cur);
-      rows.push(row);
-      row = [];
-      cur = '';
-      if (ch === '\r' && text[i + 1] === '\n') i++;
-    } else {
-      cur += ch;
-    }
-  }
-  row.push(cur);
-  rows.push(row);
-  return rows.filter((r) => r.some((cell) => cell.length > 0));
-}
-
-// A cell becomes its JSON value when parseable (number/bool/object/array/quoted
-// string), otherwise the raw string.
-function parseCell(cell: string): unknown {
-  if (cell === '') return '';
-  try {
-    return JSON.parse(cell);
-  } catch {
-    return cell;
-  }
-}
-
-export function parseCsv(text: string): Doc[] {
-  const rows = splitCsvRows(text);
-  if (rows.length === 0) return [];
-  const headers = rows[0];
-  const docs: Doc[] = [];
-  for (let i = 1; i < rows.length; i++) {
-    const cells = rows[i];
-    if (cells.length !== headers.length) {
-      throw new Error(
-        `Malformed CSV: row ${i + 1} has ${cells.length} columns, expected ${headers.length}`
-      );
-    }
-    const doc: Doc = {};
-    headers.forEach((h, idx) => {
-      doc[h] = parseCell(cells[idx]);
-    });
-    docs.push(doc);
-  }
-  return docs;
-}


### PR DESCRIPTION
## Summary
- Adds BSON (mongoexport binary) and NDJSON/JSONL as first-class formats for both collection export and file import
- Backend parses import files (`json` / `ndjson` / `csv` / `bson`) with Extended JSON revival, so `_id` types round-trip correctly
- Duplicate handling on import: skip / update by `_id` / abort

First of a 3-PR stack: `feat/bson-ndjson-import-export` → `feat/export-options-excel` → `feat/import-wizard`.

## Test plan
- [x] Rust suite (mock export/import round-trips per format)
- [x] Frontend suite (ExportView / App flows)
- [ ] Manual: export a collection as BSON, re-import it, verify types survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)