### PR TITLE
feat: import wizard with live preview, CSV type mapping, and background tasks

### DIFF
--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -4,6 +4,7 @@ use crate::limits::{IMPORT_BATCH_SIZE, MAX_IMPORT_DOCS};
 use crate::{connection_is_mock, require_real_client, AppState};
 
 use mongodb::bson::Document;
+use std::collections::HashMap;
 
 // Convert a parsed JSON value into a BSON Document, interpreting MongoDB Extended
 // JSON (e.g. {"$oid": "..."} -> ObjectId, {"$date": ...} -> DateTime) so that writes
@@ -63,27 +64,182 @@ pub fn parse_bson_docs(bytes: &[u8]) -> Result<Vec<Document>, String> {
     Ok(docs)
 }
 
-/// Parse CSV text into documents. The first row is the header; each cell is revived
-/// to its JSON value when parseable (number/bool/object/array), else kept as a string.
-pub fn parse_csv_docs(text: &str) -> Result<Vec<Document>, String> {
+/// CSV import parsing options (camelCase over IPC). Defaults reproduce the
+/// pre-options behavior exactly.
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct CsvImportOptions {
+    pub delimiter: String,
+    pub quote: String,
+    pub skip_lines: u32,
+    pub has_headers: bool,
+    pub column_types: HashMap<String, CsvColumnType>,
+}
+
+impl Default for CsvImportOptions {
+    fn default() -> Self {
+        Self {
+            delimiter: ",".into(),
+            quote: "\"".into(),
+            skip_lines: 0,
+            has_headers: true,
+            column_types: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CsvColumnType {
+    #[default]
+    Auto,
+    String,
+    Number,
+    Boolean,
+    Date,
+    Json,
+}
+
+pub fn validate_csv_import_options(o: &CsvImportOptions) -> Result<(), String> {
+    if o.delimiter.len() != 1 || !o.delimiter.is_ascii() {
+        return Err("CSV delimiter must be a single ASCII character".to_string());
+    }
+    if o.quote.len() != 1 || !o.quote.is_ascii() {
+        return Err("CSV text qualifier must be a single ASCII character".to_string());
+    }
+    Ok(())
+}
+
+pub fn generated_headers(n: usize) -> Vec<String> {
+    (1..=n).map(|i| format!("col{}", i)).collect()
+}
+
+/// Convert one CSV cell under an explicit or auto type. `row` is 1-based
+/// (data rows, excluding the header) for error messages.
+fn convert_csv_cell(
+    cell: &str,
+    column: &str,
+    ty: CsvColumnType,
+    row: usize,
+) -> Result<serde_json::Value, String> {
+    let fail = |ty_name: &str| {
+        Err(format!(
+            "CSV row {}, column \"{}\": cannot convert \"{}\" to {}",
+            row, column, cell, ty_name
+        ))
+    };
+    match ty {
+        CsvColumnType::Auto => Ok(revive_csv_cell(cell)),
+        CsvColumnType::String => Ok(serde_json::Value::String(cell.to_string())),
+        CsvColumnType::Number => {
+            if let Ok(i) = cell.trim().parse::<i64>() {
+                // Route through the canonical EJSON $numberLong wrapper so the
+                // revived value is always Bson::Int64, regardless of whether it
+                // happens to fit i32 (bson's plain-number TryFrom auto-downcasts
+                // in-range integers to Int32, which would make column typing
+                // magnitude-dependent instead of deterministic).
+                Ok(serde_json::json!({ "$numberLong": i.to_string() }))
+            } else if let Ok(f) = cell.trim().parse::<f64>() {
+                Ok(serde_json::Value::from(f))
+            } else {
+                fail("number")
+            }
+        }
+        CsvColumnType::Boolean => match cell.trim().to_ascii_lowercase().as_str() {
+            "true" => Ok(serde_json::Value::Bool(true)),
+            "false" => Ok(serde_json::Value::Bool(false)),
+            _ => fail("boolean"),
+        },
+        CsvColumnType::Date => {
+            // RFC-3339 or epoch millis → canonical EJSON $date, revived to
+            // Bson::DateTime by value_to_bson_document.
+            let millis: Option<i64> = if let Ok(ms) = cell.trim().parse::<i64>() {
+                Some(ms)
+            } else {
+                mongodb::bson::DateTime::parse_rfc3339_str(cell.trim())
+                    .ok()
+                    .map(|dt| dt.timestamp_millis())
+            };
+            match millis {
+                Some(ms) => Ok(serde_json::json!({
+                    "$date": { "$numberLong": ms.to_string() }
+                })),
+                None => fail("date (RFC-3339 or epoch millis)"),
+            }
+        }
+        CsvColumnType::Json => serde_json::from_str(cell).or_else(|_| fail("json")),
+    }
+}
+
+/// Build one document from a CSV record. Missing cells become empty strings
+/// (auto) / conversion errors (explicit types other than String).
+pub fn csv_record_to_doc(
+    headers: &[String],
+    record: &csv::StringRecord,
+    options: &CsvImportOptions,
+    row: usize,
+) -> Result<Document, String> {
+    let mut map = serde_json::Map::with_capacity(headers.len());
+    for (col, header) in headers.iter().enumerate() {
+        let cell = record.get(col).unwrap_or("");
+        let ty = options
+            .column_types
+            .get(header)
+            .copied()
+            .unwrap_or(CsvColumnType::Auto);
+        map.insert(header.clone(), convert_csv_cell(cell, header, ty, row)?);
+    }
+    value_to_bson_document(serde_json::Value::Object(map))
+}
+
+/// Skip the first `n` lines of `text` (spec: before header detection).
+pub fn skip_lines(text: &str, n: u32) -> &str {
+    let mut rest = text;
+    for _ in 0..n {
+        match rest.find('\n') {
+            Some(idx) => rest = &rest[idx + 1..],
+            None => return "",
+        }
+    }
+    rest
+}
+
+/// Parse CSV text into documents under the given options.
+pub fn parse_csv_docs(text: &str, options: &CsvImportOptions) -> Result<Vec<Document>, String> {
+    validate_csv_import_options(options)?;
+    let body = skip_lines(text, options.skip_lines);
     let mut reader = csv::ReaderBuilder::new()
-        .has_headers(true)
-        .from_reader(text.as_bytes());
-    let headers: Vec<String> = reader
-        .headers()
-        .map_err(|e| format!("Invalid CSV header: {}", e))?
-        .iter()
-        .map(|h| h.to_string())
-        .collect();
+        .has_headers(options.has_headers)
+        .delimiter(options.delimiter.as_bytes()[0])
+        .quote(options.quote.as_bytes()[0])
+        .flexible(true)
+        .from_reader(body.as_bytes());
+    let headers: Vec<String> = if options.has_headers {
+        reader
+            .headers()
+            .map_err(|e| format!("Invalid CSV header: {}", e))?
+            .iter()
+            .map(|h| h.to_string())
+            .collect()
+    } else {
+        // Peek the first record's width for generated names.
+        let mut peek = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .delimiter(options.delimiter.as_bytes()[0])
+            .quote(options.quote.as_bytes()[0])
+            .flexible(true)
+            .from_reader(body.as_bytes());
+        match peek.records().next() {
+            Some(first) => generated_headers(
+                first.map_err(|e| format!("Invalid CSV row 1: {}", e))?.len(),
+            ),
+            None => Vec::new(),
+        }
+    };
     let mut docs = Vec::new();
     for (idx, record) in reader.records().enumerate() {
-        let record = record.map_err(|e| format!("Invalid CSV row {}: {}", idx + 2, e))?;
-        let mut map = serde_json::Map::with_capacity(headers.len());
-        for (col, header) in headers.iter().enumerate() {
-            let cell = record.get(col).unwrap_or("");
-            map.insert(header.clone(), revive_csv_cell(cell));
-        }
-        docs.push(value_to_bson_document(serde_json::Value::Object(map))?);
+        let record = record.map_err(|e| format!("Invalid CSV row {}: {}", idx + 1, e))?;
+        docs.push(csv_record_to_doc(&headers, &record, options, idx + 1)?);
     }
     Ok(docs)
 }
@@ -266,7 +422,7 @@ pub async fn import_collection_file_impl(
     let bson_docs = match format.trim().to_lowercase().as_str() {
         "json" => parse_json_array_docs(&read_text(path)?)?,
         "ndjson" | "jsonl" => parse_ndjson_docs(&read_text(path)?)?,
-        "csv" => parse_csv_docs(&read_text(path)?)?,
+        "csv" => parse_csv_docs(&read_text(path)?, &CsvImportOptions::default())?,
         "bson" => parse_bson_docs(&read_bytes(path)?)?,
         other => return Err(format!("Unsupported import format: {}", other)),
     };
@@ -443,5 +599,77 @@ async fn write_imported_docs(
                 skipped: total - inserted,
             })
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
+mod csv_import_tests {
+    use super::*;
+
+    #[test]
+    fn default_options_match_previous_behavior() {
+        let docs = parse_csv_docs("a,b\n1,x\n", &CsvImportOptions::default()).unwrap();
+        assert_eq!(docs[0].get_i64("a").ok().or(docs[0].get_i32("a").map(i64::from).ok()), Some(1));
+        assert_eq!(docs[0].get_str("b").unwrap(), "x");
+    }
+
+    #[test]
+    fn delimiter_qualifier_skip_and_headerless() {
+        let text = "junk line\nA;\"x;y\"\n2;z\n";
+        let mut o = CsvImportOptions::default();
+        o.delimiter = ";".into();
+        o.skip_lines = 1;
+        o.has_headers = false;
+        let docs = parse_csv_docs(text, &o).unwrap();
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].get_str("col1").unwrap(), "A");
+        assert_eq!(docs[0].get_str("col2").unwrap(), "x;y");
+        assert_eq!(docs[1].get_str("col2").unwrap(), "z");
+    }
+
+    #[test]
+    fn explicit_column_types_convert_and_error_with_context() {
+        let mut o = CsvImportOptions::default();
+        o.column_types.insert("n".into(), CsvColumnType::Number);
+        o.column_types.insert("ok".into(), CsvColumnType::Boolean);
+        o.column_types.insert("when".into(), CsvColumnType::Date);
+        o.column_types.insert("meta".into(), CsvColumnType::Json);
+        o.column_types.insert("s".into(), CsvColumnType::String);
+        let docs = parse_csv_docs(
+            "n,ok,when,meta,s\n4.5,TRUE,2024-01-02T03:04:05Z,{\"a\":1},42\n",
+            &o,
+        )
+        .unwrap();
+        let d = &docs[0];
+        assert_eq!(d.get_f64("n").unwrap(), 4.5);
+        assert!(d.get_bool("ok").unwrap());
+        assert!(matches!(d.get("when"), Some(mongodb::bson::Bson::DateTime(_))));
+        assert_eq!(d.get_document("meta").unwrap().get_i64("a").ok().or(d.get_document("meta").unwrap().get_i32("a").map(i64::from).ok()), Some(1));
+        assert_eq!(d.get_str("s").unwrap(), "42"); // String type keeps digits as text
+
+        let err = parse_csv_docs("n\nnot-a-number\n", &o).unwrap_err();
+        assert!(err.contains("row 1") && err.contains("\"n\"") && err.contains("number"), "{err}");
+    }
+
+    #[test]
+    fn date_accepts_epoch_millis_and_number_is_i64_when_integral() {
+        let mut o = CsvImportOptions::default();
+        o.column_types.insert("when".into(), CsvColumnType::Date);
+        o.column_types.insert("n".into(), CsvColumnType::Number);
+        let docs = parse_csv_docs("when,n\n1700000000000,7\n", &o).unwrap();
+        assert!(matches!(docs[0].get("when"), Some(mongodb::bson::Bson::DateTime(_))));
+        assert_eq!(docs[0].get_i64("n").unwrap(), 7);
+    }
+
+    #[test]
+    fn validate_rejects_multi_char_delimiter_or_quote() {
+        let mut o = CsvImportOptions::default();
+        o.delimiter = "ab".into();
+        assert!(validate_csv_import_options(&o).is_err());
+        let mut o = CsvImportOptions::default();
+        o.quote = "€".into();
+        assert!(validate_csv_import_options(&o).is_err());
+        assert!(validate_csv_import_options(&CsvImportOptions::default()).is_ok());
     }
 }

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -407,36 +407,6 @@ pub async fn import_documents_impl(
     finalize_import(state, id, database, collection, bson_docs, mode).await
 }
 
-/// Import a collection from a file on disk, parsing by `format`
-/// (`json` | `ndjson` | `bson` | `csv`). This is the source of truth for
-/// file-based import — binary BSON cannot ride the JSON-value IPC path.
-pub async fn import_collection_file_impl(
-    state: &AppState,
-    id: &str,
-    database: &str,
-    collection: &str,
-    path: &str,
-    format: &str,
-    mode: &str,
-) -> Result<ImportResult, String> {
-    let bson_docs = match format.trim().to_lowercase().as_str() {
-        "json" => parse_json_array_docs(&read_text(path)?)?,
-        "ndjson" | "jsonl" => parse_ndjson_docs(&read_text(path)?)?,
-        "csv" => parse_csv_docs(&read_text(path)?, &CsvImportOptions::default())?,
-        "bson" => parse_bson_docs(&read_bytes(path)?)?,
-        other => return Err(format!("Unsupported import format: {}", other)),
-    };
-    finalize_import(state, id, database, collection, bson_docs, mode).await
-}
-
-fn read_text(path: &str) -> Result<String, String> {
-    std::fs::read_to_string(path).map_err(|e| format!("Failed to read import file: {}", e))
-}
-
-fn read_bytes(path: &str) -> Result<Vec<u8>, String> {
-    std::fs::read(path).map_err(|e| format!("Failed to read import file: {}", e))
-}
-
 /// Enforce the batch cap, short-circuit mock connections (validate only), then
 /// write the documents to the live collection under the duplicate-handling mode.
 async fn finalize_import(

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -36,34 +36,6 @@ pub fn parse_json_array_docs(text: &str) -> Result<Vec<Document>, String> {
     arr.into_iter().map(value_to_bson_document).collect()
 }
 
-/// Parse newline-delimited JSON (NDJSON/JSONL): one Extended JSON document per line.
-/// Blank and whitespace-only lines are tolerated (incl. a trailing newline).
-pub fn parse_ndjson_docs(text: &str) -> Result<Vec<Document>, String> {
-    let mut docs = Vec::new();
-    for (idx, line) in text.lines().enumerate() {
-        if line.trim().is_empty() {
-            continue;
-        }
-        let doc =
-            json_to_bson_document(line).map_err(|e| format!("NDJSON line {}: {}", idx + 1, e))?;
-        docs.push(doc);
-    }
-    Ok(docs)
-}
-
-/// Parse concatenated BSON documents (mongoexport's `.bson` on-disk format).
-pub fn parse_bson_docs(bytes: &[u8]) -> Result<Vec<Document>, String> {
-    use std::io::Cursor;
-    let total = bytes.len() as u64;
-    let mut cursor = Cursor::new(bytes);
-    let mut docs = Vec::new();
-    while cursor.position() < total {
-        let doc = Document::from_reader(&mut cursor).map_err(|e| format!("Invalid BSON: {}", e))?;
-        docs.push(doc);
-    }
-    Ok(docs)
-}
-
 /// CSV import parsing options (camelCase over IPC). Defaults reproduce the
 /// pre-options behavior exactly.
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -190,58 +162,6 @@ pub fn csv_record_to_doc(
         map.insert(header.clone(), convert_csv_cell(cell, header, ty, row)?);
     }
     value_to_bson_document(serde_json::Value::Object(map))
-}
-
-/// Skip the first `n` lines of `text` (spec: before header detection).
-pub fn skip_lines(text: &str, n: u32) -> &str {
-    let mut rest = text;
-    for _ in 0..n {
-        match rest.find('\n') {
-            Some(idx) => rest = &rest[idx + 1..],
-            None => return "",
-        }
-    }
-    rest
-}
-
-/// Parse CSV text into documents under the given options.
-pub fn parse_csv_docs(text: &str, options: &CsvImportOptions) -> Result<Vec<Document>, String> {
-    validate_csv_import_options(options)?;
-    let body = skip_lines(text, options.skip_lines);
-    let mut reader = csv::ReaderBuilder::new()
-        .has_headers(options.has_headers)
-        .delimiter(options.delimiter.as_bytes()[0])
-        .quote(options.quote.as_bytes()[0])
-        .flexible(true)
-        .from_reader(body.as_bytes());
-    let headers: Vec<String> = if options.has_headers {
-        reader
-            .headers()
-            .map_err(|e| format!("Invalid CSV header: {}", e))?
-            .iter()
-            .map(|h| h.to_string())
-            .collect()
-    } else {
-        // Peek the first record's width for generated names.
-        let mut peek = csv::ReaderBuilder::new()
-            .has_headers(false)
-            .delimiter(options.delimiter.as_bytes()[0])
-            .quote(options.quote.as_bytes()[0])
-            .flexible(true)
-            .from_reader(body.as_bytes());
-        match peek.records().next() {
-            Some(first) => generated_headers(
-                first.map_err(|e| format!("Invalid CSV row 1: {}", e))?.len(),
-            ),
-            None => Vec::new(),
-        }
-    };
-    let mut docs = Vec::new();
-    for (idx, record) in reader.records().enumerate() {
-        let record = record.map_err(|e| format!("Invalid CSV row {}: {}", idx + 1, e))?;
-        docs.push(csv_record_to_doc(&headers, &record, options, idx + 1)?);
-    }
-    Ok(docs)
 }
 
 /// A CSV cell becomes its JSON value when parseable, otherwise the raw string
@@ -572,65 +492,16 @@ pub(crate) async fn write_imported_docs(
     }
 }
 
+// The option-matrix CSV parsing tests that used to live here (default
+// options, delimiter/qualifier/skip_lines/headerless combos, explicit column
+// types incl. failure context) now exercise db::import::ImportReader — the
+// path the shipping import pipeline actually uses. See db/import.rs's `csv_*`
+// tests. validate_csv_import_options is a pure helper with no ImportReader
+// equivalent, so its test stays here.
 #[cfg(test)]
 #[allow(clippy::field_reassign_with_default)]
 mod csv_import_tests {
     use super::*;
-
-    #[test]
-    fn default_options_match_previous_behavior() {
-        let docs = parse_csv_docs("a,b\n1,x\n", &CsvImportOptions::default()).unwrap();
-        assert_eq!(docs[0].get_i64("a").ok().or(docs[0].get_i32("a").map(i64::from).ok()), Some(1));
-        assert_eq!(docs[0].get_str("b").unwrap(), "x");
-    }
-
-    #[test]
-    fn delimiter_qualifier_skip_and_headerless() {
-        let text = "junk line\nA;\"x;y\"\n2;z\n";
-        let mut o = CsvImportOptions::default();
-        o.delimiter = ";".into();
-        o.skip_lines = 1;
-        o.has_headers = false;
-        let docs = parse_csv_docs(text, &o).unwrap();
-        assert_eq!(docs.len(), 2);
-        assert_eq!(docs[0].get_str("col1").unwrap(), "A");
-        assert_eq!(docs[0].get_str("col2").unwrap(), "x;y");
-        assert_eq!(docs[1].get_str("col2").unwrap(), "z");
-    }
-
-    #[test]
-    fn explicit_column_types_convert_and_error_with_context() {
-        let mut o = CsvImportOptions::default();
-        o.column_types.insert("n".into(), CsvColumnType::Number);
-        o.column_types.insert("ok".into(), CsvColumnType::Boolean);
-        o.column_types.insert("when".into(), CsvColumnType::Date);
-        o.column_types.insert("meta".into(), CsvColumnType::Json);
-        o.column_types.insert("s".into(), CsvColumnType::String);
-        let docs = parse_csv_docs(
-            "n,ok,when,meta,s\n4.5,TRUE,2024-01-02T03:04:05Z,{\"a\":1},42\n",
-            &o,
-        )
-        .unwrap();
-        let d = &docs[0];
-        assert_eq!(d.get_f64("n").unwrap(), 4.5);
-        assert!(d.get_bool("ok").unwrap());
-        assert!(matches!(d.get("when"), Some(mongodb::bson::Bson::DateTime(_))));
-        assert_eq!(d.get_document("meta").unwrap().get_i64("a").ok().or(d.get_document("meta").unwrap().get_i32("a").map(i64::from).ok()), Some(1));
-        assert_eq!(d.get_str("s").unwrap(), "42"); // String type keeps digits as text
-
-        let err = parse_csv_docs("n\nnot-a-number\n", &o).unwrap_err();
-        assert!(err.contains("row 1") && err.contains("\"n\"") && err.contains("number"), "{err}");
-    }
-
-    #[test]
-    fn date_accepts_epoch_millis_and_number_is_i64_when_integral() {
-        let mut o = CsvImportOptions::default();
-        o.column_types.insert("when".into(), CsvColumnType::Date);
-        o.column_types.insert("n".into(), CsvColumnType::Number);
-        let docs = parse_csv_docs("when,n\n1700000000000,7\n", &o).unwrap();
-        assert!(matches!(docs[0].get("when"), Some(mongodb::bson::Bson::DateTime(_))));
-        assert_eq!(docs[0].get_i64("n").unwrap(), 7);
-    }
 
     #[test]
     fn validate_rejects_multi_char_delimiter_or_quote() {

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -478,7 +478,7 @@ async fn finalize_import(
 
 /// Write already-converted BSON documents to a live collection under the
 /// duplicate-handling mode. Shared by the JSON-value and file import paths.
-async fn write_imported_docs(
+pub(crate) async fn write_imported_docs(
     coll: &mongodb::Collection<Document>,
     bson_docs: Vec<Document>,
     mode: &str,

--- a/src-tauri/src/db/export/mod.rs
+++ b/src-tauri/src/db/export/mod.rs
@@ -18,67 +18,14 @@ use options::ExportOptions;
 
 use crate::state::LockExt;
 use crate::{mock_db, AppState, TaskInfo};
+use crate::db::tasks::{fail_task, finish_task, now_ms, update_task};
 use futures::stream::{Stream, StreamExt};
 use mongodb::bson::{doc, Document};
 use mongodb::Client;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
-
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
-}
-
-fn update_task<F>(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>, task_id: &str, update: F)
-where
-    F: FnOnce(&mut TaskInfo),
-{
-    if let Some(task) = tasks
-        .lock()
-        .unwrap_or_else(|p| p.into_inner())
-        .get_mut(task_id)
-    {
-        update(task);
-    }
-}
-
-fn fail_task(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>, task_id: &str, err: String) {
-    update_task(tasks, task_id, |task| {
-        task.status = "failed".to_string();
-        task.message = "Export failed".to_string();
-        task.error = Some(err);
-        task.finished_at_ms = Some(now_ms());
-    });
-    prune_export_tasks(tasks);
-}
-
-fn finish_task(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>, task_id: &str, processed: u64) {
-    update_task(tasks, task_id, |task| {
-        task.status = "completed".to_string();
-        task.processed = processed;
-        task.message = "Export complete".to_string();
-        task.finished_at_ms = Some(now_ms());
-    });
-    prune_export_tasks(tasks);
-}
-
-fn prune_export_tasks(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>) {
-    use crate::limits::MAX_TASK_HISTORY;
-    let mut guard = tasks.lock().unwrap_or_else(|p| p.into_inner());
-    if guard.len() <= MAX_TASK_HISTORY {
-        return;
-    }
-    let mut entries: Vec<(String, TaskInfo)> = guard.drain().collect();
-    entries.sort_by(|a, b| b.1.created_at_ms.cmp(&a.1.created_at_ms));
-    for (id, task) in entries.into_iter().take(MAX_TASK_HISTORY) {
-        guard.insert(id, task);
-    }
-}
 
 /// What a real-connection export reads from MongoDB. Filtered exports build a
 /// [`ExportSource::Find`] (filter + optional sort/projection/skip/limit) or a
@@ -645,7 +592,7 @@ async fn start_export_task(
             .await
         };
         match result {
-            Ok(processed) => finish_task(&tasks, &task_id, processed),
+            Ok(processed) => finish_task(&tasks, &task_id, processed, "Export complete".to_string()),
             Err(err) => fail_task(&tasks, &task_id, err),
         }
     });

--- a/src-tauri/src/db/import.rs
+++ b/src-tauri/src/db/import.rs
@@ -1,0 +1,321 @@
+//! File/paste import pipeline: a pull-based document reader shared by the
+//! preview command (first N docs) and the background import task (Task 4).
+
+use crate::db::documents::{
+    csv_record_to_doc, generated_headers, parse_json_array_docs, validate_csv_import_options,
+    CsvImportOptions,
+};
+use mongodb::bson::Document;
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, BufReader, Read};
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ImportSourceArg {
+    pub path: Option<String>,
+    pub text: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportPreview {
+    pub docs: Vec<String>,
+    pub columns: Vec<String>,
+    pub total_hint: Option<u64>,
+    pub error: Option<String>,
+}
+
+/// Boxed byte source: an open file or the pasted text.
+type ByteSource = Box<dyn Read + Send>;
+
+fn open_bytes(source: &ImportSourceArg) -> Result<ByteSource, String> {
+    match (&source.path, &source.text) {
+        (Some(path), None) => {
+            let file = std::fs::File::open(path)
+                .map_err(|e| format!("Failed to read import file: {}", e))?;
+            Ok(Box::new(file))
+        }
+        (None, Some(text)) => Ok(Box::new(std::io::Cursor::new(text.clone().into_bytes()))),
+        _ => Err("Import source must be exactly one of a file path or pasted text".to_string()),
+    }
+}
+
+impl std::fmt::Debug for ImportReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let variant = match self {
+            ImportReader::JsonArray { .. } => "JsonArray",
+            ImportReader::Ndjson { .. } => "Ndjson",
+            ImportReader::Csv { .. } => "Csv",
+            ImportReader::Bson { .. } => "Bson",
+        };
+        f.debug_struct("ImportReader").field("variant", &variant).finish()
+    }
+}
+
+pub(crate) enum ImportReader {
+    JsonArray {
+        docs: std::vec::IntoIter<Document>,
+        total: u64,
+    },
+    Ndjson {
+        lines: std::io::Lines<BufReader<ByteSource>>,
+        line_no: usize,
+    },
+    Csv {
+        records: csv::StringRecordsIntoIter<BufReader<ByteSource>>,
+        headers: Vec<String>,
+        options: CsvImportOptions,
+        row: usize,
+    },
+    Bson {
+        reader: BufReader<ByteSource>,
+        eof: bool,
+    },
+}
+
+impl ImportReader {
+    pub fn open(
+        source: &ImportSourceArg,
+        format: &str,
+        csv: &CsvImportOptions,
+    ) -> Result<ImportReader, String> {
+        let format = format.trim().to_lowercase();
+        match format.as_str() {
+            "json" => {
+                let mut text = String::new();
+                open_bytes(source)?
+                    .read_to_string(&mut text)
+                    .map_err(|e| format!("Failed to read import file: {}", e))?;
+                let docs = parse_json_array_docs(&text)?;
+                Ok(ImportReader::JsonArray {
+                    total: docs.len() as u64,
+                    docs: docs.into_iter(),
+                })
+            }
+            "ndjson" | "jsonl" => Ok(ImportReader::Ndjson {
+                lines: BufReader::new(open_bytes(source)?).lines(),
+                line_no: 0,
+            }),
+            "csv" => {
+                validate_csv_import_options(csv)?;
+                // skip_lines + headers need text-mode preprocessing; for the
+                // header row we read it via the csv Reader itself.
+                let mut buf = BufReader::new(open_bytes(source)?);
+                let mut skipped = String::new();
+                for _ in 0..csv.skip_lines {
+                    skipped.clear();
+                    if buf
+                        .read_line(&mut skipped)
+                        .map_err(|e| format!("Failed to read import file: {}", e))?
+                        == 0
+                    {
+                        break;
+                    }
+                }
+                let mut reader = csv::ReaderBuilder::new()
+                    .has_headers(csv.has_headers)
+                    .delimiter(csv.delimiter.as_bytes()[0])
+                    .quote(csv.quote.as_bytes()[0])
+                    .flexible(true)
+                    .from_reader(buf);
+                let headers: Vec<String> = if csv.has_headers {
+                    reader
+                        .headers()
+                        .map_err(|e| format!("Invalid CSV header: {}", e))?
+                        .iter()
+                        .map(|h| h.to_string())
+                        .collect()
+                } else {
+                    Vec::new() // resolved lazily from the first record's width
+                };
+                Ok(ImportReader::Csv {
+                    records: reader.into_records(),
+                    headers,
+                    options: csv.clone(),
+                    row: 0,
+                })
+            }
+            "bson" => {
+                if source.text.is_some() {
+                    return Err("BSON import requires a file source".to_string());
+                }
+                Ok(ImportReader::Bson {
+                    reader: BufReader::new(open_bytes(source)?),
+                    eof: false,
+                })
+            }
+            other => Err(format!("Unsupported import format: {}", other)),
+        }
+    }
+
+    pub fn columns(&self) -> &[String] {
+        match self {
+            ImportReader::Csv { headers, .. } => headers,
+            _ => &[],
+        }
+    }
+
+    pub fn total_hint(&self) -> Option<u64> {
+        match self {
+            ImportReader::JsonArray { total, .. } => Some(*total),
+            _ => None,
+        }
+    }
+
+    pub fn next_doc(&mut self) -> Result<Option<Document>, String> {
+        match self {
+            ImportReader::JsonArray { docs, .. } => Ok(docs.next()),
+            ImportReader::Ndjson { lines, line_no } => {
+                for line in lines.by_ref() {
+                    *line_no += 1;
+                    let line = line.map_err(|e| format!("Failed to read import file: {}", e))?;
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    return crate::json_to_bson_document(&line)
+                        .map(Some)
+                        .map_err(|e| format!("NDJSON line {}: {}", line_no, e));
+                }
+                Ok(None)
+            }
+            ImportReader::Csv { records, headers, options, row } => {
+                match records.next() {
+                    None => Ok(None),
+                    Some(record) => {
+                        *row += 1;
+                        let record =
+                            record.map_err(|e| format!("Invalid CSV row {}: {}", row, e))?;
+                        if headers.is_empty() {
+                            *headers = generated_headers(record.len());
+                        }
+                        csv_record_to_doc(headers, &record, options, *row).map(Some)
+                    }
+                }
+            }
+            ImportReader::Bson { reader, eof } => {
+                if *eof {
+                    return Ok(None);
+                }
+                // Peek one byte to detect clean EOF before from_reader errors.
+                let mut peek = [0u8; 1];
+                match reader.read(&mut peek) {
+                    Ok(0) => {
+                        *eof = true;
+                        return Ok(None);
+                    }
+                    Ok(_) => {}
+                    Err(e) => return Err(format!("Failed to read import file: {}", e)),
+                }
+                let chained = std::io::Cursor::new(peek).chain(reader.by_ref());
+                Document::from_reader(chained)
+                    .map(Some)
+                    .map_err(|e| format!("Invalid BSON: {}", e))
+            }
+        }
+    }
+}
+
+/// Preview: parse up to `limit` docs; parse errors come back inline so the
+/// UI can render them next to the rows that did parse.
+pub async fn preview_import_impl(
+    source: ImportSourceArg,
+    format: &str,
+    csv_options: Option<CsvImportOptions>,
+    limit: usize,
+) -> Result<ImportPreview, String> {
+    let csv = csv_options.unwrap_or_default();
+    let format = format.to_string();
+    // Parsing is synchronous file I/O — run it off the async thread.
+    tokio::task::spawn_blocking(move || {
+        let mut reader = ImportReader::open(&source, &format, &csv)?;
+        let total_hint = reader.total_hint();
+        let mut docs = Vec::new();
+        let mut error = None;
+        while docs.len() < limit {
+            match reader.next_doc() {
+                Ok(Some(doc)) => docs.push(
+                    serde_json::to_string(
+                        &mongodb::bson::Bson::Document(doc).into_relaxed_extjson(),
+                    )
+                    .unwrap_or_default(),
+                ),
+                Ok(None) => break,
+                Err(e) => {
+                    error = Some(e);
+                    break;
+                }
+            }
+        }
+        Ok(ImportPreview {
+            columns: reader.columns().to_vec(),
+            total_hint,
+            docs,
+            error,
+        })
+    })
+    .await
+    .map_err(|e| format!("Preview task failed: {}", e))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::documents::CsvImportOptions;
+
+    fn text_source(s: &str) -> ImportSourceArg {
+        ImportSourceArg { path: None, text: Some(s.to_string()) }
+    }
+
+    #[test]
+    fn reader_streams_ndjson_and_stops_at_error_line() {
+        let mut r = ImportReader::open(
+            &text_source("{\"a\":1}\n\n{\"a\":2}\nnot json\n"),
+            "ndjson",
+            &CsvImportOptions::default(),
+        )
+        .unwrap();
+        // Small JSON integers round-trip as Bson::Int32 (see
+        // Bson::try_from<serde_json::Value> in the bson crate), not Int64.
+        assert_eq!(r.next_doc().unwrap().unwrap().get_i32("a").ok(), Some(1));
+        assert_eq!(r.next_doc().unwrap().unwrap().get_i32("a").ok(), Some(2));
+        let err = r.next_doc().unwrap_err();
+        assert!(err.contains("line 4"), "{err}");
+    }
+
+    #[test]
+    fn reader_csv_exposes_columns() {
+        let mut r = ImportReader::open(
+            &text_source("a,b\n1,2\n"),
+            "csv",
+            &CsvImportOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(r.columns(), &["a".to_string(), "b".to_string()]);
+        assert!(r.next_doc().unwrap().is_some());
+        assert!(r.next_doc().unwrap().is_none());
+    }
+
+    #[test]
+    fn reader_json_array_has_total_hint() {
+        let mut r = ImportReader::open(
+            &text_source("[{\"a\":1},{\"a\":2}]"),
+            "json",
+            &CsvImportOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(r.total_hint(), Some(2));
+        assert!(r.next_doc().unwrap().is_some());
+    }
+
+    #[test]
+    fn source_arg_validation() {
+        let both = ImportSourceArg { path: Some("x".into()), text: Some("y".into()) };
+        assert!(ImportReader::open(&both, "json", &CsvImportOptions::default()).is_err());
+        let neither = ImportSourceArg { path: None, text: None };
+        assert!(ImportReader::open(&neither, "json", &CsvImportOptions::default()).is_err());
+        let bson_text = ImportSourceArg { path: None, text: Some("x".into()) };
+        assert!(ImportReader::open(&bson_text, "bson", &CsvImportOptions::default())
+            .unwrap_err()
+            .contains("file"));
+    }
+}

--- a/src-tauri/src/db/import.rs
+++ b/src-tauri/src/db/import.rs
@@ -494,6 +494,40 @@ mod tests {
     }
 
     #[test]
+    fn reader_bson_reads_docs_from_file_and_reports_eof() {
+        use mongodb::bson::doc;
+        let path = std::env::temp_dir().join(format!(
+            "mqlens-import-reader-bson-test-{}-{}.bson",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut bytes = mongodb::bson::to_vec(&doc! { "_id": 1, "name": "Ada" }).unwrap();
+        bytes.extend(mongodb::bson::to_vec(&doc! { "_id": 2, "name": "Bob" }).unwrap());
+        std::fs::write(&path, &bytes).unwrap();
+
+        let mut r = ImportReader::open(
+            &ImportSourceArg { path: Some(path.to_string_lossy().to_string()), text: None },
+            "bson",
+            &CsvImportOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(r.next_doc().unwrap().unwrap().get_i32("_id").ok(), Some(1));
+        assert_eq!(r.next_doc().unwrap().unwrap().get_i32("_id").ok(), Some(2));
+        assert!(r.next_doc().unwrap().is_none());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn open_rejects_unknown_format() {
+        let err = ImportReader::open(&text_source("nope"), "yaml", &CsvImportOptions::default())
+            .unwrap_err();
+        assert!(err.contains("Unsupported import format"), "{err}");
+    }
+
+    #[test]
     fn source_arg_validation() {
         let both = ImportSourceArg { path: Some("x".into()), text: Some("y".into()) };
         assert!(ImportReader::open(&both, "json", &CsvImportOptions::default()).is_err());

--- a/src-tauri/src/db/import.rs
+++ b/src-tauri/src/db/import.rs
@@ -57,6 +57,9 @@ impl std::fmt::Debug for ImportReader {
     }
 }
 
+// One ImportReader is built per import/preview job (not a hot path), so the
+// size gap between the Bson variant (a BufReader) and the others is irrelevant.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum ImportReader {
     JsonArray {
         docs: std::vec::IntoIter<Document>,
@@ -212,9 +215,15 @@ impl ImportReader {
                     Err(e) => return Err(format!("Failed to read import file: {}", e)),
                 }
                 let chained = std::io::Cursor::new(peek).chain(reader.by_ref());
-                Document::from_reader(chained)
-                    .map(Some)
-                    .map_err(|e| format!("Invalid BSON: {}", e))
+                match Document::from_reader(chained) {
+                    Ok(doc) => Ok(Some(doc)),
+                    Err(e) => {
+                        // A parse error leaves the reader's position undefined for a
+                        // retry, so stop pulling further docs from this reader.
+                        *eof = true;
+                        Err(format!("Invalid BSON: {}", e))
+                    }
+                }
             }
         }
     }
@@ -238,12 +247,17 @@ pub async fn preview_import_impl(
         let mut error = None;
         while docs.len() < limit {
             match reader.next_doc() {
-                Ok(Some(doc)) => docs.push(
-                    serde_json::to_string(
+                Ok(Some(doc)) => {
+                    match serde_json::to_string(
                         &mongodb::bson::Bson::Document(doc).into_relaxed_extjson(),
-                    )
-                    .unwrap_or_default(),
-                ),
+                    ) {
+                        Ok(s) => docs.push(s),
+                        Err(e) => {
+                            error = Some(format!("Failed to serialize document for preview: {}", e));
+                            break;
+                        }
+                    }
+                }
                 Ok(None) => break,
                 Err(e) => {
                     error = Some(e);
@@ -444,12 +458,102 @@ pub async fn start_import_task_impl(
 }
 
 #[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
-    use crate::db::documents::CsvImportOptions;
+    use crate::db::documents::{CsvColumnType, CsvImportOptions};
 
     fn text_source(s: &str) -> ImportSourceArg {
         ImportSourceArg { path: None, text: Some(s.to_string()) }
+    }
+
+    /// Drain an ImportReader into a Vec<Document>, mirroring the old
+    /// parse_csv_docs return shape for these ported option-matrix tests.
+    fn drain(r: &mut ImportReader) -> Result<Vec<Document>, String> {
+        let mut docs = Vec::new();
+        while let Some(doc) = r.next_doc()? {
+            docs.push(doc);
+        }
+        Ok(docs)
+    }
+
+    // The following csv_* tests port the option-matrix coverage that used to
+    // exercise documents::parse_csv_docs directly (now deleted — it had no
+    // production callers) onto ImportReader, the path the app actually ships.
+
+    #[test]
+    fn csv_default_options_match_previous_behavior() {
+        let mut r =
+            ImportReader::open(&text_source("a,b\n1,x\n"), "csv", &CsvImportOptions::default())
+                .unwrap();
+        let docs = drain(&mut r).unwrap();
+        assert_eq!(
+            docs[0].get_i64("a").ok().or(docs[0].get_i32("a").map(i64::from).ok()),
+            Some(1)
+        );
+        assert_eq!(docs[0].get_str("b").unwrap(), "x");
+    }
+
+    #[test]
+    fn csv_delimiter_qualifier_skip_and_headerless() {
+        let text = "junk line\nA;\"x;y\"\n2;z\n";
+        let mut o = CsvImportOptions::default();
+        o.delimiter = ";".into();
+        o.skip_lines = 1;
+        o.has_headers = false;
+        let mut r = ImportReader::open(&text_source(text), "csv", &o).unwrap();
+        let docs = drain(&mut r).unwrap();
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].get_str("col1").unwrap(), "A");
+        assert_eq!(docs[0].get_str("col2").unwrap(), "x;y");
+        assert_eq!(docs[1].get_str("col2").unwrap(), "z");
+    }
+
+    #[test]
+    fn csv_explicit_column_types_convert_and_error_with_context() {
+        let mut o = CsvImportOptions::default();
+        o.column_types.insert("n".into(), CsvColumnType::Number);
+        o.column_types.insert("ok".into(), CsvColumnType::Boolean);
+        o.column_types.insert("when".into(), CsvColumnType::Date);
+        o.column_types.insert("meta".into(), CsvColumnType::Json);
+        o.column_types.insert("s".into(), CsvColumnType::String);
+        let mut r = ImportReader::open(
+            &text_source("n,ok,when,meta,s\n4.5,TRUE,2024-01-02T03:04:05Z,{\"a\":1},42\n"),
+            "csv",
+            &o,
+        )
+        .unwrap();
+        let docs = drain(&mut r).unwrap();
+        let d = &docs[0];
+        assert_eq!(d.get_f64("n").unwrap(), 4.5);
+        assert!(d.get_bool("ok").unwrap());
+        assert!(matches!(d.get("when"), Some(mongodb::bson::Bson::DateTime(_))));
+        assert_eq!(
+            d.get_document("meta")
+                .unwrap()
+                .get_i64("a")
+                .ok()
+                .or(d.get_document("meta").unwrap().get_i32("a").map(i64::from).ok()),
+            Some(1)
+        );
+        assert_eq!(d.get_str("s").unwrap(), "42"); // String type keeps digits as text
+
+        let mut err_reader =
+            ImportReader::open(&text_source("n\nnot-a-number\n"), "csv", &o).unwrap();
+        let err = drain(&mut err_reader).unwrap_err();
+        assert!(err.contains("row 1") && err.contains("\"n\"") && err.contains("number"), "{err}");
+    }
+
+    #[test]
+    fn csv_date_accepts_epoch_millis_and_number_is_i64_when_integral() {
+        let mut o = CsvImportOptions::default();
+        o.column_types.insert("when".into(), CsvColumnType::Date);
+        o.column_types.insert("n".into(), CsvColumnType::Number);
+        let mut r =
+            ImportReader::open(&text_source("when,n\n1700000000000,7\n"), "csv", &o).unwrap();
+        let docs = drain(&mut r).unwrap();
+        assert!(matches!(docs[0].get("when"), Some(mongodb::bson::Bson::DateTime(_))));
+        assert_eq!(docs[0].get_i64("n").unwrap(), 7);
     }
 
     #[test]
@@ -516,6 +620,43 @@ mod tests {
         .unwrap();
         assert_eq!(r.next_doc().unwrap().unwrap().get_i32("_id").ok(), Some(1));
         assert_eq!(r.next_doc().unwrap().unwrap().get_i32("_id").ok(), Some(2));
+        assert!(r.next_doc().unwrap().is_none());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn bson_reader_sets_eof_after_a_parse_error_so_it_does_not_retry() {
+        use mongodb::bson::doc;
+        // A valid document, then a malformed 12-byte "document" (declared
+        // length but not null-terminated, so it fails validation without
+        // consuming trailing bytes), then trailing bytes that would
+        // otherwise look like more input to (unsuccessfully) parse.
+        let mut bytes = mongodb::bson::to_vec(&doc! { "a": 1 }).unwrap();
+        bytes.extend_from_slice(&12i32.to_le_bytes());
+        bytes.extend_from_slice(&[0xFFu8; 8]);
+        bytes.extend_from_slice(b"TRAILING");
+
+        let path = std::env::temp_dir().join(format!(
+            "mqlens-import-reader-bson-badeof-{}-{}.bson",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, &bytes).unwrap();
+
+        let mut r = ImportReader::open(
+            &ImportSourceArg { path: Some(path.to_string_lossy().to_string()), text: None },
+            "bson",
+            &CsvImportOptions::default(),
+        )
+        .unwrap();
+        assert!(r.next_doc().unwrap().is_some());
+        let err = r.next_doc().unwrap_err();
+        assert!(err.contains("Invalid BSON"), "{err}");
+        // The reader must report EOF rather than attempt to parse the
+        // trailing bytes as another document.
         assert!(r.next_doc().unwrap().is_none());
         let _ = std::fs::remove_file(&path);
     }

--- a/src-tauri/src/db/import.rs
+++ b/src-tauri/src/db/import.rs
@@ -5,9 +5,14 @@ use crate::db::documents::{
     csv_record_to_doc, generated_headers, parse_json_array_docs, validate_csv_import_options,
     CsvImportOptions,
 };
+use crate::db::tasks::{fail_task, finish_task, now_ms, update_task};
+use crate::{AppState, LockExt, TaskInfo};
 use mongodb::bson::Document;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read};
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
 
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
@@ -255,6 +260,187 @@ pub async fn preview_import_impl(
     })
     .await
     .map_err(|e| format!("Preview task failed: {}", e))?
+}
+
+/// Read → batch → write loop for the background import task. Returns the
+/// processed count plus the insert/update/skip totals across all batches.
+#[allow(clippy::too_many_arguments)]
+async fn run_import(
+    tasks: Arc<Mutex<HashMap<String, TaskInfo>>>,
+    task_id: String,
+    client: Option<mongodb::Client>,
+    database: String,
+    collection: String,
+    source: ImportSourceArg,
+    format: String,
+    csv: CsvImportOptions,
+    mode: String,
+) -> Result<(u64, crate::db::documents::ImportResult), String> {
+    use crate::db::documents::ImportResult;
+    use crate::limits::IMPORT_BATCH_SIZE;
+
+    // The reader is synchronous file I/O — open and read batches on
+    // spawn_blocking, threading the reader through each hop.
+    let mut reader = tokio::task::spawn_blocking({
+        let source = source.clone();
+        let format = format.clone();
+        let csv = csv.clone();
+        move || ImportReader::open(&source, &format, &csv)
+    })
+    .await
+    .map_err(|e| format!("Import task failed: {}", e))??;
+    if let Some(total) = reader.total_hint() {
+        update_task(&tasks, &task_id, |t| t.total = Some(total));
+    }
+
+    let mut totals = ImportResult { inserted: 0, updated: 0, skipped: 0 };
+    let mut processed = 0u64;
+    loop {
+        // Pull one batch synchronously (cheap CPU; reads are buffered).
+        let (next_reader, batch) = tokio::task::spawn_blocking(move || {
+            let mut r = reader;
+            let mut batch = Vec::with_capacity(IMPORT_BATCH_SIZE);
+            let result: Result<(), String> = loop {
+                if batch.len() >= IMPORT_BATCH_SIZE {
+                    break Ok(());
+                }
+                match r.next_doc() {
+                    Ok(Some(doc)) => batch.push(doc),
+                    Ok(None) => break Ok(()),
+                    Err(e) => break Err(e),
+                }
+            };
+            (r, result.map(|_| batch))
+        })
+        .await
+        .map_err(|e| format!("Import task failed: {}", e))?;
+        reader = next_reader;
+        let batch = batch?;
+        if batch.is_empty() {
+            break;
+        }
+        let n = batch.len() as u64;
+
+        match &client {
+            None => {
+                // Mock: validate-only semantics, mirroring the parse-and-count
+                // behavior of the non-task import path.
+                if mode == "update" {
+                    totals.updated += n;
+                } else {
+                    totals.inserted += n;
+                }
+            }
+            Some(client) => {
+                let coll = client
+                    .database(&database)
+                    .collection::<Document>(&collection);
+                let res = crate::db::documents::write_imported_docs(&coll, batch, &mode).await?;
+                totals.inserted += res.inserted;
+                totals.updated += res.updated;
+                totals.skipped += res.skipped;
+            }
+        }
+        processed += n;
+        update_task(&tasks, &task_id, |t| {
+            t.processed = processed;
+            t.message = format!("Importing ({} written)", processed);
+        });
+    }
+    Ok((processed, totals))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn start_import_task_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    source: ImportSourceArg,
+    format: &str,
+    csv_options: Option<CsvImportOptions>,
+    mode: &str,
+) -> Result<TaskInfo, String> {
+    if !matches!(mode, "skip" | "update" | "abort") {
+        return Err("Import mode must be skip, update, or abort".to_string());
+    }
+    let csv = csv_options.unwrap_or_default();
+    if format.trim().eq_ignore_ascii_case("csv") {
+        validate_csv_import_options(&csv)?;
+    }
+    // Validate the source shape up front (open errors surface on the task).
+    if source.path.is_some() == source.text.is_some() {
+        return Err("Import source must be exactly one of a file path or pasted text".to_string());
+    }
+
+    let is_mock = crate::connection_is_mock(state, id)?;
+    let client = if is_mock {
+        None
+    } else {
+        Some(crate::require_real_client(state, id)?)
+    };
+
+    let source_label = source
+        .path
+        .as_deref()
+        .and_then(|p| {
+            std::path::Path::new(p)
+                .file_name()
+                .map(|f| f.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| "pasted text".to_string());
+    let task_id = Uuid::new_v4().to_string();
+    let task = TaskInfo {
+        id: task_id.clone(),
+        kind: "import".to_string(),
+        label: format!("Import {}.{} from {}", database, collection, source_label),
+        status: "running".to_string(),
+        processed: 0,
+        total: None,
+        message: "Queued".to_string(),
+        path: source.path.clone(),
+        error: None,
+        created_at_ms: now_ms(),
+        finished_at_ms: None,
+        sub_label: None,
+        items_processed: None,
+        items_total: None,
+        summary: None,
+    };
+    state.tasks.lock_safe()?.insert(task_id.clone(), task.clone());
+
+    let tasks = state.tasks.clone();
+    let database = database.to_string();
+    let collection = collection.to_string();
+    let format = format.to_string();
+    let mode = mode.to_string();
+    tokio::spawn(async move {
+        let result = run_import(
+            tasks.clone(),
+            task_id.clone(),
+            client,
+            database,
+            collection,
+            source,
+            format,
+            csv,
+            mode,
+        )
+        .await;
+        match result {
+            Ok((processed, totals)) => {
+                // TaskInfo.summary is typed for copy tasks (CopySummary), so
+                // the import counts ride on the completion message.
+                let message = format!(
+                    "Import complete: {} inserted, {} updated, {} skipped",
+                    totals.inserted, totals.updated, totals.skipped
+                );
+                finish_task(&tasks, &task_id, processed, message);
+            }
+            Err(err) => fail_task(&tasks, &task_id, err),
+        }
+    });
+    Ok(task)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -9,5 +9,6 @@ pub mod gridfs;
 pub mod metadata;
 pub mod query;
 pub mod schema;
+pub mod tasks;
 pub mod users;
 pub mod version;

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -6,6 +6,7 @@ pub mod ddl;
 pub mod documents;
 pub mod export;
 pub mod gridfs;
+pub mod import;
 pub mod metadata;
 pub mod query;
 pub mod schema;

--- a/src-tauri/src/db/tasks.rs
+++ b/src-tauri/src/db/tasks.rs
@@ -1,0 +1,64 @@
+//! Shared background-task bookkeeping for export and import jobs.
+
+use crate::TaskInfo;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+pub fn update_task<F>(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>, task_id: &str, update: F)
+where
+    F: FnOnce(&mut TaskInfo),
+{
+    if let Some(task) = tasks
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .get_mut(task_id)
+    {
+        update(task);
+    }
+}
+
+pub fn fail_task(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>, task_id: &str, err: String) {
+    update_task(tasks, task_id, |task| {
+        task.status = "failed".to_string();
+        task.message = "Task failed".to_string();
+        task.error = Some(err);
+        task.finished_at_ms = Some(now_ms());
+    });
+    prune_tasks(tasks);
+}
+
+pub fn finish_task(
+    tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>,
+    task_id: &str,
+    processed: u64,
+    message: String,
+) {
+    update_task(tasks, task_id, |task| {
+        task.status = "completed".to_string();
+        task.processed = processed;
+        task.message = message;
+        task.finished_at_ms = Some(now_ms());
+    });
+    prune_tasks(tasks);
+}
+
+pub fn prune_tasks(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>) {
+    use crate::limits::MAX_TASK_HISTORY;
+    let mut guard = tasks.lock().unwrap_or_else(|p| p.into_inner());
+    if guard.len() <= MAX_TASK_HISTORY {
+        return;
+    }
+    let mut entries: Vec<(String, TaskInfo)> = guard.drain().collect();
+    entries.sort_by(|a, b| b.1.created_at_ms.cmp(&a.1.created_at_ms));
+    for (id, task) in entries.into_iter().take(MAX_TASK_HISTORY) {
+        guard.insert(id, task);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,7 +41,7 @@ pub use db::gridfs::{
     delete_gridfs_file_impl, download_gridfs_file_impl, list_gridfs_files_impl,
     upload_gridfs_file_impl, GridFsFileInfo, GridFsTransferProgress,
 };
-pub use db::import::preview_import_impl;
+pub use db::import::{preview_import_impl, start_import_task_impl};
 pub use db::metadata::{
     create_index_impl, delete_index_impl, list_collections_impl, list_databases_impl,
     list_indexes_impl,
@@ -1406,6 +1406,31 @@ async fn preview_import(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
+async fn start_import_task(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+    collection: String,
+    source: crate::db::import::ImportSourceArg,
+    format: String,
+    csv_options: Option<crate::db::documents::CsvImportOptions>,
+    mode: String,
+) -> Result<TaskInfo, String> {
+    start_import_task_impl(
+        &state,
+        &id,
+        &database,
+        &collection,
+        source,
+        &format,
+        csv_options,
+        &mode,
+    )
+    .await
+}
+
+#[tauri::command]
 async fn update_document(
     state: tauri::State<'_, AppState>,
     id: String,
@@ -1664,6 +1689,7 @@ pub fn run() {
             insert_document,
             import_collection_file,
             preview_import,
+            start_import_task,
             update_document,
             execute_mql_query,
             execute_aggregate,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub use db::gridfs::{
     delete_gridfs_file_impl, download_gridfs_file_impl, list_gridfs_files_impl,
     upload_gridfs_file_impl, GridFsFileInfo, GridFsTransferProgress,
 };
+pub use db::import::preview_import_impl;
 pub use db::metadata::{
     create_index_impl, delete_index_impl, list_collections_impl, list_databases_impl,
     list_indexes_impl,
@@ -1395,6 +1396,16 @@ async fn import_collection_file(
 }
 
 #[tauri::command]
+async fn preview_import(
+    source: crate::db::import::ImportSourceArg,
+    format: String,
+    csv_options: Option<crate::db::documents::CsvImportOptions>,
+    limit: Option<usize>,
+) -> Result<crate::db::import::ImportPreview, String> {
+    preview_import_impl(source, &format, csv_options, limit.unwrap_or(20)).await
+}
+
+#[tauri::command]
 async fn update_document(
     state: tauri::State<'_, AppState>,
     id: String,
@@ -1652,6 +1663,7 @@ pub fn run() {
             delete_gridfs_file,
             insert_document,
             import_collection_file,
+            preview_import,
             update_document,
             execute_mql_query,
             execute_aggregate,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,8 +30,8 @@ pub use db::ddl::{
 };
 pub use db::documents::{
     delete_document_impl, delete_many_impl, import_documents_impl, insert_document_impl,
-    json_to_bson_document, parse_bson_docs, parse_csv_docs, parse_json_array_docs,
-    parse_ndjson_docs, update_document_impl, update_many_impl, ImportResult,
+    json_to_bson_document, parse_json_array_docs, update_document_impl, update_many_impl,
+    ImportResult,
 };
 pub use db::export::{
     format_current_docs_impl, preview_export_impl, sample_export_fields_impl,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,9 +29,9 @@ pub use db::ddl::{
     rename_collection_impl, rename_database_impl, DatabaseRenameResult,
 };
 pub use db::documents::{
-    delete_document_impl, delete_many_impl, import_collection_file_impl, import_documents_impl,
-    insert_document_impl, json_to_bson_document, parse_bson_docs, parse_csv_docs,
-    parse_json_array_docs, parse_ndjson_docs, update_document_impl, update_many_impl, ImportResult,
+    delete_document_impl, delete_many_impl, import_documents_impl, insert_document_impl,
+    json_to_bson_document, parse_bson_docs, parse_csv_docs, parse_json_array_docs,
+    parse_ndjson_docs, update_document_impl, update_many_impl, ImportResult,
 };
 pub use db::export::{
     format_current_docs_impl, preview_export_impl, sample_export_fields_impl,
@@ -1383,19 +1383,6 @@ async fn insert_document(
 }
 
 #[tauri::command]
-async fn import_collection_file(
-    state: tauri::State<'_, AppState>,
-    id: String,
-    database: String,
-    collection: String,
-    path: String,
-    format: String,
-    mode: String,
-) -> Result<ImportResult, String> {
-    import_collection_file_impl(&state, &id, &database, &collection, &path, &format, &mode).await
-}
-
-#[tauri::command]
 async fn preview_import(
     source: crate::db::import::ImportSourceArg,
     format: String,
@@ -1687,7 +1674,6 @@ pub fn run() {
             upload_gridfs_file,
             delete_gridfs_file,
             insert_document,
-            import_collection_file,
             preview_import,
             start_import_task,
             update_document,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -10,7 +10,7 @@ mod tests {
         format_current_docs_impl, import_documents_impl,
         insert_document_impl,
         json_to_bson_document, list_collections_impl, list_databases_impl, list_gridfs_files_impl,
-        list_indexes_impl, parse_bson_docs, parse_csv_docs, parse_json_array_docs, parse_ndjson_docs,
+        list_indexes_impl, parse_json_array_docs,
         preview_export_impl, rename_collection_impl, rename_database_impl, sample_export_fields_impl,
         start_collection_export_impl, start_filtered_export_impl, update_document_impl,
         upload_gridfs_file_impl,
@@ -267,6 +267,61 @@ mod tests {
         state.tasks.lock().unwrap().get(task_id).cloned().unwrap()
     }
 
+    /// Re-parse an on-disk export file through the shipping import reader
+    /// (used to round-trip-verify export output; `parse_ndjson_docs` /
+    /// `parse_bson_docs` were dead code and have been removed).
+    fn reparse_import_file(path: &std::path::Path, format: &str) -> Vec<mongodb::bson::Document> {
+        use crate::db::import::{ImportReader, ImportSourceArg};
+        let source = ImportSourceArg {
+            path: Some(path.to_string_lossy().to_string()),
+            text: None,
+        };
+        let mut reader =
+            ImportReader::open(&source, format, &CsvImportOptions::default()).expect("open reader");
+        let mut docs = Vec::new();
+        while let Some(doc) = reader.next_doc().expect("read doc") {
+            docs.push(doc);
+        }
+        docs
+    }
+
+    /// Parse a text source through the shipping import reader for a given
+    /// format (ports unit coverage that used to call the removed
+    /// `parse_ndjson_docs` / `parse_csv_docs` directly).
+    fn drain_text_source(
+        text: &str,
+        format: &str,
+        csv: &CsvImportOptions,
+    ) -> Result<Vec<mongodb::bson::Document>, String> {
+        use crate::db::import::{ImportReader, ImportSourceArg};
+        let source = ImportSourceArg { path: None, text: Some(text.to_string()) };
+        let mut reader = ImportReader::open(&source, format, csv)?;
+        let mut docs = Vec::new();
+        while let Some(doc) = reader.next_doc()? {
+            docs.push(doc);
+        }
+        Ok(docs)
+    }
+
+    /// Parse concatenated BSON bytes through the shipping import reader.
+    /// BSON import requires a file source, so this writes to a temp file
+    /// first (ports unit coverage that used to call the removed
+    /// `parse_bson_docs` directly).
+    fn drain_bson_bytes(bytes: &[u8]) -> Vec<mongodb::bson::Document> {
+        let path = std::env::temp_dir().join(format!(
+            "mqlens-tests-bson-{}-{}.bson",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, bytes).expect("write temp bson");
+        let docs = reparse_import_file(&path, "bson");
+        let _ = std::fs::remove_file(&path);
+        docs
+    }
+
     #[tokio::test]
     async fn test_mock_full_collection_export_task_writes_ndjson() {
         let state = AppState::new();
@@ -289,7 +344,7 @@ mod tests {
         let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
         assert_eq!(lines.len(), 3);
         assert!(!text.contains('['));
-        let docs = parse_ndjson_docs(&text).expect("re-parse ndjson");
+        let docs = reparse_import_file(&path, "ndjson");
         assert_eq!(docs.len(), 3);
         assert!(text.contains("Alice Smith"));
         let _ = std::fs::remove_file(&path);
@@ -313,8 +368,7 @@ mod tests {
         assert_eq!(finished.processed, 3);
 
         // The on-disk bytes are concatenated BSON and parse back to 3 documents.
-        let bytes = std::fs::read(&path).expect("bson file");
-        let docs = parse_bson_docs(&bytes).expect("re-parse bson");
+        let docs = reparse_import_file(&path, "bson");
         assert_eq!(docs.len(), 3);
         let names: Vec<String> = docs
             .iter()
@@ -2764,7 +2818,8 @@ mod tests {
     fn test_parse_ndjson_docs_skips_blank_lines() {
         // One doc per line, blank lines (incl. trailing newline) tolerated.
         let text = "{\"_id\": 1, \"name\": \"Ada\"}\n\n{\"_id\": 2, \"name\": \"Bob\"}\n";
-        let docs = parse_ndjson_docs(text).expect("parse ndjson");
+        let docs =
+            drain_text_source(text, "ndjson", &CsvImportOptions::default()).expect("parse ndjson");
         assert_eq!(docs.len(), 2);
         assert_eq!(docs[0].get_str("name").unwrap(), "Ada");
         assert_eq!(docs[1].get_str("name").unwrap(), "Bob");
@@ -2775,7 +2830,8 @@ mod tests {
         // An $oid wrapper must revive to a real ObjectId, not a sub-document.
         let oid = mongodb::bson::oid::ObjectId::new();
         let line = format!("{{\"_id\": {{\"$oid\": \"{}\"}}}}", oid.to_hex());
-        let docs = parse_ndjson_docs(&line).expect("parse ndjson ejson");
+        let docs = drain_text_source(&line, "ndjson", &CsvImportOptions::default())
+            .expect("parse ndjson ejson");
         assert_eq!(docs[0].get_object_id("_id").unwrap(), oid);
     }
 
@@ -2791,7 +2847,7 @@ mod tests {
         let mut bytes = mongodb::bson::to_vec(&original).expect("serialize bson");
         bytes.extend(mongodb::bson::to_vec(&doc! { "_id": 2, "name": "Bob" }).unwrap());
 
-        let docs = parse_bson_docs(&bytes).expect("parse bson");
+        let docs = drain_bson_bytes(&bytes);
         assert_eq!(docs.len(), 2);
         assert_eq!(docs[0].get_object_id("_id").unwrap(), oid);
         assert_eq!(docs[0].get_datetime("when").unwrap(), &when);
@@ -2804,14 +2860,15 @@ mod tests {
 
     #[test]
     fn test_parse_bson_docs_empty_input() {
-        assert_eq!(parse_bson_docs(&[]).expect("empty bson").len(), 0);
+        assert_eq!(drain_bson_bytes(&[]).len(), 0);
     }
 
     #[test]
     fn test_parse_csv_docs_revives_cell_values() {
         // Numbers/bools/objects parse as JSON; bare text stays a string.
         let text = "_id,name,active,tags\n1,Ada,true,\"[1,2]\"\n2,Bob,false,plain";
-        let docs = parse_csv_docs(text, &CsvImportOptions::default()).expect("parse csv");
+        let docs =
+            drain_text_source(text, "csv", &CsvImportOptions::default()).expect("parse csv");
         assert_eq!(docs.len(), 2);
         assert_eq!(docs[0].get_i32("_id").unwrap(), 1);
         assert_eq!(docs[0].get_str("name").unwrap(), "Ada");

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2899,4 +2899,33 @@ mod tests {
         assert!(res.is_err(), "unknown import format must error");
         let _ = std::fs::remove_file(&path);
     }
+
+    #[tokio::test]
+    async fn test_preview_import_truncates_and_reports_inline_errors() {
+        use crate::db::import::{preview_import_impl, ImportSourceArg};
+        // 30 NDJSON lines → only 20 previewed.
+        let text: String = (0..30).map(|i| format!("{{\"n\":{}}}\n", i)).collect();
+        let p = preview_import_impl(
+            ImportSourceArg { path: None, text: Some(text) },
+            "ndjson",
+            None,
+            20,
+        )
+        .await
+        .unwrap();
+        assert_eq!(p.docs.len(), 20);
+        assert!(p.error.is_none());
+
+        // Parse error surfaces inline, docs keep the good prefix.
+        let p = preview_import_impl(
+            ImportSourceArg { path: None, text: Some("{\"a\":1}\nboom\n".into()) },
+            "ndjson",
+            None,
+            20,
+        )
+        .await
+        .unwrap();
+        assert_eq!(p.docs.len(), 1);
+        assert!(p.error.as_deref().unwrap_or("").contains("line 2"));
+    }
 }

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use crate::db::documents::CsvImportOptions;
     use crate::AppState;
     use crate::{
         connect_db_impl, count_documents_impl, create_collection_impl, create_index_impl,
@@ -2810,7 +2811,7 @@ mod tests {
     fn test_parse_csv_docs_revives_cell_values() {
         // Numbers/bools/objects parse as JSON; bare text stays a string.
         let text = "_id,name,active,tags\n1,Ada,true,\"[1,2]\"\n2,Bob,false,plain";
-        let docs = parse_csv_docs(text).expect("parse csv");
+        let docs = parse_csv_docs(text, &CsvImportOptions::default()).expect("parse csv");
         assert_eq!(docs.len(), 2);
         assert_eq!(docs[0].get_i32("_id").unwrap(), 1);
         assert_eq!(docs[0].get_str("name").unwrap(), "Ada");

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2928,4 +2928,85 @@ mod tests {
         assert_eq!(p.docs.len(), 1);
         assert!(p.error.as_deref().unwrap_or("").contains("line 2"));
     }
+
+    #[tokio::test]
+    async fn test_import_task_streams_ndjson_from_file_on_mock() {
+        use crate::db::import::{start_import_task_impl, ImportSourceArg};
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+        let path = std::env::temp_dir().join(format!(
+            "mqlens-import-test-{}-{}.jsonl",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        // 1200 docs → 3 batches of 500/500/200.
+        let text: String = (0..1200).map(|i| format!("{{\"n\":{}}}\n", i)).collect();
+        std::fs::write(&path, text).unwrap();
+
+        let task = start_import_task_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            ImportSourceArg { path: Some(path.to_string_lossy().to_string()), text: None },
+            "ndjson",
+            None,
+            "skip",
+        )
+        .await
+        .unwrap();
+        assert_eq!(task.kind, "import");
+        wait_for_task(&state, &task.id).await;
+
+        let finished = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(finished.status, "completed");
+        assert_eq!(finished.processed, 1200, "cap must not apply to task imports");
+        // TaskInfo.summary is the copy-task CopySummary struct, so import
+        // counts ride on the completion message instead.
+        assert!(finished.message.contains("1200 inserted"), "{}", finished.message);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn test_import_task_fails_on_parse_error_and_reports_line() {
+        use crate::db::import::{start_import_task_impl, ImportSourceArg};
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+        let task = start_import_task_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            ImportSourceArg { path: None, text: Some("{\"a\":1}\nboom\n".into()) },
+            "ndjson",
+            None,
+            "skip",
+        )
+        .await
+        .unwrap();
+        wait_for_task(&state, &task.id).await;
+        let finished = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(finished.status, "failed");
+        assert!(finished.error.as_deref().unwrap_or("").contains("line 2"));
+    }
+
+    #[tokio::test]
+    async fn test_import_task_validates_mode_and_source() {
+        use crate::db::import::{start_import_task_impl, ImportSourceArg};
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+        let err = start_import_task_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            ImportSourceArg { path: None, text: Some("[]".into()) },
+            "json",
+            None,
+            "yolo",
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("mode"));
+    }
 }

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -7,7 +7,7 @@ mod tests {
         delete_document_impl, delete_gridfs_file_impl, disconnect_db_impl,
         download_gridfs_file_impl, drop_collection_impl,
         drop_database_impl, execute_aggregate_impl, execute_mql_query_impl, explain_mql_query_impl,
-        format_current_docs_impl, import_collection_file_impl, import_documents_impl,
+        format_current_docs_impl, import_documents_impl,
         insert_document_impl,
         json_to_bson_document, list_collections_impl, list_databases_impl, list_gridfs_files_impl,
         list_indexes_impl, parse_bson_docs, parse_csv_docs, parse_json_array_docs, parse_ndjson_docs,
@@ -2821,83 +2821,6 @@ mod tests {
             &vec![mongodb::bson::Bson::Int32(1), mongodb::bson::Bson::Int32(2)]
         );
         assert_eq!(docs[1].get_str("tags").unwrap(), "plain");
-    }
-
-    #[tokio::test]
-    async fn test_mock_import_collection_file_ndjson() {
-        let state = AppState::new();
-        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
-            .await
-            .expect("connect mock");
-        let path = temp_import_path("ndjson");
-        std::fs::write(
-            &path,
-            "{\"_id\": 1, \"name\": \"Ada\"}\n{\"_id\": 2, \"name\": \"Bob\"}\n",
-        )
-        .unwrap();
-
-        let res = import_collection_file_impl(
-            &state,
-            &conn_id,
-            "sales_db",
-            "customers",
-            &path.to_string_lossy(),
-            "ndjson",
-            "skip",
-        )
-        .await
-        .expect("ndjson import validates on mock");
-        assert_eq!(res.inserted, 2);
-        let _ = std::fs::remove_file(&path);
-    }
-
-    #[tokio::test]
-    async fn test_mock_import_collection_file_bson() {
-        use mongodb::bson::doc;
-        let state = AppState::new();
-        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
-            .await
-            .expect("connect mock");
-        let path = temp_import_path("bson");
-        let mut bytes = mongodb::bson::to_vec(&doc! { "_id": 1, "name": "Ada" }).unwrap();
-        bytes.extend(mongodb::bson::to_vec(&doc! { "_id": 2, "name": "Bob" }).unwrap());
-        std::fs::write(&path, &bytes).unwrap();
-
-        let res = import_collection_file_impl(
-            &state,
-            &conn_id,
-            "sales_db",
-            "customers",
-            &path.to_string_lossy(),
-            "bson",
-            "skip",
-        )
-        .await
-        .expect("bson import validates on mock");
-        assert_eq!(res.inserted, 2);
-        let _ = std::fs::remove_file(&path);
-    }
-
-    #[tokio::test]
-    async fn test_import_collection_file_rejects_unknown_format() {
-        let state = AppState::new();
-        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
-            .await
-            .expect("connect mock");
-        let path = temp_import_path("txt");
-        std::fs::write(&path, "nope").unwrap();
-        let res = import_collection_file_impl(
-            &state,
-            &conn_id,
-            "sales_db",
-            "customers",
-            &path.to_string_lossy(),
-            "yaml",
-            "skip",
-        )
-        .await;
-        assert!(res.is_err(), "unknown import format must error");
-        let _ = std::fs::remove_file(&path);
     }
 
     #[tokio::test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -336,6 +336,13 @@ function Workspace() {
   }, []);
 
   const [exportTasks, setExportTasks] = useState<ExportTaskInfo[]>([]);
+  // Import tasks started from the Import tab, keyed by task id, so the poll
+  // below can refresh the source collection tab once the task completes.
+  // TaskInfo has no connection/db/collection fields, so we track them here
+  // at the point the task is started instead of trying to recover them later.
+  const pendingImportRefreshRef = React.useRef(
+    new Map<string, { connectionId: string; db: string; collection: string }>()
+  );
   const loadExportTasks = React.useCallback(async () => {
     try {
       const tasks = await invoke<ExportTaskInfo[]>('list_export_tasks');
@@ -1278,6 +1285,29 @@ function Workspace() {
     }
   };
 
+  // When a tracked import task (started from the Import tab) is observed
+  // completed by the task poll, refresh the matching open collection tab so
+  // newly-imported documents show up without a manual re-run.
+  useEffect(() => {
+    const pending = pendingImportRefreshRef.current;
+    if (pending.size === 0) return;
+    for (const task of exportTasks) {
+      if (task.kind !== 'import' || task.status !== 'completed') continue;
+      const info = pending.get(task.id);
+      if (!info) continue;
+      pending.delete(task.id);
+      const match = tabs.find(
+        (t) =>
+          t.type === 'collection' &&
+          t.connectionId === info.connectionId &&
+          t.db === info.db &&
+          t.collection === info.collection
+      );
+      if (match) refreshTabResults(match);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [exportTasks]);
+
   const [documentModal, setDocumentModal] = useState<
     { mode: 'insert' | 'edit'; initialJson: string; targetDoc: Record<string, any> | null } | null
   >(null);
@@ -2049,6 +2079,11 @@ function Workspace() {
                           format,
                           csvOptions,
                           mode,
+                        });
+                        pendingImportRefreshRef.current.set(task.id, {
+                          connectionId: activeTab.connectionId,
+                          db: activeTab.db,
+                          collection: activeTab.collection,
                         });
                         setExportTasks(prev => [task, ...prev.filter(t => t.id !== task.id)]);
                         handleOpenTasksTab();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
   type FilteredExportSeed,
   type FilteredExportQuery,
 } from './components/ExportView';
+import { ImportView, type ImportPreviewData } from './components/ImportView';
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
 import { CreateViewView } from './components/CreateViewView';
@@ -44,12 +45,12 @@ import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
-import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks } from 'lucide-react';
+import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 interface QueryTab {
   id: string;
-  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users';
+  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users';
   connectionId: string;
   db: string;
   collection: string;
@@ -172,6 +173,8 @@ const tabIconFor = (tab: QueryTab, isActive: boolean): React.ReactNode => {
       return <Rocket size={size} className={className} />;
     case 'export':
       return <Download size={size} className={className} />;
+    case 'import':
+      return <Upload size={size} className={className} />;
     case 'tasks':
       return <ListChecks size={size} className={className} />;
     case 'schema':
@@ -204,6 +207,8 @@ const tabLabelFor = (
       return 'Quick Start';
     case 'export':
       return `Export: ${tab.collection}`;
+    case 'import':
+      return `Import: ${tab.collection}`;
     case 'tasks':
       return 'Tasks';
     case 'schema':
@@ -222,7 +227,7 @@ const tabLabelFor = (
 };
 
 function Workspace() {
-  const { toast, confirm, choose, prompt } = useDialogs();
+  const { toast, confirm, prompt } = useDialogs();
   const { config, resolvedMode, setMode, setSpacingDensity, resetZoom } = useTheme();
   const density = config.spacingDensity;
   // Open the Quick Start tab by default so the app never starts on a blank canvas.
@@ -692,6 +697,27 @@ function Workspace() {
         db: sourceTab.db,
         collection: sourceTab.collection,
         exportSourceTabId: sourceTab.id,
+        results: [],
+        loading: false,
+        error: null,
+        explainResult: null,
+      }]);
+    }
+    setActiveTabId(tabId);
+    loadExportTasks();
+  };
+
+  const handleOpenImportTab = (sourceTab: QueryTab) => {
+    if (sourceTab.type !== 'collection') return;
+    const tabId = `import.${sourceTab.connectionId}.${sourceTab.db}.${sourceTab.collection}`;
+    const tabExists = tabs.some(t => t.id === tabId);
+    if (!tabExists) {
+      setTabs(prev => [...prev, {
+        id: tabId,
+        type: 'import',
+        connectionId: sourceTab.connectionId,
+        db: sourceTab.db,
+        collection: sourceTab.collection,
         results: [],
         loading: false,
         error: null,
@@ -1412,52 +1438,9 @@ function Workspace() {
     };
   };
 
-  // Map a chosen import file to its backend format by extension.
-  const importFormatForPath = (path: string): 'json' | 'ndjson' | 'csv' | 'bson' => {
-    const lower = path.toLowerCase();
-    if (lower.endsWith('.bson')) return 'bson';
-    if (lower.endsWith('.csv')) return 'csv';
-    if (lower.endsWith('.jsonl') || lower.endsWith('.ndjson')) return 'ndjson';
-    return 'json';
-  };
-
-  const handleImport = async () => {
+  const handleImport = () => {
     if (!activeTab || activeTab.type !== 'collection') return;
-    try {
-      const path = await open({
-        multiple: false,
-        filters: [{ name: 'Data', extensions: ['json', 'jsonl', 'ndjson', 'csv', 'bson'] }],
-      });
-      if (!path || typeof path !== 'string') return; // cancelled
-      const format = importFormatForPath(path);
-      // Choose the duplicate-handling mode. The backend parses the file (binary
-      // BSON cannot be read in the browser), so a malformed file fails there.
-      const mode = await choose({
-        title: 'Import documents',
-        message: 'How should existing documents with the same _id be handled?',
-        choices: [
-          { value: 'skip', label: 'Skip duplicates (insert new only)' },
-          { value: 'update', label: 'Update existing by _id' },
-          { value: 'abort', label: 'Abort if any _id already exists', destructive: true },
-        ],
-      });
-      if (!mode) return; // cancelled
-      const res = await invoke<{ inserted: number; updated: number; skipped: number }>(
-        'import_collection_file',
-        {
-          id: activeTab.connectionId,
-          database: activeTab.db,
-          collection: activeTab.collection,
-          path,
-          format,
-          mode,
-        }
-      );
-      await refreshTabResults(activeTab);
-      toast(`Imported: ${res.inserted} inserted, ${res.updated} updated, ${res.skipped} skipped`, 'success');
-    } catch (err: any) {
-      toast(`Import failed: ${err?.message || err}`, 'error');
-    }
+    handleOpenImportTab(activeTab);
   };
 
   const handleEditDocument = (doc: Record<string, any>) => {
@@ -2033,6 +2016,47 @@ function Workspace() {
                     onScanFields={handleScanExportFields}
                     onCopyCurrent={handleCopyCurrentExport}
                     onPreview={handlePreviewExport}
+                  />
+                );
+              })()}
+              {activeTab && activeTab.type === 'import' && (() => {
+                const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
+                const connectionName = activeConnection ? activeConnection.name : activeTab.connectionId;
+                return (
+                  <ImportView
+                    key={`import:${activeTab.connectionId}:${activeTab.db}:${activeTab.collection}`}
+                    connectionName={connectionName}
+                    databaseName={activeTab.db}
+                    collectionName={activeTab.collection}
+                    onOpenTasks={handleOpenTasksTab}
+                    onPickFile={async () => {
+                      const p = await open({
+                        multiple: false,
+                        filters: [{ name: 'Data', extensions: ['json', 'jsonl', 'ndjson', 'csv', 'bson'] }],
+                      });
+                      return typeof p === 'string' ? p : null;
+                    }}
+                    onPreview={(source, format, csvOptions) =>
+                      invoke<ImportPreviewData>('preview_import', { source, format, csvOptions, limit: 20 })
+                    }
+                    onRunImport={async (source, format, csvOptions, mode) => {
+                      try {
+                        const task = await invoke<ExportTaskInfo>('start_import_task', {
+                          id: activeTab.connectionId,
+                          database: activeTab.db,
+                          collection: activeTab.collection,
+                          source,
+                          format,
+                          csvOptions,
+                          mode,
+                        });
+                        setExportTasks(prev => [task, ...prev.filter(t => t.id !== task.id)]);
+                        handleOpenTasksTab();
+                        await loadExportTasks();
+                      } catch (err: any) {
+                        toast(`Import failed to start: ${err?.message || err}`, 'error');
+                      }
+                    }}
                   />
                 );
               })()}

--- a/src/components/ImportView.tsx
+++ b/src/components/ImportView.tsx
@@ -87,11 +87,16 @@ const selectClassName =
 
 const checkboxLabelClassName = 'flex cursor-pointer items-center gap-2 text-xs text-foreground';
 
+const CSV_COLUMN_TYPES: CsvColumnType[] = ['auto', 'string', 'number', 'boolean', 'date', 'json'];
+
+const PREVIEW_DEBOUNCE_MS = 300;
+
 export const ImportView: React.FC<ImportViewProps> = ({
   connectionName,
   databaseName,
   collectionName,
   onPickFile,
+  onPreview,
   onRunImport,
   onOpenTasks,
 }) => {
@@ -108,6 +113,7 @@ export const ImportView: React.FC<ImportViewProps> = ({
   const [delimiterChoice, setDelimiterChoice] = React.useState<',' | ';' | '\t' | 'custom'>(',');
   const [customDelimiter, setCustomDelimiter] = React.useState('|');
   const [mode, setMode] = React.useState<'skip' | 'update' | 'abort'>('skip');
+  const [preview, setPreview] = React.useState<ImportPreviewData | null>(null);
 
   const effectiveDelimiter = delimiterChoice === 'custom' ? customDelimiter : delimiterChoice;
   const delimiterValid =
@@ -124,7 +130,45 @@ export const ImportView: React.FC<ImportViewProps> = ({
   const hasSource =
     sourceKind === 'file' ? filePath !== null : text.length > 0 && !pasteOverCap;
 
-  const canRun = hasSource && delimiterValid && quoteValid;
+  const canRun = hasSource && delimiterValid && quoteValid && preview?.error == null;
+
+  React.useEffect(() => {
+    if (!hasSource || !onPreview) {
+      setPreview(null);
+      return;
+    }
+    const source: ImportSource = sourceKind === 'file' ? { path: filePath! } : { text };
+    const timer = setTimeout(() => {
+      onPreview(source, format, effectiveCsvOptions)
+        .then(setPreview)
+        .catch((err) => setPreview({ docs: [], columns: [], totalHint: null, error: String(err) }));
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+    // columnTypes changes intentionally excluded — they affect import, not the raw preview parse.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    sourceKind,
+    filePath,
+    text,
+    format,
+    delimiterChoice,
+    customDelimiter,
+    csvOptions.quote,
+    csvOptions.skipLines,
+    csvOptions.hasHeaders,
+  ]);
+
+  const setColumnType = (column: string, type: CsvColumnType) => {
+    setCsvOptions((o) => {
+      const columnTypes = { ...o.columnTypes };
+      if (type === 'auto') {
+        delete columnTypes[column];
+      } else {
+        columnTypes[column] = type;
+      }
+      return { ...o, columnTypes };
+    });
+  };
 
   const pickFile = async () => {
     const path = await onPickFile();
@@ -323,6 +367,90 @@ export const ImportView: React.FC<ImportViewProps> = ({
             )}
           </section>
         )}
+
+        <section className="flex flex-col gap-2 px-3.5 py-3" data-testid="import-preview-section">
+          <div>
+            <h3 className="text-sm font-medium text-foreground">Preview</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground" data-testid="import-preview-caption">
+              {preview
+                ? `Previewing first ${preview.docs.length} document(s)` +
+                  (preview.totalHint !== null ? ` of ~${preview.totalHint}` : '')
+                : 'Choose a source to preview'}
+            </p>
+          </div>
+          {preview?.error && (
+            <div data-testid="import-preview-error" className="text-xs text-destructive">
+              {preview.error}
+            </div>
+          )}
+          {preview && format === 'csv' && preview.columns.length > 0 && (
+            <div className="max-h-64 overflow-auto">
+              <table data-testid="import-preview-grid" className="w-full border-collapse text-xs">
+                <thead>
+                  <tr>
+                    {preview.columns.map((col) => (
+                      <th
+                        key={col}
+                        className="border border-border bg-muted/30 px-2 py-1 text-left align-top font-medium"
+                      >
+                        <div className="flex flex-col gap-1">
+                          <span className="truncate">{col}</span>
+                          <select
+                            value={csvOptions.columnTypes[col] ?? 'auto'}
+                            onChange={(e) => setColumnType(col, e.target.value as CsvColumnType)}
+                            className={selectClassName}
+                            data-testid={'import-coltype-' + col}
+                          >
+                            {CSV_COLUMN_TYPES.map((t) => (
+                              <option key={t} value={t}>
+                                {t}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.docs.map((doc, i) => {
+                    let parsed: Record<string, unknown> = {};
+                    try {
+                      parsed = JSON.parse(doc) as Record<string, unknown>;
+                    } catch {
+                      // leave the row empty if a preview doc is malformed
+                    }
+                    return (
+                      <tr key={i}>
+                        {preview.columns.map((col) => (
+                          <td key={col} className="border border-border px-2 py-1">
+                            {String(parsed[col] ?? '')}
+                          </td>
+                        ))}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {preview && (format !== 'csv' || preview.columns.length === 0) && preview.docs.length > 0 && (
+            <pre
+              data-testid="import-preview-docs"
+              className="max-h-64 overflow-auto rounded-md border border-border bg-muted/30 p-2 text-xs"
+            >
+              {preview.docs
+                .map((d) => {
+                  try {
+                    return JSON.stringify(JSON.parse(d), null, 2);
+                  } catch {
+                    return d;
+                  }
+                })
+                .join('\n')}
+            </pre>
+          )}
+        </section>
 
         <section className="flex flex-col gap-2 px-3.5 py-3">
           <div>

--- a/src/components/ImportView.tsx
+++ b/src/components/ImportView.tsx
@@ -119,7 +119,8 @@ export const ImportView: React.FC<ImportViewProps> = ({
   const effectiveDelimiter = delimiterChoice === 'custom' ? customDelimiter : delimiterChoice;
   const delimiterValid =
     format !== 'csv' || (effectiveDelimiter.length === 1 && /^[\x00-\x7F]$/.test(effectiveDelimiter));
-  const quoteValid = format !== 'csv' || csvOptions.quote.length === 1;
+  const quoteValid =
+    format !== 'csv' || (csvOptions.quote.length === 1 && /^[\x00-\x7F]$/.test(csvOptions.quote));
 
   const effectiveCsvOptions: CsvImportOptions = {
     ...csvOptions,
@@ -135,6 +136,9 @@ export const ImportView: React.FC<ImportViewProps> = ({
 
   React.useEffect(() => {
     if (!hasSource || !onPreview) {
+      // Bump the generation so a response already in flight from before the
+      // source/preview handler was cleared can't repopulate this cleared preview.
+      previewGen.current++;
       setPreview(null);
       return;
     }
@@ -343,7 +347,7 @@ export const ImportView: React.FC<ImportViewProps> = ({
                 min={0}
                 value={csvOptions.skipLines}
                 onChange={(e) =>
-                  setCsvOptions((o) => ({ ...o, skipLines: Number(e.target.value) || 0 }))
+                  setCsvOptions((o) => ({ ...o, skipLines: Math.max(0, Number(e.target.value) || 0) }))
                 }
                 className="h-8 w-24 text-xs"
                 data-testid="import-csv-skiplines"
@@ -370,7 +374,7 @@ export const ImportView: React.FC<ImportViewProps> = ({
             )}
             {!quoteValid && (
               <span className="w-full text-xs text-destructive">
-                Quote must be a single character.
+                Quote must be a single ASCII character
               </span>
             )}
           </section>

--- a/src/components/ImportView.tsx
+++ b/src/components/ImportView.tsx
@@ -114,6 +114,7 @@ export const ImportView: React.FC<ImportViewProps> = ({
   const [customDelimiter, setCustomDelimiter] = React.useState('|');
   const [mode, setMode] = React.useState<'skip' | 'update' | 'abort'>('skip');
   const [preview, setPreview] = React.useState<ImportPreviewData | null>(null);
+  const previewGen = React.useRef(0);
 
   const effectiveDelimiter = delimiterChoice === 'custom' ? customDelimiter : delimiterChoice;
   const delimiterValid =
@@ -139,9 +140,16 @@ export const ImportView: React.FC<ImportViewProps> = ({
     }
     const source: ImportSource = sourceKind === 'file' ? { path: filePath! } : { text };
     const timer = setTimeout(() => {
+      const gen = ++previewGen.current;
       onPreview(source, format, effectiveCsvOptions)
-        .then(setPreview)
-        .catch((err) => setPreview({ docs: [], columns: [], totalHint: null, error: String(err) }));
+        .then((data) => {
+          if (gen === previewGen.current) setPreview(data);
+        })
+        .catch((err) => {
+          if (gen === previewGen.current) {
+            setPreview({ docs: [], columns: [], totalHint: null, error: String(err) });
+          }
+        });
     }, PREVIEW_DEBOUNCE_MS);
     return () => clearTimeout(timer);
     // columnTypes changes intentionally excluded — they affect import, not the raw preview parse.

--- a/src/components/ImportView.tsx
+++ b/src/components/ImportView.tsx
@@ -1,0 +1,400 @@
+import React from 'react';
+import { Upload, ListChecks } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+
+/** File formats the import view can read. */
+export type ImportFormat = 'json' | 'ndjson' | 'csv' | 'bson';
+
+/** Column type override for CSV field coercion. */
+export type CsvColumnType = 'auto' | 'string' | 'number' | 'boolean' | 'date' | 'json';
+
+/** CSV-specific import options. */
+export interface CsvImportOptions {
+  /** Single char; UI presets , ; \t plus a custom character. */
+  delimiter: string;
+  quote: string;
+  skipLines: number;
+  hasHeaders: boolean;
+  /** Per-column type overrides, keyed by column name. Populated by a later task's preview. */
+  columnTypes: Record<string, CsvColumnType>;
+}
+
+export const DEFAULT_CSV_IMPORT_OPTIONS: CsvImportOptions = {
+  delimiter: ',',
+  quote: '"',
+  skipLines: 0,
+  hasHeaders: true,
+  columnTypes: {},
+};
+
+/** The chosen input: a file on disk or pasted text. */
+export interface ImportSource {
+  path?: string;
+  text?: string;
+}
+
+/** Sample rows/columns from a preview run (produced by a later task). */
+export interface ImportPreviewData {
+  docs: string[];
+  columns: string[];
+  totalHint: number | null;
+  error: string | null;
+}
+
+/** Pasted text over this size should be saved to a file and imported that way instead. */
+export const PASTE_LIMIT = 2_000_000;
+
+/** Map a file path's extension to an import format, case-insensitive. */
+export function detectImportFormat(path: string): ImportFormat {
+  const lower = path.toLowerCase();
+  if (lower.endsWith('.bson')) return 'bson';
+  if (lower.endsWith('.csv')) return 'csv';
+  if (lower.endsWith('.jsonl') || lower.endsWith('.ndjson')) return 'ndjson';
+  return 'json';
+}
+
+interface ImportViewProps {
+  connectionName: string;
+  databaseName: string;
+  collectionName: string;
+  onPickFile: () => Promise<string | null>;
+  onPreview?: (
+    source: ImportSource,
+    format: ImportFormat,
+    csvOptions: CsvImportOptions
+  ) => Promise<ImportPreviewData>;
+  onRunImport: (
+    source: ImportSource,
+    format: ImportFormat,
+    csvOptions: CsvImportOptions,
+    mode: 'skip' | 'update' | 'abort'
+  ) => void;
+  onOpenTasks?: () => void;
+}
+
+const IMPORT_FORMATS: { value: ImportFormat; label: string }[] = [
+  { value: 'json', label: 'JSON array' },
+  { value: 'ndjson', label: 'NDJSON' },
+  { value: 'csv', label: 'CSV' },
+  { value: 'bson', label: 'BSON' },
+];
+
+const selectClassName =
+  'h-8 min-w-0 rounded-md border border-input bg-background px-2 text-xs shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+const checkboxLabelClassName = 'flex cursor-pointer items-center gap-2 text-xs text-foreground';
+
+export const ImportView: React.FC<ImportViewProps> = ({
+  connectionName,
+  databaseName,
+  collectionName,
+  onPickFile,
+  onRunImport,
+  onOpenTasks,
+}) => {
+  const [sourceKind, setSourceKind] = React.useState<'file' | 'paste'>('file');
+  const [filePath, setFilePath] = React.useState<string | null>(null);
+  const [text, setText] = React.useState('');
+  const [format, setFormat] = React.useState<ImportFormat>('json');
+  const [csvOptions, setCsvOptions] = React.useState<Omit<CsvImportOptions, 'delimiter'>>({
+    quote: DEFAULT_CSV_IMPORT_OPTIONS.quote,
+    skipLines: DEFAULT_CSV_IMPORT_OPTIONS.skipLines,
+    hasHeaders: DEFAULT_CSV_IMPORT_OPTIONS.hasHeaders,
+    columnTypes: DEFAULT_CSV_IMPORT_OPTIONS.columnTypes,
+  });
+  const [delimiterChoice, setDelimiterChoice] = React.useState<',' | ';' | '\t' | 'custom'>(',');
+  const [customDelimiter, setCustomDelimiter] = React.useState('|');
+  const [mode, setMode] = React.useState<'skip' | 'update' | 'abort'>('skip');
+
+  const effectiveDelimiter = delimiterChoice === 'custom' ? customDelimiter : delimiterChoice;
+  const delimiterValid =
+    format !== 'csv' || (effectiveDelimiter.length === 1 && /^[\x00-\x7F]$/.test(effectiveDelimiter));
+  const quoteValid = format !== 'csv' || csvOptions.quote.length === 1;
+
+  const effectiveCsvOptions: CsvImportOptions = {
+    ...csvOptions,
+    delimiter: effectiveDelimiter,
+  };
+
+  const pasteOverCap = text.length > PASTE_LIMIT;
+
+  const hasSource =
+    sourceKind === 'file' ? filePath !== null : text.length > 0 && !pasteOverCap;
+
+  const canRun = hasSource && delimiterValid && quoteValid;
+
+  const pickFile = async () => {
+    const path = await onPickFile();
+    if (!path) return;
+    setFilePath(path);
+    setFormat(detectImportFormat(path));
+  };
+
+  const selectSourceKind = (kind: 'file' | 'paste') => {
+    setSourceKind(kind);
+    if (kind === 'paste' && format === 'bson') setFormat('json');
+  };
+
+  const runImport = () => {
+    if (!canRun) return;
+    const source: ImportSource =
+      sourceKind === 'file' ? { path: filePath! } : { text };
+    onRunImport(source, format, effectiveCsvOptions, mode);
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-auto" data-testid="import-view">
+      <header className="flex items-center justify-between gap-4 border-b border-border bg-muted/30 px-3.5 py-2">
+        <div>
+          <h2 className="text-sm font-semibold text-foreground">Import</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {connectionName} / {databaseName}.{collectionName}
+          </p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={onOpenTasks}>
+          <ListChecks size={12} />
+          View Tasks
+        </Button>
+      </header>
+
+      <div className="divide-y divide-border">
+        <section className="flex flex-col gap-2 px-3.5 py-3">
+          <div>
+            <h3 className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <Upload size={14} />
+              <span>Source</span>
+            </h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Choose a file to import, or paste documents directly.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="import-source-kind"
+                data-testid="import-source-file"
+                checked={sourceKind === 'file'}
+                onChange={() => selectSourceKind('file')}
+              />
+              <span>File</span>
+            </label>
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="import-source-kind"
+                data-testid="import-source-paste"
+                checked={sourceKind === 'paste'}
+                onChange={() => selectSourceKind('paste')}
+              />
+              <span>Paste</span>
+            </label>
+          </div>
+
+          {sourceKind === 'file' ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={pickFile}
+                data-testid="import-pick-file-btn"
+              >
+                Choose file…
+              </Button>
+              {filePath && (
+                <span
+                  className="truncate text-xs text-muted-foreground"
+                  data-testid="import-file-path"
+                >
+                  {filePath}
+                </span>
+              )}
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1">
+              <textarea
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                className="h-32 w-full rounded-md border border-input bg-background px-2 py-1.5 font-mono text-xs shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                data-testid="import-paste-textarea"
+              />
+              {pasteOverCap && (
+                <span className="text-xs text-destructive" data-testid="import-paste-cap-note">
+                  paste is limited to 2 MB — save it as a file and import that
+                </span>
+              )}
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <Label className="text-xs text-muted-foreground">Format</Label>
+            <select
+              value={format}
+              onChange={(e) => setFormat(e.target.value as ImportFormat)}
+              className={cn(selectClassName, 'w-40')}
+              data-testid="import-format-select"
+            >
+              {IMPORT_FORMATS.map((f) => (
+                <option key={f.value} value={f.value} disabled={f.value === 'bson' && sourceKind === 'paste'}>
+                  {f.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </section>
+
+        {format === 'csv' && (
+          <section className="flex flex-wrap items-end gap-x-4 gap-y-2 px-3.5 py-3">
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">Delimiter</Label>
+              <select
+                value={delimiterChoice}
+                onChange={(e) => setDelimiterChoice(e.target.value as ',' | ';' | '\t' | 'custom')}
+                className={selectClassName}
+                data-testid="import-csv-delimiter"
+              >
+                <option value=",">Comma (,)</option>
+                <option value=";">Semicolon (;)</option>
+                <option value={'\t'}>Tab</option>
+                <option value="custom">Custom…</option>
+              </select>
+            </div>
+            {delimiterChoice === 'custom' && (
+              <div className="flex flex-col gap-1">
+                <Label className="text-xs">Custom delimiter</Label>
+                <Input
+                  value={customDelimiter}
+                  onChange={(e) => setCustomDelimiter(e.target.value)}
+                  className="h-8 w-20 text-xs"
+                  data-testid="import-csv-delimiter-custom"
+                />
+              </div>
+            )}
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">Quote</Label>
+              <Input
+                value={csvOptions.quote}
+                onChange={(e) => setCsvOptions((o) => ({ ...o, quote: e.target.value }))}
+                className="h-8 w-16 text-xs"
+                data-testid="import-csv-quote"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs">Skip lines</Label>
+              <Input
+                type="number"
+                min={0}
+                value={csvOptions.skipLines}
+                onChange={(e) =>
+                  setCsvOptions((o) => ({ ...o, skipLines: Number(e.target.value) || 0 }))
+                }
+                className="h-8 w-24 text-xs"
+                data-testid="import-csv-skiplines"
+              />
+            </div>
+            <div className="flex items-center gap-4 pb-2">
+              <label className={checkboxLabelClassName}>
+                <input
+                  type="checkbox"
+                  checked={csvOptions.hasHeaders}
+                  onChange={() =>
+                    setCsvOptions((o) => ({ ...o, hasHeaders: !o.hasHeaders }))
+                  }
+                  className="rounded border-input"
+                  data-testid="import-csv-headers"
+                />
+                <span>First row is headers</span>
+              </label>
+            </div>
+            {!delimiterValid && (
+              <span className="w-full text-xs text-destructive">
+                Delimiter must be a single ASCII character.
+              </span>
+            )}
+            {!quoteValid && (
+              <span className="w-full text-xs text-destructive">
+                Quote must be a single character.
+              </span>
+            )}
+          </section>
+        )}
+
+        <section className="flex flex-col gap-2 px-3.5 py-3">
+          <div>
+            <h3 className="text-sm font-medium text-foreground">Duplicate handling</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              How should existing documents with the same _id be handled?
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="import-mode"
+                data-testid="import-mode-skip"
+                checked={mode === 'skip'}
+                onChange={() => setMode('skip')}
+              />
+              <span>Skip duplicates (insert new only)</span>
+            </label>
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="import-mode"
+                data-testid="import-mode-update"
+                checked={mode === 'update'}
+                onChange={() => setMode('update')}
+              />
+              <span>Update existing by _id</span>
+            </label>
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="import-mode"
+                data-testid="import-mode-abort"
+                checked={mode === 'abort'}
+                onChange={() => setMode('abort')}
+              />
+              <span>Abort if any _id already exists</span>
+            </label>
+          </div>
+        </section>
+
+        <section className="flex flex-wrap items-center justify-between gap-3 px-3.5 py-3">
+          <div>
+            <h3 className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <Upload size={14} />
+              <span>Run</span>
+            </h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Runs in the background and reports progress in the Tasks tab.
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!canRun}
+            onClick={runImport}
+            data-testid="import-run-btn"
+          >
+            <Upload size={13} />
+            Import
+          </Button>
+        </section>
+      </div>
+
+      <p className="px-3.5 py-3 text-xs text-muted-foreground">
+        Imports run in the background. Track their progress in the{' '}
+        <button type="button" className="underline hover:text-foreground" onClick={onOpenTasks}>
+          Tasks
+        </button>{' '}
+        tab.
+      </p>
+    </div>
+  );
+};

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -568,8 +568,21 @@ describe('App Component', () => {
     expect(await screen.findByText(/"VIP Vic"/)).toBeInTheDocument();
   });
 
-  it('imports documents from a file via import_collection_file (H5)', async () => {
+  it('opens the Import tab and starts a background import task', async () => {
     const calls: any[] = [];
+    const task = {
+      id: 'task-3',
+      kind: 'import',
+      label: 'Import into sales_db.customers',
+      status: 'running',
+      processed: 0,
+      total: null,
+      message: 'Queued',
+      path: null,
+      error: null,
+      createdAtMs: 1,
+      finishedAtMs: null,
+    };
     mockInvoke.mockImplementation((cmd: string, args: any) => {
       calls.push({ cmd, args });
       if (cmd === 'execute_mql_query') {
@@ -578,13 +591,18 @@ describe('App Component', () => {
       if (cmd === 'load_collection_queries') {
         return Promise.resolve({ saved: [], history: [], default: null });
       }
-      if (cmd === 'import_collection_file') {
-        return Promise.resolve({ inserted: 2, updated: 0, skipped: 0 });
+      if (cmd === 'preview_import') {
+        return Promise.resolve({ docs: [], columns: [], totalHint: null, error: null });
+      }
+      if (cmd === 'start_import_task') {
+        return Promise.resolve(task);
+      }
+      if (cmd === 'list_export_tasks') {
+        return Promise.resolve([task]);
       }
       return Promise.resolve([]);
     });
-    // The backend parses the file from disk; the frontend only forwards path + format.
-    openMock.mockResolvedValue('/tmp/data.jsonl');
+    openMock.mockResolvedValue('/tmp/d.jsonl');
 
     const { fireEvent, waitFor } = await import('@testing-library/react');
     renderWithProviders(<App />);
@@ -594,21 +612,63 @@ describe('App Component', () => {
     expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('import-btn'));
+    expect(await screen.findByTestId('import-view')).toBeInTheDocument();
 
-    // Pick the duplicate-handling mode via the in-app choose dialog.
-    fireEvent.click(await screen.findByTestId('dialog-choice-skip'));
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await waitFor(() =>
+      expect(screen.getByTestId('import-file-path')).toHaveTextContent('/tmp/d.jsonl'));
+
+    fireEvent.click(screen.getByTestId('import-run-btn'));
 
     await waitFor(() => {
-      const imp = calls.find((c) => c.cmd === 'import_collection_file');
+      const imp = calls.find((c) => c.cmd === 'start_import_task');
       expect(imp).toBeTruthy();
       expect(imp.args).toMatchObject({
         database: 'sales_db',
         collection: 'customers',
-        path: '/tmp/data.jsonl',
+        source: { path: '/tmp/d.jsonl' },
         format: 'ndjson',
         mode: 'skip',
       });
     });
+    expect(await screen.findByTestId('task-manager')).toBeInTheDocument();
+  });
+
+  it('previews through preview_import', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'execute_mql_query') {
+        return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+      }
+      if (cmd === 'load_collection_queries') {
+        return Promise.resolve({ saved: [], history: [], default: null });
+      }
+      if (cmd === 'preview_import') {
+        return Promise.resolve({ docs: [], columns: [], totalHint: null, error: null });
+      }
+      return Promise.resolve([]);
+    });
+    openMock.mockResolvedValue('/tmp/d.jsonl');
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('select-collection-btn'));
+    expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('import-btn'));
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+
+    await waitFor(
+      () => {
+        const prev = calls.find((c) => c.cmd === 'preview_import');
+        expect(prev).toBeTruthy();
+        expect(prev.args).toMatchObject({ format: 'ndjson', limit: 20 });
+      },
+      { timeout: 2000 }
+    );
   });
 
   it('starts a background task for full collection export', async () => {
@@ -890,35 +950,6 @@ describe('App Component', () => {
     // No extra count: same filter.
     const countAfter = calls.filter(c => c.cmd === 'count_documents').length;
     expect(countAfter).toBe(1);
-  });
-
-  it('surfaces a malformed-file backend error as an import error toast (H5)', async () => {
-    mockInvoke.mockImplementation((cmd: string) => {
-      if (cmd === 'execute_mql_query') {
-        return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
-      }
-      if (cmd === 'load_collection_queries') {
-        return Promise.resolve({ saved: [], history: [], default: null });
-      }
-      if (cmd === 'import_collection_file') {
-        // The backend parses the file and rejects on malformed input.
-        return Promise.reject('Invalid JSON: expected value at line 1');
-      }
-      return Promise.resolve([]);
-    });
-    openMock.mockResolvedValue('/tmp/bad.json');
-
-    const { fireEvent } = await import('@testing-library/react');
-    renderWithProviders(<App />);
-    await screen.findByTestId('mock-sidebar');
-
-    fireEvent.click(screen.getByTestId('select-collection-btn'));
-    expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId('import-btn'));
-    // Pick a duplicate-handling mode, then the backend reports the parse failure.
-    fireEvent.click(await screen.findByTestId('dialog-choice-skip'));
-    expect(await screen.findByText(/Import failed/)).toBeInTheDocument();
   });
 
   it('isolates query editor state per collection tab (#120)', async () => {

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -634,6 +634,79 @@ describe('App Component', () => {
     expect(await screen.findByTestId('task-manager')).toBeInTheDocument();
   });
 
+  it('refreshes the source collection tab once its import task completes', async () => {
+    vi.useFakeTimers();
+    try {
+      const calls: any[] = [];
+      const runningTask = {
+        id: 'task-import-refresh',
+        kind: 'import',
+        label: 'Import sales_db.customers from d.jsonl',
+        status: 'running',
+        processed: 0,
+        total: null,
+        message: 'Queued',
+        path: null,
+        error: null,
+        createdAtMs: 1,
+        finishedAtMs: null,
+      };
+      let taskStatus = 'running';
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'execute_mql_query') {
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+        }
+        if (cmd === 'load_collection_queries') {
+          return Promise.resolve({ saved: [], history: [], default: null });
+        }
+        if (cmd === 'preview_import') {
+          return Promise.resolve({ docs: [], columns: [], totalHint: null, error: null });
+        }
+        if (cmd === 'start_import_task') {
+          return Promise.resolve(runningTask);
+        }
+        if (cmd === 'list_export_tasks') {
+          return Promise.resolve([{ ...runningTask, status: taskStatus }]);
+        }
+        return Promise.resolve([]);
+      });
+      openMock.mockResolvedValue('/tmp/d.jsonl');
+
+      const { fireEvent } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await vi.waitFor(() => expect(screen.getByTestId('mock-sidebar')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await vi.waitFor(() => expect(screen.getByText(/"John Doe"/)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('import-btn'));
+      await vi.waitFor(() => expect(screen.getByTestId('import-view')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+      await vi.waitFor(() =>
+        expect(screen.getByTestId('import-file-path')).toHaveTextContent('/tmp/d.jsonl'));
+
+      fireEvent.click(screen.getByTestId('import-run-btn'));
+      await vi.waitFor(() =>
+        expect(calls.some((c) => c.cmd === 'start_import_task')).toBe(true));
+
+      const execCallsBefore = calls.filter((c) => c.cmd === 'execute_mql_query').length;
+
+      // The task completes; the next poll tick should notice and re-run the
+      // source collection tab's query.
+      taskStatus = 'completed';
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await vi.waitFor(() => {
+        const execCallsAfter = calls.filter((c) => c.cmd === 'execute_mql_query').length;
+        expect(execCallsAfter).toBeGreaterThan(execCallsBefore);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('previews through preview_import', async () => {
     const calls: any[] = [];
     mockInvoke.mockImplementation((cmd: string, args: any) => {

--- a/src/components/__tests__/ImportView.test.tsx
+++ b/src/components/__tests__/ImportView.test.tsx
@@ -59,3 +59,46 @@ describe('ImportView sources and options', () => {
     expect(detectImportFormat('/a/b.json')).toBe('json');
   });
 });
+
+describe('ImportView preview', () => {
+  const csvPreview = {
+    docs: ['{"a":"1","b":"x"}'], columns: ['a', 'b'], totalHint: null, error: null,
+  };
+
+  it('debounces and renders a CSV grid with type selects', async () => {
+    vi.useFakeTimers();
+    const onPreview = vi.fn().mockResolvedValue(csvPreview);
+    renderImportView({ onPreview });
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await vi.waitFor(() => expect(screen.getByTestId('import-file-path')).toBeInTheDocument());
+    expect(onPreview).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(350);
+    expect(onPreview).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByTestId('import-preview-grid')).toBeInTheDocument());
+    expect(screen.getByTestId('import-coltype-a')).toBeInTheDocument();
+  });
+
+  it('type select changes flow into onRunImport payload', async () => {
+    const onPreview = vi.fn().mockResolvedValue(csvPreview);
+    const props = renderImportView({ onPreview });
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await waitFor(() => expect(screen.queryByTestId('import-coltype-a')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('import-coltype-a'), { target: { value: 'number' } });
+    fireEvent.click(screen.getByTestId('import-run-btn'));
+    expect(props.onRunImport).toHaveBeenCalledWith(
+      expect.anything(), 'csv',
+      expect.objectContaining({ columnTypes: { a: 'number' } }),
+      'skip');
+  });
+
+  it('renders parse errors inline and non-csv docs as a list', async () => {
+    const onPreview = vi.fn().mockResolvedValue({
+      docs: ['{"n":1}'], columns: [], totalHint: null, error: 'NDJSON line 2: Invalid JSON',
+    });
+    renderImportView({ onPreview, onPickFile: vi.fn().mockResolvedValue('/tmp/x.jsonl') });
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await waitFor(() => expect(screen.getByTestId('import-preview-error')).toHaveTextContent('line 2'));
+    expect(screen.getByTestId('import-preview-docs')).toHaveTextContent('"n"');
+  });
+});

--- a/src/components/__tests__/ImportView.test.tsx
+++ b/src/components/__tests__/ImportView.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ImportView, detectImportFormat } from '../ImportView';
+
+const renderImportView = (overrides: Record<string, unknown> = {}) => {
+  const props = {
+    connectionName: 'conn', databaseName: 'db', collectionName: 'coll',
+    onPickFile: vi.fn().mockResolvedValue('/tmp/data.csv'),
+    onRunImport: vi.fn(),
+    ...overrides,
+  };
+  render(<ImportView {...(props as any)} />);
+  return props;
+};
+
+describe('ImportView sources and options', () => {
+  it('detects format from the picked file and allows override', async () => {
+    renderImportView();
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await waitFor(() =>
+      expect(screen.getByTestId('import-file-path')).toHaveTextContent('/tmp/data.csv'));
+    expect((screen.getByTestId('import-format-select') as HTMLSelectElement).value).toBe('csv');
+    fireEvent.change(screen.getByTestId('import-format-select'), { target: { value: 'ndjson' } });
+    expect(screen.queryByTestId('import-csv-delimiter')).not.toBeInTheDocument();
+  });
+
+  it('paste source disables BSON and enforces the 2MB cap note', () => {
+    renderImportView();
+    fireEvent.click(screen.getByTestId('import-source-paste'));
+    const bson = screen.getByTestId('import-format-select').querySelector('option[value="bson"]');
+    expect(bson).toHaveProperty('disabled', true);
+    fireEvent.change(screen.getByTestId('import-paste-textarea'), { target: { value: 'x'.repeat(10) } });
+    expect(screen.queryByTestId('import-paste-cap-note')).not.toBeInTheDocument();
+    expect(screen.getByTestId('import-run-btn')).toBeEnabled();
+    fireEvent.change(screen.getByTestId('import-paste-textarea'), {
+      target: { value: 'x'.repeat(2_000_001) },
+    });
+    expect(screen.getByTestId('import-paste-cap-note')).toHaveTextContent('save it as a file');
+    expect(screen.getByTestId('import-run-btn')).toBeDisabled();
+  });
+
+  it('run button gates on a chosen source and calls onRunImport with options and mode', async () => {
+    const props = renderImportView();
+    expect(screen.getByTestId('import-run-btn')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await waitFor(() => expect(screen.getByTestId('import-run-btn')).toBeEnabled());
+    fireEvent.change(screen.getByTestId('import-csv-delimiter'), { target: { value: ';' } });
+    fireEvent.click(screen.getByTestId('import-mode-update'));
+    fireEvent.click(screen.getByTestId('import-run-btn'));
+    expect(props.onRunImport).toHaveBeenCalledWith(
+      { path: '/tmp/data.csv' }, 'csv',
+      expect.objectContaining({ delimiter: ';' }), 'update');
+  });
+
+  it('detectImportFormat maps extensions', () => {
+    expect(detectImportFormat('/a/b.bson')).toBe('bson');
+    expect(detectImportFormat('/a/b.CSV')).toBe('csv');
+    expect(detectImportFormat('/a/b.jsonl')).toBe('ndjson');
+    expect(detectImportFormat('/a/b.json')).toBe('json');
+  });
+});

--- a/src/components/__tests__/ImportView.test.tsx
+++ b/src/components/__tests__/ImportView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ImportView, detectImportFormat } from '../ImportView';
 
@@ -65,6 +65,10 @@ describe('ImportView preview', () => {
     docs: ['{"a":"1","b":"x"}'], columns: ['a', 'b'], totalHint: null, error: null,
   };
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('debounces and renders a CSV grid with type selects', async () => {
     vi.useFakeTimers();
     const onPreview = vi.fn().mockResolvedValue(csvPreview);
@@ -90,6 +94,44 @@ describe('ImportView preview', () => {
       expect.anything(), 'csv',
       expect.objectContaining({ columnTypes: { a: 'number' } }),
       'skip');
+  });
+
+  it('ignores a stale preview response that resolves after a newer one', async () => {
+    vi.useFakeTimers();
+    let resolveA!: (value: typeof csvPreview) => void;
+    let resolveB!: (value: typeof csvPreview) => void;
+    const pA = new Promise<typeof csvPreview>((r) => {
+      resolveA = r;
+    });
+    const pB = new Promise<typeof csvPreview>((r) => {
+      resolveB = r;
+    });
+    const onPreview = vi.fn().mockReturnValueOnce(pA).mockReturnValueOnce(pB);
+    renderImportView({ onPreview });
+
+    // Request A: pick the file, let the debounce fire.
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await vi.waitFor(() => expect(screen.getByTestId('import-file-path')).toBeInTheDocument());
+    await vi.advanceTimersByTimeAsync(350);
+    expect(onPreview).toHaveBeenCalledTimes(1);
+
+    // Request B: change the delimiter, let the debounce fire again.
+    fireEvent.change(screen.getByTestId('import-csv-delimiter'), { target: { value: ';' } });
+    await vi.advanceTimersByTimeAsync(350);
+    expect(onPreview).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+
+    // B resolves first, with the fresh content.
+    resolveB({ docs: ['{"fresh":true}'], columns: [], totalHint: null, error: null });
+    await waitFor(() =>
+      expect(screen.getByTestId('import-preview-docs')).toHaveTextContent('fresh'));
+
+    // A resolves late, with stale content — it must not overwrite B's result.
+    resolveA({ docs: ['{"stale":true}'], columns: [], totalHint: null, error: null });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByTestId('import-preview-docs')).toHaveTextContent('fresh');
+    expect(screen.getByTestId('import-preview-docs')).not.toHaveTextContent('stale');
   });
 
   it('renders parse errors inline and non-csv docs as a list', async () => {

--- a/src/components/__tests__/ImportView.test.tsx
+++ b/src/components/__tests__/ImportView.test.tsx
@@ -52,6 +52,23 @@ describe('ImportView sources and options', () => {
       expect.objectContaining({ delimiter: ';' }), 'update');
   });
 
+  it('clamps skip-lines input to a non-negative integer', async () => {
+    renderImportView();
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await waitFor(() => expect(screen.getByTestId('import-csv-skiplines')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('import-csv-skiplines'), { target: { value: '-5' } });
+    expect((screen.getByTestId('import-csv-skiplines') as HTMLInputElement).value).toBe('0');
+  });
+
+  it('quote validity requires a single ASCII character', async () => {
+    renderImportView();
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await waitFor(() => expect(screen.getByTestId('import-csv-quote')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('import-csv-quote'), { target: { value: '€' } });
+    expect(screen.getByText('Quote must be a single ASCII character')).toBeInTheDocument();
+    expect(screen.getByTestId('import-run-btn')).toBeDisabled();
+  });
+
   it('detectImportFormat maps extensions', () => {
     expect(detectImportFormat('/a/b.bson')).toBe('bson');
     expect(detectImportFormat('/a/b.CSV')).toBe('csv');
@@ -132,6 +149,34 @@ describe('ImportView preview', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(screen.getByTestId('import-preview-docs')).toHaveTextContent('fresh');
     expect(screen.getByTestId('import-preview-docs')).not.toHaveTextContent('stale');
+  });
+
+  it('a stale preview response cannot repopulate a preview cleared by removing the source', async () => {
+    vi.useFakeTimers();
+    let resolvePreview!: (value: typeof csvPreview) => void;
+    const pending = new Promise<typeof csvPreview>((r) => {
+      resolvePreview = r;
+    });
+    const onPreview = vi.fn().mockReturnValueOnce(pending);
+    renderImportView({ onPreview });
+
+    // Kick off a preview request for the file source.
+    fireEvent.click(screen.getByTestId('import-pick-file-btn'));
+    await vi.waitFor(() => expect(screen.getByTestId('import-file-path')).toBeInTheDocument());
+    await vi.advanceTimersByTimeAsync(350);
+    expect(onPreview).toHaveBeenCalledTimes(1);
+
+    // Clear the source before the in-flight preview resolves — switching to
+    // paste with no text drops hasSource, which clears the preview.
+    fireEvent.click(screen.getByTestId('import-source-paste'));
+
+    vi.useRealTimers();
+    resolvePreview(csvPreview);
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The stale response must not repopulate the cleared preview.
+    expect(screen.queryByTestId('import-preview-grid')).not.toBeInTheDocument();
+    expect(screen.getByTestId('import-preview-caption')).toHaveTextContent('Choose a source to preview');
   });
 
   it('renders parse errors inline and non-csv docs as a list', async () => {


### PR DESCRIPTION
## Summary
- Replaces the file-dialog + popup import with a dedicated Import tab: file or pasted-text source (2 MB paste cap), format auto-detect with override
- CSV parsing options (delimiter, text qualifier, skip first N lines, header row) and per-column type mapping (auto/string/number/boolean/date/json) in a live preview grid of the first 20 docs with inline parse errors
- Imports run as background tasks streaming 500-doc batches — the 10,000-document cap is gone for NDJSON/CSV/BSON; completion shows inserted/updated/skipped and auto-refreshes the source collection view
- Shared task bookkeeping extracted to `db/tasks.rs`; old `import_collection_file` flow fully removed with test coverage ported to the shipping `ImportReader` path

Stacked on #161; final multi-agent review verdict: ready to merge.

## Test plan
- [x] Rust suites (reader option matrix, batch streaming, abort semantics, preview truncation)
- [x] Frontend suites (preview debounce, stale-response race, type-grid payloads) + typecheck
- [ ] Manual: import a type-mapped CSV and a >10k-line NDJSON file, watch progress in Tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)