### PR TITLE
feat: dump/restore tabs and guided MongoDB tool setup

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -175,6 +175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1224,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -1571,6 +1598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "delegate"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1720,7 @@ dependencies = [
  "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -2814,6 +2848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,6 +3402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,6 +3505,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
+dependencies = [
+ "sha2 0.11.0",
+]
 
 [[package]]
 name = "macro_magic"
@@ -4585,6 +4640,12 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "ppv-lite86"
@@ -6244,6 +6305,7 @@ dependencies = [
  "argon2 0.5.3",
  "base64 0.22.1",
  "csv",
+ "flate2",
  "futures",
  "mongodb",
  "rand 0.8.6",
@@ -6252,7 +6314,9 @@ dependencies = [
  "rust_xlsxwriter",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "sysinfo",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-biometry",
@@ -6262,8 +6326,11 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tempfile",
+ "tiny_http",
  "tokio",
  "uuid",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -6658,6 +6725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6688,6 +6756,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -8438,6 +8518,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "aes 0.9.1",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.4.2",
+ "hmac 0.13.0",
+ "indexmap 2.14.0",
+ "lzma-rust2",
+ "memchr",
+ "pbkdf2 0.13.0",
+ "ppmd-rust",
+ "sha1 0.11.0",
+ "time",
+ "typed-path",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8459,6 +8566,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,4 +44,12 @@ aes-gcm = "0.10"
 rand = "0.8"
 base64 = "0.22"
 rust_xlsxwriter = "0.96.0"
+tempfile = "3.27.0"
+sha2 = "0.11.0"
+zip = "8.6.0"
+tar = "0.4.46"
+flate2 = "1.1.9"
+
+[dev-dependencies]
+tiny_http = "0.12.0"
 

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -500,13 +500,10 @@ pub fn reencrypt_data_files(
 }
 
 #[tauri::command]
-pub async fn test_mongosh_path(path: String) -> Result<String, String> {
-    let executable = if path.trim().is_empty() {
-        "mongosh"
-    } else {
-        path.trim()
-    };
-    let output = Command::new(executable)
+pub async fn test_mongosh_path(app_handle: tauri::AppHandle, path: String) -> Result<String, String> {
+    let app_data_dir = app_handle.path().app_data_dir().ok();
+    let executable = crate::toolsetup::resolve_mongosh_executable(&path, app_data_dir.as_deref());
+    let output = Command::new(&executable)
         .arg("--version")
         .output()
         .map_err(|e| format!("Failed to run mongosh: {}", e))?;

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -8,6 +8,7 @@ pub mod export;
 pub mod gridfs;
 pub mod import;
 pub mod metadata;
+pub mod mongotools;
 pub mod query;
 pub mod schema;
 pub mod tasks;

--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -1,0 +1,1901 @@
+//! mongodump/mongorestore integration: option structs, argv builders with
+//! flag-legality validation, URI password redaction, a stderr progress-line
+//! parser, and the cancellable background-task runner that actually spawns
+//! the tools.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::Write;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use uuid::Uuid;
+
+use crate::db::tasks::{fail_task, finish_task, now_ms, update_task};
+use crate::state::{AppState, LockExt};
+use crate::TaskInfo;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum DumpScope {
+    Server,
+    Db { db: String },
+    Collection { db: String, coll: String },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum DumpTarget {
+    Folder { out: String },
+    Archive { file: String },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct DumpOptions {
+    pub scope: DumpScope,
+    pub target: DumpTarget,
+    pub gzip: bool,
+    pub query: Option<String>,
+    pub force_table_scan: bool,
+    pub dump_users_and_roles: bool,
+    pub oplog: bool,
+}
+
+impl Default for DumpOptions {
+    fn default() -> Self {
+        Self {
+            scope: DumpScope::Server,
+            target: DumpTarget::Folder { out: String::new() },
+            gzip: true,
+            query: None,
+            force_table_scan: false,
+            dump_users_and_roles: false,
+            oplog: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NsSelection {
+    pub db: String,
+    pub coll: String,
+    pub rename_to: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum RestoreSource {
+    Folder { dir: String },
+    Archive { file: String },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct RestoreOptions {
+    pub source: RestoreSource,
+    pub gzip: bool,
+    pub selections: Vec<NsSelection>,
+    pub filter_db: Option<String>,
+    pub filter_coll: Option<String>,
+    pub drop: bool,
+    pub keep_index_version: bool,
+    pub no_index_restore: bool,
+    pub no_options_restore: bool,
+    pub maintain_insertion_order: bool,
+    pub stop_on_error: bool,
+    pub bypass_document_validation: bool,
+    pub restore_db_users_and_roles: bool,
+    pub oplog_replay: bool,
+}
+
+impl Default for RestoreOptions {
+    fn default() -> Self {
+        Self {
+            source: RestoreSource::Folder { dir: String::new() },
+            gzip: false,
+            selections: Vec::new(),
+            filter_db: None,
+            filter_coll: None,
+            drop: false,
+            keep_index_version: false,
+            no_index_restore: false,
+            no_options_restore: false,
+            maintain_insertion_order: false,
+            stop_on_error: false,
+            bypass_document_validation: false,
+            restore_db_users_and_roles: false,
+            oplog_replay: false,
+        }
+    }
+}
+
+/// Build the argv (excluding the URI, which the runner supplies via a
+/// temp config file) for a `mongodump` invocation.
+pub fn build_dump_args(o: &DumpOptions) -> Result<Vec<String>, String> {
+    if o.oplog && !matches!(o.scope, DumpScope::Server) {
+        return Err("oplog requires a whole-server dump".to_string());
+    }
+    if o.dump_users_and_roles && !matches!(o.scope, DumpScope::Db { .. }) {
+        return Err("dumpDbUsersAndRoles requires database scope".to_string());
+    }
+    if o.query.is_some() && !matches!(o.scope, DumpScope::Collection { .. }) {
+        return Err("query requires collection scope".to_string());
+    }
+    match &o.target {
+        DumpTarget::Folder { out } if out.is_empty() => {
+            return Err("destination is required".to_string());
+        }
+        DumpTarget::Archive { file } if file.is_empty() => {
+            return Err("destination is required".to_string());
+        }
+        _ => {}
+    }
+
+    let mut args = Vec::new();
+
+    // User/server-controlled values ride in single `--flag=value` tokens so a
+    // value starting with '-' can't be parsed as a flag by go-flags.
+    match &o.scope {
+        DumpScope::Server => {}
+        DumpScope::Db { db } => {
+            args.push(format!("--db={}", db));
+        }
+        DumpScope::Collection { db, coll } => {
+            args.push(format!("--db={}", db));
+            args.push(format!("--collection={}", coll));
+        }
+    }
+
+    match &o.target {
+        DumpTarget::Folder { out } => {
+            args.push(format!("--out={}", out));
+        }
+        DumpTarget::Archive { file } => {
+            args.push(format!("--archive={}", file));
+        }
+    }
+
+    if o.gzip {
+        args.push("--gzip".to_string());
+    }
+    if let Some(query) = &o.query {
+        args.push(format!("--query={}", query));
+    }
+    if o.force_table_scan {
+        args.push("--forceTableScan".to_string());
+    }
+    if o.dump_users_and_roles {
+        args.push("--dumpDbUsersAndRoles".to_string());
+    }
+    if o.oplog {
+        args.push("--oplog".to_string());
+    }
+
+    Ok(args)
+}
+
+/// Build the argv (excluding the URI, which the runner supplies via a
+/// temp config file) for a `mongorestore` invocation.
+pub fn build_restore_args(o: &RestoreOptions) -> Result<Vec<String>, String> {
+    if o.filter_coll.is_some() && o.filter_db.is_none() {
+        return Err("archive filter collection requires a database".to_string());
+    }
+    if o.oplog_replay
+        && (!o.selections.is_empty() || o.filter_db.is_some() || o.filter_coll.is_some())
+    {
+        return Err("oplogReplay cannot be combined with namespace filters".to_string());
+    }
+    if o.restore_db_users_and_roles {
+        let single_db = match &o.source {
+            RestoreSource::Folder { .. } => {
+                let dbs: HashSet<&str> = o.selections.iter().map(|s| s.db.as_str()).collect();
+                dbs.len() == 1
+            }
+            RestoreSource::Archive { .. } => o.filter_db.is_some() && o.filter_coll.is_none(),
+        };
+        if !single_db {
+            return Err("restoreDbUsersAndRoles requires a single database selection".to_string());
+        }
+    }
+    match &o.source {
+        RestoreSource::Folder { dir } if dir.is_empty() => {
+            return Err("destination is required".to_string());
+        }
+        RestoreSource::Archive { file } if file.is_empty() => {
+            return Err("destination is required".to_string());
+        }
+        _ => {}
+    }
+
+    let mut args = Vec::new();
+
+    if let RestoreSource::Archive { file } = &o.source {
+        args.push(format!("--archive={}", file));
+    }
+
+    if o.gzip {
+        args.push("--gzip".to_string());
+    }
+    if o.drop {
+        args.push("--drop".to_string());
+    }
+    if o.keep_index_version {
+        args.push("--keepIndexVersion".to_string());
+    }
+    if o.no_index_restore {
+        args.push("--noIndexRestore".to_string());
+    }
+    if o.no_options_restore {
+        args.push("--noOptionsRestore".to_string());
+    }
+    if o.maintain_insertion_order {
+        args.push("--maintainInsertionOrder".to_string());
+    }
+    if o.stop_on_error {
+        args.push("--stopOnError".to_string());
+    }
+    if o.bypass_document_validation {
+        args.push("--bypassDocumentValidation".to_string());
+    }
+    if o.restore_db_users_and_roles {
+        args.push("--restoreDbUsersAndRoles".to_string());
+    }
+    if o.oplog_replay {
+        args.push("--oplogReplay".to_string());
+    }
+
+    // User/server-controlled values ride in single `--flag=value` tokens so a
+    // value starting with '-' can't be parsed as a flag by go-flags.
+    match &o.source {
+        RestoreSource::Folder { .. } => {
+            for sel in &o.selections {
+                args.push(format!("--nsInclude={}.{}", sel.db, sel.coll));
+                if let Some(rename_to) = &sel.rename_to {
+                    args.push(format!("--nsFrom={}.{}", sel.db, sel.coll));
+                    // --nsTo requires a full db.collection namespace; qualify
+                    // a bare collection name with the selection's db.
+                    if rename_to.contains('.') {
+                        args.push(format!("--nsTo={}", rename_to));
+                    } else {
+                        args.push(format!("--nsTo={}.{}", sel.db, rename_to));
+                    }
+                }
+            }
+        }
+        RestoreSource::Archive { .. } => {
+            if let Some(db) = &o.filter_db {
+                match &o.filter_coll {
+                    Some(coll) => args.push(format!("--nsInclude={}.{}", db, coll)),
+                    None => args.push(format!("--nsInclude={}.*", db)),
+                }
+            }
+        }
+    }
+
+    if let RestoreSource::Folder { dir } = &o.source {
+        args.push(format!("--dir={}", dir));
+    }
+
+    Ok(args)
+}
+
+/// Redact the password component of a MongoDB connection string, if any.
+/// `mongodb://user:pass@host` -> `mongodb://user:***@host`. Leaves the URI
+/// unchanged when there is no userinfo or no password.
+pub fn redact_uri_password(uri: &str) -> String {
+    let scheme_end = match uri.find("://") {
+        Some(idx) => idx + 3,
+        None => return uri.to_string(),
+    };
+    let rest = &uri[scheme_end..];
+    let authority_end = rest.find('/').unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    let at_pos = match authority.rfind('@') {
+        Some(idx) => idx,
+        None => return uri.to_string(),
+    };
+    let userinfo = &authority[..at_pos];
+    let colon_pos = match userinfo.find(':') {
+        Some(idx) => idx,
+        None => return uri.to_string(),
+    };
+    let user = &userinfo[..colon_pos];
+
+    let mut result = String::with_capacity(uri.len());
+    result.push_str(&uri[..scheme_end]);
+    result.push_str(user);
+    result.push_str(":***");
+    result.push_str(&authority[at_pos..]);
+    result.push_str(&rest[authority_end..]);
+    result
+}
+
+/// Redact URI passwords in free-form text (raw tool stderr): every
+/// whitespace-separated token containing "://" is run through
+/// [`redact_uri_password`]; all other tokens — and the original whitespace —
+/// pass through unchanged.
+fn redact_uris_in_text(text: &str) -> String {
+    if !text.contains("://") {
+        return text.to_string();
+    }
+    text.split_inclusive(char::is_whitespace)
+        .map(|token| {
+            if token.contains("://") {
+                redact_uri_password(token)
+            } else {
+                token.to_string()
+            }
+        })
+        .collect()
+}
+
+/// Strip the path database from a MongoDB URI for tool invocations, then
+/// append the query parameters mongodump/mongorestore need to avoid hanging
+/// on unreachable topology members:
+///
+/// - `directConnection=true` when `direct_connection` is set (tunneled
+///   connections only see one reachable host: the local tunnel endpoint;
+///   without this, the driver discovers replica-set members' real IPs via
+///   topology discovery and retries them indefinitely) — unless the URI
+///   already has an explicit `directConnection=` param, which always wins.
+/// - `serverSelectionTimeoutMS=30000` (all invocations) so an unreachable
+///   topology fails fast with the tool's own error instead of hanging
+///   forever, unless the URI already sets one.
+///
+/// Parameter names are matched ASCII-case-insensitively per the MongoDB URI
+/// spec (connection-string option names are case-insensitive); the query
+/// string is not percent-decoded.
+pub fn prepare_tool_uri(uri: &str, direct_connection: bool) -> String {
+    let stripped = strip_path_database(uri);
+    append_tool_query_params(&stripped, direct_connection)
+}
+
+/// True when a query-string param's key (the part before '=') equals `name`
+/// ASCII-case-insensitively — connection-string option names are
+/// case-insensitive per the MongoDB URI spec, so `authsource=` must be
+/// recognized as `authSource=` (the Go tools take last-one-wins on
+/// duplicates, so a missed match would append a conflicting param).
+fn query_param_has_key(param: &str, name: &str) -> bool {
+    let key = param.split('=').next().unwrap_or("");
+    key.eq_ignore_ascii_case(name)
+}
+
+/// Strip the path database from a MongoDB URI for tool invocations
+/// (mongodump/mongorestore treat it as a db selector that conflicts with
+/// --db/--nsInclude). MongoDB auth semantics: when no authSource query param
+/// is present, the path database IS the auth database — so preserve it as
+/// authSource=<pathdb> in that case.
+fn strip_path_database(uri: &str) -> String {
+    let scheme_end = match uri.find("://") {
+        Some(idx) => idx + 3,
+        None => return uri.to_string(),
+    };
+    let rest = &uri[scheme_end..];
+    // Authority window: everything up to the first '/' after "://". Percent-
+    // encoded credentials (e.g. `p%40ss%2Fx`) never contain a raw '/', so this
+    // can't be confused by userinfo content — same technique as
+    // `redact_uri_password`.
+    let authority_end = match rest.find('/') {
+        Some(idx) => idx,
+        None => return uri.to_string(), // no path at all
+    };
+    let authority = &rest[..authority_end];
+    let after_authority = &rest[authority_end..]; // starts with '/'
+    let path_and_rest = &after_authority[1..];
+
+    // The path database is everything up to the next '?' or '#' (or end).
+    let path_end = path_and_rest.find(['?', '#']).unwrap_or(path_and_rest.len());
+    let db = &path_and_rest[..path_end];
+    if db.is_empty() {
+        return uri.to_string();
+    }
+    let remainder = &path_and_rest[path_end..];
+
+    let mut result = String::with_capacity(uri.len() + db.len());
+    result.push_str(&uri[..scheme_end]);
+    result.push_str(authority);
+    result.push('/');
+
+    if let Some(rest_after_q) = remainder.strip_prefix('?') {
+        let frag_idx = rest_after_q.find('#').unwrap_or(rest_after_q.len());
+        let query = &rest_after_q[..frag_idx];
+        let fragment = &rest_after_q[frag_idx..];
+        let has_authsource = query.split('&').any(|p| query_param_has_key(p, "authSource"));
+        result.push('?');
+        if has_authsource {
+            result.push_str(query);
+        } else if query.is_empty() {
+            result.push_str("authSource=");
+            result.push_str(db);
+        } else {
+            result.push_str(query);
+            result.push_str("&authSource=");
+            result.push_str(db);
+        }
+        result.push_str(fragment);
+    } else {
+        // No query string: `remainder` is either empty or a fragment.
+        result.push_str("?authSource=");
+        result.push_str(db);
+        result.push_str(remainder);
+    }
+
+    result
+}
+
+/// Append `directConnection=true` (if requested and not already present) and
+/// `serverSelectionTimeoutMS=30000` (if not already present) to a URI's query
+/// string. Operates after [`strip_path_database`], whose output is always
+/// either the original `uri` unchanged (no path / empty path segment) or
+/// normalized to `scheme://authority/?query`, so the only shapes reaching
+/// here are "no path at all", "bare trailing slash", and "slash with query".
+fn append_tool_query_params(uri: &str, direct_connection: bool) -> String {
+    let scheme_end = match uri.find("://") {
+        Some(idx) => idx + 3,
+        None => return uri.to_string(),
+    };
+    let rest = &uri[scheme_end..];
+    let after_authority_idx = rest.find(['/', '?']).unwrap_or(rest.len());
+    let authority = &rest[..after_authority_idx];
+    let after_authority = &rest[after_authority_idx..];
+
+    let query_and_frag = match after_authority.find('?') {
+        Some(q_idx) => &after_authority[q_idx + 1..],
+        None => "",
+    };
+    let frag_idx = query_and_frag.find('#').unwrap_or(query_and_frag.len());
+    let query = &query_and_frag[..frag_idx];
+    let fragment = &query_and_frag[frag_idx..];
+
+    let has_direct_connection =
+        query.split('&').any(|p| query_param_has_key(p, "directConnection"));
+    let has_timeout =
+        query.split('&').any(|p| query_param_has_key(p, "serverSelectionTimeoutMS"));
+
+    let mut extra: Vec<&str> = Vec::new();
+    if direct_connection && !has_direct_connection {
+        extra.push("directConnection=true");
+    }
+    if !has_timeout {
+        extra.push("serverSelectionTimeoutMS=30000");
+    }
+
+    if extra.is_empty() {
+        return uri.to_string();
+    }
+
+    let mut result = String::with_capacity(uri.len() + 64);
+    result.push_str(&uri[..scheme_end]);
+    result.push_str(authority);
+    result.push('/');
+    result.push('?');
+    if query.is_empty() {
+        result.push_str(&extra.join("&"));
+    } else {
+        result.push_str(query);
+        result.push('&');
+        result.push_str(&extra.join("&"));
+    }
+    result.push_str(fragment);
+    result
+}
+
+/// Strip TLS-relaxation parameters the MongoDB Database Tools don't support
+/// in connection strings and return the equivalent command-line flag.
+///
+/// The app's Rust driver honors `tlsAllowInvalidCertificates=true` in the
+/// URI, but mongodump/mongorestore print "ignoring unsupported URI parameter"
+/// and enforce full certificate validation — against a cluster with
+/// self-signed certs every handshake then fails and server selection hangs
+/// until timeout. `--tlsInsecure` disables certificate and hostname
+/// validation, covering all three URI spellings. Option names are matched
+/// case-insensitively per the connection-string spec.
+pub fn extract_unsupported_tls_params(uri: &str) -> (String, Vec<String>) {
+    let query_start = match uri.find('?') {
+        Some(idx) => idx,
+        None => return (uri.to_string(), Vec::new()),
+    };
+    let after_q = &uri[query_start + 1..];
+    let frag_idx = after_q.find('#').unwrap_or(after_q.len());
+    let query = &after_q[..frag_idx];
+    let fragment = &after_q[frag_idx..];
+
+    let mut insecure = false;
+    let mut matched_any = false;
+    let kept: Vec<&str> = query
+        .split('&')
+        .filter(|param| {
+            let key = param.split('=').next().unwrap_or("");
+            let is_tls_relax = key.eq_ignore_ascii_case("tlsInsecure")
+                || key.eq_ignore_ascii_case("tlsAllowInvalidCertificates")
+                || key.eq_ignore_ascii_case("tlsAllowInvalidHostnames");
+            if is_tls_relax {
+                matched_any = true;
+                let value = param.split_once('=').map(|(_, v)| v).unwrap_or("");
+                if value.eq_ignore_ascii_case("true") {
+                    insecure = true;
+                }
+            }
+            !is_tls_relax
+        })
+        .collect();
+
+    if !matched_any {
+        return (uri.to_string(), Vec::new());
+    }
+
+    let mut result = String::with_capacity(uri.len());
+    result.push_str(&uri[..query_start]);
+    if !kept.is_empty() {
+        result.push('?');
+        result.push_str(&kept.join("&"));
+    }
+    result.push_str(fragment);
+
+    let flags = if insecure { vec!["--tlsInsecure".to_string()] } else { Vec::new() };
+    (result, flags)
+}
+
+/// A single line of progress parsed from mongodump/mongorestore stderr.
+#[derive(Clone, Debug)]
+pub enum ToolProgress {
+    NamespaceDone { ns: String, docs: u64 },
+    Info(String),
+}
+
+fn parse_ns_docs(rest: &str) -> Option<ToolProgress> {
+    let paren_idx = rest.find(" (")?;
+    let ns = rest[..paren_idx].to_string();
+    let after_paren = &rest[paren_idx + 2..];
+    let digits_end = after_paren.find(' ')?;
+    let docs: u64 = after_paren[..digits_end].parse().ok()?;
+    Some(ToolProgress::NamespaceDone { ns, docs })
+}
+
+/// Parse one line of mongodump/mongorestore stderr output into a
+/// [`ToolProgress`] event, or `None` if the line carries no progress
+/// information we understand.
+pub fn parse_tool_progress(line: &str) -> Option<ToolProgress> {
+    let content = match line.find('\t') {
+        Some(idx) => &line[idx + 1..],
+        None => line,
+    };
+
+    if let Some(rest) = content.strip_prefix("done dumping ") {
+        return parse_ns_docs(rest);
+    }
+    if let Some(rest) = content.strip_prefix("finished restoring ") {
+        return parse_ns_docs(rest);
+    }
+    if let Some(rest) = content.strip_prefix("writing ") {
+        let ns = rest.split(" to ").next()?;
+        return Some(ToolProgress::Info(format!("writing {}", ns)));
+    }
+    if content.contains("document(s)") {
+        return Some(ToolProgress::Info(content.to_string()));
+    }
+    // Periodic in-flight progress for one namespace, e.g.
+    // "[########................]  sales.orders  12345/50000  (24.7%)"
+    // (mongorestore reports bytes instead of documents; pass both through).
+    if let Some(rest) = content.strip_prefix('[').and_then(|r| r.split_once(']')) {
+        let progress = rest.1.split_whitespace().collect::<Vec<_>>().join(" ");
+        if !progress.is_empty() {
+            return Some(ToolProgress::Info(progress));
+        }
+    }
+
+    None
+}
+
+/// Look up the normalized connection URI (post-SSH-tunnel rewrite) stashed by
+/// `connect_db_impl` for a real connection. Mock connections are never
+/// inserted into `conn_uris`, so they — and unknown ids — fail here.
+pub fn resolve_conn_uri(state: &AppState, id: &str) -> Result<String, String> {
+    let conn_uris = state.conn_uris.lock_safe()?;
+    conn_uris
+        .get(id)
+        .cloned()
+        .ok_or_else(|| "Connection not found".to_string())
+}
+
+/// Resolve the real connection URI for a dump/restore task, rejecting mock
+/// connections with a friendlier message than the bare `resolve_conn_uri`
+/// "Connection not found" (mocks are never in `conn_uris`, but we want a
+/// specific error for "you picked a mock" vs. "that id doesn't exist").
+fn require_real_conn_uri(state: &AppState, id: &str) -> Result<String, String> {
+    let is_mock = state.mocks.lock_safe()?.get(id).copied().unwrap_or(false);
+    if is_mock {
+        return Err(
+            "MongoDB Database Tools require a real connection, not a mock connection".to_string(),
+        );
+    }
+    resolve_conn_uri(state, id)
+}
+
+fn basename(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string())
+}
+
+fn dump_destination(target: &DumpTarget) -> &str {
+    match target {
+        DumpTarget::Folder { out } => out,
+        DumpTarget::Archive { file } => file,
+    }
+}
+
+fn restore_source_path(source: &RestoreSource) -> &str {
+    match source {
+        RestoreSource::Folder { dir } => dir,
+        RestoreSource::Archive { file } => file,
+    }
+}
+
+fn dump_scope_desc(scope: &DumpScope) -> String {
+    match scope {
+        DumpScope::Server => "server".to_string(),
+        DumpScope::Db { db } => db.clone(),
+        DumpScope::Collection { db, coll } => format!("{}.{}", db, coll),
+    }
+}
+
+/// Write the temp YAML config mongodump/mongorestore read the URI from
+/// (`--uri` on the command line would leak the password via `ps`). 0600 on
+/// unix; Windows' default per-user temp-dir ACLs are adequate as-is.
+fn write_tool_config(uri: &str) -> Result<tempfile::NamedTempFile, String> {
+    let mut file = tempfile::NamedTempFile::new()
+        .map_err(|e| format!("Failed to create temp config file: {}", e))?;
+    // Escape backslashes and double quotes so a URI containing either can't break out
+    // of the YAML double-quoted scalar (or, worst case, inject extra YAML keys).
+    let escaped_uri = uri.replace('\\', "\\\\").replace('"', "\\\"");
+    writeln!(file, "uri: \"{}\"", escaped_uri)
+        .map_err(|e| format!("Failed to write temp config file: {}", e))?;
+    file.flush().map_err(|e| format!("Failed to write temp config file: {}", e))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(file.path(), std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("Failed to set temp config file permissions: {}", e))?;
+    }
+    Ok(file)
+}
+
+const STDERR_TAIL_LINES: usize = 10;
+
+enum ToolOutcome {
+    Success(u64),
+    Cancelled,
+}
+
+/// Spawn `tool_path` with `args` plus a `--config` pointing at a temp file
+/// holding `uri`, streaming stderr for progress while polling `cancel` every
+/// 250ms. The config file guard is kept alive for the whole process lifetime.
+async fn run_tool_process(
+    tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>,
+    task_id: &str,
+    cancel: &Arc<AtomicBool>,
+    tool_path: &str,
+    args: &[String],
+    uri: &str,
+    direct_connection: bool,
+) -> Result<ToolOutcome, String> {
+    // mongodump/mongorestore treat a URI path database as a db selector that
+    // conflicts with --db/--collection/--nsInclude; strip it (preserving auth
+    // semantics via authSource) before it reaches the tool's config file.
+    // Also append directConnection/serverSelectionTimeoutMS so a tunneled
+    // connection doesn't chase replica-set members' unreachable real IPs
+    // forever — see `prepare_tool_uri`.
+    let prepared_uri = prepare_tool_uri(uri, direct_connection);
+    // TLS-relaxation params must travel as flags — the tools ignore them in
+    // the URI and then fail certificate validation (see the extractor's docs).
+    let (prepared_uri, tls_flags) = extract_unsupported_tls_params(&prepared_uri);
+    let cfg = write_tool_config(&prepared_uri)?;
+
+    let mut child = tokio::process::Command::new(tool_path)
+        .args(args)
+        .args(&tls_flags)
+        .arg("--config")
+        .arg(cfg.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to start {}: {}", tool_path, e))?;
+
+    // The tool is alive from here on — say so immediately, and keep saying so
+    // (with elapsed time) until it reports real progress. mongodump can sit
+    // silent for its whole connect/server-selection phase; without this the
+    // task looks stuck on its initial message even though the process runs.
+    // The redacted URI goes on the sub label so a connection that hangs or
+    // fails can be diagnosed against what the tool was actually given.
+    let tool_name = basename(tool_path);
+    let mut invocation = redact_uri_password(&prepared_uri);
+    if !tls_flags.is_empty() {
+        invocation.push(' ');
+        invocation.push_str(&tls_flags.join(" "));
+    }
+    update_task(tasks, task_id, |t| {
+        t.message = format!("{} started — connecting…", tool_name);
+        t.sub_label = Some(invocation);
+    });
+    let started_at = std::time::Instant::now();
+    let mut had_progress = false;
+    let mut saw_line = false;
+
+    let stderr = child.stderr.take().expect("stderr is piped");
+    let mut reader = BufReader::new(stderr);
+    let mut line_buf: Vec<u8> = Vec::new();
+    let mut tail: VecDeque<String> = VecDeque::with_capacity(STDERR_TAIL_LINES);
+    let mut processed: u64 = 0;
+    let mut poll = tokio::time::interval(Duration::from_millis(250));
+
+    let cancelled = loop {
+        tokio::select! {
+            // Raw bytes + lossy decode rather than next_line(): the tools can
+            // echo non-UTF-8 bytes (server errors, locale output), and
+            // next_line() turns that into a stream error — breaking this loop
+            // with the pipe undrained, which wedges the wait below.
+            read = reader.read_until(b'\n', &mut line_buf) => {
+                match read {
+                    // EOF with nothing buffered (a final unterminated line
+                    // still arrives as Ok(n > 0) and is processed below).
+                    Ok(0) if line_buf.is_empty() => break false,
+                    Ok(_) => {
+                        let mut l = String::from_utf8_lossy(&line_buf).into_owned();
+                        line_buf.clear();
+                        while l.ends_with('\n') || l.ends_with('\r') {
+                            l.pop();
+                        }
+                        saw_line = true;
+                        if tail.len() == STDERR_TAIL_LINES {
+                            tail.pop_front();
+                        }
+                        tail.push_back(l.clone());
+                        match parse_tool_progress(&l) {
+                            Some(ToolProgress::NamespaceDone { ns, docs }) => {
+                                processed += 1;
+                                had_progress = true;
+                                update_task(tasks, task_id, |t| {
+                                    t.processed = processed;
+                                    t.message = format!("{} done ({} documents)", ns, docs);
+                                });
+                            }
+                            Some(ToolProgress::Info(msg)) => {
+                                had_progress = true;
+                                update_task(tasks, task_id, |t| t.message = msg);
+                            }
+                            None => {
+                                // Until real progress arrives, raw stderr (driver
+                                // warnings, connection failures) is the only signal
+                                // the user has — surface it (passwords redacted)
+                                // rather than dropping it.
+                                if !had_progress {
+                                    let content =
+                                        l.split_once('\t').map(|(_, c)| c).unwrap_or(l.as_str());
+                                    let msg: String =
+                                        redact_uris_in_text(content).chars().take(200).collect();
+                                    if !msg.trim().is_empty() {
+                                        update_task(tasks, task_id, |t| t.message = msg);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(_) => break false,
+                }
+            }
+            _ = poll.tick() => {
+                if cancel.load(Ordering::SeqCst) {
+                    let _ = child.kill().await;
+                    break true;
+                }
+                if !had_progress && !saw_line {
+                    let secs = started_at.elapsed().as_secs();
+                    if secs >= 2 {
+                        update_task(tasks, task_id, |t| {
+                            t.message =
+                                format!("{} running — waiting for server ({}s)", tool_name, secs);
+                        });
+                    }
+                }
+            }
+        }
+    };
+
+    if cancelled {
+        let _ = child.wait().await;
+        return Ok(ToolOutcome::Cancelled);
+    }
+
+    // The tool can close stderr while still running; a bare wait() here would
+    // leave the task uncancellable from that point on. Keep polling the
+    // cancel flag (killing on cancel) until the process actually exits.
+    let status = loop {
+        tokio::select! {
+            status = child.wait() => {
+                break status.map_err(|e| format!("Failed to wait for {}: {}", tool_path, e))?;
+            }
+            _ = poll.tick() => {
+                if cancel.load(Ordering::SeqCst) {
+                    let _ = child.kill().await;
+                    let _ = child.wait().await;
+                    return Ok(ToolOutcome::Cancelled);
+                }
+            }
+        }
+    };
+
+    if status.success() {
+        Ok(ToolOutcome::Success(processed))
+    } else {
+        let msg: Vec<String> = tail.into_iter().collect();
+        if msg.is_empty() {
+            Err(format!("{} exited with {}", tool_path, status))
+        } else {
+            // The tail is raw stderr — it can quote the connection string
+            // (the redacted variant only goes on the sub label).
+            Err(redact_uris_in_text(&msg.join("\n")))
+        }
+    }
+}
+
+/// Drive one dump/restore task to completion: run the tool, update task
+/// status on every exit path (success/failure/cancel), and always clean up
+/// the cancel-flag entry.
+#[allow(clippy::too_many_arguments)]
+async fn run_tool_task(
+    tasks: Arc<Mutex<HashMap<String, TaskInfo>>>,
+    cancels: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
+    task_id: String,
+    cancel: Arc<AtomicBool>,
+    tool_path: String,
+    args: Vec<String>,
+    uri: String,
+    direct_connection: bool,
+    verb: &'static str,
+) {
+    let outcome =
+        run_tool_process(&tasks, &task_id, &cancel, &tool_path, &args, &uri, direct_connection)
+            .await;
+    match outcome {
+        Ok(ToolOutcome::Success(processed)) => {
+            finish_task(&tasks, &task_id, processed, format!("{} complete", verb));
+        }
+        Ok(ToolOutcome::Cancelled) => {
+            update_task(&tasks, &task_id, |t| {
+                t.status = "cancelled".to_string();
+                t.message = "Cancelled".to_string();
+                t.finished_at_ms = Some(now_ms());
+            });
+            crate::db::tasks::prune_tasks(&tasks);
+        }
+        Err(err) => fail_task(&tasks, &task_id, err),
+    }
+    if let Ok(mut guard) = cancels.lock() {
+        guard.remove(&task_id);
+    }
+}
+
+/// Start a `mongodump` background task for a real (non-mock) connection.
+pub async fn start_dump_task_impl(
+    state: &AppState,
+    id: &str,
+    tool_path: &str,
+    options: DumpOptions,
+) -> Result<TaskInfo, String> {
+    let uri = require_real_conn_uri(state, id)?;
+    let tunneled = state.ssh_tunnels.lock_safe()?.contains_key(id);
+    let args = build_dump_args(&options)?;
+    let dest = dump_destination(&options.target).to_string();
+    let label = format!("Dump {} \u{2192} {}", dump_scope_desc(&options.scope), basename(&dest));
+
+    let task_id = Uuid::new_v4().to_string();
+    let task = TaskInfo {
+        id: task_id.clone(),
+        kind: "dump".to_string(),
+        label,
+        status: "running".to_string(),
+        processed: 0,
+        total: None,
+        message: "Starting mongodump…".to_string(),
+        path: Some(dest),
+        error: None,
+        created_at_ms: now_ms(),
+        finished_at_ms: None,
+        sub_label: None,
+        items_processed: None,
+        items_total: None,
+        summary: None,
+    };
+    state.tasks.lock_safe()?.insert(task_id.clone(), task.clone());
+    let cancel = state.register_cancel(&task_id);
+
+    let tasks = state.tasks.clone();
+    let cancels = state.cancels.clone();
+    let tool_path = tool_path.to_string();
+    let task_id2 = task_id.clone();
+    tokio::spawn(async move {
+        run_tool_task(tasks, cancels, task_id2, cancel, tool_path, args, uri, tunneled, "Dump")
+            .await;
+    });
+
+    Ok(task)
+}
+
+/// Start a `mongorestore` background task for a real (non-mock) connection.
+pub async fn start_restore_task_impl(
+    state: &AppState,
+    id: &str,
+    tool_path: &str,
+    options: RestoreOptions,
+) -> Result<TaskInfo, String> {
+    let uri = require_real_conn_uri(state, id)?;
+    let tunneled = state.ssh_tunnels.lock_safe()?.contains_key(id);
+    let args = build_restore_args(&options)?;
+    let source = restore_source_path(&options.source).to_string();
+    let label = format!("Restore {}", basename(&source));
+
+    let task_id = Uuid::new_v4().to_string();
+    let task = TaskInfo {
+        id: task_id.clone(),
+        kind: "restore".to_string(),
+        label,
+        status: "running".to_string(),
+        processed: 0,
+        total: None,
+        message: "Starting mongorestore…".to_string(),
+        path: Some(source),
+        error: None,
+        created_at_ms: now_ms(),
+        finished_at_ms: None,
+        sub_label: None,
+        items_processed: None,
+        items_total: None,
+        summary: None,
+    };
+    state.tasks.lock_safe()?.insert(task_id.clone(), task.clone());
+    let cancel = state.register_cancel(&task_id);
+
+    let tasks = state.tasks.clone();
+    let cancels = state.cancels.clone();
+    let tool_path = tool_path.to_string();
+    let task_id2 = task_id.clone();
+    tokio::spawn(async move {
+        run_tool_task(tasks, cancels, task_id2, cancel, tool_path, args, uri, tunneled, "Restore")
+            .await;
+    });
+
+    Ok(task)
+}
+
+/// One collection discovered under `<dump-root>/<db>/`.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DumpCollection {
+    pub name: String,
+    pub has_metadata: bool,
+    pub gzip: bool,
+}
+
+/// One database directory discovered under a dump root.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DumpDb {
+    pub name: String,
+    pub collections: Vec<DumpCollection>,
+}
+
+/// The full tree of databases/collections found under a dump folder, for the
+/// restore UI's namespace picker.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DumpTree {
+    pub dbs: Vec<DumpDb>,
+}
+
+#[derive(Default)]
+struct CollAccum {
+    has_data: bool,
+    gzip: bool,
+    has_metadata: bool,
+}
+
+fn scan_dump_db_dir(dir: &std::path::Path) -> Result<Vec<DumpCollection>, String> {
+    let mut acc: HashMap<String, CollAccum> = HashMap::new();
+    let entries = std::fs::read_dir(dir).map_err(|e| format!("Failed to read dump folder: {}", e))?;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let is_file = entry.file_type().map(|t| t.is_file()).unwrap_or(false);
+        if !is_file {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if let Some(base) = name.strip_suffix(".metadata.json.gz") {
+            acc.entry(base.to_string()).or_default().has_metadata = true;
+        } else if let Some(base) = name.strip_suffix(".metadata.json") {
+            acc.entry(base.to_string()).or_default().has_metadata = true;
+        } else if let Some(base) = name.strip_suffix(".bson.gz") {
+            let e = acc.entry(base.to_string()).or_default();
+            e.has_data = true;
+            e.gzip = true;
+        } else if let Some(base) = name.strip_suffix(".bson") {
+            acc.entry(base.to_string()).or_default().has_data = true;
+        }
+    }
+    let mut collections: Vec<DumpCollection> = acc
+        .into_iter()
+        .filter(|(_, v)| v.has_data)
+        .map(|(name, v)| DumpCollection { name, has_metadata: v.has_metadata, gzip: v.gzip })
+        .collect();
+    collections.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(collections)
+}
+
+/// Scan a mongodump output folder into a [`DumpTree`]: one entry per
+/// `<db>/<coll>.bson[.gz]` pair found, `hasMetadata` set when the matching
+/// `<coll>.metadata.json[.gz]` sidecar exists. Non-directories at the root
+/// and files that don't match the `.bson`/`.metadata.json` shape are skipped.
+pub async fn browse_dump_folder_impl(path: &str) -> Result<DumpTree, String> {
+    let root = std::path::Path::new(path);
+    let entries =
+        std::fs::read_dir(root).map_err(|e| format!("Failed to read dump folder: {}", e))?;
+
+    let mut dbs = Vec::new();
+    for entry in entries.filter_map(|e| e.ok()) {
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        if !is_dir {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let collections = scan_dump_db_dir(&entry.path())?;
+        dbs.push(DumpDb { name, collections });
+    }
+    dbs.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(DumpTree { dbs })
+}
+
+/// Render the shell-ish command a preview panel shows the user (the real
+/// runner never invokes a shell — this is display-only).
+pub fn preview_tool_command(tool_path: &str, redacted_uri: &str, args: &[String]) -> String {
+    format!("{} --uri={} {}", tool_path, redacted_uri, args.join(" "))
+}
+
+/// A discovered `mongodump`/`mongorestore` executable.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolInfo {
+    pub path: String,
+    pub version: String,
+}
+
+/// Discovery result for both MongoDB Database Tools binaries.
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolsStatus {
+    pub mongodump: Option<ToolInfo>,
+    pub mongorestore: Option<ToolInfo>,
+}
+
+/// Run `<candidate> --version` and, if it succeeds, return the first line of
+/// stdout (trimmed) as the version string. Any spawn failure or non-zero-ish
+/// output is treated as "not this candidate" rather than an error.
+fn probe_tool(candidate: &std::path::Path) -> Option<ToolInfo> {
+    let output = std::process::Command::new(candidate)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // Some tool builds print `--version` output to stderr instead of stdout;
+    // fall back deliberately rather than treating that as "not this candidate".
+    let text = if !output.stdout.is_empty() {
+        String::from_utf8_lossy(&output.stdout)
+    } else {
+        String::from_utf8_lossy(&output.stderr)
+    };
+    let version = text.lines().next()?.trim().to_string();
+    if version.is_empty() {
+        return None;
+    }
+    Some(ToolInfo { path: candidate.to_string_lossy().to_string(), version })
+}
+
+fn binary_name(tool: &str) -> String {
+    if cfg!(windows) {
+        format!("{tool}.exe")
+    } else {
+        tool.to_string()
+    }
+}
+
+/// Locate one tool: prefer `configured_dir` if given (and it works), then
+/// `managed_dir` (the app-managed install's bin directory), else walk `PATH`.
+fn locate_tool(tool: &str, configured_dir: Option<&str>, managed_dir: Option<&Path>) -> Option<ToolInfo> {
+    let name = binary_name(tool);
+
+    if let Some(dir) = configured_dir {
+        let candidate = std::path::Path::new(dir).join(&name);
+        if let Some(info) = probe_tool(&candidate) {
+            return Some(info);
+        }
+    }
+
+    if let Some(dir) = managed_dir {
+        let candidate = dir.join(&name);
+        if let Some(info) = probe_tool(&candidate) {
+            return Some(info);
+        }
+    }
+
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(&name);
+        if let Some(info) = probe_tool(&candidate) {
+            return Some(info);
+        }
+    }
+
+    None
+}
+
+/// Detect `mongodump` and `mongorestore` on disk. Probe order: `configured_dir`
+/// (used only if the tool actually runs there), then `managed_dir` (the
+/// app-managed install's bin directory), then `PATH`.
+pub fn detect_mongo_tools(configured_dir: Option<&str>, managed_dir: Option<&Path>) -> ToolsStatus {
+    ToolsStatus {
+        mongodump: locate_tool("mongodump", configured_dir, managed_dir),
+        mongorestore: locate_tool("mongorestore", configured_dir, managed_dir),
+    }
+}
+
+/// Test-only helper for spawning a throwaway shell script in place of a real
+/// `mongodump`/`mongorestore` binary, exposed to `tests.rs` (outside this
+/// module) via `pub mod test_support`.
+#[cfg(test)]
+pub mod test_support {
+    #[cfg(unix)]
+    pub fn write_fake_tool(script_body: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = std::env::temp_dir().join(format!(
+            "mqlens-fake-tool-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::write(&path, format!("#!/bin/sh\n{}", script_body)).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dump_defaults(scope: DumpScope) -> DumpOptions {
+        DumpOptions {
+            scope,
+            target: DumpTarget::Folder { out: "/tmp/dump".into() },
+            gzip: true,
+            query: None,
+            force_table_scan: false,
+            dump_users_and_roles: false,
+            oplog: false,
+        }
+    }
+
+    #[test]
+    fn dump_args_collection_scope_with_query() {
+        let mut o = dump_defaults(DumpScope::Collection { db: "sales".into(), coll: "orders".into() });
+        o.query = Some(r#"{"status":"open"}"#.into());
+        o.force_table_scan = true;
+        let args = build_dump_args(&o).unwrap();
+        assert_eq!(
+            args,
+            [
+                "--db=sales", "--collection=orders",
+                "--out=/tmp/dump", "--gzip",
+                r#"--query={"status":"open"}"#, "--forceTableScan",
+            ].iter().map(|s| s.to_string()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn dump_args_archive_server_with_oplog() {
+        let mut o = dump_defaults(DumpScope::Server);
+        o.target = DumpTarget::Archive { file: "/tmp/all.archive.gz".into() };
+        o.oplog = true;
+        let args = build_dump_args(&o).unwrap();
+        assert_eq!(args, ["--archive=/tmp/all.archive.gz", "--gzip", "--oplog"]
+            .iter().map(|s| s.to_string()).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn dump_args_legality() {
+        let mut o = dump_defaults(DumpScope::Db { db: "sales".into() });
+        o.oplog = true;
+        assert!(build_dump_args(&o).unwrap_err().contains("whole-server"));
+        let mut o = dump_defaults(DumpScope::Server);
+        o.dump_users_and_roles = true;
+        assert!(build_dump_args(&o).unwrap_err().contains("database scope"));
+        let mut o = dump_defaults(DumpScope::Db { db: "sales".into() });
+        o.query = Some("{}".into());
+        assert!(build_dump_args(&o).unwrap_err().contains("collection scope"));
+        let mut o = dump_defaults(DumpScope::Server);
+        o.target = DumpTarget::Folder { out: "".into() };
+        assert!(build_dump_args(&o).unwrap_err().contains("destination"));
+    }
+
+    fn restore_defaults(source: RestoreSource) -> RestoreOptions {
+        RestoreOptions {
+            source, gzip: false, selections: vec![], filter_db: None, filter_coll: None,
+            drop: false, keep_index_version: false, no_index_restore: false,
+            no_options_restore: false, maintain_insertion_order: false, stop_on_error: false,
+            bypass_document_validation: false, restore_db_users_and_roles: false,
+            oplog_replay: false,
+        }
+    }
+
+    #[test]
+    fn restore_args_folder_selection_and_rename() {
+        let mut o = restore_defaults(RestoreSource::Folder { dir: "/tmp/dump".into() });
+        o.gzip = true;
+        o.drop = true;
+        o.selections = vec![
+            NsSelection { db: "sales".into(), coll: "orders".into(), rename_to: None },
+            NsSelection { db: "sales".into(), coll: "users".into(), rename_to: Some("crm.people".into()) },
+        ];
+        let args = build_restore_args(&o).unwrap();
+        assert_eq!(
+            args,
+            [
+                "--gzip", "--drop",
+                "--nsInclude=sales.orders",
+                "--nsInclude=sales.users", "--nsFrom=sales.users", "--nsTo=crm.people",
+                "--dir=/tmp/dump",
+            ].iter().map(|s| s.to_string()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn restore_args_bare_rename_is_qualified_with_source_db() {
+        // --nsTo requires a full db.collection namespace; a bare collection
+        // name from the UI must be qualified with the selection's db.
+        let mut o = restore_defaults(RestoreSource::Folder { dir: "/tmp/dump".into() });
+        o.selections = vec![
+            NsSelection { db: "sales".into(), coll: "users".into(), rename_to: Some("people".into()) },
+        ];
+        let args = build_restore_args(&o).unwrap();
+        assert_eq!(
+            args,
+            [
+                "--nsInclude=sales.users", "--nsFrom=sales.users", "--nsTo=sales.people",
+                "--dir=/tmp/dump",
+            ].iter().map(|s| s.to_string()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn restore_args_archive_filters_and_legality() {
+        let mut o = restore_defaults(RestoreSource::Archive { file: "/tmp/a.archive".into() });
+        o.filter_db = Some("sales".into());
+        let args = build_restore_args(&o).unwrap();
+        assert_eq!(args, ["--archive=/tmp/a.archive", "--nsInclude=sales.*"]
+            .iter().map(|s| s.to_string()).collect::<Vec<_>>());
+
+        let mut o = restore_defaults(RestoreSource::Archive { file: "/tmp/a.archive".into() });
+        o.filter_coll = Some("orders".into());
+        assert!(build_restore_args(&o).unwrap_err().contains("requires a database"));
+
+        let mut o = restore_defaults(RestoreSource::Folder { dir: "/tmp/dump".into() });
+        o.oplog_replay = true;
+        o.selections = vec![NsSelection { db: "a".into(), coll: "b".into(), rename_to: None }];
+        assert!(build_restore_args(&o).unwrap_err().contains("namespace filters"));
+
+        let mut o = restore_defaults(RestoreSource::Folder { dir: "/tmp/dump".into() });
+        o.restore_db_users_and_roles = true; // zero selections = all dbs → illegal
+        assert!(build_restore_args(&o).unwrap_err().contains("single database"));
+    }
+
+    #[test]
+    fn redacts_password_only_when_present() {
+        assert_eq!(
+            redact_uri_password("mongodb://alice:s3cr3t@host:27017/db?x=1"),
+            "mongodb://alice:***@host:27017/db?x=1"
+        );
+        assert_eq!(redact_uri_password("mongodb://host:27017"), "mongodb://host:27017");
+        assert_eq!(
+            redact_uri_password("mongodb+srv://u:p%40ss@cluster.example.com"),
+            "mongodb+srv://u:***@cluster.example.com"
+        );
+    }
+
+    #[test]
+    fn redacts_uris_in_free_text() {
+        // Non-URI-ish text passes through untouched (whitespace preserved).
+        assert_eq!(redact_uris_in_text("plain error  text"), "plain error  text");
+        // Any token containing "://" gets its password redacted in place.
+        assert_eq!(
+            redact_uris_in_text("connect failed: mongodb://u:s3cr3t@h:27017/db timed out"),
+            "connect failed: mongodb://u:***@h:27017/db timed out"
+        );
+        // Multi-line text (the joined stderr tail) is redacted across lines.
+        assert_eq!(
+            redact_uris_in_text("line one\nerror at mongodb+srv://a:pw@c.example.com\nline three"),
+            "line one\nerror at mongodb+srv://a:***@c.example.com\nline three"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_no_path_adds_default_timeout_only() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://h:27017", false),
+            "mongodb://h:27017/?serverSelectionTimeoutMS=30000"
+        );
+        assert_eq!(
+            prepare_tool_uri("mongodb://h:27017/", false),
+            "mongodb://h:27017/?serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_strips_path_db_and_sets_authsource() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://u:p@h:27017/admin", false),
+            "mongodb://u:p@h:27017/?authSource=admin&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_strips_path_db_preserving_existing_query() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://u:p@h:27017/admin?replicaSet=rs0", false),
+            "mongodb://u:p@h:27017/?replicaSet=rs0&authSource=admin&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_does_not_duplicate_existing_authsource() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://h/mydb?authSource=admin", false),
+            "mongodb://h/?authSource=admin&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_matches_authsource_case_insensitively() {
+        // Connection-string keys are case-insensitive per the spec; a
+        // lowercase authsource must not gain a conflicting duplicate (the Go
+        // tools take last-one-wins, which would flip the auth database).
+        assert_eq!(
+            prepare_tool_uri("mongodb://h/mydb?authsource=admin", false),
+            "mongodb://h/?authsource=admin&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_matches_timeout_case_insensitively() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://h:27017/?serverselectiontimeoutms=5000", false),
+            "mongodb://h:27017/?serverselectiontimeoutms=5000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_matches_direct_connection_case_insensitively() {
+        // The user's explicit (lowercase) directconnection=false must win
+        // over the tunnel default, exactly like the canonical spelling.
+        assert_eq!(
+            prepare_tool_uri("mongodb://h:27017/?directconnection=false", true),
+            "mongodb://h:27017/?directconnection=false&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_handles_mongodb_srv_scheme() {
+        assert_eq!(
+            prepare_tool_uri("mongodb+srv://u:p@cluster.example.com/admin", false),
+            "mongodb+srv://u:p@cluster.example.com/?authSource=admin&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_ignores_percent_encoded_credentials() {
+        // Percent-encoded '@' and '/' inside userinfo must not confuse the
+        // authority-window parse (same technique as redact_uri_password).
+        assert_eq!(
+            prepare_tool_uri("mongodb://user:p%40ss%2Fx@h:27017/admin", false),
+            "mongodb://user:p%40ss%2Fx@h:27017/?authSource=admin&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_empty_path_segment_gets_default_timeout() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://h:27017/?x=1", false),
+            "mongodb://h:27017/?x=1&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_tunneled_appends_direct_connection_and_timeout() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://h:27017", true),
+            "mongodb://h:27017/?directConnection=true&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_tunneled_respects_explicit_direct_connection_false() {
+        // The user's own config wins — never override an explicit setting.
+        assert_eq!(
+            prepare_tool_uri("mongodb://h:27017/?directConnection=false", true),
+            "mongodb://h:27017/?directConnection=false&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_not_tunneled_omits_direct_connection() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://h:27017", false),
+            "mongodb://h:27017/?serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_existing_timeout_is_untouched() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://h:27017/?serverSelectionTimeoutMS=5000", false),
+            "mongodb://h:27017/?serverSelectionTimeoutMS=5000"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_uri_tunneled_combines_with_path_db_strip() {
+        assert_eq!(
+            prepare_tool_uri("mongodb://u:p@127.0.0.1:33445/admin", true),
+            "mongodb://u:p@127.0.0.1:33445/?authSource=admin&directConnection=true&serverSelectionTimeoutMS=30000"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detects_tool_from_configured_dir_before_path() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("mqlens-tools-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let tool = dir.join("mongodump");
+        std::fs::write(&tool, "#!/bin/sh\necho 'mongodump version: 100.9.9'\n").unwrap();
+        std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let status = detect_mongo_tools(Some(dir.to_str().unwrap()), None);
+        let info = status.mongodump.expect("configured dir should win");
+        assert_eq!(info.path, tool.to_string_lossy());
+        assert!(info.version.contains("100.9.9"));
+        // mongorestore is absent from the dir; whatever PATH yields is acceptable — no assert.
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_tool_config_escapes_backslash_and_quote() {
+        let uri = r#"mongodb://user:p"a\ss@host:27017/db"#;
+        let file = write_tool_config(uri).unwrap();
+        let contents = std::fs::read_to_string(file.path()).unwrap();
+        assert_eq!(contents, "uri: \"mongodb://user:p\\\"a\\\\ss@host:27017/db\"\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn probe_tool_rejects_failing_binary() {
+        let tool = crate::db::mongotools::test_support::write_fake_tool(
+            "echo 'mongodump version: 100.9.9'\nexit 1\n",
+        );
+        assert!(
+            probe_tool(&tool).is_none(),
+            "a binary that prints a version line but exits non-zero must not be detected"
+        );
+        let _ = std::fs::remove_file(&tool);
+    }
+
+    #[test]
+    fn missing_tools_yield_none() {
+        let status = detect_mongo_tools(Some("/definitely/not/a/dir"), None);
+        // Tools may still be found on PATH in dev machines; only assert the configured-dir miss
+        // falls back rather than erroring.
+        let _ = status; // structural smoke: no panic; None-vs-Some depends on the machine
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_prefers_configured_then_managed_then_path() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = std::env::temp_dir().join(format!(
+            "mqlens-tools-order-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+
+        // Stub mongodump printing "version: 1" in dirA (configured).
+        let configured_dir = base.join("configured");
+        std::fs::create_dir_all(&configured_dir).unwrap();
+        let configured_tool = configured_dir.join("mongodump");
+        std::fs::write(&configured_tool, "#!/bin/sh\necho 'mongodump version: 1'\n").unwrap();
+        std::fs::set_permissions(&configured_tool, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Another stub printing "version: 2" in {tmp_app_data}/tools/database-tools-100.17.0/bin (managed).
+        let managed_dir = base.join("tools/database-tools-100.17.0/bin");
+        std::fs::create_dir_all(&managed_dir).unwrap();
+        let managed_tool = managed_dir.join("mongodump");
+        std::fs::write(&managed_tool, "#!/bin/sh\necho 'mongodump version: 2'\n").unwrap();
+        std::fs::set_permissions(&managed_tool, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // configured=Some(dirA) -> version 1
+        let status = detect_mongo_tools(Some(configured_dir.to_str().unwrap()), Some(managed_dir.as_path()));
+        let info = status.mongodump.expect("configured dir should win");
+        assert_eq!(info.path, configured_tool.to_string_lossy());
+        assert!(info.version.contains("version: 1"), "{:?}", info.version);
+
+        // configured=None, managed=Some -> version 2
+        let status = detect_mongo_tools(None, Some(managed_dir.as_path()));
+        let info = status.mongodump.expect("managed dir should be used when configured is absent");
+        assert_eq!(info.path, managed_tool.to_string_lossy());
+        assert!(info.version.contains("version: 2"), "{:?}", info.version);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn parses_tool_progress_lines() {
+        let l = "2026-07-03T12:00:00.000+0200\tdone dumping sales.orders (1234 documents)";
+        match parse_tool_progress(l) {
+            Some(ToolProgress::NamespaceDone { ns, docs }) => {
+                assert_eq!(ns, "sales.orders");
+                assert_eq!(docs, 1234);
+            }
+            other => panic!("unexpected: {:?}", other.is_some()),
+        }
+        let l = "2026-07-03T12:00:01.000+0200\tfinished restoring sales.orders (99 documents, 0 failures)";
+        assert!(matches!(parse_tool_progress(l), Some(ToolProgress::NamespaceDone { docs: 99, .. })));
+        let l = "2026-07-03T12:00:02.000+0200\twriting sales.orders to /tmp/x.bson";
+        assert!(matches!(parse_tool_progress(l), Some(ToolProgress::Info(_))));
+        assert!(parse_tool_progress("random noise").is_none());
+    }
+
+    #[test]
+    fn tls_insecure_uri_params_become_tool_flags() {
+        // The database tools reject tlsAllowInvalidCertificates & friends as
+        // URI parameters ("ignoring unsupported URI parameter") and then fail
+        // TLS validation; they must be stripped and passed as --tlsInsecure.
+        let (uri, flags) = extract_unsupported_tls_params(
+            "mongodb://u:p@h1:27017,h2:27017/?replicaSet=rs&tls=true&tlsAllowInvalidCertificates=true&authSource=admin",
+        );
+        assert_eq!(
+            uri,
+            "mongodb://u:p@h1:27017,h2:27017/?replicaSet=rs&tls=true&authSource=admin"
+        );
+        assert_eq!(flags, vec!["--tlsInsecure".to_string()]);
+
+        // All three spellings map to the one flag, deduplicated, and option
+        // names match case-insensitively per the connection-string spec.
+        let (uri, flags) = extract_unsupported_tls_params(
+            "mongodb://h/?tlsinsecure=true&tlsAllowInvalidCertificates=TRUE&tlsAllowInvalidHostnames=true&x=1",
+        );
+        assert_eq!(uri, "mongodb://h/?x=1");
+        assert_eq!(flags, vec!["--tlsInsecure".to_string()]);
+
+        // =false still strips the param (the tools would warn) but adds no flag.
+        let (uri, flags) =
+            extract_unsupported_tls_params("mongodb://h/?tlsAllowInvalidCertificates=false&tls=true");
+        assert_eq!(uri, "mongodb://h/?tls=true");
+        assert!(flags.is_empty());
+
+        // Nothing to do → URI unchanged.
+        let (uri, flags) = extract_unsupported_tls_params("mongodb://h/?tls=true");
+        assert_eq!(uri, "mongodb://h/?tls=true");
+        assert!(flags.is_empty());
+
+        // Removing the only param must not leave a dangling '?'.
+        let (uri, flags) = extract_unsupported_tls_params("mongodb://h/?tlsInsecure=true");
+        assert_eq!(uri, "mongodb://h/");
+        assert_eq!(flags, vec!["--tlsInsecure".to_string()]);
+    }
+
+    #[test]
+    fn parses_bracket_progress_bar_lines() {
+        // mongodump/mongorestore periodic in-flight progress for one namespace.
+        let l = "2026-07-10T12:00:00.000+0200\t[########................]  sales.orders  12345/50000  (24.7%)";
+        match parse_tool_progress(l) {
+            Some(ToolProgress::Info(msg)) => assert_eq!(msg, "sales.orders 12345/50000 (24.7%)"),
+            other => panic!("unexpected: {:?}", other),
+        }
+        // mongorestore reports byte-based progress for large namespaces.
+        let l = "ts\t[#.......................]  logs.events  10.5MB/28.7MB  (36.6%)";
+        assert!(matches!(parse_tool_progress(l), Some(ToolProgress::Info(_))));
+        // A bare bracket with nothing after it carries no information.
+        assert!(parse_tool_progress("ts\t[####]").is_none());
+    }
+
+    fn dump_server_folder_opts(out: &str) -> DumpOptions {
+        DumpOptions {
+            scope: DumpScope::Server,
+            target: DumpTarget::Folder { out: out.to_string() },
+            gzip: false,
+            query: None,
+            force_table_scan: false,
+            dump_users_and_roles: false,
+            oplog: false,
+        }
+    }
+
+    async fn wait_for_task(state: &AppState, task_id: &str) {
+        for _ in 0..50 {
+            let status = state.tasks.lock().unwrap().get(task_id).map(|t| t.status.clone());
+            if status.as_deref() != Some("running") {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dump_task_success_parses_progress_and_cleans_up() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        let tool = crate::db::mongotools::test_support::write_fake_tool(
+            "echo 'ts\tdone dumping a.x (5 documents)' 1>&2\n\
+             echo 'ts\tdone dumping a.y (7 documents)' 1>&2\n\
+             exit 0\n",
+        );
+        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out");
+        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        assert_eq!(task.kind, "dump");
+        wait_for_task(&state, &task.id).await;
+        let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(t.status, "completed");
+        assert_eq!(t.processed, 2);
+        assert!(state.cancels.lock().unwrap().get(&task.id).is_none(), "flag cleaned up");
+        let _ = std::fs::remove_file(&tool);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dump_task_failure_captures_stderr_tail() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        let tool = crate::db::mongotools::test_support::write_fake_tool(
+            "echo 'boom line' 1>&2\n\
+             echo 'cannot connect to mongodb://u:sekrit@h:27017/db' 1>&2\n\
+             exit 3\n",
+        );
+        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out2");
+        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        wait_for_task(&state, &task.id).await;
+        let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(t.status, "failed");
+        let error = t.error.as_deref().unwrap_or("");
+        assert!(error.contains("boom line"), "{:?}", t.error);
+        // Raw stderr can quote the connection string — never with the password.
+        assert!(error.contains("mongodb://u:***@h:27017/db"), "{:?}", t.error);
+        assert!(!error.contains("sekrit"), "password must be redacted, got {:?}", t.error);
+        assert!(state.cancels.lock().unwrap().get(&task.id).is_none(), "flag cleaned up");
+        let _ = std::fs::remove_file(&tool);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_cancel_kills_the_tool() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        let tool = crate::db::mongotools::test_support::write_fake_tool(
+            "echo 'ts\tdone dumping a.x (1 documents)' 1>&2\nsleep 30\n",
+        );
+        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out3");
+        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+
+        // Wait until the fake tool has reported at least one namespace done.
+        for _ in 0..100 {
+            let processed = state.tasks.lock().unwrap().get(&task.id).map(|t| t.processed).unwrap_or(0);
+            if processed >= 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let started = std::time::Instant::now();
+        assert!(state.request_cancel(&task.id), "task should be known to the cancel registry");
+        wait_for_task(&state, &task.id).await;
+        let elapsed = started.elapsed();
+
+        let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(t.status, "cancelled");
+        assert_eq!(t.message, "Cancelled");
+        assert!(elapsed.as_secs() < 5, "cancel should be fast, took {:?}", elapsed);
+        let _ = std::fs::remove_file(&tool);
+    }
+
+    /// A tool that produces no stderr for a while (mongodump stuck in server
+    /// selection) must still tell the user the process has started, and then
+    /// surface elapsed time instead of sitting on the initial message forever.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_dump_task_reports_process_start_and_elapsed() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        let tool = crate::db::mongotools::test_support::write_fake_tool("sleep 30\n");
+        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out4");
+        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        assert_ne!(task.message, "Queued", "initial message should say the tool is starting");
+
+        // Shortly after spawn the message must reflect a live process.
+        let mut message = String::new();
+        for _ in 0..250 {
+            message = state.tasks.lock().unwrap().get(&task.id).map(|t| t.message.clone()).unwrap_or_default();
+            if message.contains("started") || message.contains("running") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            message.contains("started") || message.contains("running"),
+            "message should reflect the spawned process, got {:?}",
+            message
+        );
+
+        // With no tool output after a couple of seconds, elapsed time shows up.
+        let mut message = String::new();
+        for _ in 0..250 {
+            message = state.tasks.lock().unwrap().get(&task.id).map(|t| t.message.clone()).unwrap_or_default();
+            if message.contains("s)") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(message.contains("s)"), "elapsed time expected in message, got {:?}", message);
+
+        assert!(state.request_cancel(&task.id), "task should be cancellable while running");
+        wait_for_task(&state, &task.id).await;
+        let _ = std::fs::remove_file(&tool);
+    }
+
+    /// A stderr line that isn't valid UTF-8 (tools can echo raw bytes from a
+    /// server error) must not wedge the task: the stream keeps draining, later
+    /// progress lines still parse, and the task completes.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_invalid_utf8_stderr_line_does_not_wedge_task() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        let tool = crate::db::mongotools::test_support::write_fake_tool(
+            "printf 'warn \\377\\376 invalid bytes\\n' 1>&2\n\
+             echo 'ts\tdone dumping a.x (5 documents)' 1>&2\n\
+             exit 0\n",
+        );
+        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out7");
+        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        wait_for_task(&state, &task.id).await;
+        let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(t.status, "completed");
+        assert_eq!(t.processed, 1, "progress after the invalid-UTF-8 line must still parse");
+        let _ = std::fs::remove_file(&tool);
+    }
+
+    /// A tool that closes stderr but keeps running must stay cancellable:
+    /// after stream EOF the runner still polls the cancel flag while waiting
+    /// for the process instead of blocking in a bare wait().
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_cancel_after_stderr_close_kills_the_tool() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        let tool = crate::db::mongotools::test_support::write_fake_tool(
+            "echo 'ts\tdone dumping a.x (1 documents)' 1>&2\nexec 2>&-\nsleep 30\n",
+        );
+        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out8");
+        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+
+        // Wait until the stderr line was consumed, then a beat for the EOF.
+        for _ in 0..100 {
+            let processed = state.tasks.lock().unwrap().get(&task.id).map(|t| t.processed).unwrap_or(0);
+            if processed >= 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let started = std::time::Instant::now();
+        assert!(state.request_cancel(&task.id), "task should be known to the cancel registry");
+        wait_for_task(&state, &task.id).await;
+        let elapsed = started.elapsed();
+
+        let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(t.status, "cancelled");
+        assert!(elapsed.as_secs() < 5, "cancel should be fast, took {:?}", elapsed);
+        let _ = std::fs::remove_file(&tool);
+    }
+
+    /// Before the first parsable progress event, raw stderr lines (driver
+    /// warnings, connection errors) must reach the task message instead of
+    /// being dropped — they're the only clue when a tool can't connect. The
+    /// redacted URI handed to the tool is surfaced as the sub label.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_unparsed_stderr_and_uri_surface_before_first_progress() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        let tool = crate::db::mongotools::test_support::write_fake_tool(
+            "echo 'ts\tconnection warning: cluster unreachable' 1>&2\nsleep 30\n",
+        );
+        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out6");
+        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+
+        let mut snapshot: Option<TaskInfo> = None;
+        for _ in 0..250 {
+            snapshot = state.tasks.lock().unwrap().get(&task.id).cloned();
+            if snapshot.as_ref().is_some_and(|t| t.message.contains("connection warning")) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let t = snapshot.expect("task exists");
+        assert!(
+            t.message.contains("connection warning: cluster unreachable"),
+            "raw stderr should surface, got {:?}",
+            t.message
+        );
+        let sub = t.sub_label.unwrap_or_default();
+        assert!(sub.contains("***") && !sub.contains("pw"), "URI must be redacted, got {:?}", sub);
+        assert!(sub.contains("serverSelectionTimeoutMS"), "prepared URI expected, got {:?}", sub);
+
+        assert!(state.request_cancel(&task.id));
+        wait_for_task(&state, &task.id).await;
+        let _ = std::fs::remove_file(&tool);
+    }
+
+    /// Cancelling a task that has already finished is a no-op, not an error —
+    /// the flag is gone, but yelling "cannot be cancelled" at the user for a
+    /// race they can't see is wrong. Unknown ids still error.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_cancel_after_finish_is_acknowledged() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        let tool = crate::db::mongotools::test_support::write_fake_tool("exit 0\n");
+        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out5");
+        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        // Wait until the task has finished AND its cancel flag is gone (the
+        // flag is removed just after the status flips; poll both).
+        for _ in 0..250 {
+            let finished = state.tasks.lock().unwrap().get(&task.id).map(|t| t.status != "running").unwrap_or(false);
+            let flag_gone = state.cancels.lock().unwrap().get(&task.id).is_none();
+            if finished && flag_gone {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(state.cancels.lock().unwrap().get(&task.id).is_none(), "flag cleaned up");
+
+        assert!(state.cancel_or_ack(&task.id).is_ok(), "cancel after finish should be a quiet no-op");
+        assert!(state.cancel_or_ack("no-such-task").is_err(), "unknown task ids still error");
+        let _ = std::fs::remove_file(&tool);
+    }
+}

--- a/src-tauri/src/db/tasks.rs
+++ b/src-tauri/src/db/tasks.rs
@@ -56,9 +56,63 @@ pub fn prune_tasks(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>) {
     if guard.len() <= MAX_TASK_HISTORY {
         return;
     }
-    let mut entries: Vec<(String, TaskInfo)> = guard.drain().collect();
-    entries.sort_by(|a, b| b.1.created_at_ms.cmp(&a.1.created_at_ms));
-    for (id, task) in entries.into_iter().take(MAX_TASK_HISTORY) {
+    // Never evict a running task: its background job would keep updating a
+    // ghost entry (update_task silently no-ops on a missing id) and the task
+    // would vanish from the UI while the process keeps running. Keep all
+    // running tasks plus the newest finished ones up to the cap.
+    let (running, mut finished): (Vec<(String, TaskInfo)>, Vec<(String, TaskInfo)>) =
+        guard.drain().partition(|(_, task)| task.status == "running");
+    finished.sort_by(|a, b| b.1.created_at_ms.cmp(&a.1.created_at_ms));
+    let finished_budget = MAX_TASK_HISTORY.saturating_sub(running.len());
+    for (id, task) in running.into_iter().chain(finished.into_iter().take(finished_budget)) {
         guard.insert(id, task);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::limits::MAX_TASK_HISTORY;
+
+    fn task(id: &str, status: &str, created_at_ms: u64) -> TaskInfo {
+        TaskInfo {
+            id: id.to_string(),
+            kind: "dump".to_string(),
+            label: String::new(),
+            status: status.to_string(),
+            processed: 0,
+            total: None,
+            message: String::new(),
+            path: None,
+            error: None,
+            created_at_ms,
+            finished_at_ms: None,
+            sub_label: None,
+            items_processed: None,
+            items_total: None,
+            summary: None,
+        }
+    }
+
+    /// A still-RUNNING task must never be pruned, even when it is the oldest
+    /// entry: its background job keeps calling update_task (which would
+    /// silently no-op) while the task vanishes from the UI with the process
+    /// still alive. Finished tasks absorb the eviction instead.
+    #[test]
+    fn prune_never_evicts_running_tasks() {
+        let tasks: Arc<Mutex<HashMap<String, TaskInfo>>> = Arc::new(Mutex::new(HashMap::new()));
+        {
+            let mut guard = tasks.lock().unwrap();
+            guard.insert("running-old".into(), task("running-old", "running", 0));
+            for i in 0..MAX_TASK_HISTORY as u64 {
+                let id = format!("done-{}", i);
+                guard.insert(id.clone(), task(&id, "completed", 1 + i));
+            }
+        }
+        prune_tasks(&tasks);
+        let guard = tasks.lock().unwrap();
+        assert_eq!(guard.len(), MAX_TASK_HISTORY);
+        assert!(guard.contains_key("running-old"), "running task must survive pruning");
+        assert!(!guard.contains_key("done-0"), "oldest finished task is evicted instead");
     }
 }

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -301,6 +301,9 @@ mod integration {
             return;
         };
 
+        // The normalized connection URI is retained for external tools (mongodump/mongorestore).
+        assert!(state.conn_uris.lock().unwrap().get(&id).unwrap().starts_with("mongodb"));
+
         // insert_document_impl returns the inserted id as extended JSON.
         let inserted = insert_document_impl(
             &state,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ pub mod path_env;
 pub mod queries;
 pub mod ssh_tunnel;
 mod state;
+pub mod toolsetup;
 pub mod updater;
 mod vault;
 mod window;
@@ -42,6 +43,10 @@ pub use db::gridfs::{
     upload_gridfs_file_impl, GridFsFileInfo, GridFsTransferProgress,
 };
 pub use db::import::{preview_import_impl, start_import_task_impl};
+pub use db::mongotools::{
+    browse_dump_folder_impl, resolve_conn_uri, start_dump_task_impl, start_restore_task_impl,
+    DumpTree, ToolInfo, ToolsStatus,
+};
 pub use db::metadata::{
     create_index_impl, delete_index_impl, list_collections_impl, list_databases_impl,
     list_indexes_impl,
@@ -467,6 +472,10 @@ pub async fn connect_db_impl(
         let mut mocks = state.mocks.lock_safe()?;
         mocks.insert(connection_id.clone(), false);
     }
+    {
+        let mut conn_uris = state.conn_uris.lock_safe()?;
+        conn_uris.insert(connection_id.clone(), normalized_uri.clone());
+    }
     if let Some(t) = tunnel {
         let mut tunnels = state.ssh_tunnels.lock_safe()?;
         tunnels.insert(connection_id.clone(), t);
@@ -500,6 +509,10 @@ pub async fn disconnect_db_impl(state: &AppState, id: &str) -> Result<(), String
     {
         let mut mocks = state.mocks.lock_safe()?;
         mocks.remove(id);
+    }
+    {
+        let mut conn_uris = state.conn_uris.lock_safe()?;
+        conn_uris.remove(id);
     }
     // Tear down the SSH tunnel (if any) — dropping SshTunnel aborts its accept loop.
     {
@@ -639,6 +652,111 @@ async fn connect_db(
 }
 
 #[tauri::command]
+async fn detect_mongo_tools(
+    app_handle: tauri::AppHandle,
+    configured_dir: Option<String>,
+) -> Result<ToolsStatus, String> {
+    use tauri::Manager;
+    // app_data_dir() can fail in headless/test environments; treat that as
+    // "no managed dir" rather than failing detection outright.
+    let app_data_dir = app_handle.path().app_data_dir().ok();
+    let managed_dir = app_data_dir
+        .as_deref()
+        .and_then(|dir| toolsetup::find_pinned_tool("database-tools").ok().map(|tool| toolsetup::managed_bin_dir(dir, tool)));
+    Ok(db::mongotools::detect_mongo_tools(configured_dir.as_deref(), managed_dir.as_deref()))
+}
+
+#[tauri::command]
+async fn start_dump_task(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    tool_path: String,
+    options: db::mongotools::DumpOptions,
+) -> Result<TaskInfo, String> {
+    start_dump_task_impl(&state, &id, &tool_path, options).await
+}
+
+#[tauri::command]
+async fn start_restore_task(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    tool_path: String,
+    options: db::mongotools::RestoreOptions,
+) -> Result<TaskInfo, String> {
+    start_restore_task_impl(&state, &id, &tool_path, options).await
+}
+
+#[tauri::command]
+async fn start_tool_install_task(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    tools: Vec<String>,
+    force: bool,
+) -> Result<TaskInfo, String> {
+    use tauri::Manager;
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data directory: {e}"))?;
+    toolsetup::start_tool_install_task_impl(&state, app_data_dir, tools, force, None).await
+}
+
+#[tauri::command]
+async fn managed_tools_status(app_handle: tauri::AppHandle) -> Result<Vec<toolsetup::ManagedToolStatus>, String> {
+    use tauri::Manager;
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data directory: {e}"))?;
+    Ok(toolsetup::managed_tools_status(&app_data_dir))
+}
+
+#[tauri::command]
+async fn browse_dump_folder(path: String) -> Result<DumpTree, String> {
+    browse_dump_folder_impl(&path).await
+}
+
+#[tauri::command]
+async fn preview_dump_command(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    tool_path: String,
+    options: db::mongotools::DumpOptions,
+) -> Result<String, String> {
+    let uri = resolve_conn_uri(&state, &id)?;
+    let tunneled = state.ssh_tunnels.lock_safe()?.contains_key(&id);
+    let mut args = db::mongotools::build_dump_args(&options)?;
+    let prepared_uri = db::mongotools::prepare_tool_uri(&uri, tunneled);
+    let (prepared_uri, tls_flags) = db::mongotools::extract_unsupported_tls_params(&prepared_uri);
+    args.extend(tls_flags);
+    Ok(db::mongotools::preview_tool_command(
+        &tool_path,
+        &db::mongotools::redact_uri_password(&prepared_uri),
+        &args,
+    ))
+}
+
+#[tauri::command]
+async fn preview_restore_command(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    tool_path: String,
+    options: db::mongotools::RestoreOptions,
+) -> Result<String, String> {
+    let uri = resolve_conn_uri(&state, &id)?;
+    let tunneled = state.ssh_tunnels.lock_safe()?.contains_key(&id);
+    let mut args = db::mongotools::build_restore_args(&options)?;
+    let prepared_uri = db::mongotools::prepare_tool_uri(&uri, tunneled);
+    let (prepared_uri, tls_flags) = db::mongotools::extract_unsupported_tls_params(&prepared_uri);
+    args.extend(tls_flags);
+    Ok(db::mongotools::preview_tool_command(
+        &tool_path,
+        &db::mongotools::redact_uri_password(&prepared_uri),
+        &args,
+    ))
+}
+
+#[tauri::command]
 async fn get_resource_usage(state: tauri::State<'_, AppState>) -> Result<ResourceUsage, String> {
     Ok(resource_usage_impl(&state))
 }
@@ -727,13 +845,17 @@ async fn get_mongodb_version(
 
 #[tauri::command]
 async fn start_mongosh_session(
+    app_handle: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     connection_id: String,
     uri: String,
     database: String,
     mongosh_path: String,
 ) -> Result<MongoshSessionInfo, String> {
-    start_mongosh_session_impl(&state, &connection_id, &uri, &database, &mongosh_path).await
+    use tauri::Manager;
+    let app_data_dir = app_handle.path().app_data_dir().ok();
+    let resolved_path = toolsetup::resolve_mongosh_executable(&mongosh_path, app_data_dir.as_deref());
+    start_mongosh_session_impl(&state, &connection_id, &uri, &database, &resolved_path).await
 }
 
 #[tauri::command]
@@ -1052,11 +1174,7 @@ async fn clear_finished_export_tasks(
 
 #[tauri::command]
 async fn cancel_task(state: tauri::State<'_, AppState>, id: String) -> Result<(), String> {
-    if state.request_cancel(&id) {
-        Ok(())
-    } else {
-        Err("Task is not running or cannot be cancelled".to_string())
-    }
+    state.cancel_or_ack(&id)
 }
 
 #[tauri::command]
@@ -1653,6 +1771,14 @@ pub fn run() {
         .manage(AppState::new())
         .invoke_handler(tauri::generate_handler![
             connect_db,
+            detect_mongo_tools,
+            start_dump_task,
+            start_restore_task,
+            start_tool_install_task,
+            managed_tools_status,
+            browse_dump_folder,
+            preview_dump_command,
+            preview_restore_command,
             get_resource_usage,
             generate_mql_query,
             detect_local_agents,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -34,6 +34,10 @@ pub struct AppState {
     pub resource_tree_at: Mutex<Instant>,
     // In-memory vault key; None when locked or uninitialized.
     pub vault_key: Mutex<Option<[u8; 32]>>,
+    /// Normalized connection URI (post-SSH-tunnel rewrite) retained per real
+    /// connection id, for tools that need to hand a URI to an external
+    /// process (mongodump/mongorestore). Never populated for mock connections.
+    pub conn_uris: Mutex<HashMap<String, String>>,
 }
 
 impl AppState {
@@ -50,6 +54,7 @@ impl AppState {
             resource_pids: Mutex::new(Vec::new()),
             resource_tree_at: Mutex::new(Instant::now()),
             vault_key: Mutex::new(None),
+            conn_uris: Mutex::new(HashMap::new()),
         }
     }
 
@@ -78,6 +83,28 @@ impl AppState {
                 None => false,
             },
             Err(_) => false,
+        }
+    }
+
+    /// Request cancellation, treating "already finished" as success: the
+    /// cancel flag is removed the moment a task completes, so a Cancel click
+    /// that races the task's natural end (or a double-click) must not surface
+    /// an error for a task that is genuinely done. Unknown ids and running
+    /// tasks that were never registered for cancellation still error.
+    pub fn cancel_or_ack(&self, task_id: &str) -> Result<(), String> {
+        if self.request_cancel(task_id) {
+            return Ok(());
+        }
+        let already_finished = self
+            .tasks
+            .lock_safe()?
+            .get(task_id)
+            .map(|t| t.status != "running")
+            .unwrap_or(false);
+        if already_finished {
+            Ok(())
+        } else {
+            Err("Task is not running or cannot be cancelled".to_string())
         }
     }
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -142,6 +142,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_conn_uris_stored_for_real_and_absent_for_mock() {
+        use crate::db::mongotools::resolve_conn_uri;
+        let state = AppState::new();
+        let mock_id = connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+        assert!(resolve_conn_uri(&state, &mock_id).is_err());
+        assert!(resolve_conn_uri(&state, "nope").is_err());
+        // Real-connection storage is asserted in integration tests (needs a live server);
+        // unit-level: connect_db_impl inserts before returning — verified by reading the code
+        // path plus the integration test below.
+    }
+
+    #[tokio::test]
     async fn test_mock_full_collection_export_task_writes_file() {
         let state = AppState::new();
         let conn_id = connect_db_impl(&state, "mongodb://mock", None)
@@ -2988,5 +3000,347 @@ mod tests {
         .await
         .unwrap_err();
         assert!(err.contains("mode"));
+    }
+
+    #[tokio::test]
+    async fn test_browse_dump_folder_reads_tree() {
+        use crate::db::mongotools::browse_dump_folder_impl;
+
+        let root = std::env::temp_dir().join(format!(
+            "mqlens-browse-dump-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let db1 = root.join("db1");
+        let db2 = root.join("db2");
+        std::fs::create_dir_all(&db1).unwrap();
+        std::fs::create_dir_all(&db2).unwrap();
+
+        std::fs::write(db1.join("orders.bson"), b"").unwrap();
+        std::fs::write(db1.join("orders.metadata.json"), b"{}").unwrap();
+        std::fs::write(db1.join("notes.txt"), b"ignored").unwrap();
+        std::fs::write(db2.join("logs.bson.gz"), b"").unwrap();
+        std::fs::write(root.join("stray.txt"), b"ignored").unwrap();
+
+        let tree = browse_dump_folder_impl(root.to_str().unwrap()).await.unwrap();
+        assert_eq!(tree.dbs.iter().map(|d| d.name.as_str()).collect::<Vec<_>>(), ["db1", "db2"]);
+
+        let db1_colls = &tree.dbs[0].collections;
+        assert_eq!(db1_colls.len(), 1);
+        assert_eq!(db1_colls[0].name, "orders");
+        assert!(db1_colls[0].has_metadata);
+        assert!(!db1_colls[0].gzip);
+
+        let db2_colls = &tree.dbs[1].collections;
+        assert_eq!(db2_colls.len(), 1);
+        assert_eq!(db2_colls[0].name, "logs");
+        assert!(!db2_colls[0].has_metadata);
+        assert!(db2_colls[0].gzip);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn test_dump_rejects_mock_connections() {
+        use crate::db::mongotools::{start_dump_task_impl, DumpOptions, DumpScope, DumpTarget};
+
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+
+        let opts = DumpOptions {
+            scope: DumpScope::Server,
+            target: DumpTarget::Folder { out: "/tmp/mqlens-dump-mock-test".into() },
+            gzip: false,
+            query: None,
+            force_table_scan: false,
+            dump_users_and_roles: false,
+            oplog: false,
+        };
+        let err = start_dump_task_impl(&state, &conn_id, "mongodump", opts).await.unwrap_err();
+        assert!(err.contains("real connection"), "{}", err);
+    }
+
+    fn tool_install_test_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "mqlens-tool-install-{}-{}-{}",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_tool_install_success_and_status() {
+        use crate::toolsetup::test_support::{fixture_zip, serve_bytes};
+        use crate::toolsetup::*;
+        use std::sync::atomic::AtomicBool;
+
+        // Fixture zip for a fake "mongosh" whose top dir mirrors the real
+        // archive layout ({top}/bin/{binary}), served over HTTP so
+        // `install_one_tool` downloads it exactly like the real pipeline
+        // would.
+        let bytes = fixture_zip("mongosh-2.9.2-darwin-arm64", &["mongosh"]);
+        let sha256 = sha256_hex(&bytes);
+        let (base_url, _server) = serve_bytes(bytes);
+        let url = format!("{base_url}/mongosh-2.9.2-darwin-arm64.zip");
+
+        let app_data = tool_install_test_dir("success");
+        let cancel = AtomicBool::new(false);
+
+        // Test `install_one_tool` directly (the unit of work factored out of
+        // the task), using the real "mongosh"/"2.9.2" name+version so the
+        // resulting layout matches what `managed_tools_status` (which walks
+        // the real PINNED_TOOLS manifest) expects.
+        install_one_tool(
+            &app_data,
+            "mongosh",
+            "2.9.2",
+            &url,
+            &sha256,
+            ArchiveKind::Zip,
+            "mongosh-2.9.2-darwin-arm64/bin",
+            &["mongosh".to_string()],
+            &cancel,
+            |_, _, _| {},
+        )
+        .await
+        .unwrap();
+
+        let bin = app_data.join("tools/mongosh-2.9.2/bin/mongosh");
+        assert!(bin.exists(), "binary should exist at the managed layout path");
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&bin).unwrap().permissions().mode();
+            assert_ne!(mode & 0o111, 0, "binary should be executable");
+        }
+        assert!(
+            !app_data.join("tools/.staging-mongosh").exists(),
+            "staging dir should be cleaned up after success"
+        );
+
+        let status = managed_tools_status(&app_data);
+        let mongosh_status = status.iter().find(|s| s.name == "mongosh").unwrap();
+        assert!(mongosh_status.installed, "{:?}", mongosh_status);
+        assert_eq!(mongosh_status.version, "2.9.2");
+        assert!(mongosh_status.path.as_deref().unwrap().ends_with("mongosh-2.9.2/bin"));
+
+        let _ = std::fs::remove_dir_all(&app_data);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_tool_install_checksum_mismatch_cleans_up() {
+        use crate::toolsetup::test_support::{fixture_zip, serve_bytes};
+        use crate::toolsetup::*;
+        use std::sync::atomic::AtomicBool;
+
+        let bytes = fixture_zip("mongosh-2.9.2-darwin-arm64", &["mongosh"]);
+        let (base_url, _server) = serve_bytes(bytes);
+        let url = format!("{base_url}/mongosh-2.9.2-darwin-arm64.zip");
+        let wrong_sha256 = "0".repeat(64);
+
+        let app_data = tool_install_test_dir("badsum");
+        let cancel = AtomicBool::new(false);
+
+        let err = install_one_tool(
+            &app_data,
+            "mongosh",
+            "2.9.2",
+            &url,
+            &wrong_sha256,
+            ArchiveKind::Zip,
+            "mongosh-2.9.2-darwin-arm64/bin",
+            &["mongosh".to_string()],
+            &cancel,
+            |_, _, _| {},
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("checksum mismatch"), "{err}");
+
+        let tools_dir = app_data.join("tools");
+        if tools_dir.exists() {
+            let leftovers: Vec<_> = std::fs::read_dir(&tools_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .filter(|n| n.starts_with("mongosh") || n.starts_with(".staging-"))
+                .collect();
+            assert!(leftovers.is_empty(), "no mongosh-*/.staging-* dir should remain: {:?}", leftovers);
+        }
+
+        let _ = std::fs::remove_dir_all(&app_data);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_tool_install_probe_failure_leaves_no_install_dir() {
+        use crate::toolsetup::test_support::{fixture_zip_with_script, serve_bytes};
+        use crate::toolsetup::*;
+        use std::sync::atomic::AtomicBool;
+
+        // A "binary" that survives extraction (checksum + extract both
+        // succeed) but exits non-zero on `--version`, simulating a corrupt or
+        // incompatible executable. Per the spec, the staged copy must be
+        // probed *before* the managed install dir is ever created.
+        let bytes = fixture_zip_with_script("mongosh-2.9.2-darwin-arm64", &["mongosh"], b"#!/bin/sh\nexit 1\n");
+        let sha256 = sha256_hex(&bytes);
+        let (base_url, _server) = serve_bytes(bytes);
+        let url = format!("{base_url}/mongosh-2.9.2-darwin-arm64.zip");
+
+        let app_data = tool_install_test_dir("probefail");
+        let cancel = AtomicBool::new(false);
+
+        let err = install_one_tool(
+            &app_data,
+            "mongosh",
+            "2.9.2",
+            &url,
+            &sha256,
+            ArchiveKind::Zip,
+            "mongosh-2.9.2-darwin-arm64/bin",
+            &["mongosh".to_string()],
+            &cancel,
+            |_, _, _| {},
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("failed to run --version"), "{err}");
+
+        // NOTE: with staging-first probing, the managed install dir is never
+        // created on a probe failure (probe happens before mkdir+rename, the
+        // atomic swap). We can only observe its absence, not distinguish
+        // "never created" from "created then removed by cleanup" purely from
+        // outside the function — both leave no trace on disk. The ordering
+        // itself (verified by reading `install_one_tool`) is what proves the
+        // stronger claim; this assertion just guards the observable contract.
+        let install_dir = app_data.join("tools/mongosh-2.9.2");
+        assert!(!install_dir.exists(), "install dir should not exist after a probe failure");
+        assert!(
+            !app_data.join("tools/.staging-mongosh").exists(),
+            "staging dir should be cleaned up after probe failure"
+        );
+
+        let _ = std::fs::remove_dir_all(&app_data);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_tool_install_probes_staged_copy_before_moving_into_install_dir() {
+        use crate::toolsetup::test_support::{fixture_zip_with_script, serve_bytes};
+        use crate::toolsetup::*;
+        use std::sync::atomic::AtomicBool;
+
+        // Directly verifies the spec-mandated ordering (probe the STAGING
+        // copy first, then atomically swap into place) rather than just
+        // inferring it from absence-on-failure, which both orderings satisfy
+        // identically. The probed script reports its own invocation
+        // directory (via `$0`) to a marker file that lives outside the
+        // staging/install tree, so it survives regardless of what
+        // `install_one_tool` does with the staging dir afterwards.
+        let app_data = tool_install_test_dir("probe-order");
+        let marker = app_data.join("probe-marker.txt");
+        let script = format!(
+            "#!/bin/sh\necho \"$(dirname \"$0\")\" > '{}'\necho tool version 9.9.9\n",
+            marker.display()
+        );
+        let bytes = fixture_zip_with_script("mongosh-2.9.2-darwin-arm64", &["mongosh"], script.as_bytes());
+        let sha256 = sha256_hex(&bytes);
+        let (base_url, _server) = serve_bytes(bytes);
+        let url = format!("{base_url}/mongosh-2.9.2-darwin-arm64.zip");
+
+        let cancel = AtomicBool::new(false);
+        install_one_tool(
+            &app_data,
+            "mongosh",
+            "2.9.2",
+            &url,
+            &sha256,
+            ArchiveKind::Zip,
+            "mongosh-2.9.2-darwin-arm64/bin",
+            &["mongosh".to_string()],
+            &cancel,
+            |_, _, _| {},
+        )
+        .await
+        .unwrap();
+
+        let probed_from = std::fs::read_to_string(&marker).unwrap();
+        let probed_from = probed_from.trim();
+        assert!(
+            probed_from.contains(".staging-mongosh"),
+            "probe must run against the staging copy before the install swap, was probed from: {probed_from}"
+        );
+        let final_bin_dir = app_data.join("tools/mongosh-2.9.2/bin");
+        assert_ne!(
+            probed_from,
+            final_bin_dir.to_string_lossy(),
+            "probe must not run against the already-installed copy"
+        );
+
+        let _ = std::fs::remove_dir_all(&app_data);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_tool_install_task_end_to_end_with_cancel_flag_cleanup() {
+        use crate::toolsetup::test_support::{fixture_zip, serve_bytes, test_tool};
+        use crate::toolsetup::*;
+
+        let bytes = fixture_zip("test-mongosh-9.9.9-test", &["mongosh"]);
+        let sha256 = sha256_hex(&bytes);
+        let (base_url, _server) = serve_bytes(bytes);
+
+        // Registers a synthetic pinned tool (name "test-mongosh") so
+        // `start_tool_install_task_impl`'s manifest resolution doesn't need
+        // real network access or a real checksum.
+        test_tool(
+            "test-mongosh",
+            "https://example.invalid/test-mongosh-fixture.zip",
+            &sha256,
+            "test-mongosh-9.9.9-test/bin",
+            &["mongosh"],
+        );
+
+        let app_data = tool_install_test_dir("e2e");
+        let state = AppState::new();
+
+        let task = start_tool_install_task_impl(
+            &state,
+            app_data.clone(),
+            vec!["test-mongosh".to_string()],
+            false,
+            Some(base_url.clone()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(task.kind, "tool_install");
+
+        wait_for_task(&state, &task.id).await;
+        let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(t.status, "completed", "{:?}", t.error);
+        assert!(state.cancels.lock().unwrap().get(&task.id).is_none(), "cancel flag cleaned up");
+
+        // Same tool, force=false: should skip straight to "already installed"
+        // without re-downloading.
+        let task2 = start_tool_install_task_impl(
+            &state,
+            app_data.clone(),
+            vec!["test-mongosh".to_string()],
+            false,
+            Some(base_url),
+        )
+        .await
+        .unwrap();
+        wait_for_task(&state, &task2.id).await;
+        let t2 = state.tasks.lock().unwrap().get(&task2.id).cloned().unwrap();
+        assert_eq!(t2.status, "completed");
+        assert!(t2.message.contains("already installed"), "{}", t2.message);
+        assert!(state.cancels.lock().unwrap().get(&task2.id).is_none(), "cancel flag cleaned up");
+
+        let _ = std::fs::remove_dir_all(&app_data);
     }
 }

--- a/src-tauri/src/toolsetup.rs
+++ b/src-tauri/src/toolsetup.rs
@@ -1,0 +1,1203 @@
+//! Pinned MongoDB tool manifest, platform selection, checksum verification,
+//! archive extraction helpers, and the download/verify/extract/probe install
+//! pipeline that turns a manifest entry into a managed, ready-to-run tool
+//! (run as a cancellable background task from `lib.rs`).
+
+use std::collections::{HashMap, HashSet};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::db::tasks::{fail_task, finish_task, now_ms, update_task};
+use crate::state::{AppState, LockExt};
+use crate::TaskInfo;
+
+/// Supported host operating systems for tool artifacts.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Os {
+    Macos,
+    Windows,
+    Linux,
+}
+
+/// Supported host architectures for tool artifacts.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Arch {
+    Arm64,
+    X64,
+}
+
+/// Archive container format for a pinned artifact.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum ArchiveKind {
+    Zip,
+    Tgz,
+}
+
+/// A single platform-specific downloadable artifact for a pinned tool.
+#[derive(Debug)]
+pub struct PinnedArtifact {
+    pub os: Os,
+    pub arch: Arch,
+    pub url: &'static str,
+    pub sha256: &'static str,
+    pub archive: ArchiveKind,
+    /// Path of the directory (inside the extracted archive) that contains the
+    /// tool's binaries, e.g. `mongosh-2.9.2-darwin-arm64/bin`.
+    pub bin_subpath: &'static str,
+}
+
+/// A pinned tool: a fixed name/version plus one artifact per supported
+/// platform.
+pub struct PinnedTool {
+    pub name: &'static str,
+    pub version: &'static str,
+    pub binaries: &'static [&'static str],
+    pub artifacts: &'static [PinnedArtifact],
+}
+
+/// The compiled-in manifest of tools MQLens knows how to install.
+///
+/// Values (URLs, sha256 digests, bin_subpaths) are transcribed verbatim from
+/// the resolved manifest in `docs/superpowers/plans/2026-07-06-guided-tool-setup.md`.
+pub const PINNED_TOOLS: [PinnedTool; 2] = [
+    PinnedTool {
+        name: "database-tools",
+        version: "100.17.0",
+        binaries: &["mongodump", "mongorestore"],
+        artifacts: &[
+            PinnedArtifact {
+                os: Os::Macos,
+                arch: Arch::Arm64,
+                url: "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-macos-arm64-100.17.0.zip",
+                sha256: "099691c9059b25504a1b318bc31b3b9bd965ff78ce6b9f629090f89b25539dac",
+                archive: ArchiveKind::Zip,
+                bin_subpath: "mongodb-database-tools-macos-arm64-100.17.0/bin",
+            },
+            PinnedArtifact {
+                os: Os::Macos,
+                arch: Arch::X64,
+                url: "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-macos-x86_64-100.17.0.zip",
+                sha256: "b488e12a3e2399f8ee3ba0abf6da54dbac1bda678c230963edaa7c435887ae99",
+                archive: ArchiveKind::Zip,
+                bin_subpath: "mongodb-database-tools-macos-x86_64-100.17.0/bin",
+            },
+            PinnedArtifact {
+                os: Os::Windows,
+                arch: Arch::X64,
+                url: "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-windows-x86_64-100.17.0.zip",
+                sha256: "07b8fca56272397490102051edad4aeadc79369365ffdcda4ff70b4549512c5b",
+                archive: ArchiveKind::Zip,
+                bin_subpath: "mongodb-database-tools-windows-x86_64-100.17.0/bin",
+            },
+            PinnedArtifact {
+                os: Os::Linux,
+                arch: Arch::X64,
+                url: "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.17.0.tgz",
+                sha256: "f30d0b3115cc31b1f360af2341a794d890c74ceb41e5a4931d3b945efeeb628e",
+                archive: ArchiveKind::Tgz,
+                bin_subpath: "mongodb-database-tools-ubuntu2204-x86_64-100.17.0/bin",
+            },
+        ],
+    },
+    PinnedTool {
+        name: "mongosh",
+        version: "2.9.2",
+        binaries: &["mongosh"],
+        artifacts: &[
+            PinnedArtifact {
+                os: Os::Macos,
+                arch: Arch::Arm64,
+                url: "https://github.com/mongodb-js/mongosh/releases/download/v2.9.2/mongosh-2.9.2-darwin-arm64.zip",
+                sha256: "386392be90e5ff4b827d8c21cc828ff6f82cdbc045a6f6a7eb8bc3c641c9181f",
+                archive: ArchiveKind::Zip,
+                bin_subpath: "mongosh-2.9.2-darwin-arm64/bin",
+            },
+            PinnedArtifact {
+                os: Os::Macos,
+                arch: Arch::X64,
+                url: "https://github.com/mongodb-js/mongosh/releases/download/v2.9.2/mongosh-2.9.2-darwin-x64.zip",
+                sha256: "56c5c0b36213335ac375c9a5e2a8ebbdc3910ebe73019c24fa02a24dbdc68b86",
+                archive: ArchiveKind::Zip,
+                bin_subpath: "mongosh-2.9.2-darwin-x64/bin",
+            },
+            PinnedArtifact {
+                os: Os::Windows,
+                arch: Arch::X64,
+                url: "https://github.com/mongodb-js/mongosh/releases/download/v2.9.2/mongosh-2.9.2-win32-x64.zip",
+                sha256: "1e9b505f78830a717bfc8c22d6a904cc68e3aa5a3b47fe1453a9eb2ed400fbc0",
+                archive: ArchiveKind::Zip,
+                bin_subpath: "mongosh-2.9.2-win32-x64/bin",
+            },
+            PinnedArtifact {
+                os: Os::Linux,
+                arch: Arch::X64,
+                url: "https://github.com/mongodb-js/mongosh/releases/download/v2.9.2/mongosh-2.9.2-linux-x64.tgz",
+                sha256: "b0febe385c10c9be755c29095ffa95a42bed16ea6625ea3fbde36ae33b42da79",
+                archive: ArchiveKind::Tgz,
+                bin_subpath: "mongosh-2.9.2-linux-x64/bin",
+            },
+        ],
+    },
+];
+
+/// Detects the current host's OS/arch pair via `cfg!` checks.
+pub fn current_platform() -> (Os, Arch) {
+    let os = if cfg!(target_os = "macos") {
+        Os::Macos
+    } else if cfg!(target_os = "windows") {
+        Os::Windows
+    } else {
+        Os::Linux
+    };
+    let arch = if cfg!(target_arch = "aarch64") {
+        Arch::Arm64
+    } else {
+        Arch::X64
+    };
+    (os, arch)
+}
+
+/// Selects the artifact matching `os`/`arch` from `tool`'s manifest.
+pub fn select_artifact(tool: &PinnedTool, os: Os, arch: Arch) -> Result<&'static PinnedArtifact, String> {
+    tool.artifacts
+        .iter()
+        .find(|a| a.os == os && a.arch == arch)
+        .ok_or_else(|| format!("{} is not supported on {:?}/{:?}", tool.name, os, arch))
+}
+
+/// Looks up a pinned tool by name.
+pub fn find_pinned_tool(name: &str) -> Result<&'static PinnedTool, String> {
+    PINNED_TOOLS
+        .iter()
+        .find(|t| t.name == name)
+        .ok_or_else(|| format!("unknown tool: {name}"))
+}
+
+/// Returns the lowercase hex SHA-256 digest of `bytes`.
+#[allow(dead_code)] // used by Task 2
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_encode(&hasher.finalize())
+}
+
+/// Streams `path` through SHA-256 (8 KiB buffer) and compares against
+/// `expected_hex`. Returns an error containing "checksum mismatch" on
+/// mismatch.
+pub fn verify_sha256(path: &Path, expected_hex: &str) -> Result<(), String> {
+    let mut file = std::fs::File::open(path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let actual = hex_encode(&hasher.finalize());
+    if actual.eq_ignore_ascii_case(expected_hex) {
+        Ok(())
+    } else {
+        Err(format!(
+            "checksum mismatch for {}: expected {expected_hex}, got {actual}",
+            path.display()
+        ))
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Extracts `archive` (of `kind`) into `dest_dir`, creating it if needed.
+///
+/// Zip entries are sandboxed via `enclosed_name()` (rejecting `..`/absolute
+/// paths); unix file modes are restored when present in the zip entry.
+/// Tgz entries are sandboxed by `tar::Archive::unpack`'s built-in guard.
+pub fn extract_archive(archive: &Path, kind: ArchiveKind, dest_dir: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(dest_dir).map_err(|e| format!("failed to create {}: {e}", dest_dir.display()))?;
+    match kind {
+        ArchiveKind::Zip => extract_zip(archive, dest_dir),
+        ArchiveKind::Tgz => extract_tgz(archive, dest_dir),
+    }
+}
+
+fn extract_zip(archive: &Path, dest_dir: &Path) -> Result<(), String> {
+    let file = std::fs::File::open(archive).map_err(|e| format!("failed to open {}: {e}", archive.display()))?;
+    let mut zip = zip::ZipArchive::new(file).map_err(|e| format!("invalid zip {}: {e}", archive.display()))?;
+
+    for i in 0..zip.len() {
+        let mut entry = zip
+            .by_index(i)
+            .map_err(|e| format!("failed to read zip entry {i}: {e}"))?;
+        let Some(enclosed) = entry.enclosed_name() else {
+            // Skip entries with unsafe paths (e.g. containing "..") instead of
+            // failing the whole extraction.
+            continue;
+        };
+        let out_path = dest_dir.join(enclosed);
+
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out_path)
+                .map_err(|e| format!("failed to create dir {}: {e}", out_path.display()))?;
+            continue;
+        }
+
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("failed to create dir {}: {e}", parent.display()))?;
+        }
+
+        let mut out_file =
+            std::fs::File::create(&out_path).map_err(|e| format!("failed to create {}: {e}", out_path.display()))?;
+        std::io::copy(&mut entry, &mut out_file)
+            .map_err(|e| format!("failed to write {}: {e}", out_path.display()))?;
+
+        #[cfg(unix)]
+        if let Some(mode) = entry.unix_mode() {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(mode));
+        }
+    }
+    Ok(())
+}
+
+fn extract_tgz(archive: &Path, dest_dir: &Path) -> Result<(), String> {
+    let file = std::fs::File::open(archive).map_err(|e| format!("failed to open {}: {e}", archive.display()))?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut tar_archive = tar::Archive::new(decoder);
+    tar_archive
+        .unpack(dest_dir)
+        .map_err(|e| format!("failed to extract {}: {e}", archive.display()))?;
+    Ok(())
+}
+
+/// `{app_data}/tools`
+pub fn managed_tools_dir(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("tools")
+}
+
+/// `{app_data}/tools/{name}-{version}`
+pub fn managed_install_dir(app_data_dir: &Path, tool: &PinnedTool) -> PathBuf {
+    install_dir_for(app_data_dir, tool.name, tool.version)
+}
+
+/// `{app_data}/tools/{name}-{version}/bin` — platform-free; the install
+/// pipeline moves the archive's `bin_subpath` contents here regardless of the
+/// archive's internal top-level directory name.
+pub fn managed_bin_dir(app_data_dir: &Path, tool: &PinnedTool) -> PathBuf {
+    bin_dir_for(app_data_dir, tool.name, tool.version)
+}
+
+fn install_dir_for(app_data_dir: &Path, name: &str, version: &str) -> PathBuf {
+    managed_tools_dir(app_data_dir).join(format!("{name}-{version}"))
+}
+
+fn bin_dir_for(app_data_dir: &Path, name: &str, version: &str) -> PathBuf {
+    install_dir_for(app_data_dir, name, version).join("bin")
+}
+
+fn binary_file_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+/// Resolve the `mongosh` executable to invoke: a non-empty (trimmed)
+/// `configured` path wins outright (even if the file turns out not to
+/// exist — the caller's spawn will surface that error); otherwise, if the
+/// managed `mongosh` install's binary exists under `app_data_dir`, its path
+/// is used; otherwise fall back to the bare `"mongosh"` (resolved via `PATH`
+/// by the caller's process spawn).
+pub fn resolve_mongosh_executable(configured: &str, app_data_dir: Option<&Path>) -> String {
+    let trimmed = configured.trim();
+    if !trimmed.is_empty() {
+        return trimmed.to_string();
+    }
+
+    if let Some(app_data_dir) = app_data_dir {
+        if let Ok(tool) = find_pinned_tool("mongosh") {
+            let candidate = managed_bin_dir(app_data_dir, tool).join(binary_file_name("mongosh"));
+            if candidate.is_file() {
+                return candidate.to_string_lossy().into_owned();
+            }
+        }
+    }
+
+    "mongosh".to_string()
+}
+
+/// Runs `path --version`, treating any spawn failure or non-zero exit as
+/// "not usable" — the safety net after extraction, and the check
+/// `managed_tools_status` uses to decide `installed`.
+fn probe_binary_ok(path: &Path) -> bool {
+    std::process::Command::new(path)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Time allowed for a `--version` probe during an install before it counts as
+/// failed — a wedged binary must not block the install task forever.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// [`probe_binary_ok`] on a blocking thread with a hard timeout, used by the
+/// async install flow (a timed-out probe counts as failure).
+/// `managed_tools_status` keeps the plain synchronous probe.
+async fn probe_binary_ok_timeout(path: &Path) -> bool {
+    let path = path.to_path_buf();
+    let probe = tokio::task::spawn_blocking(move || probe_binary_ok(&path));
+    matches!(tokio::time::timeout(PROBE_TIMEOUT, probe).await, Ok(Ok(true)))
+}
+
+/// Staging directories (one per tool name + app data dir) with an install
+/// currently in flight. Guards against two concurrent installs of the same
+/// tool corrupting each other's staging dir or a just-completed install.
+static IN_FLIGHT_INSTALLS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+
+fn in_flight_installs() -> &'static Mutex<HashSet<PathBuf>> {
+    IN_FLIGHT_INSTALLS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// RAII registration of one in-flight install, keyed by its staging dir.
+/// Acquiring fails when the same tool is already being installed into the
+/// same app data dir; dropping releases the slot on every exit path.
+struct InstallGuard {
+    key: PathBuf,
+}
+
+impl InstallGuard {
+    fn acquire(name: &str, staging_dir: &Path) -> Result<Self, String> {
+        let mut in_flight = in_flight_installs()
+            .lock()
+            .map_err(|_| "in-flight install registry lock poisoned".to_string())?;
+        if !in_flight.insert(staging_dir.to_path_buf()) {
+            return Err(format!("{name} is already being installed"));
+        }
+        Ok(Self { key: staging_dir.to_path_buf() })
+    }
+}
+
+impl Drop for InstallGuard {
+    fn drop(&mut self) {
+        if let Ok(mut in_flight) = in_flight_installs().lock() {
+            in_flight.remove(&self.key);
+        }
+    }
+}
+
+/// Installed/available status for one pinned tool, reported to the frontend
+/// (camelCase over IPC).
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedToolStatus {
+    pub name: String,
+    pub version: String,
+    pub installed: bool,
+    pub path: Option<String>,
+}
+
+/// Status for every pinned tool: `installed` requires the managed bin dir to
+/// exist AND every one of the tool's binaries to probe `--version`
+/// successfully (a stale or partially-removed install reports
+/// `installed: false`).
+pub fn managed_tools_status(app_data_dir: &Path) -> Vec<ManagedToolStatus> {
+    PINNED_TOOLS
+        .iter()
+        .map(|tool| {
+            let bin_dir = managed_bin_dir(app_data_dir, tool);
+            let installed = bin_dir.is_dir()
+                && tool
+                    .binaries
+                    .iter()
+                    .all(|b| probe_binary_ok(&bin_dir.join(binary_file_name(b))));
+            ManagedToolStatus {
+                name: tool.name.to_string(),
+                version: tool.version.to_string(),
+                installed,
+                path: if installed { Some(bin_dir.to_string_lossy().into_owned()) } else { None },
+            }
+        })
+        .collect()
+}
+
+/// A tool resolved to concrete, owned download coordinates: either from the
+/// real (network-backed) [`PINNED_TOOLS`] manifest, or — in test builds only
+/// — from the [`test_support`] registry, so tests never need real network
+/// access or a `'static` synthetic [`PinnedTool`].
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedTool {
+    name: String,
+    version: String,
+    url: String,
+    sha256: String,
+    archive: ArchiveKind,
+    bin_subpath: String,
+    binaries: Vec<String>,
+}
+
+fn resolve_tool(name: &str) -> Result<ResolvedTool, String> {
+    #[cfg(test)]
+    if let Some(tool) = test_support::lookup(name) {
+        return Ok(tool);
+    }
+    let tool = find_pinned_tool(name)?;
+    let (os, arch) = current_platform();
+    let artifact = select_artifact(tool, os, arch)?;
+    Ok(ResolvedTool {
+        name: tool.name.to_string(),
+        version: tool.version.to_string(),
+        url: artifact.url.to_string(),
+        sha256: artifact.sha256.to_string(),
+        archive: artifact.archive,
+        bin_subpath: artifact.bin_subpath.to_string(),
+        binaries: tool.binaries.iter().map(|s| s.to_string()).collect(),
+    })
+}
+
+/// Test seam: when `base_url_override` is `Some`, rewrite `url` to
+/// `{override}/{original file name}` so tests can redirect a real (or
+/// test-registered) artifact URL to a local server without touching the
+/// checksum, archive kind, or bin layout.
+fn apply_base_url_override(url: &str, base_url_override: Option<&str>) -> String {
+    match base_url_override {
+        Some(base) => {
+            let file_name = url.rsplit('/').next().unwrap_or(url);
+            format!("{}/{}", base.trim_end_matches('/'), file_name)
+        }
+        None => url.to_string(),
+    }
+}
+
+/// Time allowed to establish the download connection.
+const DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Time allowed for the response headers, and for each streamed chunk, to
+/// arrive — a stalled server fails the download instead of hanging the task
+/// forever (cancel is only checked between chunks).
+const DOWNLOAD_READ_TIMEOUT: Duration = Duration::from_secs(60);
+/// Hard cap on artifact size while streaming; the real pinned artifacts are
+/// all well under 200 MB, so anything past this is aborted as an error.
+const MAX_DOWNLOAD_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Streams `url` to `dest`, checking `cancel` before requesting each chunk
+/// and reporting `("downloading", bytes_so_far, content_length)` after every
+/// chunk is written to disk. Connect/read timeouts and the
+/// [`MAX_DOWNLOAD_BYTES`] cap all surface as ordinary download errors.
+async fn download_to_file(
+    url: &str,
+    dest: &Path,
+    cancel: &AtomicBool,
+    progress: &mut impl FnMut(&str, u64, Option<u64>),
+) -> Result<(), String> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(DOWNLOAD_CONNECT_TIMEOUT)
+        .build()
+        .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+    let mut resp = tokio::time::timeout(DOWNLOAD_READ_TIMEOUT, client.get(url).send())
+        .await
+        .map_err(|_| format!("timed out downloading {url}"))?
+        .map_err(|e| format!("failed to download {url}: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("failed to download {url}: HTTP {}", resp.status()));
+    }
+    let total = resp.content_length();
+    if total.is_some_and(|t| t > MAX_DOWNLOAD_BYTES) {
+        return Err(format!(
+            "refusing to download {url}: {} bytes exceeds the {MAX_DOWNLOAD_BYTES} byte limit",
+            total.unwrap_or(0)
+        ));
+    }
+    let mut file =
+        std::fs::File::create(dest).map_err(|e| format!("failed to create {}: {e}", dest.display()))?;
+    let mut processed: u64 = 0;
+    progress("downloading", processed, total);
+    loop {
+        if cancel.load(Ordering::SeqCst) {
+            return Err("Cancelled".to_string());
+        }
+        let chunk = tokio::time::timeout(DOWNLOAD_READ_TIMEOUT, resp.chunk())
+            .await
+            .map_err(|_| format!("timed out downloading {url}"))?
+            .map_err(|e| format!("failed to download {url}: {e}"))?;
+        match chunk {
+            Some(bytes) => {
+                file.write_all(&bytes)
+                    .map_err(|e| format!("failed to write {}: {e}", dest.display()))?;
+                processed += bytes.len() as u64;
+                if processed > MAX_DOWNLOAD_BYTES {
+                    return Err(format!("download of {url} exceeded the {MAX_DOWNLOAD_BYTES} byte limit"));
+                }
+                progress("downloading", processed, total);
+            }
+            None => break,
+        }
+    }
+    Ok(())
+}
+
+/// Download → verify → extract → move-into-place → probe one tool. The
+/// directly-testable unit of work behind [`start_tool_install_task_impl`]
+/// (mirroring how `db::import::run_import` is factored out from its task
+/// wrapper): callers pass plain, owned parameters — no `'static`
+/// [`PinnedTool`] required.
+///
+/// On any error (including cancellation, which surfaces as `Err("Cancelled")`
+/// so the caller can distinguish it from a real failure), the staging
+/// directory is removed before returning. A pre-existing install directory is
+/// left untouched — it is removed only when the final swap into it fails
+/// after this run has already started mutating it.
+///
+/// At most one install per tool (per app data dir) may be in flight at a
+/// time; a second concurrent call fails with an "already being installed"
+/// error instead of corrupting the first one's staging dir.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn install_one_tool(
+    app_data_dir: &Path,
+    name: &str,
+    version: &str,
+    url: &str,
+    sha256: &str,
+    archive: ArchiveKind,
+    bin_subpath: &str,
+    binaries: &[String],
+    cancel: &AtomicBool,
+    mut progress: impl FnMut(&str, u64, Option<u64>),
+) -> Result<(), String> {
+    let staging_dir = managed_tools_dir(app_data_dir).join(format!(".staging-{name}"));
+    let install_dir = install_dir_for(app_data_dir, name, version);
+
+    // NOTE: acquired before any filesystem mutation, and returning here must
+    // not touch the staging dir — it belongs to the in-flight install.
+    let _guard = InstallGuard::acquire(name, &staging_dir)?;
+
+    let cleanup = |staging_dir: &Path, msg: String| -> String {
+        let _ = std::fs::remove_dir_all(staging_dir);
+        msg
+    };
+
+    // Clear any stale staging left by a previous failed attempt.
+    let _ = std::fs::remove_dir_all(&staging_dir);
+    if let Err(e) = std::fs::create_dir_all(&staging_dir) {
+        return Err(cleanup(&staging_dir, format!("failed to create {}: {e}", staging_dir.display())));
+    }
+
+    let archive_path = staging_dir.join("archive");
+    if let Err(e) = download_to_file(url, &archive_path, cancel, &mut progress).await {
+        return Err(cleanup(&staging_dir, e));
+    }
+    if cancel.load(Ordering::SeqCst) {
+        return Err(cleanup(&staging_dir, "Cancelled".to_string()));
+    }
+
+    progress("verifying", 0, None);
+    let verified = {
+        let archive_path = archive_path.clone();
+        let sha256 = sha256.to_string();
+        tokio::task::spawn_blocking(move || verify_sha256(&archive_path, &sha256))
+            .await
+            .map_err(|e| format!("verify task failed: {e}"))
+            .and_then(|r| r)
+    };
+    if let Err(e) = verified {
+        return Err(cleanup(&staging_dir, e));
+    }
+
+    progress("extracting", 0, None);
+    let extracted_dir = staging_dir.join("extracted");
+    let extracted = {
+        let archive_path = archive_path.clone();
+        let extracted_dir = extracted_dir.clone();
+        tokio::task::spawn_blocking(move || extract_archive(&archive_path, archive, &extracted_dir))
+            .await
+            .map_err(|e| format!("extract task failed: {e}"))
+            .and_then(|r| r)
+    };
+    if let Err(e) = extracted {
+        return Err(cleanup(&staging_dir, e));
+    }
+
+    let extracted_bin = extracted_dir.join(bin_subpath);
+    if !extracted_bin.is_dir() {
+        return Err(cleanup(
+            &staging_dir,
+            format!("archive did not contain the expected {}", bin_subpath),
+        ));
+    }
+
+    // Set exec bits and probe `--version` on the STAGING copy first, before
+    // any part of the managed install dir exists. This way a binary that
+    // fails to run (corrupt archive, wrong architecture, etc.) never leaves
+    // behind a half-installed managed dir — the atomic rename below is the
+    // last, and only, fallible step that touches it.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for b in binaries {
+            let _ =
+                std::fs::set_permissions(extracted_bin.join(binary_file_name(b)), std::fs::Permissions::from_mode(0o755));
+        }
+    }
+
+    progress("checking", 0, None);
+    for b in binaries {
+        let bin_path = extracted_bin.join(binary_file_name(b));
+        if !probe_binary_ok_timeout(&bin_path).await {
+            return Err(cleanup(
+                &staging_dir,
+                format!("{} failed to run --version", bin_path.display()),
+            ));
+        }
+    }
+
+    if let Err(e) = std::fs::create_dir_all(&install_dir) {
+        return Err(cleanup(&staging_dir, format!("failed to create {}: {e}", install_dir.display())));
+    }
+    let dest_bin = install_dir.join("bin");
+    let _ = std::fs::remove_dir_all(&dest_bin);
+    if let Err(e) = std::fs::rename(&extracted_bin, &dest_bin) {
+        // This run already started mutating the install dir (its old bin dir,
+        // if any, is gone), so a half-swapped dir must not survive to look
+        // like a working install. This is the only failure path allowed to
+        // remove the install dir.
+        let _ = std::fs::remove_dir_all(&install_dir);
+        return Err(cleanup(
+            &staging_dir,
+            format!("failed to move {} into place: {e}", extracted_bin.display()),
+        ));
+    }
+
+    let _ = std::fs::remove_dir_all(&staging_dir);
+    Ok(())
+}
+
+/// Start a cancellable background task that installs (or re-installs, when
+/// `force`) each of `tools` (by [`PinnedTool::name`]) for the current
+/// platform. `base_url_override` is a test seam only — the
+/// `start_tool_install_task` Tauri command always passes `None`.
+pub async fn start_tool_install_task_impl(
+    state: &AppState,
+    app_data_dir: PathBuf,
+    tools: Vec<String>,
+    force: bool,
+    base_url_override: Option<String>,
+) -> Result<TaskInfo, String> {
+    if tools.is_empty() {
+        return Err("No tools specified".to_string());
+    }
+    // Resolve every requested tool up front so an unknown/unsupported name
+    // fails synchronously instead of surfacing only after the task starts.
+    let mut resolved = Vec::with_capacity(tools.len());
+    for name in &tools {
+        resolved.push(resolve_tool(name)?);
+    }
+
+    let names = tools.join(", ");
+    let task_id = Uuid::new_v4().to_string();
+    let task = TaskInfo {
+        id: task_id.clone(),
+        kind: "tool_install".to_string(),
+        label: format!("Install MongoDB tools ({names})"),
+        status: "running".to_string(),
+        processed: 0,
+        total: None,
+        message: "Queued".to_string(),
+        path: None,
+        error: None,
+        created_at_ms: now_ms(),
+        finished_at_ms: None,
+        sub_label: None,
+        items_processed: None,
+        items_total: None,
+        summary: None,
+    };
+    state.tasks.lock_safe()?.insert(task_id.clone(), task.clone());
+    let cancel = state.register_cancel(&task_id);
+
+    let tasks = state.tasks.clone();
+    let cancels = state.cancels.clone();
+    let task_id2 = task_id.clone();
+    tokio::spawn(async move {
+        run_tool_install_task(tasks, cancels, task_id2, cancel, app_data_dir, resolved, force, base_url_override)
+            .await;
+    });
+
+    Ok(task)
+}
+
+/// Drive one tool-install task to completion: install each tool in order,
+/// updating task status on every exit path (success/failure/cancel), and
+/// always clean up the cancel-flag entry (mirrors
+/// `db::mongotools::run_tool_task`'s discipline).
+#[allow(clippy::too_many_arguments)]
+async fn run_tool_install_task(
+    tasks: Arc<Mutex<HashMap<String, TaskInfo>>>,
+    cancels: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
+    task_id: String,
+    cancel: Arc<AtomicBool>,
+    app_data_dir: PathBuf,
+    tools: Vec<ResolvedTool>,
+    force: bool,
+    base_url_override: Option<String>,
+) {
+    let mut installed_names: Vec<String> = Vec::new();
+    let mut skip_notes: Vec<String> = Vec::new();
+    let mut outcome: Result<(), String> = Ok(());
+
+    for tool in &tools {
+        if cancel.load(Ordering::SeqCst) {
+            outcome = Err("Cancelled".to_string());
+            break;
+        }
+
+        let bin_dir = bin_dir_for(&app_data_dir, &tool.name, &tool.version);
+        let mut already_installed = bin_dir.is_dir();
+        if already_installed {
+            for b in &tool.binaries {
+                if !probe_binary_ok_timeout(&bin_dir.join(binary_file_name(b))).await {
+                    already_installed = false;
+                    break;
+                }
+            }
+        }
+        // `force` merely bypasses this short-circuit; the existing install is
+        // only replaced by `install_one_tool`'s final swap, after the new
+        // artifact has been downloaded, verified, and probed — so a failed
+        // force-reinstall never leaves the user without a working tool.
+        if already_installed && !force {
+            let note = format!("{} already installed", tool.name);
+            update_task(&tasks, &task_id, |t| t.message = note.clone());
+            skip_notes.push(note);
+            continue;
+        }
+
+        let url = apply_base_url_override(&tool.url, base_url_override.as_deref());
+        let tasks_cb = tasks.clone();
+        let task_id_cb = task_id.clone();
+        let tool_name_cb = tool.name.clone();
+        let mut progress = move |stage: &str, processed: u64, total: Option<u64>| {
+            update_task(&tasks_cb, &task_id_cb, |t| {
+                t.message = format!("{}: {}", tool_name_cb, stage);
+                if stage == "downloading" {
+                    t.processed = processed;
+                    t.total = total;
+                }
+            });
+        };
+
+        let result = install_one_tool(
+            &app_data_dir,
+            &tool.name,
+            &tool.version,
+            &url,
+            &tool.sha256,
+            tool.archive,
+            &tool.bin_subpath,
+            &tool.binaries,
+            &cancel,
+            &mut progress,
+        )
+        .await;
+
+        match result {
+            Ok(()) => installed_names.push(tool.name.clone()),
+            Err(e) => {
+                outcome = Err(e);
+                break;
+            }
+        }
+    }
+
+    match outcome {
+        Err(e) if e == "Cancelled" => {
+            update_task(&tasks, &task_id, |t| {
+                t.status = "cancelled".to_string();
+                t.message = "Cancelled".to_string();
+                t.finished_at_ms = Some(now_ms());
+            });
+            crate::db::tasks::prune_tasks(&tasks);
+        }
+        Err(e) => fail_task(&tasks, &task_id, e),
+        Ok(()) => {
+            let mut parts = Vec::new();
+            if !installed_names.is_empty() {
+                parts.push(format!("Installed {}", installed_names.join(", ")));
+            }
+            parts.extend(skip_notes);
+            let message = if parts.is_empty() { "Nothing to do".to_string() } else { parts.join("; ") };
+            finish_task(&tasks, &task_id, tools.len() as u64, message);
+        }
+    }
+
+    if let Ok(mut guard) = cancels.lock() {
+        guard.remove(&task_id);
+    }
+}
+
+/// Test-only helpers exposed to `tests.rs` (outside this module) for
+/// exercising the install pipeline against a local HTTP server instead of the
+/// real network, mirroring `db::mongotools::test_support`.
+#[cfg(test)]
+pub mod test_support {
+    use super::{ArchiveKind, ResolvedTool};
+    use std::collections::HashMap;
+    use std::io::Write;
+    use std::sync::{Mutex, OnceLock};
+
+    static REGISTRY: OnceLock<Mutex<HashMap<String, ResolvedTool>>> = OnceLock::new();
+
+    fn registry() -> &'static Mutex<HashMap<String, ResolvedTool>> {
+        REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// Registers (and returns) a synthetic pinned tool for tests, keyed by
+    /// `name`, so `start_tool_install_task_impl`'s manifest resolution
+    /// (`resolve_tool`) can find it without touching the real, network-backed
+    /// `PINNED_TOOLS` manifest. Version is fixed at `"9.9.9-test"`.
+    pub(crate) fn test_tool(name: &str, url: &str, sha256: &str, bin_subpath: &str, binaries: &[&str]) -> ResolvedTool {
+        let tool = ResolvedTool {
+            name: name.to_string(),
+            version: "9.9.9-test".to_string(),
+            url: url.to_string(),
+            sha256: sha256.to_string(),
+            archive: ArchiveKind::Zip,
+            bin_subpath: bin_subpath.to_string(),
+            binaries: binaries.iter().map(|s| s.to_string()).collect(),
+        };
+        registry().lock().unwrap().insert(name.to_string(), tool.clone());
+        tool
+    }
+
+    pub(crate) fn lookup(name: &str) -> Option<ResolvedTool> {
+        registry().lock().unwrap().get(name).cloned()
+    }
+
+    /// Serves `bytes` at any GET path from an ephemeral localhost port for
+    /// the lifetime of the returned `Server` handle.
+    pub fn serve_bytes(bytes: Vec<u8>) -> (String, std::sync::Arc<tiny_http::Server>) {
+        let server = std::sync::Arc::new(tiny_http::Server::http("127.0.0.1:0").unwrap());
+        let base = format!("http://{}", server.server_addr());
+        let s2 = server.clone();
+        std::thread::spawn(move || {
+            for req in s2.incoming_requests() {
+                let _ = req.respond(tiny_http::Response::from_data(bytes.clone()));
+            }
+        });
+        (base, server)
+    }
+
+    /// Builds a zip whose layout matches a pinned artifact: `{top}/bin/{name}`
+    /// for each `name`, with `script` as each entry's content. Used by
+    /// [`fixture_zip`] (a script that prints a version and exits 0) and by
+    /// probe-failure tests (a script that `exit`s non-zero, simulating a
+    /// binary that survives extraction but fails `--version`).
+    pub fn fixture_zip_with_script(top: &str, names: &[&str], script: &[u8]) -> Vec<u8> {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let mut z = zip::ZipWriter::new(&mut buf);
+            let opts = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+            for n in names {
+                z.start_file(format!("{top}/bin/{n}"), opts).unwrap();
+                z.write_all(script).unwrap();
+            }
+            z.finish().unwrap();
+        }
+        buf.into_inner()
+    }
+
+    /// Builds a zip whose layout matches a pinned artifact: `{top}/bin/{name}`
+    /// (a tiny executable `sh` script) for each `name`.
+    pub fn fixture_zip(top: &str, names: &[&str]) -> Vec<u8> {
+        fixture_zip_with_script(top, names, b"#!/bin/sh\necho tool version 9.9.9\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_covers_all_four_platforms_for_both_tools() {
+        for tool in &PINNED_TOOLS {
+            for (os, arch) in [(Os::Macos, Arch::Arm64), (Os::Macos, Arch::X64), (Os::Windows, Arch::X64), (Os::Linux, Arch::X64)] {
+                let a = select_artifact(tool, os, arch).unwrap();
+                assert!(a.url.starts_with("https://"), "{}", a.url);
+                assert_eq!(a.sha256.len(), 64);
+                assert!(!a.bin_subpath.is_empty());
+            }
+            assert!(select_artifact(tool, Os::Linux, Arch::Arm64).unwrap_err().contains("not supported on"));
+        }
+    }
+
+    #[test]
+    fn current_platform_selects_something_on_this_host() {
+        let (os, arch) = current_platform();
+        for tool in &PINNED_TOOLS {
+            select_artifact(tool, os, arch).expect("host platform must be in the manifest");
+        }
+    }
+
+    #[test]
+    fn sha256_verify_accepts_good_and_rejects_bad() {
+        let dir = std::env::temp_dir().join(format!("mqlens-sha-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("x.bin");
+        std::fs::write(&f, b"hello").unwrap();
+        let good = sha256_hex(b"hello");
+        assert_eq!(good, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+        verify_sha256(&f, &good).unwrap();
+        let err = verify_sha256(&f, &"0".repeat(64)).unwrap_err();
+        assert!(err.contains("checksum mismatch"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn extracts_zip_and_tgz_fixtures() {
+        // Build fixtures in-memory: a zip and a tgz each containing dir/bin/toolbin (content "#!x")
+        let dir = std::env::temp_dir().join(format!("mqlens-extract-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let zip_path = dir.join("f.zip");
+        {
+            let file = std::fs::File::create(&zip_path).unwrap();
+            let mut z = zip::ZipWriter::new(file);
+            let opts: zip::write::SimpleFileOptions = Default::default();
+            z.start_file("d/bin/toolbin", opts).unwrap();
+            use std::io::Write;
+            z.write_all(b"#!x").unwrap();
+            z.finish().unwrap();
+        }
+        let out = dir.join("outz");
+        extract_archive(&zip_path, ArchiveKind::Zip, &out).unwrap();
+        assert_eq!(std::fs::read(out.join("d/bin/toolbin")).unwrap(), b"#!x");
+
+        let tgz_path = dir.join("f.tgz");
+        {
+            let file = std::fs::File::create(&tgz_path).unwrap();
+            let enc = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+            let mut t = tar::Builder::new(enc);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(3);
+            header.set_mode(0o755);
+            header.set_cksum();
+            t.append_data(&mut header, "d/bin/toolbin", &b"#!x"[..]).unwrap();
+            t.into_inner().unwrap().finish().unwrap();
+        }
+        let out = dir.join("outt");
+        extract_archive(&tgz_path, ArchiveKind::Tgz, &out).unwrap();
+        assert_eq!(std::fs::read(out.join("d/bin/toolbin")).unwrap(), b"#!x");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn managed_dirs_are_version_scoped_and_platform_free() {
+        let base = Path::new("/data");
+        let tool = find_pinned_tool("mongosh").unwrap();
+        assert_eq!(managed_install_dir(base, tool), Path::new("/data/tools/mongosh-2.9.2"));
+        assert_eq!(managed_bin_dir(base, tool), Path::new("/data/tools/mongosh-2.9.2/bin"));
+        assert!(find_pinned_tool("nope").is_err());
+    }
+
+    #[test]
+    fn resolve_mongosh_prefers_configured_then_managed_then_bare() {
+        // configured "/x/mongosh" -> itself even if missing.
+        assert_eq!(resolve_mongosh_executable("/x/mongosh", None), "/x/mongosh");
+        assert_eq!(resolve_mongosh_executable("  /x/mongosh  ", None), "/x/mongosh");
+
+        let app_data = std::env::temp_dir().join(format!(
+            "mqlens-mongosh-resolve-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+
+        // configured "" + no managed file -> "mongosh".
+        assert_eq!(resolve_mongosh_executable("", Some(&app_data)), "mongosh");
+        assert_eq!(resolve_mongosh_executable("   ", Some(&app_data)), "mongosh");
+        assert_eq!(resolve_mongosh_executable("", None), "mongosh");
+
+        // configured "" + managed file exists -> managed path.
+        let tool = find_pinned_tool("mongosh").unwrap();
+        let bin_dir = managed_bin_dir(&app_data, tool);
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let bin_name = if cfg!(windows) { "mongosh.exe" } else { "mongosh" };
+        let managed_path = bin_dir.join(bin_name);
+        std::fs::write(&managed_path, b"stub").unwrap();
+
+        assert_eq!(resolve_mongosh_executable("", Some(&app_data)), managed_path.to_string_lossy());
+
+        let _ = std::fs::remove_dir_all(&app_data);
+    }
+
+    fn test_app_data(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "mqlens-toolsetup-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Polls the task map until `task_id` leaves "running", returning its
+    /// final snapshot (local sibling of `tests.rs`'s `wait_for_task`).
+    async fn wait_for_task_done(state: &AppState, task_id: &str) -> TaskInfo {
+        for _ in 0..1500 {
+            if let Some(t) = state.tasks.lock().unwrap().get(task_id).cloned() {
+                if t.status != "running" {
+                    return t;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("task {task_id} did not finish");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn concurrent_installs_of_same_tool_one_succeeds_one_is_rejected() {
+        use test_support::{fixture_zip, serve_bytes};
+
+        let bytes = fixture_zip("mongosh-2.9.2-darwin-arm64", &["mongosh"]);
+        let sha256 = sha256_hex(&bytes);
+        let (base_url, _server) = serve_bytes(bytes);
+        let url = format!("{base_url}/mongosh-2.9.2-darwin-arm64.zip");
+
+        let app_data = test_app_data("concurrent");
+        let binaries = vec!["mongosh".to_string()];
+        let cancel_a = AtomicBool::new(false);
+        let cancel_b = AtomicBool::new(false);
+
+        // `join!` polls A first: A registers the in-flight guard before its
+        // first await (the download), so B's guard acquisition — also before
+        // any await — deterministically sees A in flight and must fail
+        // without touching A's staging dir.
+        let fut_a = install_one_tool(
+            &app_data,
+            "mongosh",
+            "2.9.2",
+            &url,
+            &sha256,
+            ArchiveKind::Zip,
+            "mongosh-2.9.2-darwin-arm64/bin",
+            &binaries,
+            &cancel_a,
+            |_, _, _| {},
+        );
+        let fut_b = install_one_tool(
+            &app_data,
+            "mongosh",
+            "2.9.2",
+            &url,
+            &sha256,
+            ArchiveKind::Zip,
+            "mongosh-2.9.2-darwin-arm64/bin",
+            &binaries,
+            &cancel_b,
+            |_, _, _| {},
+        );
+        let results = tokio::join!(fut_a, fut_b);
+        let results = [results.0, results.1];
+
+        let oks = results.iter().filter(|r| r.is_ok()).count();
+        assert_eq!(oks, 1, "exactly one install must win: {results:?}");
+        let err = results.iter().find_map(|r| r.as_ref().err()).unwrap();
+        assert!(err.contains("already being installed"), "{err}");
+
+        // The winner's install must survive intact.
+        let bin = app_data.join("tools/mongosh-2.9.2/bin/mongosh");
+        assert!(bin.exists(), "installed binary must survive the rejected concurrent attempt");
+        assert!(probe_binary_ok(&bin), "installed binary must still run --version");
+        assert!(
+            !app_data.join("tools/.staging-mongosh").exists(),
+            "staging dir should be cleaned up after the winning install"
+        );
+        // The guard slot must be released on every exit path.
+        assert!(
+            !in_flight_installs().lock().unwrap().contains(&app_data.join("tools/.staging-mongosh")),
+            "in-flight guard must be released"
+        );
+
+        let _ = std::fs::remove_dir_all(&app_data);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn force_reinstall_keeps_existing_install_when_download_fails() {
+        use test_support::{fixture_zip, serve_bytes, test_tool};
+
+        let bytes = fixture_zip("test-force-tool-9.9.9-test", &["mongoforce"]);
+        let sha256 = sha256_hex(&bytes);
+        let (base_url, _server) = serve_bytes(bytes);
+        test_tool(
+            "test-force-tool",
+            "https://example.invalid/test-force-tool-fixture.zip",
+            &sha256,
+            "test-force-tool-9.9.9-test/bin",
+            &["mongoforce"],
+        );
+
+        let app_data = test_app_data("force-fail");
+        let state = AppState::new();
+
+        // First install succeeds.
+        let task = start_tool_install_task_impl(
+            &state,
+            app_data.clone(),
+            vec!["test-force-tool".to_string()],
+            false,
+            Some(base_url),
+        )
+        .await
+        .unwrap();
+        let t = wait_for_task_done(&state, &task.id).await;
+        assert_eq!(t.status, "completed", "{:?}", t.error);
+        let bin = bin_dir_for(&app_data, "test-force-tool", "9.9.9-test").join("mongoforce");
+        assert!(probe_binary_ok(&bin), "initial install must probe ok");
+
+        // Force reinstall against a dead server (connection refused): the
+        // download fails, and the existing install must survive untouched.
+        let dead_port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let task2 = start_tool_install_task_impl(
+            &state,
+            app_data.clone(),
+            vec!["test-force-tool".to_string()],
+            true,
+            Some(format!("http://127.0.0.1:{dead_port}")),
+        )
+        .await
+        .unwrap();
+        let t2 = wait_for_task_done(&state, &task2.id).await;
+        assert_eq!(t2.status, "failed", "{t2:?}");
+        assert!(
+            t2.error.as_deref().unwrap_or("").contains("failed to download"),
+            "{:?}",
+            t2.error
+        );
+
+        assert!(bin.exists(), "old install must survive a failed force reinstall");
+        assert!(probe_binary_ok(&bin), "old install must still probe as installed");
+
+        let _ = std::fs::remove_dir_all(&app_data);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,11 @@ import { CommandPalette, type PaletteAction } from './components/CommandPalette'
 import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import { DataGrid } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
-import { SettingsView, type SettingsTabId } from './components/SettingsModal';
+import { SettingsView, type SettingsTabId, MONGO_TOOLS_DIR_KEY } from './components/SettingsModal';
 import { IndexViewer } from './components/IndexViewer';
 import { IndexModal } from './components/IndexModal';
 import { MongoShell } from './components/MongoShell';
+import { ToolSetupDialog, type ManagedToolStatusUi, type InstallTaskUi } from './components/ToolSetupDialog';
 import { QuickStart } from './components/QuickStart';
 import { DocumentEditModal } from './components/DocumentEditModal';
 import {
@@ -24,6 +25,17 @@ import {
   type FilteredExportQuery,
 } from './components/ExportView';
 import { ImportView, type ImportPreviewData } from './components/ImportView';
+import {
+  DumpView,
+  type ToolsStatusUi,
+  type DumpScopeUi,
+  type DumpOptionsUi,
+} from './components/DumpView';
+import {
+  RestoreView,
+  type DumpTreeUi,
+  type RestoreOptionsUi,
+} from './components/RestoreView';
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
 import { CreateViewView } from './components/CreateViewView';
@@ -45,12 +57,12 @@ import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
-import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks } from 'lucide-react';
+import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 interface QueryTab {
   id: string;
-  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users';
+  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users' | 'dump' | 'restore';
   connectionId: string;
   db: string;
   collection: string;
@@ -76,6 +88,15 @@ const DEFAULT_QUERY = { filter: '{}', sort: '{}', projection: '{}', limit: 50, s
 const isEmptyFilter = (s: string): boolean => {
   const t = (s || '').trim();
   return t === '' || t === '{}';
+};
+
+/** The configured MongoDB Database Tools directory (mongodump/mongorestore); '' means unset (use PATH). */
+const getMongoToolsDir = (): string => {
+  try {
+    return localStorage.getItem(MONGO_TOOLS_DIR_KEY) || '';
+  } catch {
+    return '';
+  }
 };
 
 // Describe whatever a tab last executed, for the DataGrid "Query Code" tab
@@ -187,6 +208,10 @@ const tabIconFor = (tab: QueryTab, isActive: boolean): React.ReactNode => {
       return <Activity size={size} className={className} />;
     case 'users':
       return <Users size={size} className={className} />;
+    case 'dump':
+      return <DatabaseBackup size={size} className={className} />;
+    case 'restore':
+      return <DatabaseZap size={size} className={className} />;
     default:
       return <FolderCode size={size} className={className} />;
   }
@@ -221,6 +246,10 @@ const tabLabelFor = (
       return `Monitor: ${connectionName(tab.connectionId)}`;
     case 'users':
       return `Users: ${connectionName(tab.connectionId)}`;
+    case 'dump':
+      return `Dump: ${tab.db || connectionName(tab.connectionId)}`;
+    case 'restore':
+      return `Restore: ${connectionName(tab.connectionId)}`;
     default:
       return tab.collection;
   }
@@ -343,13 +372,24 @@ function Workspace() {
   const pendingImportRefreshRef = React.useRef(
     new Map<string, { connectionId: string; db: string; collection: string }>()
   );
+  // Bumped on every optimistic task insert below. A list_export_tasks response
+  // requested BEFORE a start_*_task registered could otherwise resolve AFTER the
+  // optimistic insert and clobber it for a whole poll cycle — so a load only
+  // applies when no insert happened since it started (the next poll is ≤1s away).
+  const exportTasksSeqRef = React.useRef(0);
   const loadExportTasks = React.useCallback(async () => {
+    const seq = exportTasksSeqRef.current;
     try {
       const tasks = await invoke<ExportTaskInfo[]>('list_export_tasks');
-      setExportTasks(tasks);
+      if (exportTasksSeqRef.current === seq) setExportTasks(tasks);
     } catch {
       /* ignore — task polling should not interrupt the main workspace */
     }
+  }, []);
+  // Optimistically surface freshly-started tasks ahead of the next poll.
+  const insertExportTasks = React.useCallback((tasks: ExportTaskInfo[]) => {
+    exportTasksSeqRef.current += 1;
+    setExportTasks((prev) => [...tasks, ...prev.filter((t) => !tasks.some((n) => n.id === t.id))]);
   }, []);
 
   useEffect(() => {
@@ -429,12 +469,14 @@ function Workspace() {
     setCopyDialog({ source: copyClipboard, target: { connectionId, db } });
   };
 
-  const handleCancelTask = async (taskId: string) => {
+  const handleCancelTask = async (taskId: string): Promise<boolean> => {
     try {
       await invoke('cancel_task', { id: taskId });
       await loadExportTasks();
+      return true;
     } catch (err: any) {
       toast(`Could not cancel: ${err?.message || err}`, 'error');
+      return false;
     }
   };
 
@@ -683,6 +725,9 @@ function Workspace() {
   };
 
   const handleOpenSettingsTab = () => openSettingsTab('appearance');
+  // Tool guidance cards ("mongodump was not found…") point the user at the
+  // tool paths, so they land on the Tools section rather than Appearance.
+  const handleOpenToolsSettings = () => openSettingsTab('tools');
   const handleOpenShortcutsReference = () => openSettingsTab('shortcuts');
 
   const handleOpenTasksTab = () => {
@@ -733,6 +778,209 @@ function Workspace() {
     }
     setActiveTabId(tabId);
     loadExportTasks();
+  };
+
+  // Detection of the mongodump/mongorestore binaries, refreshed whenever a Dump
+  // or Restore tab is opened (so a Settings change to the tools directory takes
+  // effect the next time either tab is opened).
+  const [mongoTools, setMongoTools] = useState<ToolsStatusUi | null>(null);
+  const loadMongoTools = React.useCallback(async () => {
+    try {
+      const dir = getMongoToolsDir();
+      const status = await invoke<ToolsStatusUi>('detect_mongo_tools', {
+        configuredDir: dir || null,
+      });
+      setMongoTools(status);
+    } catch {
+      setMongoTools({ mongodump: null, mongorestore: null });
+    }
+  }, []);
+
+  // Guided MongoDB tool setup — a single dialog instance at app level. Entry
+  // points (Dump/Restore guidance cards, the shell's spawn-failure gate,
+  // Settings) all call handleOpenToolSetup(); the running/most-recent install
+  // task is fed in from the existing task-polling list (exportTasks) by id.
+  const [toolSetupOpen, setToolSetupOpen] = useState(false);
+  const [managedToolStatuses, setManagedToolStatuses] = useState<ManagedToolStatusUi[] | null>(null);
+  const [toolInstallTaskId, setToolInstallTaskId] = useState<string | null>(null);
+  // Bumped when the tool-install dialog finishes, so an open mongosh tab (gated
+  // on a failed session) re-attempts its session the same way its own Retry does.
+  const [shellReconnectNonce, setShellReconnectNonce] = useState(0);
+  // Bumped when the tool-install dialog finishes, so a mounted Settings view
+  // re-fetches managed_tools_status instead of showing a stale "Managed tools" card.
+  const [toolStatusRefreshNonce, setToolStatusRefreshNonce] = useState(0);
+
+  const refreshManagedToolStatuses = React.useCallback(async () => {
+    try {
+      const statuses = await invoke<ManagedToolStatusUi[]>('managed_tools_status');
+      setManagedToolStatuses(statuses);
+      return statuses;
+    } catch {
+      setManagedToolStatuses([]);
+      return [];
+    }
+  }, []);
+
+  const handleOpenToolSetup = React.useCallback(async () => {
+    setManagedToolStatuses(null);
+    await refreshManagedToolStatuses();
+    setToolSetupOpen(true);
+  }, [refreshManagedToolStatuses]);
+
+  const handleInstallTools = React.useCallback(
+    async (tools: string[], force: boolean) => {
+      try {
+        const task = await invoke<ExportTaskInfo>('start_tool_install_task', { tools, force });
+        setToolInstallTaskId(task.id);
+        insertExportTasks([task]);
+        await loadExportTasks();
+      } catch (err: any) {
+        toast(`Could not start tool install: ${err?.message || err}`, 'error');
+      }
+    },
+    [loadExportTasks, toast]
+  );
+
+  const handleCancelToolInstall = React.useCallback(() => {
+    if (toolInstallTaskId) void handleCancelTask(toolInstallTaskId);
+  }, [toolInstallTaskId]);
+
+  // Completion side effects — refresh tool discovery, managed statuses, and the
+  // shell/Settings nonces. Runs from the Done button AND from any other way of
+  // closing the dialog after the install reached a terminal state (ESC, X,
+  // overlay), so guidance cards can't keep showing "not found" for tools that
+  // just got installed.
+  const finalizeToolSetup = React.useCallback(() => {
+    setToolInstallTaskId(null);
+    void loadMongoTools();
+    void refreshManagedToolStatuses();
+    setShellReconnectNonce((n) => n + 1);
+    setToolStatusRefreshNonce((n) => n + 1);
+  }, [loadMongoTools, refreshManagedToolStatuses]);
+
+  const handleToolSetupDone = React.useCallback(() => {
+    setToolSetupOpen(false);
+    finalizeToolSetup();
+  }, [finalizeToolSetup]);
+
+  const handleToolSetupOpenChange = React.useCallback(
+    (open: boolean) => {
+      setToolSetupOpen(open);
+      if (!open && toolInstallTaskId) {
+        const task = exportTasks.find((t) => t.id === toolInstallTaskId);
+        if (task && task.status !== 'running') finalizeToolSetup();
+      }
+    },
+    [toolInstallTaskId, exportTasks, finalizeToolSetup]
+  );
+
+  const toolInstallTask: InstallTaskUi | null = React.useMemo(() => {
+    if (!toolInstallTaskId) return null;
+    const task = exportTasks.find((t) => t.id === toolInstallTaskId);
+    if (!task) return null;
+    return {
+      status: task.status,
+      message: task.status === 'failed' ? task.error || task.message : task.message,
+      processed: task.processed,
+      total: task.total ?? null,
+    };
+  }, [exportTasks, toolInstallTaskId]);
+
+  // Database/collection tree per connection, for the Dump view's scope picker.
+  // Dump has no standing sidebar-tree state to reuse from App, so this loads it
+  // directly via list_databases/list_collections when a Dump tab is opened.
+  const [dumpDbTrees, setDumpDbTrees] = useState<Record<string, { name: string; collections: string[] }[]>>({});
+  const loadDumpDbTree = React.useCallback(async (connectionId: string) => {
+    try {
+      const dbs = await invoke<string[]>('list_databases', { id: connectionId });
+      const withColls = await Promise.all(
+        dbs.map(async (name) => {
+          try {
+            const colls = await invoke<{ name: string }[]>('list_collections', { id: connectionId, db: name });
+            return { name, collections: colls.map((c) => c.name) };
+          } catch {
+            return { name, collections: [] as string[] };
+          }
+        })
+      );
+      setDumpDbTrees((prev) => ({ ...prev, [connectionId]: withColls }));
+    } catch {
+      setDumpDbTrees((prev) => ({ ...prev, [connectionId]: [] }));
+    }
+  }, []);
+
+  const handleOpenDumpTab = (connectionId: string, db?: string, coll?: string) => {
+    const idParts = ['dump', connectionId, db, coll].filter((p): p is string => !!p);
+    const tabId = idParts.join('.');
+    if (!tabs.some(t => t.id === tabId)) {
+      setTabs(prev => [...prev, {
+        id: tabId,
+        type: 'dump',
+        connectionId,
+        db: db ?? '',
+        collection: coll ?? '',
+        results: [],
+        loading: false,
+        error: null,
+        explainResult: null,
+      }]);
+    }
+    setActiveTabId(tabId);
+    void loadMongoTools();
+    void loadDumpDbTree(connectionId);
+  };
+
+  const handleOpenRestoreTab = (connectionId: string) => {
+    const tabId = `restore.${connectionId}`;
+    if (!tabs.some(t => t.id === tabId)) {
+      setTabs(prev => [...prev, {
+        id: tabId,
+        type: 'restore',
+        connectionId,
+        db: '',
+        collection: '',
+        results: [],
+        loading: false,
+        error: null,
+        explainResult: null,
+      }]);
+    }
+    setActiveTabId(tabId);
+    void loadMongoTools();
+  };
+
+  const handleRunDump = async (tab: QueryTab, options: DumpOptionsUi) => {
+    const toolPath = mongoTools?.mongodump?.path;
+    if (!toolPath) return;
+    try {
+      const task = await invoke<ExportTaskInfo>('start_dump_task', {
+        id: tab.connectionId,
+        toolPath,
+        options,
+      });
+      insertExportTasks([task]);
+      handleOpenTasksTab();
+      await loadExportTasks();
+    } catch (err: any) {
+      toast(`Dump failed to start: ${err?.message || err}`, 'error');
+    }
+  };
+
+  const handleRunRestore = async (tab: QueryTab, options: RestoreOptionsUi) => {
+    const toolPath = mongoTools?.mongorestore?.path;
+    if (!toolPath) return;
+    try {
+      const task = await invoke<ExportTaskInfo>('start_restore_task', {
+        id: tab.connectionId,
+        toolPath,
+        options,
+      });
+      insertExportTasks([task]);
+      handleOpenTasksTab();
+      await loadExportTasks();
+    } catch (err: any) {
+      toast(`Restore failed to start: ${err?.message || err}`, 'error');
+    }
   };
 
   // M7: open a Create-View tab for a database.
@@ -1348,7 +1596,7 @@ function Workspace() {
           path,
           options,
         });
-        setExportTasks((prev) => [task, ...prev.filter((t) => t.id !== task.id)]);
+        insertExportTasks([task]);
         handleOpenTasksTab();
         await loadExportTasks();
         return;
@@ -1369,7 +1617,7 @@ function Workspace() {
           limit: !isAgg && query.limit > 0 ? query.limit : null,
           options,
         });
-        setExportTasks((prev) => [task, ...prev.filter((t) => t.id !== task.id)]);
+        insertExportTasks([task]);
         handleOpenTasksTab();
         await loadExportTasks();
         return;
@@ -1709,6 +1957,8 @@ function Workspace() {
           onAnalyzeSchema={handleOpenSchemaTab}
           onCreateView={handleOpenCreateViewTab}
           onOpenGridfs={handleOpenGridfsTab}
+          onOpenDump={handleOpenDumpTab}
+          onOpenRestore={handleOpenRestoreTab}
           collectionMutationTrigger={collectionMutationTrigger}
           onCollectionRenamed={handleCollectionRenamed}
           onDatabaseDropped={handleDatabaseDropped}
@@ -1820,6 +2070,16 @@ function Workspace() {
 
           <UpdatePrompt />
 
+          <ToolSetupDialog
+            open={toolSetupOpen}
+            onOpenChange={handleToolSetupOpenChange}
+            statuses={managedToolStatuses}
+            installTask={toolInstallTask}
+            onInstall={handleInstallTools}
+            onCancel={handleCancelToolInstall}
+            onDone={handleToolSetupDone}
+          />
+
           {copyDialog && (
             <CopyToDialog
               open={!!copyDialog}
@@ -1861,7 +2121,7 @@ function Workspace() {
                       targetId: req.targetId, targetDb: req.targetDb, targetCollection: name,
                       filter: null, includeIndexes: req.includeIndexes, conflictMode: req.conflictMode,
                     })));
-                  setExportTasks((prev) => [...tasks, ...prev.filter((t) => !tasks.some((n) => n.id === t.id))]);
+                  insertExportTasks(tasks);
                   await loadExportTasks();
                   return;
                 } else {
@@ -1871,7 +2131,7 @@ function Workspace() {
                     filter: req.filter ?? null, includeIndexes: req.includeIndexes, conflictMode: req.conflictMode,
                   });
                 }
-                setExportTasks((prev) => [task, ...prev.filter((t) => t.id !== task.id)]);
+                insertExportTasks([task]);
                 await loadExportTasks();
               }}
             />
@@ -2085,13 +2345,81 @@ function Workspace() {
                           db: activeTab.db,
                           collection: activeTab.collection,
                         });
-                        setExportTasks(prev => [task, ...prev.filter(t => t.id !== task.id)]);
+                        insertExportTasks([task]);
                         handleOpenTasksTab();
                         await loadExportTasks();
                       } catch (err: any) {
                         toast(`Import failed to start: ${err?.message || err}`, 'error');
                       }
                     }}
+                  />
+                );
+              })()}
+              {activeTab && activeTab.type === 'dump' && (() => {
+                const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
+                const connectionName = activeConnection ? activeConnection.name : activeTab.connectionId;
+                const initialScope: DumpScopeUi = activeTab.collection
+                  ? { kind: 'collection', db: activeTab.db, coll: activeTab.collection }
+                  : activeTab.db
+                    ? { kind: 'db', db: activeTab.db }
+                    : { kind: 'server' };
+                return (
+                  <DumpView
+                    key={activeTab.id}
+                    connectionName={connectionName}
+                    databases={dumpDbTrees[activeTab.connectionId] ?? []}
+                    initialScope={initialScope}
+                    tools={mongoTools}
+                    onOpenSettings={handleOpenToolsSettings}
+                    onInstallTools={handleOpenToolSetup}
+                    onPickFolder={async () => {
+                      const p = await open({ directory: true });
+                      return typeof p === 'string' ? p : null;
+                    }}
+                    onPickArchiveFile={async (defaultName) => {
+                      const p = await save({ defaultPath: defaultName });
+                      return p ?? null;
+                    }}
+                    onPreviewCommand={(options) =>
+                      invoke<string>('preview_dump_command', {
+                        id: activeTab.connectionId,
+                        toolPath: mongoTools?.mongodump?.path ?? '',
+                        options,
+                      })
+                    }
+                    onRunDump={(options) => handleRunDump(activeTab, options)}
+                    onOpenTasks={handleOpenTasksTab}
+                  />
+                );
+              })()}
+              {activeTab && activeTab.type === 'restore' && (() => {
+                const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
+                const connectionName = activeConnection ? activeConnection.name : activeTab.connectionId;
+                return (
+                  <RestoreView
+                    key={activeTab.id}
+                    connectionName={connectionName}
+                    tools={mongoTools}
+                    onOpenSettings={handleOpenToolsSettings}
+                    onInstallTools={handleOpenToolSetup}
+                    onPickFolder={async () => {
+                      const p = await open({ directory: true });
+                      return typeof p === 'string' ? p : null;
+                    }}
+                    onPickArchiveFile={async () => {
+                      const p = await open({ multiple: false });
+                      return typeof p === 'string' ? p : null;
+                    }}
+                    onBrowseFolder={(path) => invoke<DumpTreeUi>('browse_dump_folder', { path })}
+                    onPreviewCommand={(options) =>
+                      invoke<string>('preview_restore_command', {
+                        id: activeTab.connectionId,
+                        toolPath: mongoTools?.mongorestore?.path ?? '',
+                        options,
+                      })
+                    }
+                    onRunRestore={(options) => handleRunRestore(activeTab, options)}
+                    onOpenTasks={handleOpenTasksTab}
                   />
                 );
               })()}
@@ -2125,12 +2453,18 @@ function Workspace() {
                     collectionName={activeTab.collection || undefined}
                     initialCommand={activeTab.initialShellCommand}
                     density={density}
-                    onOpenSettings={handleOpenSettingsTab}
+                    onOpenSettings={handleOpenToolsSettings}
+                    onInstallTools={handleOpenToolSetup}
+                    reconnectSignal={shellReconnectNonce}
                   />
                 );
               })()}
               {activeTab && activeTab.type === 'settings' && (
-                <SettingsView initialTab={settingsInitialTab} />
+                <SettingsView
+                  initialTab={settingsInitialTab}
+                  onInstallTools={handleOpenToolSetup}
+                  toolStatusRefreshNonce={toolStatusRefreshNonce}
+                />
               )}
               {activeTab && activeTab.type === 'quickstart' && (
                 <QuickStart

--- a/src/components/DumpView.tsx
+++ b/src/components/DumpView.tsx
@@ -1,0 +1,511 @@
+import React from 'react';
+import { DatabaseBackup, ListChecks, Settings } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import { QueryEditor } from './QueryEditor';
+
+/** Where an installed mongodump/mongorestore binary was found. */
+export interface ToolInfoUi {
+  path: string;
+  version: string;
+}
+
+/** Detection result for both Database Tools binaries; null while detecting. */
+export interface ToolsStatusUi {
+  mongodump: ToolInfoUi | null;
+  mongorestore: ToolInfoUi | null;
+}
+
+/** What a dump should cover. */
+export type DumpScopeUi =
+  | { kind: 'server' }
+  | { kind: 'db'; db: string }
+  | { kind: 'collection'; db: string; coll: string };
+
+/** Options passed to mongodump, mirrored from its CLI flags. */
+export interface DumpOptionsUi {
+  scope: DumpScopeUi;
+  target: { kind: 'folder'; out: string } | { kind: 'archive'; file: string };
+  gzip: boolean;
+  query?: string;
+  forceTableScan: boolean;
+  dumpUsersAndRoles: boolean;
+  oplog: boolean;
+}
+
+interface DumpViewProps {
+  connectionName: string;
+  databases: { name: string; collections: string[] }[];
+  initialScope?: DumpScopeUi;
+  tools: ToolsStatusUi | null;
+  onOpenSettings?: () => void;
+  onInstallTools?: () => void;
+  onPickFolder: () => Promise<string | null>;
+  onPickArchiveFile: (defaultName: string) => Promise<string | null>;
+  onPreviewCommand?: (options: DumpOptionsUi) => Promise<string>;
+  onRunDump: (options: DumpOptionsUi) => void | Promise<void>;
+  onOpenTasks?: () => void;
+}
+
+const selectClassName =
+  'h-8 min-w-0 rounded-md border border-input bg-background px-2 text-xs shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+const checkboxLabelClassName = 'flex cursor-pointer items-center gap-2 text-xs text-foreground';
+
+const editorShellClassName =
+  'rounded-md border border-input bg-background px-1.5 py-1 shadow-sm focus-within:ring-2 focus-within:ring-ring';
+
+const PREVIEW_DEBOUNCE_MS = 300;
+
+function scopeName(scope: DumpScopeUi, connectionName: string): string {
+  if (scope.kind === 'server') return connectionName || 'dump';
+  if (scope.kind === 'db') return scope.db || 'dump';
+  return `${scope.db}.${scope.coll}`;
+}
+
+export const DumpView: React.FC<DumpViewProps> = ({
+  connectionName,
+  databases,
+  initialScope,
+  tools,
+  onOpenSettings,
+  onInstallTools,
+  onPickFolder,
+  onPickArchiveFile,
+  onPreviewCommand,
+  onRunDump,
+  onOpenTasks,
+}) => {
+  const [scope, setScope] = React.useState<DumpScopeUi>(initialScope ?? { kind: 'server' });
+  const [query, setQuery] = React.useState('');
+  const [targetKind, setTargetKind] = React.useState<'folder' | 'archive'>('folder');
+  const [folderOut, setFolderOut] = React.useState<string | null>(null);
+  const [archiveFile, setArchiveFile] = React.useState<string | null>(null);
+  const [gzip, setGzip] = React.useState(true);
+  const [forceTableScan, setForceTableScan] = React.useState(false);
+  const [dumpUsersAndRoles, setDumpUsersAndRoles] = React.useState(false);
+  const [oplog, setOplog] = React.useState(false);
+  const [previewCmd, setPreviewCmd] = React.useState('');
+  const [starting, setStarting] = React.useState(false);
+  const previewGen = React.useRef(0);
+
+  // Reset options that only make sense for a specific scope once that scope is left.
+  React.useEffect(() => {
+    if (scope.kind !== 'db' && dumpUsersAndRoles) setDumpUsersAndRoles(false);
+    if (scope.kind !== 'server' && oplog) setOplog(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scope.kind]);
+
+  const selectScopeKind = (kind: DumpScopeUi['kind']) => {
+    if (kind === 'server') {
+      setScope({ kind: 'server' });
+      return;
+    }
+    const db = scope.kind === 'server' ? databases[0]?.name ?? '' : scope.db;
+    if (kind === 'db') {
+      setScope({ kind: 'db', db });
+      return;
+    }
+    const dbEntry = databases.find((d) => d.name === db);
+    const coll = dbEntry?.collections[0] ?? '';
+    setScope({ kind: 'collection', db, coll });
+  };
+
+  const selectDb = (db: string) => {
+    if (scope.kind === 'db') {
+      setScope({ kind: 'db', db });
+    } else if (scope.kind === 'collection') {
+      const dbEntry = databases.find((d) => d.name === db);
+      const coll = dbEntry?.collections[0] ?? '';
+      setScope({ kind: 'collection', db, coll });
+    }
+  };
+
+  const selectColl = (coll: string) => {
+    if (scope.kind === 'collection') setScope({ ...scope, coll });
+  };
+
+  const destPath = targetKind === 'folder' ? folderOut : archiveFile;
+
+  const buildOptions = React.useCallback((): DumpOptionsUi => ({
+    scope,
+    target:
+      targetKind === 'folder'
+        ? { kind: 'folder', out: folderOut ?? '' }
+        : { kind: 'archive', file: archiveFile ?? '' },
+    gzip,
+    query: scope.kind === 'collection' && query.trim() ? query : undefined,
+    forceTableScan,
+    dumpUsersAndRoles,
+    oplog,
+  }), [scope, targetKind, folderOut, archiveFile, gzip, query, forceTableScan, dumpUsersAndRoles, oplog]);
+
+  React.useEffect(() => {
+    if (!onPreviewCommand) return;
+    // Without a detected mongodump the backend can only answer with an error;
+    // invalidate any in-flight request and show nothing instead.
+    if (!tools?.mongodump) {
+      previewGen.current++;
+      setPreviewCmd('');
+      return;
+    }
+    const options = buildOptions();
+    const timer = setTimeout(() => {
+      const gen = ++previewGen.current;
+      onPreviewCommand(options)
+        .then((cmd) => {
+          if (gen === previewGen.current) setPreviewCmd(cmd);
+        })
+        .catch((err) => {
+          if (gen === previewGen.current) setPreviewCmd(String(err));
+        });
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [buildOptions, onPreviewCommand, tools]);
+
+  const pickDestination = async () => {
+    if (targetKind === 'folder') {
+      const path = await onPickFolder();
+      if (path) setFolderOut(path);
+    } else {
+      const defaultName = `${scopeName(scope, connectionName)}.archive${gzip ? '.gz' : ''}`;
+      const path = await onPickArchiveFile(defaultName);
+      if (path) setArchiveFile(path);
+    }
+  };
+
+  const scopeReady =
+    scope.kind === 'server'
+      ? true
+      : scope.kind === 'db'
+        ? !!scope.db
+        : !!scope.db && !!scope.coll;
+
+  // mongodump --query only accepts canonical extended JSON, which is strict
+  // JSON — validate here so a bad filter can't arm a run that always fails.
+  const queryError = React.useMemo(() => {
+    if (scope.kind !== 'collection' || !query.trim()) return null;
+    try {
+      JSON.parse(query);
+      return null;
+    } catch {
+      return 'Not valid JSON. mongodump only accepts canonical extended JSON.';
+    }
+  }, [scope.kind, query]);
+
+  const canRun = !!tools?.mongodump && destPath !== null && scopeReady && !queryError;
+
+  const runDump = async () => {
+    if (!canRun || starting) return;
+    setStarting(true);
+    try {
+      await onRunDump(buildOptions());
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-auto" data-testid="dump-view">
+      <header className="flex items-center justify-between gap-4 border-b border-border bg-muted/30 px-3.5 py-2">
+        <div>
+          <h2 className="text-sm font-semibold text-foreground">Dump</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">{connectionName}</p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={onOpenTasks}>
+          <ListChecks size={12} />
+          View Tasks
+        </Button>
+      </header>
+
+      <div className="divide-y divide-border">
+        <section className="flex flex-col gap-2 px-3.5 py-3" data-testid="dump-tools-status">
+          <div>
+            <h3 className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <DatabaseBackup size={14} />
+              <span>mongodump</span>
+            </h3>
+          </div>
+          {tools === null ? (
+            <p className="text-xs text-muted-foreground">Detecting mongodump / mongorestore…</p>
+          ) : tools.mongodump ? (
+            <p className="text-xs text-muted-foreground">
+              mongodump {tools.mongodump.version} — {tools.mongodump.path}
+            </p>
+          ) : (
+            <div
+              className="flex flex-col items-start gap-2 rounded-md border border-dashed border-border p-3"
+              data-testid="dump-tools-missing"
+            >
+              <p className="text-xs text-muted-foreground">
+                mongodump was not found. Install MongoDB Database Tools and set the path in
+                Settings.
+              </p>
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="outline" size="sm" onClick={onOpenSettings}>
+                  <Settings size={12} />
+                  Open Settings
+                </Button>
+                {onInstallTools && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={onInstallTools}
+                    data-testid="dump-install-tools-btn"
+                  >
+                    Install tools…
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="flex flex-col gap-2 px-3.5 py-3">
+          <div>
+            <h3 className="text-sm font-medium text-foreground">Scope</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Dump the entire server, a single database, or one collection.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="dump-scope-kind"
+                data-testid="dump-scope-server"
+                checked={scope.kind === 'server'}
+                onChange={() => selectScopeKind('server')}
+              />
+              <span>Entire server</span>
+            </label>
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="dump-scope-kind"
+                data-testid="dump-scope-db"
+                checked={scope.kind === 'db'}
+                onChange={() => selectScopeKind('db')}
+              />
+              <span>Database</span>
+            </label>
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="dump-scope-kind"
+                data-testid="dump-scope-collection"
+                checked={scope.kind === 'collection'}
+                onChange={() => selectScopeKind('collection')}
+              />
+              <span>Collection</span>
+            </label>
+          </div>
+
+          {scope.kind !== 'server' && (
+            <div className="flex flex-wrap items-center gap-2">
+              <Label className="text-xs text-muted-foreground">Database</Label>
+              <select
+                value={scope.db}
+                onChange={(e) => selectDb(e.target.value)}
+                className={cn(selectClassName, 'w-48')}
+                data-testid="dump-db-select"
+              >
+                <option value="" disabled>
+                  Select database…
+                </option>
+                {databases.map((d) => (
+                  <option key={d.name} value={d.name}>
+                    {d.name}
+                  </option>
+                ))}
+              </select>
+
+              {scope.kind === 'collection' && (
+                <>
+                  <Label className="text-xs text-muted-foreground">Collection</Label>
+                  <select
+                    value={scope.coll}
+                    onChange={(e) => selectColl(e.target.value)}
+                    className={cn(selectClassName, 'w-48')}
+                    data-testid="dump-coll-select"
+                  >
+                    <option value="" disabled>
+                      Select collection…
+                    </option>
+                    {(databases.find((d) => d.name === scope.db)?.collections ?? []).map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                </>
+              )}
+            </div>
+          )}
+
+          {scope.kind === 'collection' && (
+            <div className="flex flex-col gap-1">
+              <Label className="text-xs text-muted-foreground">Query filter (optional)</Label>
+              <div className={editorShellClassName}>
+                <QueryEditor
+                  surface="filter"
+                  value={query}
+                  onChange={setQuery}
+                  fields={['_id']}
+                  height={80}
+                  data-testid="dump-query-input"
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                mongodump requires canonical extended JSON — quoted keys and typed wrappers such
+                as {'{"$oid": "…"}'} or {'{"$date": "…"}'}.
+              </p>
+              {queryError && (
+                <p className="text-xs text-destructive" data-testid="dump-query-error">
+                  {queryError}
+                </p>
+              )}
+            </div>
+          )}
+        </section>
+
+        <section className="flex flex-col gap-2 px-3.5 py-3">
+          <div>
+            <h3 className="text-sm font-medium text-foreground">Destination</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Dump to a folder of BSON files, or a single compressed archive.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="dump-target-kind"
+                data-testid="dump-target-folder"
+                checked={targetKind === 'folder'}
+                onChange={() => setTargetKind('folder')}
+              />
+              <span>Folder (multiple files)</span>
+            </label>
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="dump-target-kind"
+                data-testid="dump-target-archive"
+                checked={targetKind === 'archive'}
+                onChange={() => setTargetKind('archive')}
+              />
+              <span>Single archive file</span>
+            </label>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={pickDestination}
+              data-testid="dump-pick-dest-btn"
+            >
+              Choose {targetKind === 'folder' ? 'folder' : 'file'}…
+            </Button>
+            {destPath && (
+              <span className="truncate text-xs text-muted-foreground" data-testid="dump-dest-path">
+                {destPath}
+              </span>
+            )}
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-2 px-3.5 py-3">
+          <div>
+            <h3 className="text-sm font-medium text-foreground">Options</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Passed through to mongodump as CLI flags.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label className={checkboxLabelClassName}>
+              <input
+                type="checkbox"
+                checked={gzip}
+                onChange={() => setGzip((g) => !g)}
+                data-testid="dump-opt-gzip"
+              />
+              <span>Gzip compress output</span>
+            </label>
+            <label className={checkboxLabelClassName}>
+              <input
+                type="checkbox"
+                checked={forceTableScan}
+                onChange={() => setForceTableScan((v) => !v)}
+                data-testid="dump-opt-forcetablescan"
+              />
+              <span>Force table scan (ignore indexes)</span>
+            </label>
+            <label className={cn(checkboxLabelClassName, scope.kind !== 'db' && 'opacity-50')}>
+              <input
+                type="checkbox"
+                checked={dumpUsersAndRoles}
+                disabled={scope.kind !== 'db'}
+                onChange={() => setDumpUsersAndRoles((v) => !v)}
+                data-testid="dump-opt-usersroles"
+              />
+              <span>Include users and roles (database scope only)</span>
+            </label>
+            <label className={cn(checkboxLabelClassName, scope.kind !== 'server' && 'opacity-50')}>
+              <input
+                type="checkbox"
+                checked={oplog}
+                disabled={scope.kind !== 'server'}
+                onChange={() => setOplog((v) => !v)}
+                data-testid="dump-opt-oplog"
+              />
+              <span>Include oplog for point-in-time restore (server scope only)</span>
+            </label>
+          </div>
+        </section>
+
+        <section className="flex flex-wrap items-center justify-between gap-3 px-3.5 py-3">
+          <div className="min-w-0 flex-1">
+            <h3 className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <DatabaseBackup size={14} />
+              <span>Run</span>
+            </h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Runs in the background and reports progress in the Tasks tab.
+            </p>
+            <code
+              data-testid="dump-preview-cmd"
+              className="mt-2 block overflow-x-auto rounded-md bg-muted/30 p-2 text-xs"
+            >
+              {previewCmd}
+            </code>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!canRun || starting}
+            onClick={runDump}
+            data-testid="dump-run-btn"
+          >
+            <DatabaseBackup size={13} />
+            {starting ? 'Starting…' : 'Run Dump'}
+          </Button>
+        </section>
+      </div>
+
+      <p className="px-3.5 py-3 text-xs text-muted-foreground">
+        Dumps run in the background. Track their progress in the{' '}
+        <button type="button" className="underline hover:text-foreground" onClick={onOpenTasks}>
+          Tasks
+        </button>{' '}
+        tab.
+      </p>
+    </div>
+  );
+};

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -53,6 +53,9 @@ interface MongoShellProps {
   initialCommand?: string;
   density?: 'roomy' | 'cozy' | 'compact';
   onOpenSettings?: () => void;
+  onInstallTools?: () => void;
+  /** Bump this (e.g. after a tool install completes) to re-attempt the mongosh session. */
+  reconnectSignal?: number;
 }
 
 interface ParsedCall {
@@ -205,6 +208,8 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   initialCommand,
   density = 'cozy',
   onOpenSettings,
+  onInstallTools,
+  reconnectSignal,
 }) => {
   const [currentDb, setCurrentDb] = useState(databaseName);
   const startupLogId = useMemo(createLogId, []);
@@ -231,6 +236,21 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [sessionAttempted, setSessionAttempted] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
+  // Reuses the retry-nonce mechanism above: when a parent-driven reconnect signal
+  // changes (e.g. the guided tool-install dialog finished), re-attempt the session
+  // the same way the gate's own Retry button does.
+  const reconnectSignalRef = useRef(reconnectSignal);
+  useEffect(() => {
+    if (reconnectSignal !== undefined && reconnectSignal !== reconnectSignalRef.current) {
+      reconnectSignalRef.current = reconnectSignal;
+      // The signal fires after ANY tool install completes — only re-attempt
+      // when no session is attached (failed/not running). A healthy session
+      // must not be restarted; that would drop its state mid-work.
+      if (sessionId === null) setRetryNonce((n) => n + 1);
+    }
+    // sessionId is only read when the signal actually changed; including it
+    // keeps the read fresh without re-triggering (the ref guard above).
+  }, [reconnectSignal, sessionId]);
   const scrollRef = useRef<HTMLDivElement>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
   const runRef = useRef<() => void>(() => {});
@@ -621,6 +641,15 @@ export const MongoShell: React.FC<MongoShellProps> = ({
                 {onOpenSettings && (
                   <Button onClick={onOpenSettings} data-testid="gate-open-settings">
                     Open Settings
+                  </Button>
+                )}
+                {onInstallTools && (
+                  <Button
+                    variant="outline"
+                    onClick={onInstallTools}
+                    data-testid="shell-install-tools-btn"
+                  >
+                    Install tools…
                   </Button>
                 )}
                 <Button variant="outline" onClick={() => setRetryNonce((n) => n + 1)} data-testid="gate-retry">

--- a/src/components/RestoreView.tsx
+++ b/src/components/RestoreView.tsx
@@ -1,0 +1,664 @@
+import React from 'react';
+import { DatabaseZap, ListChecks } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import { type ToolInfoUi, type ToolsStatusUi } from './DumpView';
+
+export type { ToolInfoUi, ToolsStatusUi };
+
+/** A dump folder's on-disk layout, as reported by browsing it. */
+export interface DumpTreeUi {
+  dbs: { name: string; collections: { name: string; hasMetadata: boolean; gzip: boolean }[] }[];
+}
+
+/** One collection to restore, optionally renamed on the way in. */
+export interface RestoreSelectionUi {
+  db: string;
+  coll: string;
+  renameTo?: string;
+}
+
+/** Full mongorestore option set assembled from the UI state. */
+export interface RestoreOptionsUi {
+  source: { kind: 'folder'; dir: string } | { kind: 'archive'; file: string };
+  gzip: boolean;
+  selections: RestoreSelectionUi[]; // folder mode
+  filterDb?: string;
+  filterColl?: string; // archive mode
+  drop: boolean;
+  keepIndexVersion: boolean;
+  noIndexRestore: boolean;
+  noOptionsRestore: boolean;
+  maintainInsertionOrder: boolean;
+  stopOnError: boolean;
+  bypassDocumentValidation: boolean;
+  restoreDbUsersAndRoles: boolean;
+  oplogReplay: boolean;
+}
+
+interface RestoreViewProps {
+  connectionName: string;
+  tools: ToolsStatusUi | null;
+  onOpenSettings?: () => void;
+  onInstallTools?: () => void;
+  onPickFolder: () => Promise<string | null>;
+  onPickArchiveFile: () => Promise<string | null>;
+  onBrowseFolder: (path: string) => Promise<DumpTreeUi>;
+  onPreviewCommand?: (options: RestoreOptionsUi) => Promise<string>;
+  onRunRestore: (options: RestoreOptionsUi) => void | Promise<void>;
+  onOpenTasks?: () => void;
+}
+
+const checkboxLabelClassName = 'flex cursor-pointer items-center gap-2 text-xs text-foreground';
+
+const PREVIEW_DEBOUNCE_MS = 300;
+
+const collKey = (db: string, coll: string) => `${db}.${coll}`;
+
+const FLAG_FIELDS: {
+  key: keyof Pick<
+    RestoreOptionsUi,
+    | 'drop'
+    | 'keepIndexVersion'
+    | 'noIndexRestore'
+    | 'noOptionsRestore'
+    | 'maintainInsertionOrder'
+    | 'stopOnError'
+    | 'bypassDocumentValidation'
+    | 'restoreDbUsersAndRoles'
+  >;
+  testid: string;
+  label: string;
+}[] = [
+  { key: 'drop', testid: 'restore-opt-drop', label: 'Drop existing collections before restoring' },
+  { key: 'keepIndexVersion', testid: 'restore-opt-keepindexversion', label: 'Keep original index version' },
+  { key: 'noIndexRestore', testid: 'restore-opt-noindexrestore', label: 'Do not restore indexes' },
+  { key: 'noOptionsRestore', testid: 'restore-opt-nooptionsrestore', label: 'Do not restore collection options' },
+  {
+    key: 'maintainInsertionOrder',
+    testid: 'restore-opt-maintaininsertionorder',
+    label: 'Maintain document insertion order',
+  },
+  { key: 'stopOnError', testid: 'restore-opt-stoponerror', label: 'Stop on error' },
+  {
+    key: 'bypassDocumentValidation',
+    testid: 'restore-opt-bypassvalidation',
+    label: 'Bypass document validation',
+  },
+  { key: 'restoreDbUsersAndRoles', testid: 'restore-opt-usersroles', label: 'Restore users and roles' },
+];
+
+export const RestoreView: React.FC<RestoreViewProps> = ({
+  connectionName,
+  tools,
+  onOpenSettings,
+  onInstallTools,
+  onPickFolder,
+  onPickArchiveFile,
+  onBrowseFolder,
+  onPreviewCommand,
+  onRunRestore,
+  onOpenTasks,
+}) => {
+  const [sourceKind, setSourceKind] = React.useState<'folder' | 'archive'>('folder');
+  const [folderPath, setFolderPath] = React.useState<string | null>(null);
+  const [archiveFile, setArchiveFile] = React.useState<string | null>(null);
+  const [gzip, setGzip] = React.useState(false);
+  const [tree, setTree] = React.useState<DumpTreeUi | null>(null);
+  const [checked, setChecked] = React.useState<Record<string, boolean>>({});
+  const [renames, setRenames] = React.useState<Record<string, string>>({});
+  const [filterDb, setFilterDb] = React.useState('');
+  const [filterColl, setFilterColl] = React.useState('');
+  const [browseError, setBrowseError] = React.useState<string | null>(null);
+
+  const [drop, setDrop] = React.useState(false);
+  const [keepIndexVersion, setKeepIndexVersion] = React.useState(false);
+  const [noIndexRestore, setNoIndexRestore] = React.useState(false);
+  const [noOptionsRestore, setNoOptionsRestore] = React.useState(false);
+  const [maintainInsertionOrder, setMaintainInsertionOrder] = React.useState(false);
+  const [stopOnError, setStopOnError] = React.useState(false);
+  const [bypassDocumentValidation, setBypassDocumentValidation] = React.useState(false);
+  const [restoreDbUsersAndRoles, setRestoreDbUsersAndRoles] = React.useState(false);
+  const [oplogReplay, setOplogReplay] = React.useState(false);
+
+  const [showDropConfirm, setShowDropConfirm] = React.useState(false);
+  const [starting, setStarting] = React.useState(false);
+  const [previewCmd, setPreviewCmd] = React.useState('');
+  const previewGen = React.useRef(0);
+
+  const toolMissing = !tools || !tools.mongorestore;
+
+  const allKeys = React.useMemo(
+    () =>
+      tree
+        ? tree.dbs.flatMap((db) => db.collections.map((c) => ({ db: db.name, coll: c.name, key: collKey(db.name, c.name) })))
+        : [],
+    [tree]
+  );
+
+  const anyRename = allKeys.some((k) => (renames[k.key] ?? '').trim() !== '');
+  const anyUnchecked = allKeys.some((k) => checked[k.key] === false);
+
+  const narrowingActive =
+    sourceKind === 'folder' ? anyUnchecked || anyRename : filterDb.trim() !== '' || filterColl.trim() !== '';
+
+  // Force oplogReplay off whenever narrowing makes it invalid, so the checkbox's
+  // disabled state always matches the value that would be sent.
+  React.useEffect(() => {
+    if (narrowingActive && oplogReplay) setOplogReplay(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [narrowingActive]);
+
+  const computeSelections = React.useCallback((): RestoreSelectionUi[] => {
+    if (sourceKind !== 'folder') return [];
+    const checkedKeys = allKeys.filter((k) => checked[k.key] !== false);
+    if (checkedKeys.length === allKeys.length && !anyRename) return [];
+    return checkedKeys.map((k) => {
+      const renameTo = (renames[k.key] ?? '').trim();
+      return renameTo ? { db: k.db, coll: k.coll, renameTo } : { db: k.db, coll: k.coll };
+    });
+  }, [sourceKind, allKeys, checked, renames, anyRename]);
+
+  const buildOptions = React.useCallback((): RestoreOptionsUi => {
+    const source =
+      sourceKind === 'folder'
+        ? ({ kind: 'folder', dir: folderPath ?? '' } as const)
+        : ({ kind: 'archive', file: archiveFile ?? '' } as const);
+    return {
+      source,
+      gzip,
+      selections: computeSelections(),
+      filterDb: sourceKind === 'archive' && filterDb.trim() ? filterDb.trim() : undefined,
+      filterColl: sourceKind === 'archive' && filterColl.trim() ? filterColl.trim() : undefined,
+      drop,
+      keepIndexVersion,
+      noIndexRestore,
+      noOptionsRestore,
+      maintainInsertionOrder,
+      stopOnError,
+      bypassDocumentValidation,
+      restoreDbUsersAndRoles,
+      oplogReplay,
+    };
+  }, [
+    sourceKind,
+    folderPath,
+    archiveFile,
+    gzip,
+    computeSelections,
+    filterDb,
+    filterColl,
+    drop,
+    keepIndexVersion,
+    noIndexRestore,
+    noOptionsRestore,
+    maintainInsertionOrder,
+    stopOnError,
+    bypassDocumentValidation,
+    restoreDbUsersAndRoles,
+    oplogReplay,
+  ]);
+
+  const hasSource = sourceKind === 'folder' ? folderPath !== null : archiveFile !== null;
+  // With every collection unchecked, `selections` would be [] — which the
+  // backend reads as "no namespace filter" (restore everything). Require at
+  // least one checked collection whenever the browsed tree has any.
+  const noneChecked = allKeys.length > 0 && allKeys.every((k) => checked[k.key] === false);
+  const canRun =
+    hasSource && !toolMissing && (sourceKind !== 'folder' || (tree !== null && !noneChecked));
+
+  React.useEffect(() => {
+    if (!hasSource || !onPreviewCommand) {
+      previewGen.current++;
+      setPreviewCmd('');
+      return;
+    }
+    const options = buildOptions();
+    const timer = setTimeout(() => {
+      const gen = ++previewGen.current;
+      onPreviewCommand(options)
+        .then((cmd) => {
+          if (gen === previewGen.current) setPreviewCmd(cmd);
+        })
+        .catch((err) => {
+          if (gen === previewGen.current) setPreviewCmd(String(err));
+        });
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasSource, buildOptions]);
+
+  const pickSource = async () => {
+    if (sourceKind === 'folder') {
+      const path = await onPickFolder();
+      if (!path) return;
+      setFolderPath(path);
+      setBrowseError(null);
+      try {
+        const dumpTree = await onBrowseFolder(path);
+        setTree(dumpTree);
+        const initialChecked: Record<string, boolean> = {};
+        let anyGzip = false;
+        for (const db of dumpTree.dbs) {
+          for (const c of db.collections) {
+            initialChecked[collKey(db.name, c.name)] = true;
+            if (c.gzip) anyGzip = true;
+          }
+        }
+        setChecked(initialChecked);
+        setRenames({});
+        setGzip(anyGzip);
+      } catch (err) {
+        // A folder that fails to browse leaves `tree` null; `canRun` requires a
+        // non-null tree in folder mode, so a failed browse can't silently arm a
+        // restore-everything run (empty `selections`).
+        setFolderPath(null);
+        setTree(null);
+        setBrowseError(err instanceof Error ? err.message : String(err));
+      }
+    } else {
+      const path = await onPickArchiveFile();
+      if (!path) return;
+      setArchiveFile(path);
+      setGzip(/\.gz$/i.test(path));
+    }
+  };
+
+  const selectSourceKind = (kind: 'folder' | 'archive') => {
+    setSourceKind(kind);
+    setBrowseError(null);
+  };
+
+  const toggleChecked = (key: string) => {
+    setChecked((prev) => ({ ...prev, [key]: prev[key] === false ? true : false }));
+  };
+
+  const setRenameValue = (key: string, value: string) => {
+    setRenames((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const dropNamespaces = (): string[] => {
+    if (sourceKind === 'folder') {
+      const selections = computeSelections();
+      if (selections.length > 0) return selections.map((s) => collKey(s.db, s.coll));
+      return allKeys.map((k) => k.key);
+    }
+    if (filterDb.trim()) {
+      return [filterColl.trim() ? collKey(filterDb.trim(), filterColl.trim()) : `${filterDb.trim()}.*`];
+    }
+    return ['(entire archive)'];
+  };
+
+  const startRestore = async () => {
+    setStarting(true);
+    try {
+      await onRunRestore(buildOptions());
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const handleRunClick = () => {
+    if (!canRun || starting) return;
+    if (drop) {
+      setShowDropConfirm(true);
+      return;
+    }
+    void startRestore();
+  };
+
+  const handleConfirmDrop = () => {
+    if (starting) return;
+    setShowDropConfirm(false);
+    void startRestore();
+  };
+
+  const setFlag = (key: (typeof FLAG_FIELDS)[number]['key'], value: boolean) => {
+    switch (key) {
+      case 'drop':
+        setDrop(value);
+        if (!value) setShowDropConfirm(false);
+        break;
+      case 'keepIndexVersion':
+        setKeepIndexVersion(value);
+        break;
+      case 'noIndexRestore':
+        setNoIndexRestore(value);
+        break;
+      case 'noOptionsRestore':
+        setNoOptionsRestore(value);
+        break;
+      case 'maintainInsertionOrder':
+        setMaintainInsertionOrder(value);
+        break;
+      case 'stopOnError':
+        setStopOnError(value);
+        break;
+      case 'bypassDocumentValidation':
+        setBypassDocumentValidation(value);
+        break;
+      case 'restoreDbUsersAndRoles':
+        setRestoreDbUsersAndRoles(value);
+        break;
+    }
+  };
+
+  const flagValue: Record<(typeof FLAG_FIELDS)[number]['key'], boolean> = {
+    drop,
+    keepIndexVersion,
+    noIndexRestore,
+    noOptionsRestore,
+    maintainInsertionOrder,
+    stopOnError,
+    bypassDocumentValidation,
+    restoreDbUsersAndRoles,
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-auto" data-testid="restore-view">
+      <header className="flex items-center justify-between gap-4 border-b border-border bg-muted/30 px-3.5 py-2">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <DatabaseZap size={14} />
+            <span>Restore</span>
+          </h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">{connectionName}</p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={onOpenTasks}>
+          <ListChecks size={12} />
+          View Tasks
+        </Button>
+      </header>
+
+      <div className="divide-y divide-border">
+        <section className="flex flex-col gap-2 px-3.5 py-3">
+          {toolMissing ? (
+            <div
+              className="flex flex-wrap items-center justify-between gap-3"
+              data-testid="restore-tools-missing"
+            >
+              <p className="text-xs text-muted-foreground">
+                mongorestore was not found. Configure the MongoDB Database Tools directory in
+                Settings.
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onOpenSettings}
+                  data-testid="restore-open-settings-btn"
+                >
+                  Open Settings
+                </Button>
+                {onInstallTools && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={onInstallTools}
+                    data-testid="restore-install-tools-btn"
+                  >
+                    Install tools…
+                  </Button>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="text-xs text-muted-foreground" data-testid="restore-tools-status">
+              mongorestore {tools!.mongorestore!.version} — {tools!.mongorestore!.path}
+            </div>
+          )}
+        </section>
+
+        <section className="flex flex-col gap-2 px-3.5 py-3">
+          <div>
+            <h3 className="text-sm font-medium text-foreground">Source</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Restore from a dump folder or a single archive file.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="restore-source-kind"
+                data-testid="restore-source-folder"
+                checked={sourceKind === 'folder'}
+                onChange={() => selectSourceKind('folder')}
+              />
+              <span>Folder</span>
+            </label>
+            <label className={checkboxLabelClassName}>
+              <input
+                type="radio"
+                name="restore-source-kind"
+                data-testid="restore-source-archive"
+                checked={sourceKind === 'archive'}
+                onChange={() => selectSourceKind('archive')}
+              />
+              <span>Archive</span>
+            </label>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={pickSource}
+              data-testid="restore-pick-source-btn"
+            >
+              {sourceKind === 'folder' ? 'Choose folder…' : 'Choose archive…'}
+            </Button>
+            {(sourceKind === 'folder' ? folderPath : archiveFile) && (
+              <span className="truncate text-xs text-muted-foreground" data-testid="restore-source-path">
+                {sourceKind === 'folder' ? folderPath : archiveFile}
+              </span>
+            )}
+          </div>
+
+          {browseError && (
+            <p className="text-xs text-destructive" data-testid="restore-browse-error">
+              Failed to browse dump folder: {browseError}
+            </p>
+          )}
+
+          <label className={checkboxLabelClassName}>
+            <input
+              type="checkbox"
+              checked={gzip}
+              onChange={() => setGzip((g) => !g)}
+              className="rounded border-input"
+              data-testid="restore-opt-gzip"
+            />
+            <span>gzip compressed</span>
+          </label>
+
+          {sourceKind === 'folder' && tree && (
+            <div className="flex flex-col gap-3 pt-1" data-testid="restore-tree">
+              {tree.dbs.map((db) => (
+                <div key={db.name} className="flex flex-col gap-1" data-testid={`restore-tree-db-${db.name}`}>
+                  <div className="text-xs font-medium text-foreground">{db.name}</div>
+                  {db.collections.map((c) => {
+                    const key = collKey(db.name, c.name);
+                    return (
+                      <div key={key} className="flex flex-wrap items-center gap-2 pl-4">
+                        <label className={checkboxLabelClassName}>
+                          <input
+                            type="checkbox"
+                            checked={checked[key] !== false}
+                            onChange={() => toggleChecked(key)}
+                            className="rounded border-input"
+                            data-testid={`restore-tree-coll-${key}`}
+                          />
+                          <span>{c.name}</span>
+                        </label>
+                        <Input
+                          value={renames[key] ?? ''}
+                          onChange={(e) => setRenameValue(key, e.target.value)}
+                          placeholder="new name (or db.name)"
+                          title="A bare name restores into the same database; use db.name to restore into a different database."
+                          className="h-7 w-44 text-xs"
+                          data-testid={`restore-rename-${key}`}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+              {noneChecked && (
+                <p className="text-xs text-destructive" data-testid="restore-empty-selection-hint">
+                  Select at least one collection to restore.
+                </p>
+              )}
+            </div>
+          )}
+
+          {sourceKind === 'archive' && (
+            <div className="flex flex-col gap-2 pt-1">
+              <div className="flex flex-wrap items-center gap-4">
+                <div className="flex items-center gap-2">
+                  <Label className="text-xs text-muted-foreground">Database filter</Label>
+                  <Input
+                    value={filterDb}
+                    onChange={(e) => setFilterDb(e.target.value)}
+                    className="h-8 w-40 text-xs"
+                    data-testid="restore-archive-filter-db"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <Label className="text-xs text-muted-foreground">Collection filter</Label>
+                  <Input
+                    value={filterColl}
+                    onChange={(e) => setFilterColl(e.target.value)}
+                    className="h-8 w-40 text-xs"
+                    data-testid="restore-archive-filter-coll"
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground" data-testid="restore-archive-note">
+                Leave both blank to restore everything in the archive, or filter to a single
+                database or namespace.
+              </p>
+            </div>
+          )}
+        </section>
+
+        <section className="flex flex-col gap-2 px-3.5 py-3">
+          <div>
+            <h3 className="text-sm font-medium text-foreground">Options</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">mongorestore flags.</p>
+          </div>
+          <div className="flex flex-col gap-2">
+            {FLAG_FIELDS.map((f) => (
+              <label key={f.key} className={checkboxLabelClassName}>
+                <input
+                  type="checkbox"
+                  checked={flagValue[f.key]}
+                  onChange={(e) => setFlag(f.key, e.target.checked)}
+                  className="rounded border-input"
+                  data-testid={f.testid}
+                />
+                <span>{f.label}</span>
+              </label>
+            ))}
+            <label
+              className={cn(checkboxLabelClassName, narrowingActive && 'cursor-not-allowed opacity-60')}
+            >
+              <input
+                type="checkbox"
+                checked={oplogReplay}
+                disabled={narrowingActive}
+                onChange={(e) => setOplogReplay(e.target.checked)}
+                className="rounded border-input"
+                data-testid="restore-opt-oplogreplay"
+              />
+              <span>Replay oplog for point-in-time consistency (full dump only)</span>
+            </label>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-3 px-3.5 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h3 className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <DatabaseZap size={14} />
+                <span>Run</span>
+              </h3>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Runs in the background and reports progress in the Tasks tab.
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              disabled={!canRun || starting}
+              onClick={handleRunClick}
+              data-testid="restore-run-btn"
+            >
+              <DatabaseZap size={13} />
+              {starting ? 'Starting…' : 'Restore'}
+            </Button>
+          </div>
+
+          {previewCmd && (
+            <code
+              data-testid="restore-preview-cmd"
+              className="block overflow-x-auto rounded-md border border-border bg-muted/30 px-2 py-1.5 text-xs"
+            >
+              {previewCmd}
+            </code>
+          )}
+
+          {showDropConfirm && (
+            <div
+              className="flex flex-col gap-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2"
+              data-testid="restore-drop-confirm"
+            >
+              <p className="text-xs text-foreground">
+                This will drop the following namespace(s) before restoring:
+              </p>
+              <ul className="list-disc pl-4 text-xs text-muted-foreground">
+                {dropNamespaces().map((ns) => (
+                  <li key={ns}>{ns}</li>
+                ))}
+              </ul>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="destructive"
+                  disabled={starting}
+                  onClick={handleConfirmDrop}
+                  data-testid="restore-drop-confirm-btn"
+                >
+                  {starting ? 'Starting…' : 'Drop and restore'}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowDropConfirm(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+
+      <p className="px-3.5 py-3 text-xs text-muted-foreground">
+        Restores run in the background. Track their progress in the{' '}
+        <button type="button" className="underline hover:text-foreground" onClick={onOpenTasks}>
+          Tasks
+        </button>{' '}
+        tab.
+      </p>
+    </div>
+  );
+};

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
   ArrowUpCircle,
   Server,
   Keyboard,
+  Wrench,
   type LucideIcon,
 } from 'lucide-react';
 import {
@@ -44,6 +45,7 @@ import {
 } from '@/components/ui/select';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
+import type { ManagedToolStatusUi } from './ToolSetupDialog';
 
 interface AppSettings {
   mongosh_path: string;
@@ -75,6 +77,9 @@ const DEFAULT_LOCAL_COMMANDS: Record<string, string> = {
   cursor: 'cursor-agent -p {prompt}',
   antigravity: 'antigravity {prompt}',
 };
+/** localStorage key for the MongoDB Database Tools directory (mongodump/mongorestore). */
+export const MONGO_TOOLS_DIR_KEY = 'mqlens.mongoToolsDir';
+
 const PROVIDER_LABELS: Record<string, string> = {
   anthropic: 'Anthropic (Claude)',
   openai: 'OpenAI (ChatGPT)',
@@ -85,7 +90,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   antigravity: 'Antigravity (local)',
 };
 
-type SettingsTabId = 'appearance' | 'ai' | 'mcp' | 'mongosh' | 'updates' | 'shortcuts' | 'security';
+type SettingsTabId = 'appearance' | 'ai' | 'mcp' | 'tools' | 'updates' | 'shortcuts' | 'security';
 
 const SETTINGS_TABS: {
   id: SettingsTabId;
@@ -114,10 +119,10 @@ const SETTINGS_TABS: {
     Icon: Server,
   },
   {
-    id: 'mongosh',
-    label: 'Mongosh',
-    description: 'Path to the MongoDB shell binary used by the integrated terminal.',
-    Icon: Terminal,
+    id: 'tools',
+    label: 'Tools',
+    description: 'Mongosh and MongoDB Database Tools binaries, plus managed installs.',
+    Icon: Wrench,
     persistFooter: true,
   },
   {
@@ -145,11 +150,27 @@ export type { SettingsTabId };
 
 export interface SettingsViewProps {
   initialTab?: SettingsTabId;
+  onInstallTools?: () => void;
+  /**
+   * Bumped by the parent (e.g. after the guided tool-setup dialog's "Done"
+   * handler) to re-trigger this view's own `managed_tools_status` fetch, so
+   * the "Managed tools" card doesn't go stale after an install completes
+   * while Settings is still mounted.
+   */
+  toolStatusRefreshNonce?: number;
 }
 
-export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab }) => {
+export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab, onInstallTools, toolStatusRefreshNonce }) => {
   const [tab, setTab] = useState<SettingsTabId>(initialTab ?? 'appearance');
   const [mongoshPath, setMongoshPath] = useState('');
+  const [managedTools, setManagedTools] = useState<ManagedToolStatusUi[] | null>(null);
+  const [mongoToolsDir, setMongoToolsDir] = useState(() => {
+    try {
+      return localStorage.getItem(MONGO_TOOLS_DIR_KEY) || '';
+    } catch {
+      return '';
+    }
+  });
   const [aiProvider, setAiProvider] = useState('anthropic');
   const [anthropicKey, setAnthropicKey] = useState('');
   const [anthropicModel, setAnthropicModel] = useState('claude-opus-4-8');
@@ -216,6 +237,14 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab }) => {
     biometricStatus().then(setBio).catch(() => setBio(null));
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    invoke<ManagedToolStatusUi[]>('managed_tools_status')
+      .then((s) => { if (!cancelled) setManagedTools(s); })
+      .catch(() => { if (!cancelled) setManagedTools([]); });
+    return () => { cancelled = true; };
+  }, [toolStatusRefreshNonce]);
+
   const localCommandFor = (agent: string) =>
     localCommands[agent] ?? DEFAULT_LOCAL_COMMANDS[agent] ?? '{prompt}';
 
@@ -246,6 +275,15 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab }) => {
       setError(String(err));
     } finally {
       setSaving(false);
+    }
+  };
+
+  const onChangeMongoToolsDir = (value: string) => {
+    setMongoToolsDir(value);
+    try {
+      localStorage.setItem(MONGO_TOOLS_DIR_KEY, value);
+    } catch {
+      /* localStorage unavailable — best-effort persistence only */
     }
   };
 
@@ -399,8 +437,9 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab }) => {
           </div>
         );
 
-      case 'mongosh':
+      case 'tools':
         return (
+          <>
           <Card className="max-w-3xl">
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">
@@ -431,6 +470,78 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab }) => {
               </div>
             </CardContent>
           </Card>
+
+          <Card className="max-w-3xl mt-6">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Terminal className="h-4 w-4 text-success" />
+                MongoDB Database Tools
+              </CardTitle>
+              <CardDescription>
+                Directory containing the mongodump/mongorestore binaries, used by the Dump and
+                Restore tabs.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Label htmlFor="mongo-tools-dir">Tools directory</Label>
+              <Input
+                id="mongo-tools-dir"
+                className="font-mono"
+                value={mongoToolsDir}
+                onChange={(event) => onChangeMongoToolsDir(event.target.value)}
+                placeholder="/usr/local/bin"
+                data-testid="mongo-tools-dir-input"
+              />
+              <p className="text-xs text-muted-foreground">
+                Directory containing mongodump/mongorestore. Leave empty to use PATH.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card className="max-w-3xl mt-6">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Wrench className="h-4 w-4 text-success" />
+                Managed tools
+              </CardTitle>
+              <CardDescription>
+                MQLens can download and manage mongodump/mongorestore and mongosh for you instead
+                of relying on your system PATH.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {managedTools === null ? (
+                <p className="text-xs text-muted-foreground">Checking installed tools…</p>
+              ) : (
+                <ul className="space-y-1">
+                  {managedTools.map((t) => (
+                    <li
+                      key={t.name}
+                      className="text-xs text-muted-foreground"
+                      data-testid={`settings-managed-tool-${t.name}`}
+                    >
+                      {t.name}: {t.installed ? `v${t.version} installed` : 'not installed'}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {onInstallTools && (
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={onInstallTools}
+                    data-testid="settings-install-tools-btn"
+                  >
+                    <Wrench className="h-3 w-3" />
+                    Install tools…
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+          </>
         );
 
       case 'ai':

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -89,6 +89,8 @@ import {
   Heart,
   Copy,
   ClipboardPaste,
+  DatabaseBackup,
+  DatabaseZap,
 } from 'lucide-react';
 
 const REPO_URL = 'https://github.com/mqlens/mqlens-mongodb';
@@ -157,6 +159,10 @@ interface SidebarProps {
   onAnalyzeSchema?: (connectionId: string, dbName: string, collName: string) => void;
   onCreateView?: (connectionId: string, dbName: string) => void;
   onOpenGridfs?: (connectionId: string, dbName: string, bucket: string) => void;
+  /** Open a Dump tab scoped to the whole connection, a database, or a single collection. */
+  onOpenDump?: (connectionId: string, dbName?: string, collName?: string) => void;
+  /** Open a Restore tab for the connection. */
+  onOpenRestore?: (connectionId: string) => void;
   onCollectionRenamed?: (connectionId: string, dbName: string, oldName: string, newName: string) => void;
   onDatabaseDropped?: (connectionId: string, dbName: string) => void;
   onDatabaseRenamed?: (connectionId: string, oldName: string, newName: string) => void;
@@ -272,6 +278,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onAnalyzeSchema,
   onCreateView,
   onOpenGridfs,
+  onOpenDump,
+  onOpenRestore,
   onCollectionRenamed,
   onDatabaseDropped,
   onDatabaseRenamed,
@@ -292,6 +300,18 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const { toast, confirm, prompt } = useDialogs();
   const [filterQuery, setFilterQuery] = useState('');
   const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Mock connections (the bundled sample data, or ids/URIs marked as such) never
+  // reach a real mongodump/mongorestore binary — the backend rejects them outright
+  // (see require_real_conn_uri in mongotools.rs) — so hide the Dump/Restore
+  // context-menu items for them rather than surfacing a doomed invoke() call.
+  const isMockConnection = React.useCallback(
+    (connectionId: string): boolean => {
+      const conn = activeConnections.find((c) => c.id === connectionId);
+      return connectionId.startsWith('mock') || Boolean(conn?.uri.startsWith('mongodb://mock'));
+    },
+    [activeConnections]
+  );
 
   useEffect(() => {
     onFilterQueryChange?.(filterQuery);
@@ -1200,6 +1220,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
               <Table2 />
               <span>Analyze Schema</span>
             </ContextMenuItem>
+            {!isMockConnection(connId) && (
+              <ContextMenuItem
+                className={ctxItemClass}
+                data-testid={`ctx-dump-coll-${connId}-${dbName}-${collName}`}
+                onClick={() => onOpenDump?.(connId, dbName, collName)}
+              >
+                <DatabaseBackup />
+                <span>Dump (mongodump)…</span>
+              </ContextMenuItem>
+            )}
             <ContextMenuItem
               className={ctxItemClass}
               onClick={() => onCopyToClipboard?.(connId, dbName, selectedNamesFor(connId, dbName, collName))}
@@ -1489,6 +1519,26 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     <Users />
                     <span>Manage users</span>
                   </ContextMenuItem>
+                  {!isMockConnection(conn.id) && (
+                    <ContextMenuItem
+                      className={ctxItemClass}
+                      data-testid={`ctx-dump-${conn.id}`}
+                      onClick={() => onOpenDump?.(conn.id)}
+                    >
+                      <DatabaseBackup />
+                      <span>Dump (mongodump)…</span>
+                    </ContextMenuItem>
+                  )}
+                  {!isMockConnection(conn.id) && (
+                    <ContextMenuItem
+                      className={ctxItemClass}
+                      data-testid={`ctx-restore-${conn.id}`}
+                      onClick={() => onOpenRestore?.(conn.id)}
+                    >
+                      <DatabaseZap />
+                      <span>Restore (mongorestore)…</span>
+                    </ContextMenuItem>
+                  )}
                   <ContextMenuSeparator />
                   <ContextMenuItem
                     className={cn(ctxItemClass, 'text-destructive focus:text-destructive')}
@@ -1648,6 +1698,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
                               <Users />
                               <span>Manage Users</span>
                             </ContextMenuItem>
+                            {!isMockConnection(conn.id) && (
+                              <ContextMenuItem
+                                className={ctxItemClass}
+                                data-testid={`ctx-dump-db-${conn.id}-${dbName}`}
+                                onClick={() => onOpenDump?.(conn.id, dbName)}
+                              >
+                                <DatabaseBackup />
+                                <span>Dump (mongodump)…</span>
+                              </ContextMenuItem>
+                            )}
                             <ContextMenuSeparator />
                             <ContextMenuItem
                               className={cn(ctxItemClass, 'text-destructive focus:text-destructive')}

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -37,7 +37,9 @@ interface TaskManagerProps {
   tasks: ExportTaskInfo[];
   onRefresh: () => void;
   onClearFinished: () => void;
-  onCancel?: (taskId: string) => void;
+  // Resolves false when the cancel request failed, so the button re-enables
+  // for a retry. A void return (tests, simple callers) keeps the old behavior.
+  onCancel?: (taskId: string) => Promise<boolean> | boolean | void;
   variant?: 'floating' | 'embedded';
 }
 
@@ -54,6 +56,33 @@ export const TaskManager: React.FC<TaskManagerProps> = ({
   variant = 'floating',
 }) => {
   const running = tasks.filter((task) => task.status === 'running').length;
+  // Ids whose Cancel was clicked — disables the button so a double-click
+  // can't race the task's teardown and produce a spurious error.
+  const [cancelling, setCancelling] = React.useState<ReadonlySet<string>>(new Set());
+  const handleCancelClick = async (taskId: string) => {
+    setCancelling((prev) => new Set(prev).add(taskId));
+    const ok = await onCancel?.(taskId);
+    // A failed cancel re-enables the button so the user can retry.
+    if (ok === false) {
+      setCancelling((prev) => {
+        const next = new Set(prev);
+        next.delete(taskId);
+        return next;
+      });
+    }
+  };
+  // Prune ids whose task is no longer running (finished or gone) so the set
+  // doesn't accumulate and a re-run of the same id gets a fresh Cancel button.
+  React.useEffect(() => {
+    setCancelling((prev) => {
+      if (prev.size === 0) return prev;
+      const stale = new Set(
+        [...prev].filter((id) => !tasks.some((t) => t.id === id && t.status === 'running'))
+      );
+      if (stale.size === 0) return prev;
+      return new Set([...prev].filter((id) => !stale.has(id)));
+    });
+  }, [tasks]);
 
   return (
     <Card
@@ -113,9 +142,12 @@ export const TaskManager: React.FC<TaskManagerProps> = ({
               const isRunning = task.status === 'running';
               const isFailed = task.status === 'failed';
               const isCancelled = task.status === 'cancelled';
-              // Only copy tasks support cancellation; exports cannot be cancelled.
+              // Copy, dump, and restore tasks support cancellation; exports cannot be cancelled.
               const isCancellable =
-                task.kind === 'collection_copy' || task.kind === 'database_copy';
+                task.kind === 'collection_copy' ||
+                task.kind === 'database_copy' ||
+                task.kind === 'dump' ||
+                task.kind === 'restore';
               return (
                 <div
                   key={task.id}
@@ -163,7 +195,10 @@ export const TaskManager: React.FC<TaskManagerProps> = ({
                       <div
                         className={cn(
                           'h-full rounded-full transition-all',
-                          isFailed ? 'bg-destructive' : isRunning ? 'bg-primary' : isCancelled ? 'bg-muted-foreground' : 'bg-success'
+                          isFailed ? 'bg-destructive' : isRunning ? 'bg-primary' : isCancelled ? 'bg-muted-foreground' : 'bg-success',
+                          // Indeterminate: no real percent yet — pulse so it reads as
+                          // "working", not as progress stuck at a fixed fraction.
+                          isRunning && percent === null && 'animate-pulse'
                         )}
                         style={{ width: `${percent ?? (isRunning ? 18 : isCancelled ? 0 : 100)}%` }}
                       />
@@ -204,10 +239,11 @@ export const TaskManager: React.FC<TaskManagerProps> = ({
                     {isRunning && isCancellable && onCancel && (
                       <button
                         type="button"
-                        className="mt-1 text-[10px] text-destructive hover:underline"
-                        onClick={() => onCancel(task.id)}
+                        className="mt-1 text-[10px] text-destructive hover:underline disabled:opacity-50 disabled:no-underline"
+                        onClick={() => handleCancelClick(task.id)}
+                        disabled={cancelling.has(task.id)}
                       >
-                        Cancel
+                        {cancelling.has(task.id) ? 'Cancelling…' : 'Cancel'}
                       </button>
                     )}
                   </div>

--- a/src/components/ToolSetupDialog.tsx
+++ b/src/components/ToolSetupDialog.tsx
@@ -1,0 +1,316 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { Download, Wrench } from 'lucide-react';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ManagedToolStatusUi {
+  name: string;
+  version: string;
+  installed: boolean;
+  path: string | null;
+}
+
+export interface InstallTaskUi {
+  status: string;
+  message: string;
+  processed: number;
+  total: number | null;
+}
+
+interface ToolSetupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  statuses: ManagedToolStatusUi[] | null; // null = loading
+  installTask: InstallTaskUi | null; // live task, null = not running
+  onInstall: (tools: string[], force: boolean) => void | Promise<void>;
+  onCancel?: () => void;
+  onDone?: () => void; // fired from the Done button; parent re-detects
+}
+
+// ─── Styling constants (ImportView idiom) ───────────────────────────────────
+
+const checkboxLabelClassName = 'flex cursor-pointer items-center gap-2 text-sm text-foreground';
+
+const TOOL_LABELS: Record<string, string> = {
+  'database-tools': 'Database Tools (mongodump, mongorestore)',
+  mongosh: 'mongosh',
+};
+
+function toolLabel(name: string): string {
+  return TOOL_LABELS[name] ?? name;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const ToolSetupDialog: React.FC<ToolSetupDialogProps> = ({
+  open,
+  onOpenChange,
+  statuses,
+  installTask,
+  onInstall,
+  onCancel,
+  onDone,
+}) => {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [lastSubmitted, setLastSubmitted] = useState<{ tools: string[]; force: boolean } | null>(
+    null
+  );
+  // True while the start-install call is in flight, so a double-click can't
+  // fire a second install before the first one registers a task.
+  const [starting, setStarting] = useState(false);
+  // Once the install task reaches a terminal state, keep a local snapshot so
+  // losing the store entry (e.g. "Clear finished" in the Task Manager) doesn't
+  // silently reset the dialog to the checklist with stale statuses.
+  const [taskSnapshot, setTaskSnapshot] = useState<InstallTaskUi | null>(null);
+  useEffect(() => {
+    if (installTask && installTask.status !== 'running') {
+      setTaskSnapshot(installTask);
+    }
+  }, [installTask]);
+  useEffect(() => {
+    if (!open) setTaskSnapshot(null);
+  }, [open]);
+  const task = installTask ?? taskSnapshot;
+
+  // Default selection: every NOT-installed tool, re-derived whenever the dialog
+  // opens or fresh statuses arrive.
+  useEffect(() => {
+    if (open && statuses) {
+      setSelected(new Set(statuses.filter((s) => !s.installed).map((s) => s.name)));
+    }
+  }, [open, statuses]);
+
+  const toggle = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  };
+
+  const selectedInstalledTools = (statuses ?? []).filter(
+    (s) => selected.has(s.name) && s.installed
+  );
+  const willReinstall = selectedInstalledTools.length > 0;
+
+  // Only holds the button in a "Starting…" state when onInstall is actually
+  // async (the app's start_tool_install_task invoke); a sync handler resolves
+  // immediately and never disables anything.
+  const submitInstall = (tools: string[], force: boolean) => {
+    if (starting) return;
+    const result = onInstall(tools, force);
+    if (result && typeof result.then === 'function') {
+      setStarting(true);
+      void result.finally(() => setStarting(false));
+    }
+  };
+
+  const handleInstall = () => {
+    const tools = Array.from(selected);
+    if (tools.length === 0) return;
+    const force = willReinstall;
+    setLastSubmitted({ tools, force });
+    submitInstall(tools, force);
+  };
+
+  const handleRetry = () => {
+    if (lastSubmitted) {
+      submitInstall(lastSubmitted.tools, lastSubmitted.force);
+    }
+  };
+
+  const isRunning = task?.status === 'running';
+  const isFailed = task?.status === 'failed';
+  const isCancelled = task?.status === 'cancelled';
+  const isCompleted = task?.status === 'completed';
+  const showChecklist = task === null;
+
+  const percent =
+    isRunning && task && task.total !== null && task.total > 0
+      ? Math.min(100, Math.round((task.processed / task.total) * 100))
+      : null;
+  const indeterminate = isRunning && percent === null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]" data-testid="toolsetup-dialog">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Wrench className="h-4 w-4" />
+            Set up MongoDB tools
+          </DialogTitle>
+        </DialogHeader>
+
+        {showChecklist && statuses === null && (
+          <div className="flex flex-col gap-2 py-6 text-center text-sm text-muted-foreground">
+            Checking installed tools…
+          </div>
+        )}
+
+        {showChecklist && statuses !== null && (
+          <div className="flex flex-col gap-4 py-2">
+            <p className="text-xs text-muted-foreground">
+              MQLens needs these command-line tools for dump, restore, import, and export. Pick
+              which ones to install or reinstall.
+            </p>
+
+            <div className="divide-y divide-border rounded-md border border-border">
+              {statuses.map((tool) => (
+                <section key={tool.name} className="flex flex-col gap-1.5 px-3.5 py-3">
+                  <label className={checkboxLabelClassName}>
+                    <input
+                      type="checkbox"
+                      checked={selected.has(tool.name)}
+                      onChange={() => toggle(tool.name)}
+                      data-testid={`toolsetup-check-${tool.name}`}
+                    />
+                    <span className="font-medium">{toolLabel(tool.name)}</span>
+                    {tool.installed && (
+                      <span className="text-xs text-muted-foreground">Installed</span>
+                    )}
+                  </label>
+                  <p
+                    className="ml-6 text-xs text-muted-foreground"
+                    data-testid={`toolsetup-version-${tool.name}`}
+                  >
+                    v{tool.version}
+                    {tool.path ? ` — ${tool.path}` : ''}
+                  </p>
+                </section>
+              ))}
+            </div>
+
+            {willReinstall && (
+              <p className="text-xs text-amber-600 dark:text-amber-400">
+                Will reinstall: already-installed tools you've kept checked will be downloaded
+                again and replaced.
+              </p>
+            )}
+
+            <p className="text-xs text-muted-foreground" data-testid="toolsetup-size-note">
+              Downloads are roughly 50–100 MB per tool and are cached in the app's data
+              directory.
+            </p>
+            <p className="text-xs text-muted-foreground" data-testid="toolsetup-license-note">
+              Official Apache-2.0 builds downloaded from mongodb.com
+            </p>
+          </div>
+        )}
+
+        {isRunning && task && (
+          <div className="flex flex-col gap-3 py-2">
+            <p className="text-sm text-foreground" data-testid="toolsetup-stage">
+              {task.message}
+            </p>
+            <div
+              role="progressbar"
+              data-testid="toolsetup-progress"
+              data-indeterminate={indeterminate ? 'true' : 'false'}
+              aria-valuenow={percent !== null ? percent : undefined}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              className="h-2 w-full overflow-hidden rounded-full bg-muted"
+            >
+              <div
+                className={cn(
+                  'h-full rounded-full bg-primary transition-all',
+                  indeterminate && 'w-1/3 animate-pulse'
+                )}
+                style={percent !== null ? { width: `${percent}%` } : undefined}
+              />
+            </div>
+          </div>
+        )}
+
+        {isFailed && task && (
+          <div className="flex flex-col gap-3 py-2">
+            <p className="text-sm text-destructive" data-testid="toolsetup-error">
+              {task.message}
+            </p>
+          </div>
+        )}
+
+        {isCancelled && task && (
+          <div className="flex flex-col gap-3 py-2">
+            <p className="text-sm font-medium text-foreground" data-testid="toolsetup-cancelled-heading">
+              Cancelled
+            </p>
+            <p className="text-sm text-muted-foreground" data-testid="toolsetup-error">
+              {task.message}
+            </p>
+          </div>
+        )}
+
+        {isCompleted && task && (
+          <div className="flex flex-col gap-3 py-2">
+            <p className="text-sm text-foreground">{task.message}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          {showChecklist && statuses !== null && (
+            <>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleInstall}
+                disabled={selected.size === 0 || starting}
+                data-testid="toolsetup-install-btn"
+              >
+                <Download className="mr-2 h-4 w-4" />
+                {starting ? 'Starting…' : 'Install'}
+              </Button>
+            </>
+          )}
+          {isRunning && (
+            <Button
+              variant="outline"
+              onClick={() => onCancel?.()}
+              data-testid="toolsetup-cancel-btn"
+            >
+              Cancel
+            </Button>
+          )}
+          {isFailed && (
+            <Button onClick={handleRetry} disabled={starting} data-testid="toolsetup-retry-btn">
+              Retry
+            </Button>
+          )}
+          {isCancelled && (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                data-testid="toolsetup-dismiss-btn"
+              >
+                Dismiss
+              </Button>
+              <Button onClick={handleRetry} disabled={starting} data-testid="toolsetup-retry-btn">
+                Retry
+              </Button>
+            </>
+          )}
+          {isCompleted && (
+            <Button onClick={() => onDone?.()} data-testid="toolsetup-done-btn">
+              Done
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 
 // Mock Sidebar component
 vi.mock('../Sidebar', () => ({
-  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings }: any) => (
+  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings, onOpenDump, onOpenRestore }: any) => (
     <div data-testid="mock-sidebar">
       <button data-testid="select-collection-btn" onClick={() => onSelectCollection('conn-1', 'sales_db', 'customers')}>
         Select Collection
@@ -78,6 +78,12 @@ vi.mock('../Sidebar', () => ({
       </button>
       <button data-testid="open-settings-btn" onClick={() => onOpenSettings && onOpenSettings()}>
         Open Settings
+      </button>
+      <button data-testid="open-dump-db-btn" onClick={() => onOpenDump && onOpenDump('conn-1', 'sales_db')}>
+        Dump sales_db
+      </button>
+      <button data-testid="open-restore-btn" onClick={() => onOpenRestore && onOpenRestore('conn-1')}>
+        Restore
       </button>
     </div>
   ),
@@ -454,7 +460,7 @@ describe('App Component', () => {
 
     expect(await screen.findByTestId('settings-view')).toBeInTheDocument();
     expect(screen.getAllByText('Settings').length).toBeGreaterThan(0);
-    fireEvent.click(screen.getByTestId('settings-tab-mongosh'));
+    fireEvent.click(screen.getByTestId('settings-tab-tools'));
     expect(await screen.findByTestId('mongosh-path-input')).toHaveValue('/usr/local/bin/mongosh');
   });
 
@@ -742,6 +748,481 @@ describe('App Component', () => {
       },
       { timeout: 2000 }
     );
+  });
+
+  it('opens the Dump tab from a database context menu and detects mongo tools', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') {
+        return Promise.resolve({
+          mongodump: { path: '/usr/local/bin/mongodump', version: '100.9.4' },
+          mongorestore: null,
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+
+    expect(await screen.findByTestId('dump-view')).toBeInTheDocument();
+    expect(screen.getByText('Dump: sales_db')).toBeInTheDocument();
+    await waitFor(() => {
+      const detect = calls.find((c) => c.cmd === 'detect_mongo_tools');
+      expect(detect).toBeTruthy();
+      expect(detect.args).toMatchObject({ configuredDir: null });
+    });
+  });
+
+  it('runs a dump (payload includes toolPath), opens Tasks, and cancels the running task', async () => {
+    const calls: any[] = [];
+    const dumpTask = {
+      id: 'task-dump-1',
+      kind: 'dump',
+      label: 'Dump sales_db → out',
+      status: 'running',
+      processed: 0,
+      total: null,
+      message: 'Running',
+      path: null,
+      error: null,
+      createdAtMs: 1,
+      finishedAtMs: null,
+    };
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') {
+        return Promise.resolve({
+          mongodump: { path: '/usr/local/bin/mongodump', version: '100.9.4' },
+          mongorestore: null,
+        });
+      }
+      if (cmd === 'preview_dump_command') return Promise.resolve('mongodump --db=sales_db');
+      if (cmd === 'start_dump_task') return Promise.resolve(dumpTask);
+      if (cmd === 'list_export_tasks') return Promise.resolve([dumpTask]);
+      if (cmd === 'cancel_task') return Promise.resolve();
+      return Promise.resolve([]);
+    });
+    openMock.mockResolvedValue('/tmp/dumpout');
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+    expect(await screen.findByTestId('dump-view')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('dump-pick-dest-btn'));
+    await waitFor(() =>
+      expect(screen.getByTestId('dump-dest-path')).toHaveTextContent('/tmp/dumpout'));
+
+    await waitFor(() => expect(screen.getByTestId('dump-run-btn')).not.toBeDisabled());
+    fireEvent.click(screen.getByTestId('dump-run-btn'));
+
+    await waitFor(() => {
+      const started = calls.find((c) => c.cmd === 'start_dump_task');
+      expect(started).toBeTruthy();
+      expect(started.args).toMatchObject({
+        id: 'conn-1',
+        toolPath: '/usr/local/bin/mongodump',
+        options: expect.objectContaining({
+          scope: { kind: 'db', db: 'sales_db' },
+          target: { kind: 'folder', out: '/tmp/dumpout' },
+        }),
+      });
+    });
+
+    // Starting the dump opens the Tasks tab with the running task, cancellable.
+    expect(await screen.findByTestId('task-manager')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    await waitFor(() => {
+      const cancelled = calls.find((c) => c.cmd === 'cancel_task');
+      expect(cancelled).toBeTruthy();
+      expect(cancelled.args).toMatchObject({ id: 'task-dump-1' });
+    });
+  });
+
+  it('opens the Restore tab from the connection context menu', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'detect_mongo_tools') {
+        return Promise.resolve({ mongodump: null, mongorestore: null });
+      }
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-restore-btn'));
+
+    expect(await screen.findByTestId('restore-view')).toBeInTheDocument();
+    expect(screen.getByText('Restore: conn-1')).toBeInTheDocument();
+  });
+
+  const managedStatusesFixture = [
+    { name: 'database-tools', version: '100.9.4', installed: false, path: null },
+    { name: 'mongosh', version: '2.3.1', installed: true, path: '/data/tools/mongosh/bin/mongosh' },
+  ];
+
+  it('opens the guided tool-setup dialog from the Dump guidance card and loads managed tool status', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') return Promise.resolve({ mongodump: null, mongorestore: null });
+      if (cmd === 'managed_tools_status') return Promise.resolve(managedStatusesFixture);
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+    expect(await screen.findByTestId('dump-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('dump-tools-missing')).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByTestId('dump-install-tools-btn'));
+
+    expect(await screen.findByTestId('toolsetup-dialog')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(calls.some((c) => c.cmd === 'managed_tools_status')).toBe(true);
+    });
+    expect(await screen.findByTestId('toolsetup-check-database-tools')).toBeInTheDocument();
+  });
+
+  it('runs a tool install (payload includes tools/force), tracks the task in the dialog, and cancels it', async () => {
+    const calls: any[] = [];
+    const installTask = {
+      id: 'task-tool-1',
+      kind: 'tool_install',
+      label: 'Install MongoDB tools',
+      status: 'running',
+      processed: 0,
+      total: null,
+      message: 'Downloading database-tools…',
+      path: null,
+      error: null,
+      createdAtMs: 1,
+      finishedAtMs: null,
+    };
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') return Promise.resolve({ mongodump: null, mongorestore: null });
+      if (cmd === 'managed_tools_status') return Promise.resolve(managedStatusesFixture);
+      if (cmd === 'start_tool_install_task') return Promise.resolve(installTask);
+      if (cmd === 'list_export_tasks') return Promise.resolve([installTask]);
+      if (cmd === 'cancel_task') return Promise.resolve();
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+    await screen.findByTestId('dump-view');
+    fireEvent.click(await screen.findByTestId('dump-install-tools-btn'));
+    await screen.findByTestId('toolsetup-check-database-tools');
+
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+
+    await waitFor(() => {
+      const started = calls.find((c) => c.cmd === 'start_tool_install_task');
+      expect(started).toBeTruthy();
+      expect(started.args).toMatchObject({ tools: ['database-tools'], force: false });
+    });
+
+    expect(await screen.findByTestId('toolsetup-cancel-btn')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('toolsetup-cancel-btn'));
+
+    await waitFor(() => {
+      const cancelled = calls.find((c) => c.cmd === 'cancel_task');
+      expect(cancelled).toBeTruthy();
+      expect(cancelled.args).toMatchObject({ id: 'task-tool-1' });
+    });
+  });
+
+  it('completing the tool install and clicking Done re-detects mongo tools, refreshes managed status, and closes the dialog', async () => {
+    const calls: any[] = [];
+    const completedTask = {
+      id: 'task-tool-2',
+      kind: 'tool_install',
+      label: 'Install MongoDB tools',
+      status: 'completed',
+      processed: 2,
+      total: 2,
+      message: 'Installed database-tools, mongosh',
+      path: null,
+      error: null,
+      createdAtMs: 1,
+      finishedAtMs: 2,
+    };
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') return Promise.resolve({ mongodump: null, mongorestore: null });
+      if (cmd === 'managed_tools_status') return Promise.resolve(managedStatusesFixture);
+      if (cmd === 'start_tool_install_task') return Promise.resolve(completedTask);
+      if (cmd === 'list_export_tasks') return Promise.resolve([completedTask]);
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+    await screen.findByTestId('dump-view');
+    const detectCallCount = () => calls.filter((c) => c.cmd === 'detect_mongo_tools').length;
+    const detectBefore = detectCallCount();
+
+    fireEvent.click(await screen.findByTestId('dump-install-tools-btn'));
+    await screen.findByTestId('toolsetup-check-database-tools');
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+
+    expect(await screen.findByTestId('toolsetup-done-btn')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('toolsetup-done-btn'));
+
+    await waitFor(() => {
+      expect(detectCallCount()).toBeGreaterThan(detectBefore);
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('toolsetup-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders the cancelled state in the guided tool-setup dialog when the install task is cancelled', async () => {
+    const calls: any[] = [];
+    const cancelledTask = {
+      id: 'task-tool-3',
+      kind: 'tool_install',
+      label: 'Install MongoDB tools',
+      status: 'cancelled',
+      processed: 1,
+      total: 2,
+      message: 'Install cancelled',
+      path: null,
+      error: null,
+      createdAtMs: 1,
+      finishedAtMs: 2,
+    };
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') return Promise.resolve({ mongodump: null, mongorestore: null });
+      if (cmd === 'managed_tools_status') return Promise.resolve(managedStatusesFixture);
+      if (cmd === 'start_tool_install_task') return Promise.resolve(cancelledTask);
+      if (cmd === 'list_export_tasks') return Promise.resolve([cancelledTask]);
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+    await screen.findByTestId('dump-view');
+    fireEvent.click(await screen.findByTestId('dump-install-tools-btn'));
+    await screen.findByTestId('toolsetup-check-database-tools');
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+
+    expect(await screen.findByTestId('toolsetup-cancelled-heading')).toBeInTheDocument();
+  });
+
+  it('surfaces the real failure reason (task.error) instead of the generic task.message when the install task fails', async () => {
+    const calls: any[] = [];
+    const failedTask = {
+      id: 'task-tool-4',
+      kind: 'tool_install',
+      label: 'Install MongoDB tools',
+      status: 'failed',
+      processed: 0,
+      total: 2,
+      message: 'Task failed',
+      path: null,
+      error: 'checksum mismatch — download corrupted or tampered',
+      createdAtMs: 1,
+      finishedAtMs: 2,
+    };
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') return Promise.resolve({ mongodump: null, mongorestore: null });
+      if (cmd === 'managed_tools_status') return Promise.resolve(managedStatusesFixture);
+      if (cmd === 'start_tool_install_task') return Promise.resolve(failedTask);
+      if (cmd === 'list_export_tasks') return Promise.resolve([failedTask]);
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+    await screen.findByTestId('dump-view');
+    fireEvent.click(await screen.findByTestId('dump-install-tools-btn'));
+    await screen.findByTestId('toolsetup-check-database-tools');
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+
+    const errorEl = await screen.findByTestId('toolsetup-error');
+    expect(errorEl).toHaveTextContent('checksum mismatch — download corrupted or tampered');
+    expect(errorEl).not.toHaveTextContent('Task failed');
+  });
+
+  it('closing the completed tool-setup dialog without Done still finalizes, and reopening shows the checklist', async () => {
+    const calls: any[] = [];
+    const completedTask = {
+      id: 'task-tool-5',
+      kind: 'tool_install',
+      label: 'Install MongoDB tools',
+      status: 'completed',
+      processed: 2,
+      total: 2,
+      message: 'Installed database-tools, mongosh',
+      path: null,
+      error: null,
+      createdAtMs: 1,
+      finishedAtMs: 2,
+    };
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') return Promise.resolve({ mongodump: null, mongorestore: null });
+      if (cmd === 'managed_tools_status') return Promise.resolve(managedStatusesFixture);
+      if (cmd === 'start_tool_install_task') return Promise.resolve(completedTask);
+      if (cmd === 'list_export_tasks') return Promise.resolve([completedTask]);
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+    await screen.findByTestId('dump-view');
+    const detectCallCount = () => calls.filter((c) => c.cmd === 'detect_mongo_tools').length;
+
+    fireEvent.click(await screen.findByTestId('dump-install-tools-btn'));
+    await screen.findByTestId('toolsetup-check-database-tools');
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+    expect(await screen.findByTestId('toolsetup-done-btn')).toBeInTheDocument();
+
+    // Close via the dialog's X (Radix onOpenChange(false)) instead of Done —
+    // the completion side effects must still run.
+    const detectBefore = detectCallCount();
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('toolsetup-dialog')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(detectCallCount()).toBeGreaterThan(detectBefore);
+    });
+
+    // Reopening shows the fresh checklist, not the stale completed screen.
+    fireEvent.click(await screen.findByTestId('dump-install-tools-btn'));
+    expect(await screen.findByTestId('toolsetup-check-database-tools')).toBeInTheDocument();
+    expect(screen.queryByTestId('toolsetup-done-btn')).not.toBeInTheDocument();
+  });
+
+  it('a stale list_export_tasks response cannot clobber an optimistically inserted install task', async () => {
+    const installTask = {
+      id: 'task-tool-6',
+      kind: 'tool_install',
+      label: 'Install MongoDB tools',
+      status: 'running',
+      processed: 0,
+      total: null,
+      message: 'Downloading database-tools…',
+      path: null,
+      error: null,
+      createdAtMs: 1,
+      finishedAtMs: null,
+    };
+    // The FIRST list_export_tasks request (mount poll) is held open and only
+    // resolves — empty, as fetched before the task registered — after the
+    // optimistic insert. It must be dropped, not applied.
+    let resolveStaleList!: (tasks: any[]) => void;
+    const staleList = new Promise<any[]>((resolve) => { resolveStaleList = resolve; });
+    let listCalls = 0;
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') return Promise.resolve({ mongodump: null, mongorestore: null });
+      if (cmd === 'managed_tools_status') return Promise.resolve(managedStatusesFixture);
+      if (cmd === 'start_tool_install_task') return Promise.resolve(installTask);
+      if (cmd === 'list_export_tasks') {
+        listCalls += 1;
+        return listCalls === 1 ? staleList : Promise.resolve([installTask]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor, act } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+    await screen.findByTestId('dump-view');
+    fireEvent.click(await screen.findByTestId('dump-install-tools-btn'));
+    await screen.findByTestId('toolsetup-check-database-tools');
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+
+    // The dialog tracks the optimistically inserted running task.
+    expect(await screen.findByTestId('toolsetup-cancel-btn')).toBeInTheDocument();
+
+    // The pre-insert snapshot resolves late and empty.
+    await act(async () => {
+      resolveStaleList([]);
+    });
+
+    // The dialog must NOT flash back to the checklist.
+    await waitFor(() => {
+      expect(screen.getByTestId('toolsetup-cancel-btn')).toBeInTheDocument();
+      expect(screen.queryByTestId('toolsetup-install-btn')).not.toBeInTheDocument();
+    });
+  });
+
+  it('the dump guidance card "Open Settings" opens Settings on the Tools section', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      if (cmd === 'detect_mongo_tools') return Promise.resolve({ mongodump: null, mongorestore: null });
+      if (cmd === 'managed_tools_status') return Promise.resolve(managedStatusesFixture);
+      if (cmd === 'load_app_settings') return Promise.resolve({});
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, within } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-dump-db-btn'));
+    const guidance = await screen.findByTestId('dump-tools-missing');
+
+    fireEvent.click(within(guidance).getByRole('button', { name: /open settings/i }));
+
+    expect(await screen.findByTestId('settings-view')).toBeInTheDocument();
+    // The Tools section (mongosh/tools paths) is active, not Appearance.
+    expect(await screen.findByTestId('mongosh-path-input')).toBeInTheDocument();
   });
 
   it('starts a background task for full collection export', async () => {

--- a/src/components/__tests__/DumpView.test.tsx
+++ b/src/components/__tests__/DumpView.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DumpView } from '../DumpView';
+
+vi.mock('@monaco-editor/react', () => ({
+  default: ({
+    value,
+    onChange,
+    wrapperProps,
+  }: {
+    value: string;
+    onChange?: (v: string) => void;
+    wrapperProps?: Record<string, unknown>;
+  }) => (
+    <textarea
+      data-testid={wrapperProps?.['data-testid'] as string | undefined}
+      value={value}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  ),
+}));
+
+const renderDumpView = (overrides: Record<string, unknown> = {}) => {
+  const props = {
+    connectionName: 'conn',
+    databases: [{ name: 'sales', collections: ['orders', 'users'] }],
+    tools: { mongodump: { path: '/usr/bin/mongodump', version: '100.9' }, mongorestore: null },
+    onPickFolder: vi.fn().mockResolvedValue('/tmp/out'),
+    onPickArchiveFile: vi.fn().mockResolvedValue('/tmp/out.archive.gz'),
+    onRunDump: vi.fn(),
+    ...overrides,
+  };
+  render(<DumpView {...(props as any)} />);
+  return props;
+};
+
+describe('DumpView', () => {
+  it('shows guidance and disables run when mongodump tooling is missing', () => {
+    const onOpenSettings = vi.fn();
+    renderDumpView({
+      tools: { mongodump: null, mongorestore: null },
+      onOpenSettings,
+    });
+
+    expect(screen.getByTestId('dump-tools-missing')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }));
+    expect(onOpenSettings).toHaveBeenCalled();
+    expect(screen.getByTestId('dump-run-btn')).toBeDisabled();
+  });
+
+  it('omits the Install tools button when onInstallTools is not provided', () => {
+    renderDumpView({ tools: { mongodump: null, mongorestore: null } });
+    expect(screen.queryByTestId('dump-install-tools-btn')).not.toBeInTheDocument();
+  });
+
+  it('wires the Install tools button in the guidance card to onInstallTools', () => {
+    const onInstallTools = vi.fn();
+    renderDumpView({ tools: { mongodump: null, mongorestore: null }, onInstallTools });
+    fireEvent.click(screen.getByTestId('dump-install-tools-btn'));
+    expect(onInstallTools).toHaveBeenCalled();
+  });
+
+  it('scope selection gates the db/collection selects, query editor, and scope-limited checkboxes', () => {
+    renderDumpView();
+
+    // default: server scope
+    expect(screen.queryByTestId('dump-db-select')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dump-coll-select')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dump-query-input')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dump-opt-oplog')).not.toBeDisabled();
+    expect(screen.getByTestId('dump-opt-usersroles')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('dump-scope-db'));
+    expect(screen.getByTestId('dump-db-select')).toBeInTheDocument();
+    expect(screen.queryByTestId('dump-coll-select')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dump-query-input')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dump-opt-usersroles')).not.toBeDisabled();
+    expect(screen.getByTestId('dump-opt-oplog')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('dump-scope-collection'));
+    expect(screen.getByTestId('dump-db-select')).toBeInTheDocument();
+    expect(screen.getByTestId('dump-coll-select')).toBeInTheDocument();
+    expect(screen.getByTestId('dump-query-input')).toBeInTheDocument();
+    expect(screen.getByTestId('dump-opt-usersroles')).toBeDisabled();
+    expect(screen.getByTestId('dump-opt-oplog')).toBeDisabled();
+  });
+
+  it('handles folder and archive destination pickers with a computed default archive name', async () => {
+    const props = renderDumpView();
+
+    fireEvent.click(screen.getByTestId('dump-pick-dest-btn'));
+    expect(props.onPickFolder).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByTestId('dump-dest-path')).toHaveTextContent('/tmp/out'));
+
+    fireEvent.click(screen.getByTestId('dump-target-archive'));
+    fireEvent.click(screen.getByTestId('dump-pick-dest-btn'));
+    expect(props.onPickArchiveFile).toHaveBeenCalledWith('conn.archive.gz');
+    await waitFor(() =>
+      expect(screen.getByTestId('dump-dest-path')).toHaveTextContent('/tmp/out.archive.gz'));
+
+    fireEvent.click(screen.getByTestId('dump-opt-gzip'));
+    fireEvent.click(screen.getByTestId('dump-pick-dest-btn'));
+    expect(props.onPickArchiveFile).toHaveBeenLastCalledWith('conn.archive');
+  });
+
+  it('run button gates on a destination and forwards the full options payload', async () => {
+    const props = renderDumpView();
+
+    fireEvent.click(screen.getByTestId('dump-scope-collection'));
+    fireEvent.change(screen.getByTestId('dump-coll-select'), { target: { value: 'users' } });
+    fireEvent.change(screen.getByTestId('dump-query-input'), {
+      target: { value: '{"active":true}' },
+    });
+    fireEvent.click(screen.getByTestId('dump-opt-forcetablescan'));
+
+    expect(screen.getByTestId('dump-run-btn')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('dump-pick-dest-btn'));
+    await waitFor(() => expect(screen.getByTestId('dump-run-btn')).toBeEnabled());
+
+    fireEvent.click(screen.getByTestId('dump-run-btn'));
+    expect(props.onRunDump).toHaveBeenCalledWith({
+      scope: { kind: 'collection', db: 'sales', coll: 'users' },
+      target: { kind: 'folder', out: '/tmp/out' },
+      gzip: true,
+      query: '{"active":true}',
+      forceTableScan: true,
+      dumpUsersAndRoles: false,
+      oplog: false,
+    });
+  });
+
+  it('gzip compression defaults on', () => {
+    renderDumpView();
+    expect(screen.getByTestId('dump-opt-gzip')).toBeChecked();
+  });
+
+  it('double-clicking Run starts the dump only once and shows Starting…', async () => {
+    let resolveRun!: () => void;
+    const onRunDump = vi.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRun = resolve;
+      })
+    );
+    renderDumpView({ onRunDump });
+
+    fireEvent.click(screen.getByTestId('dump-pick-dest-btn'));
+    await waitFor(() => expect(screen.getByTestId('dump-run-btn')).toBeEnabled());
+
+    fireEvent.click(screen.getByTestId('dump-run-btn'));
+    fireEvent.click(screen.getByTestId('dump-run-btn'));
+
+    expect(onRunDump).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('dump-run-btn')).toBeDisabled();
+    expect(screen.getByTestId('dump-run-btn')).toHaveTextContent('Starting…');
+
+    resolveRun();
+    await waitFor(() => expect(screen.getByTestId('dump-run-btn')).toBeEnabled());
+  });
+
+  it('invalid query JSON disables Run and shows an inline error; valid JSON passes through', async () => {
+    const props = renderDumpView();
+
+    fireEvent.click(screen.getByTestId('dump-scope-collection'));
+    fireEvent.click(screen.getByTestId('dump-pick-dest-btn'));
+    await waitFor(() => expect(screen.getByTestId('dump-run-btn')).toBeEnabled());
+
+    fireEvent.change(screen.getByTestId('dump-query-input'), {
+      target: { value: '{active: true}' },
+    });
+    expect(screen.getByTestId('dump-query-error')).toBeInTheDocument();
+    expect(screen.getByTestId('dump-run-btn')).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('dump-query-input'), {
+      target: { value: '{"active": true}' },
+    });
+    expect(screen.queryByTestId('dump-query-error')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dump-run-btn')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('dump-run-btn'));
+    expect(props.onRunDump).toHaveBeenCalledWith(
+      expect.objectContaining({ query: '{"active": true}' })
+    );
+  });
+
+  it('does not request a preview while mongodump is missing', async () => {
+    vi.useFakeTimers();
+    const onPreviewCommand = vi.fn().mockResolvedValue('mongodump …');
+    renderDumpView({ tools: { mongodump: null, mongorestore: null }, onPreviewCommand });
+    await vi.advanceTimersByTimeAsync(400);
+    expect(onPreviewCommand).not.toHaveBeenCalled();
+    expect(screen.getByTestId('dump-preview-cmd')).toBeEmptyDOMElement();
+  });
+
+  it('ignores out-of-order preview responses and keeps the latest command', async () => {
+    vi.useFakeTimers();
+    const resolvers: Array<(v: string) => void> = [];
+    const onPreviewCommand = vi.fn().mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    renderDumpView({ onPreviewCommand });
+
+    await vi.advanceTimersByTimeAsync(350);
+    expect(onPreviewCommand).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('dump-opt-forcetablescan'));
+    await vi.advanceTimersByTimeAsync(350);
+    expect(onPreviewCommand).toHaveBeenCalledTimes(2);
+
+    // The newer request resolves first, then the stale one arrives late.
+    resolvers[1]('fresh command');
+    await vi.advanceTimersByTimeAsync(0);
+    resolvers[0]('stale command');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(screen.getByTestId('dump-preview-cmd')).toHaveTextContent('fresh command');
+  });
+
+  it('shows a disabled db placeholder when no databases are available', async () => {
+    renderDumpView({ databases: [] });
+
+    fireEvent.click(screen.getByTestId('dump-pick-dest-btn'));
+    await waitFor(() => expect(screen.getByTestId('dump-dest-path')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('dump-scope-db'));
+    const dbSelect = screen.getByTestId('dump-db-select') as HTMLSelectElement;
+    expect(dbSelect.value).toBe('');
+    expect(screen.getByText('Select database…')).toBeInTheDocument();
+    expect(screen.getByTestId('dump-run-btn')).toBeDisabled();
+  });
+
+  it('shows a disabled collection placeholder when the database has no collections', async () => {
+    renderDumpView({ databases: [{ name: 'empty', collections: [] }] });
+
+    fireEvent.click(screen.getByTestId('dump-pick-dest-btn'));
+    await waitFor(() => expect(screen.getByTestId('dump-dest-path')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('dump-scope-collection'));
+    const collSelect = screen.getByTestId('dump-coll-select') as HTMLSelectElement;
+    expect(collSelect.value).toBe('');
+    expect(screen.getByText('Select collection…')).toBeInTheDocument();
+    expect(screen.getByTestId('dump-run-btn')).toBeDisabled();
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -334,6 +334,107 @@ describe('MongoShell Component', () => {
     });
   });
 
+  it('shows an Install tools button on the gate that opens the guided setup dialog', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '' });
+      if (cmd === 'test_mongosh_path') return Promise.reject('not found');
+      if (cmd === 'start_mongosh_session') return Promise.reject('mongosh not found');
+      return Promise.resolve([]);
+    });
+
+    const onInstallTools = vi.fn();
+    render(
+      <MongoShell
+        connectionId="conn-1"
+        connectionName="mock"
+        connectionUri="mongodb://prod-replica-set"
+        databaseName="user_analytics"
+        collectionName="events"
+        onInstallTools={onInstallTools}
+      />
+    );
+
+    fireEvent.click(await screen.findByTestId('shell-install-tools-btn'));
+    expect(onInstallTools).toHaveBeenCalled();
+  });
+
+  it('re-attempts the mongosh session when reconnectSignal changes (tool-install Done)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '' });
+      if (cmd === 'test_mongosh_path') return Promise.reject('not found');
+      if (cmd === 'start_mongosh_session') return Promise.reject('mongosh not found');
+      return Promise.resolve([]);
+    });
+
+    const { rerender } = render(
+      <MongoShell
+        connectionId="conn-1"
+        connectionName="mock"
+        connectionUri="mongodb://prod-replica-set"
+        databaseName="user_analytics"
+        collectionName="events"
+        reconnectSignal={0}
+      />
+    );
+
+    await screen.findByTestId('shell-session-gate');
+    const before = mockInvoke.mock.calls.filter((c) => c[0] === 'start_mongosh_session').length;
+
+    rerender(
+      <MongoShell
+        connectionId="conn-1"
+        connectionName="mock"
+        connectionUri="mongodb://prod-replica-set"
+        databaseName="user_analytics"
+        collectionName="events"
+        reconnectSignal={1}
+      />
+    );
+
+    await waitFor(() => {
+      const after = mockInvoke.mock.calls.filter((c) => c[0] === 'start_mongosh_session').length;
+      expect(after).toBeGreaterThan(before);
+    });
+  });
+
+  it('does not restart a healthy attached session when reconnectSignal changes', async () => {
+    const { rerender } = render(
+      <MongoShell
+        connectionId="conn-1"
+        connectionName="mock"
+        connectionUri="mongodb://prod-replica-set"
+        databaseName="user_analytics"
+        collectionName="events"
+        reconnectSignal={0}
+      />
+    );
+
+    // Default mocks: the session attaches successfully.
+    await screen.findByText(/mongosh session attached/);
+    const sessionStarts = () =>
+      mockInvoke.mock.calls.filter((c) => c[0] === 'start_mongosh_session').length;
+    const before = sessionStarts();
+
+    // A tool install completing bumps the signal for EVERY open shell tab —
+    // a healthy session must not be torn down and restarted.
+    rerender(
+      <MongoShell
+        connectionId="conn-1"
+        connectionName="mock"
+        connectionUri="mongodb://prod-replica-set"
+        databaseName="user_analytics"
+        collectionName="events"
+        reconnectSignal={1}
+      />
+    );
+
+    await waitFor(() => expect(sessionStarts()).toBe(before));
+    expect(mockInvoke).not.toHaveBeenCalledWith('stop_mongosh_session', expect.anything());
+    expect(screen.queryByTestId('shell-session-gate')).not.toBeInTheDocument();
+  });
+
   it('gates a destructive AI script behind a confirm modal', async () => {
     const script = 'db.users.deleteMany({ active: false })';
     mockInvoke.mockImplementation((cmd: string) => {

--- a/src/components/__tests__/RestoreView.test.tsx
+++ b/src/components/__tests__/RestoreView.test.tsx
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RestoreView, type DumpTreeUi } from '../RestoreView';
+
+const treeFixture: DumpTreeUi = {
+  dbs: [
+    {
+      name: 'sales',
+      collections: [
+        { name: 'orders', hasMetadata: true, gzip: false },
+        { name: 'users', hasMetadata: true, gzip: true },
+      ],
+    },
+    {
+      name: 'inventory',
+      collections: [{ name: 'items', hasMetadata: true, gzip: false }],
+    },
+  ],
+};
+
+const renderRestoreView = (overrides: Record<string, unknown> = {}) => {
+  const props = {
+    connectionName: 'conn',
+    tools: { mongodump: null, mongorestore: { path: '/usr/bin/mongorestore', version: '100.9' } },
+    onOpenSettings: vi.fn(),
+    onPickFolder: vi.fn().mockResolvedValue('/tmp/dump'),
+    onPickArchiveFile: vi.fn().mockResolvedValue('/tmp/dump.archive.gz'),
+    onBrowseFolder: vi.fn().mockResolvedValue(treeFixture),
+    onPreviewCommand: vi.fn().mockResolvedValue('mongorestore --dir=/tmp/dump'),
+    onRunRestore: vi.fn(),
+    onOpenTasks: vi.fn(),
+    ...overrides,
+  };
+  render(<RestoreView {...(props as any)} />);
+  return props;
+};
+
+const browseFolder = async (props: ReturnType<typeof renderRestoreView>) => {
+  fireEvent.click(screen.getByTestId('restore-pick-source-btn'));
+  await waitFor(() => expect(screen.getByTestId('restore-tree')).toBeInTheDocument());
+  return props;
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('RestoreView tool detection', () => {
+  it('shows guidance and disables Run when mongorestore is missing', () => {
+    const props = renderRestoreView({ tools: { mongodump: null, mongorestore: null } });
+    expect(screen.getByTestId('restore-tools-missing')).toBeInTheDocument();
+    expect(screen.getByTestId('restore-run-btn')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('restore-open-settings-btn'));
+    expect(props.onOpenSettings).toHaveBeenCalled();
+  });
+
+  it('omits the Install tools button when onInstallTools is not provided', () => {
+    renderRestoreView({ tools: { mongodump: null, mongorestore: null } });
+    expect(screen.queryByTestId('restore-install-tools-btn')).not.toBeInTheDocument();
+  });
+
+  it('wires the Install tools button in the guidance card to onInstallTools', () => {
+    const onInstallTools = vi.fn();
+    renderRestoreView({ tools: { mongodump: null, mongorestore: null }, onInstallTools });
+    fireEvent.click(screen.getByTestId('restore-install-tools-btn'));
+    expect(onInstallTools).toHaveBeenCalled();
+  });
+});
+
+describe('RestoreView folder browsing', () => {
+  it('browses a folder and auto-sets gzip when any collection is gzipped', async () => {
+    const props = renderRestoreView();
+    await browseFolder(props);
+    expect(props.onBrowseFolder).toHaveBeenCalledWith('/tmp/dump');
+    expect(screen.getByTestId('restore-tree-db-sales')).toBeInTheDocument();
+    expect(screen.getByTestId('restore-tree-db-inventory')).toBeInTheDocument();
+    expect(screen.getByTestId('restore-tree-coll-sales.orders')).toBeInTheDocument();
+    expect((screen.getByTestId('restore-opt-gzip') as HTMLInputElement).checked).toBe(true);
+    // every collection starts checked
+    expect((screen.getByTestId('restore-tree-coll-sales.orders') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('restore-tree-coll-sales.users') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('restore-tree-coll-inventory.items') as HTMLInputElement).checked).toBe(true);
+  });
+});
+
+describe('RestoreView folder browse failure', () => {
+  it('shows a browse error and keeps Run disabled when onBrowseFolder rejects', async () => {
+    const onBrowseFolder = vi.fn().mockRejectedValue(new Error('permission denied'));
+    renderRestoreView({ onBrowseFolder });
+    fireEvent.click(screen.getByTestId('restore-pick-source-btn'));
+    await waitFor(() => expect(screen.getByTestId('restore-browse-error')).toBeInTheDocument());
+    expect(screen.getByTestId('restore-browse-error')).toHaveTextContent('permission denied');
+    expect(screen.queryByTestId('restore-tree')).not.toBeInTheDocument();
+    expect(screen.getByTestId('restore-run-btn')).toBeDisabled();
+  });
+
+  it('resets gzip to false when re-browsing a folder with no gzipped collections', async () => {
+    const nonGzipTree: DumpTreeUi = {
+      dbs: [{ name: 'sales', collections: [{ name: 'orders', hasMetadata: true, gzip: false }] }],
+    };
+    const onBrowseFolder = vi.fn().mockResolvedValueOnce(treeFixture).mockResolvedValueOnce(nonGzipTree);
+    const props = renderRestoreView({ onBrowseFolder });
+    await browseFolder(props);
+    expect((screen.getByTestId('restore-opt-gzip') as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(screen.getByTestId('restore-pick-source-btn'));
+    await waitFor(() => expect(onBrowseFolder).toHaveBeenCalledTimes(2));
+    expect((screen.getByTestId('restore-opt-gzip') as HTMLInputElement).checked).toBe(false);
+  });
+});
+
+describe('RestoreView selection semantics', () => {
+  it('sends selections: [] when everything is checked with no renames', async () => {
+    const props = renderRestoreView();
+    await browseFolder(props);
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+    expect(props.onRunRestore).toHaveBeenCalledWith(expect.objectContaining({ selections: [] }));
+  });
+
+  it('excludes an unchecked collection from selections', async () => {
+    const props = renderRestoreView();
+    await browseFolder(props);
+    fireEvent.click(screen.getByTestId('restore-tree-coll-sales.orders'));
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+    expect(props.onRunRestore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selections: [
+          { db: 'sales', coll: 'users' },
+          { db: 'inventory', coll: 'items' },
+        ],
+      })
+    );
+  });
+
+  it('adds renameTo and still enumerates every collection when all are checked but one is renamed', async () => {
+    const props = renderRestoreView();
+    await browseFolder(props);
+    fireEvent.change(screen.getByTestId('restore-rename-sales.users'), {
+      target: { value: 'usersRenamed' },
+    });
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+    expect(props.onRunRestore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selections: [
+          { db: 'sales', coll: 'orders' },
+          { db: 'sales', coll: 'users', renameTo: 'usersRenamed' },
+          { db: 'inventory', coll: 'items' },
+        ],
+      })
+    );
+  });
+});
+
+describe('RestoreView empty selection guard', () => {
+  it('unchecking every collection disables Run and shows a hint', async () => {
+    const props = renderRestoreView();
+    await browseFolder(props);
+
+    fireEvent.click(screen.getByTestId('restore-tree-coll-sales.orders'));
+    fireEvent.click(screen.getByTestId('restore-tree-coll-sales.users'));
+    expect(screen.queryByTestId('restore-empty-selection-hint')).not.toBeInTheDocument();
+    expect(screen.getByTestId('restore-run-btn')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('restore-tree-coll-inventory.items'));
+    expect(screen.getByTestId('restore-empty-selection-hint')).toBeInTheDocument();
+    expect(screen.getByTestId('restore-run-btn')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+    expect(props.onRunRestore).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('restore-tree-coll-sales.orders'));
+    expect(screen.queryByTestId('restore-empty-selection-hint')).not.toBeInTheDocument();
+    expect(screen.getByTestId('restore-run-btn')).toBeEnabled();
+  });
+});
+
+describe('RestoreView rename contract', () => {
+  it('labels the rename input with the db.name contract', async () => {
+    const props = renderRestoreView();
+    await browseFolder(props);
+    const input = screen.getByTestId('restore-rename-sales.users');
+    expect(input).toHaveAttribute('placeholder', 'new name (or db.name)');
+    expect(input.getAttribute('title')).toMatch(/same database/i);
+  });
+});
+
+describe('RestoreView double-submit guard', () => {
+  it('double-clicking Restore starts only one run and shows Starting…', async () => {
+    let resolveRun!: () => void;
+    const onRunRestore = vi.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRun = resolve;
+      })
+    );
+    const props = renderRestoreView({ onRunRestore });
+    await browseFolder(props);
+
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+
+    expect(onRunRestore).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('restore-run-btn')).toBeDisabled();
+    expect(screen.getByTestId('restore-run-btn')).toHaveTextContent('Starting…');
+
+    resolveRun();
+    await waitFor(() => expect(screen.getByTestId('restore-run-btn')).toBeEnabled());
+  });
+
+  it('confirming a drop restore keeps further clicks from starting a second run', async () => {
+    const onRunRestore = vi.fn().mockReturnValue(new Promise<void>(() => {}));
+    const props = renderRestoreView({ onRunRestore });
+    await browseFolder(props);
+
+    fireEvent.click(screen.getByTestId('restore-opt-drop'));
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+    fireEvent.click(screen.getByTestId('restore-drop-confirm-btn'));
+
+    expect(onRunRestore).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('restore-run-btn')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+    expect(onRunRestore).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('RestoreView archive mode', () => {
+  it('hides the tree and shows filter inputs plus a note', () => {
+    renderRestoreView();
+    fireEvent.click(screen.getByTestId('restore-source-archive'));
+    expect(screen.queryByTestId('restore-tree')).not.toBeInTheDocument();
+    expect(screen.getByTestId('restore-archive-filter-db')).toBeInTheDocument();
+    expect(screen.getByTestId('restore-archive-filter-coll')).toBeInTheDocument();
+    expect(screen.getByTestId('restore-archive-note')).toBeInTheDocument();
+  });
+
+  it('auto-sets gzip when the picked archive file ends with .gz', async () => {
+    const onPickArchiveFile = vi.fn().mockResolvedValue('/tmp/dump.archive.GZ');
+    renderRestoreView({ onPickArchiveFile });
+    fireEvent.click(screen.getByTestId('restore-source-archive'));
+    fireEvent.click(screen.getByTestId('restore-pick-source-btn'));
+    await waitFor(() => expect(screen.getByTestId('restore-source-path')).toHaveTextContent('.GZ'));
+    expect((screen.getByTestId('restore-opt-gzip') as HTMLInputElement).checked).toBe(true);
+  });
+});
+
+describe('RestoreView oplog replay narrowing', () => {
+  it('disables oplogReplay whenever narrowing is active', async () => {
+    const props = renderRestoreView();
+    await browseFolder(props);
+    expect(screen.getByTestId('restore-opt-oplogreplay')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('restore-tree-coll-sales.orders'));
+    expect(screen.getByTestId('restore-opt-oplogreplay')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('restore-tree-coll-sales.orders'));
+    expect(screen.getByTestId('restore-opt-oplogreplay')).toBeEnabled();
+
+    fireEvent.change(screen.getByTestId('restore-rename-sales.users'), {
+      target: { value: 'usersRenamed' },
+    });
+    expect(screen.getByTestId('restore-opt-oplogreplay')).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('restore-rename-sales.users'), { target: { value: '' } });
+    expect(screen.getByTestId('restore-opt-oplogreplay')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('restore-source-archive'));
+    expect(screen.getByTestId('restore-opt-oplogreplay')).toBeEnabled();
+    fireEvent.change(screen.getByTestId('restore-archive-filter-db'), { target: { value: 'sales' } });
+    expect(screen.getByTestId('restore-opt-oplogreplay')).toBeDisabled();
+  });
+});
+
+describe('RestoreView drop confirmation', () => {
+  it('requires an inline confirm before running when drop is enabled', async () => {
+    const props = renderRestoreView();
+    await browseFolder(props);
+    fireEvent.click(screen.getByTestId('restore-opt-drop'));
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+    expect(props.onRunRestore).not.toHaveBeenCalled();
+    const confirm = screen.getByTestId('restore-drop-confirm');
+    expect(confirm).toHaveTextContent('sales.orders');
+    expect(confirm).toHaveTextContent('sales.users');
+    expect(confirm).toHaveTextContent('inventory.items');
+    fireEvent.click(screen.getByTestId('restore-drop-confirm-btn'));
+    expect(props.onRunRestore).toHaveBeenCalledWith(expect.objectContaining({ drop: true }));
+  });
+
+  it('runs immediately without drop', async () => {
+    const props = renderRestoreView();
+    await browseFolder(props);
+    fireEvent.click(screen.getByTestId('restore-run-btn'));
+    expect(screen.queryByTestId('restore-drop-confirm')).not.toBeInTheDocument();
+    expect(props.onRunRestore).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('RestoreView command preview', () => {
+  it('debounces onPreviewCommand by 300ms and renders the result', async () => {
+    vi.useFakeTimers();
+    const onPreviewCommand = vi.fn().mockResolvedValue('mongorestore --drop /tmp/dump');
+    renderRestoreView({ onPreviewCommand });
+    fireEvent.click(screen.getByTestId('restore-pick-source-btn'));
+    await vi.waitFor(() => expect(screen.getByTestId('restore-source-path')).toBeInTheDocument());
+    expect(onPreviewCommand).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(350);
+    expect(onPreviewCommand).toHaveBeenCalled();
+    vi.useRealTimers();
+    await waitFor(() =>
+      expect(screen.getByTestId('restore-preview-cmd')).toHaveTextContent('mongorestore --drop /tmp/dump')
+    );
+  });
+});

--- a/src/components/__tests__/SettingsModal.test.tsx
+++ b/src/components/__tests__/SettingsModal.test.tsx
@@ -1,6 +1,7 @@
+import type { ComponentProps } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { SettingsView } from '../SettingsModal';
+import { SettingsView, MONGO_TOOLS_DIR_KEY } from '../SettingsModal';
 import { writeUpdateCheckSnapshot } from '../../lib/updateCheckState';
 
 const mockInvoke = vi.fn();
@@ -25,8 +26,8 @@ vi.mock('../../lib/vault', () => ({
   biometricDisable: () => mockBiometricDisable(),
 }));
 
-function renderSettings() {
-  return render(<SettingsView />);
+function renderSettings(props: Partial<ComponentProps<typeof SettingsView>> = {}) {
+  return render(<SettingsView {...props} />);
 }
 
 async function openTab(tabId: string) {
@@ -51,6 +52,12 @@ describe('SettingsView Component', () => {
       if (cmd === 'detect_local_agents') {
         return Promise.resolve([]);
       }
+      if (cmd === 'managed_tools_status') {
+        return Promise.resolve([
+          { name: 'database-tools', version: '100.9.4', installed: false, path: null },
+          { name: 'mongosh', version: '2.3.1', installed: true, path: '/data/tools/mongosh/bin/mongosh' },
+        ]);
+      }
       return Promise.resolve();
     });
   });
@@ -61,15 +68,81 @@ describe('SettingsView Component', () => {
     expect(await screen.findByText('Settings')).toBeInTheDocument();
     expect(await screen.findByText('Theme preset')).toBeInTheDocument();
 
-    await openTab('settings-tab-mongosh');
+    await openTab('settings-tab-tools');
     const pathInput = await screen.findByTestId('mongosh-path-input') as HTMLInputElement;
     expect(pathInput.value).toBe('/usr/local/bin/mongosh');
+  });
+
+  it('round-trips the MongoDB Database Tools directory through localStorage', async () => {
+    localStorage.setItem(MONGO_TOOLS_DIR_KEY, '/opt/homebrew/bin');
+    renderSettings();
+
+    await openTab('settings-tab-tools');
+    const dirInput = await screen.findByTestId('mongo-tools-dir-input') as HTMLInputElement;
+    expect(dirInput.value).toBe('/opt/homebrew/bin');
+
+    fireEvent.change(dirInput, { target: { value: '/usr/local/mongodb-tools/bin' } });
+    expect(dirInput.value).toBe('/usr/local/mongodb-tools/bin');
+    expect(localStorage.getItem(MONGO_TOOLS_DIR_KEY)).toBe('/usr/local/mongodb-tools/bin');
+  });
+
+  it('shows managed tool versions and wires the Install tools button', async () => {
+    const onInstallTools = vi.fn();
+    renderSettings({ onInstallTools });
+
+    await openTab('settings-tab-tools');
+
+    expect(await screen.findByTestId('settings-managed-tool-database-tools')).toHaveTextContent(
+      'not installed'
+    );
+    expect(screen.getByTestId('settings-managed-tool-mongosh')).toHaveTextContent(
+      'v2.3.1 installed'
+    );
+
+    fireEvent.click(screen.getByTestId('settings-install-tools-btn'));
+    expect(onInstallTools).toHaveBeenCalled();
+  });
+
+  it('refreshes the managed tools card when toolStatusRefreshNonce changes (regression: stale card after install)', async () => {
+    let call = 0;
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '' });
+      if (cmd === 'detect_local_agents') return Promise.resolve([]);
+      if (cmd === 'managed_tools_status') {
+        call += 1;
+        if (call === 1) {
+          return Promise.resolve([
+            { name: 'database-tools', version: '100.9.4', installed: false, path: null },
+            { name: 'mongosh', version: '2.3.1', installed: false, path: null },
+          ]);
+        }
+        return Promise.resolve([
+          { name: 'database-tools', version: '100.9.4', installed: true, path: '/data/tools/database-tools/bin' },
+          { name: 'mongosh', version: '2.3.1', installed: true, path: '/data/tools/mongosh/bin/mongosh' },
+        ]);
+      }
+      return Promise.resolve();
+    });
+
+    const { rerender } = renderSettings({ toolStatusRefreshNonce: 0 });
+    await openTab('settings-tab-tools');
+
+    expect(await screen.findByTestId('settings-managed-tool-mongosh')).toHaveTextContent('not installed');
+
+    // Simulate the App-level ToolSetupDialog "Done" handler bumping the nonce
+    // after an install completes while Settings is still mounted.
+    rerender(<SettingsView toolStatusRefreshNonce={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('settings-managed-tool-mongosh')).toHaveTextContent('v2.3.1 installed');
+    });
+    expect(call).toBeGreaterThanOrEqual(2);
   });
 
   it('saves and tests mongosh path through backend settings commands', async () => {
     renderSettings();
 
-    await openTab('settings-tab-mongosh');
+    await openTab('settings-tab-tools');
     const pathInput = await screen.findByTestId('mongosh-path-input') as HTMLInputElement;
     fireEvent.change(pathInput, { target: { value: '/opt/homebrew/bin/mongosh' } });
 

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -612,6 +612,108 @@ describe('Sidebar Component', () => {
     expect(handleDisconnect).toHaveBeenCalledWith('uuid-1234');
   });
 
+  it('opens Dump/Restore from the connection, database, and collection context menus', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases' && args.id === 'conn-1') {
+        return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections' && args.id === 'conn-1' && args.db === 'sales_db') {
+        return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    const handleOpenDump = vi.fn();
+    const handleOpenRestore = vi.fn();
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Prod DB Server', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onOpenDump={handleOpenDump}
+        onOpenRestore={handleOpenRestore}
+      />
+    );
+
+    // Connection-level: Dump (server scope) and Restore.
+    const serverNode = await screen.findByText('Prod DB Server');
+    fireEvent.contextMenu(serverNode.closest('div')!);
+    fireEvent.click(screen.getByTestId('ctx-dump-conn-1'));
+    expect(handleOpenDump).toHaveBeenCalledWith('conn-1');
+
+    fireEvent.contextMenu(serverNode.closest('div')!);
+    fireEvent.click(screen.getByTestId('ctx-restore-conn-1'));
+    expect(handleOpenRestore).toHaveBeenCalledWith('conn-1');
+
+    // Database-level: Dump scoped to the database.
+    const dbNode = await screen.findByText('sales_db');
+    fireEvent.contextMenu(dbNode);
+    fireEvent.click(screen.getByTestId('ctx-dump-db-conn-1-sales_db'));
+    expect(handleOpenDump).toHaveBeenCalledWith('conn-1', 'sales_db');
+
+    // Collection-level: Dump scoped to the collection.
+    fireEvent.click(dbNode);
+    const collectionsFolder = await screen.findByText('Collections');
+    fireEvent.click(collectionsFolder);
+    const collectionNode = await screen.findByText('customers');
+    fireEvent.contextMenu(collectionNode);
+    fireEvent.click(screen.getByTestId('ctx-dump-coll-conn-1-sales_db-customers'));
+    expect(handleOpenDump).toHaveBeenCalledWith('conn-1', 'sales_db', 'customers');
+  });
+
+  it('hides Dump/Restore context-menu items for mock connections', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases' && args.id === 'conn-1') {
+        return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections' && args.id === 'conn-1' && args.db === 'sales_db') {
+        return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Sample (mqlens_demo)', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onOpenDump={vi.fn()}
+        onOpenRestore={vi.fn()}
+      />
+    );
+
+    // Connection-level: neither Dump nor Restore is offered.
+    const serverNode = await screen.findByText('Sample (mqlens_demo)');
+    fireEvent.contextMenu(serverNode.closest('div')!);
+    expect(screen.queryByTestId('ctx-dump-conn-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ctx-restore-conn-1')).not.toBeInTheDocument();
+    // Close the menu before opening the next one.
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    // Database-level: no Dump item.
+    const dbNode = await screen.findByText('sales_db');
+    fireEvent.contextMenu(dbNode);
+    expect(screen.queryByTestId('ctx-dump-db-conn-1-sales_db')).not.toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    // Collection-level: no Dump item.
+    fireEvent.click(dbNode);
+    const collectionsFolder = await screen.findByText('Collections');
+    fireEvent.click(collectionsFolder);
+    const collectionNode = await screen.findByText('customers');
+    fireEvent.contextMenu(collectionNode);
+    expect(screen.queryByTestId('ctx-dump-coll-conn-1-sales_db-customers')).not.toBeInTheDocument();
+  });
+
   it('creates, renames, and drops collections/databases via the backend for a real connection (C6/H6)', async () => {
     const calls: any[] = [];
     mockInvoke.mockImplementation((cmd, args) => {
@@ -833,12 +935,17 @@ describe('Sidebar Component', () => {
     fireEvent.click(screen.getByRole('button', { name: /pinned/i }));
     fireEvent.click(await screen.findByTestId('pinned-item-coll::Local::sales_db::orders'));
 
-    await waitFor(() => {
-      expect(onConnectProfile).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'prof-1', name: 'Local' }),
-      );
-      expect(onSelectCollection).toHaveBeenCalledWith('conn-new', 'sales_db', 'orders');
-    });
+    // The auto-connect chain (connect profile → select collection) crosses two
+    // awaits; under CI's coverage instrumentation the default 1s can flake.
+    await waitFor(
+      () => {
+        expect(onConnectProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'prof-1', name: 'Local' }),
+        );
+        expect(onSelectCollection).toHaveBeenCalledWith('conn-new', 'sales_db', 'orders');
+      },
+      { timeout: 5000 },
+    );
   });
 
   it('shows a color dot for tagged active connections', async () => {

--- a/src/components/__tests__/TaskManager.copy.test.tsx
+++ b/src/components/__tests__/TaskManager.copy.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { TaskManager, type ExportTaskInfo } from '../TaskManager';
 
@@ -26,6 +26,40 @@ describe('TaskManager copy tasks', () => {
     expect(onCancel).toHaveBeenCalledWith('t1');
   });
 
+  it('re-enables the Cancel button when the cancel request fails (onCancel resolves false)', async () => {
+    const onCancel = vi.fn().mockResolvedValue(false);
+    const running: ExportTaskInfo = { ...copyTask, status: 'running', summary: undefined };
+    render(<TaskManager tasks={[running]} onRefresh={() => {}} onClearFinished={() => {}} onCancel={onCancel} />);
+
+    const btn = screen.getByRole('button', { name: /cancel/i });
+    fireEvent.click(btn);
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent('Cancelling…');
+    expect(onCancel).toHaveBeenCalledWith('t1');
+
+    // The cancel failed — the button must come back so the user can retry.
+    await waitFor(() => expect(btn).not.toBeDisabled());
+    expect(btn).toHaveTextContent('Cancel');
+  });
+
+  it('prunes cancelling state once the task leaves running, so a later run gets a fresh Cancel', async () => {
+    const onCancel = vi.fn().mockResolvedValue(true);
+    const running: ExportTaskInfo = { ...copyTask, status: 'running', summary: undefined };
+    const { rerender } = render(
+      <TaskManager tasks={[running]} onRefresh={() => {}} onClearFinished={() => {}} onCancel={onCancel} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.getByRole('button', { name: /cancelling/i })).toBeDisabled();
+
+    // Task reaches a terminal state — the stale id is pruned from the set…
+    const cancelled: ExportTaskInfo = { ...running, status: 'cancelled' };
+    rerender(<TaskManager tasks={[cancelled]} onRefresh={() => {}} onClearFinished={() => {}} onCancel={onCancel} />);
+    // …so when the same id runs again (e.g. a retried task), Cancel is enabled.
+    rerender(<TaskManager tasks={[running]} onRefresh={() => {}} onClearFinished={() => {}} onCancel={onCancel} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /^cancel$/i })).not.toBeDisabled());
+  });
+
   it('renders cancelled task as muted/neutral, not as success', () => {
     const cancelled: ExportTaskInfo = {
       ...copyTask, status: 'cancelled', processed: 3, total: 5, message: 'Copy cancelled', summary: undefined,
@@ -48,6 +82,26 @@ describe('TaskManager copy tasks', () => {
     // No Cancel button shown for a cancelled task
     expect(screen.queryByRole('button', { name: /cancel/i })).toBeNull();
   });
+
+  it.each(['dump', 'restore'] as const)(
+    'shows a Cancel button for running %s tasks and calls onCancel',
+    (kind) => {
+      const onCancel = vi.fn();
+      const running: ExportTaskInfo = {
+        id: 'tool-task-1',
+        kind,
+        label: kind === 'dump' ? 'Dump sales_db → out' : 'Restore out → sales_db',
+        status: 'running',
+        processed: 0,
+        total: null,
+        message: 'Running',
+        createdAtMs: 1,
+      };
+      render(<TaskManager tasks={[running]} onRefresh={() => {}} onClearFinished={() => {}} onCancel={onCancel} />);
+      screen.getByRole('button', { name: /cancel/i }).click();
+      expect(onCancel).toHaveBeenCalledWith('tool-task-1');
+    }
+  );
 
   it('shows failure tooltip on summary block when failures present', () => {
     const withFailures: ExportTaskInfo = {

--- a/src/components/__tests__/ToolSetupDialog.test.tsx
+++ b/src/components/__tests__/ToolSetupDialog.test.tsx
@@ -1,0 +1,205 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ToolSetupDialog, type ManagedToolStatusUi } from '../ToolSetupDialog';
+
+const statuses: ManagedToolStatusUi[] = [
+  { name: 'database-tools', version: '100.9.4', installed: false, path: null },
+  { name: 'mongosh', version: '2.3.1', installed: true, path: '/data/tools/mongosh/bin/mongosh' },
+];
+
+const baseProps = {
+  open: true,
+  onOpenChange: () => {},
+  statuses,
+  installTask: null,
+  onInstall: vi.fn(),
+};
+
+describe('ToolSetupDialog', () => {
+  it('lists both tools with versions; defaults checked to not-installed tools only', () => {
+    render(<ToolSetupDialog {...baseProps} onInstall={vi.fn()} />);
+
+    expect(screen.getByTestId('toolsetup-dialog')).toBeInTheDocument();
+
+    expect(screen.getByTestId('toolsetup-version-database-tools')).toHaveTextContent('100.9.4');
+    expect(screen.getByTestId('toolsetup-version-mongosh')).toHaveTextContent('2.3.1');
+
+    const dbToolsCheck = screen.getByTestId('toolsetup-check-database-tools') as HTMLInputElement;
+    const mongoshCheck = screen.getByTestId('toolsetup-check-mongosh') as HTMLInputElement;
+    expect(dbToolsCheck.checked).toBe(true);
+    expect(mongoshCheck.checked).toBe(false);
+
+    // Installed tool shows an "Installed" indicator.
+    expect(screen.getByText(/installed/i)).toBeInTheDocument();
+
+    expect(screen.getByTestId('toolsetup-size-note')).toBeInTheDocument();
+    expect(screen.getByTestId('toolsetup-license-note')).toHaveTextContent(
+      'Official Apache-2.0 builds downloaded from mongodb.com'
+    );
+  });
+
+  it('disables Install with zero tools checked, and fires onInstall(names, false) for a fresh install', () => {
+    const onInstall = vi.fn();
+    render(<ToolSetupDialog {...baseProps} onInstall={onInstall} />);
+
+    const dbToolsCheck = screen.getByTestId('toolsetup-check-database-tools') as HTMLInputElement;
+    fireEvent.click(dbToolsCheck); // uncheck the only selected tool
+    expect(screen.getByTestId('toolsetup-install-btn')).toBeDisabled();
+
+    fireEvent.click(dbToolsCheck); // re-check
+    expect(screen.getByTestId('toolsetup-install-btn')).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+    expect(onInstall).toHaveBeenCalledWith(['database-tools'], false);
+  });
+
+  it('shows a reinstall note and fires force:true when any selected tool is already installed', () => {
+    const onInstall = vi.fn();
+    render(<ToolSetupDialog {...baseProps} onInstall={onInstall} />);
+
+    const mongoshCheck = screen.getByTestId('toolsetup-check-mongosh') as HTMLInputElement;
+    fireEvent.click(mongoshCheck); // also select the already-installed tool
+
+    expect(screen.getByText(/will reinstall/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+    expect(onInstall).toHaveBeenCalledWith(['database-tools', 'mongosh'], true);
+  });
+
+  it('renders stage message and a percent progress bar while running, and wires Cancel', () => {
+    const onCancel = vi.fn();
+    render(
+      <ToolSetupDialog
+        {...baseProps}
+        onCancel={onCancel}
+        installTask={{ status: 'running', message: 'Downloading database-tools…', processed: 40, total: 100 }}
+      />
+    );
+
+    expect(screen.getByTestId('toolsetup-stage')).toHaveTextContent('Downloading database-tools…');
+    const progress = screen.getByTestId('toolsetup-progress');
+    expect(progress).toBeInTheDocument();
+    expect(progress).toHaveAttribute('aria-valuenow', '40');
+
+    fireEvent.click(screen.getByTestId('toolsetup-cancel-btn'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('renders an indeterminate progress bar when total is unknown', () => {
+    render(
+      <ToolSetupDialog
+        {...baseProps}
+        installTask={{ status: 'running', message: 'Extracting…', processed: 0, total: null }}
+      />
+    );
+    const progress = screen.getByTestId('toolsetup-progress');
+    expect(progress).not.toHaveAttribute('aria-valuenow');
+    expect(progress.getAttribute('data-indeterminate')).toBe('true');
+  });
+
+  it('shows the error and retries onInstall with the same args on failure', () => {
+    const onInstall = vi.fn();
+    const { rerender } = render(<ToolSetupDialog {...baseProps} onInstall={onInstall} installTask={null} />);
+
+    // Select both tools (one installed) so the submitted call uses force: true.
+    fireEvent.click(screen.getByTestId('toolsetup-check-mongosh'));
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+    expect(onInstall).toHaveBeenNthCalledWith(1, ['database-tools', 'mongosh'], true);
+
+    rerender(
+      <ToolSetupDialog
+        {...baseProps}
+        onInstall={onInstall}
+        installTask={{ status: 'failed', message: 'Network error', processed: 0, total: null }}
+      />
+    );
+
+    expect(screen.getByTestId('toolsetup-error')).toHaveTextContent('Network error');
+
+    fireEvent.click(screen.getByTestId('toolsetup-retry-btn'));
+    expect(onInstall).toHaveBeenNthCalledWith(2, ['database-tools', 'mongosh'], true);
+  });
+
+  it('treats a cancelled task as terminal: shows a Cancelled heading, retries with the same args, and dismisses', () => {
+    const onInstall = vi.fn();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <ToolSetupDialog {...baseProps} onInstall={onInstall} onOpenChange={onOpenChange} installTask={null} />
+    );
+
+    fireEvent.click(screen.getByTestId('toolsetup-install-btn'));
+    expect(onInstall).toHaveBeenNthCalledWith(1, ['database-tools'], false);
+
+    rerender(
+      <ToolSetupDialog
+        {...baseProps}
+        onInstall={onInstall}
+        onOpenChange={onOpenChange}
+        installTask={{ status: 'cancelled', message: 'Install cancelled', processed: 1, total: 2 }}
+      />
+    );
+
+    expect(screen.getByTestId('toolsetup-cancelled-heading')).toHaveTextContent('Cancelled');
+    expect(screen.getByTestId('toolsetup-error')).toHaveTextContent('Install cancelled');
+
+    fireEvent.click(screen.getByTestId('toolsetup-retry-btn'));
+    expect(onInstall).toHaveBeenNthCalledWith(2, ['database-tools'], false);
+
+    fireEvent.click(screen.getByTestId('toolsetup-dismiss-btn'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('disables Install and shows Starting… while the start call is in flight, so a double-click fires once', async () => {
+    let resolveStart!: () => void;
+    const onInstall = vi.fn(() => new Promise<void>((resolve) => { resolveStart = resolve; }));
+    render(<ToolSetupDialog {...baseProps} onInstall={onInstall} />);
+
+    const btn = screen.getByTestId('toolsetup-install-btn');
+    fireEvent.click(btn);
+    fireEvent.click(btn); // double-click must not start a second install
+
+    expect(onInstall).toHaveBeenCalledTimes(1);
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent('Starting…');
+
+    resolveStart();
+    await waitFor(() => expect(btn).not.toBeDisabled());
+    expect(btn).toHaveTextContent('Install');
+  });
+
+  it('retains a terminal install state when the task entry disappears (Clear finished), and resets on close', () => {
+    const { rerender } = render(
+      <ToolSetupDialog
+        {...baseProps}
+        installTask={{ status: 'completed', message: 'Installed database-tools', processed: 2, total: 2 }}
+      />
+    );
+    expect(screen.getByTestId('toolsetup-done-btn')).toBeInTheDocument();
+
+    // "Clear finished" removes the store entry — the dialog must keep showing
+    // the completed screen, not silently revert to the checklist.
+    rerender(<ToolSetupDialog {...baseProps} installTask={null} />);
+    expect(screen.getByTestId('toolsetup-done-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('toolsetup-install-btn')).not.toBeInTheDocument();
+
+    // Closing drops the snapshot, so reopening shows the fresh checklist.
+    rerender(<ToolSetupDialog {...baseProps} open={false} installTask={null} />);
+    rerender(<ToolSetupDialog {...baseProps} open installTask={null} />);
+    expect(screen.getByTestId('toolsetup-install-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('toolsetup-done-btn')).not.toBeInTheDocument();
+  });
+
+  it('shows Done when completed and fires onDone', () => {
+    const onDone = vi.fn();
+    render(
+      <ToolSetupDialog
+        {...baseProps}
+        onDone={onDone}
+        installTask={{ status: 'completed', message: 'Done', processed: 2, total: 2 }}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('toolsetup-done-btn'));
+    expect(onDone).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds Dump and Restore tabs backed by mongodump/mongorestore, plus a guided setup flow that lets MQLens download and manage the MongoDB Database Tools and mongosh itself.

### Dump & Restore
- Dump tab with scope (server/database/collection), format, and mongodump options; Restore tab with dump browsing, collection renames, and mongorestore options
- Runs the tools as cancellable background tasks with live progress parsed from tool output
- argv builders strip the URI path database where the tools reject it, and tunneled runs use direct connection with fail-fast server selection

### Guided tool setup & managed installs
- Tool discovery for the MongoDB Database Tools with a configurable tools directory (falls back to PATH)
- Guided setup dialog reachable from guidance cards, shell errors, and Settings when tools are missing; surfaces real install failure reasons
- Managed install pipeline: pinned manifest with checksums, archive extraction, staged-binary probing before the install swap, all as a cancellable background task
- Managed tool directory feeds mongodump, mongorestore, and mongosh resolution

### Settings
- The Mongosh settings section is now **Tools**: mongosh binary path, Database Tools directory, and managed tool status with an install entry point

## Test plan
- [x] Frontend unit tests (vitest) pass, including new coverage for dump/restore tabs, the setup dialog, and the Tools settings section
- [x] TypeScript typecheck clean
- [ ] Manual: dump + restore against a live server, managed install on a machine without the tools

### Task experience fixes (from manual testing)
- Task rows track the tool process live: "started — connecting", elapsed-time ticks while the server is silent, raw stderr surfaced until real progress arrives, in-flight `[####]` progress lines parsed, and the redacted URI shown on the row for diagnosis
- Cancelling a task that just finished is a quiet no-op instead of an error; the Cancel button disables after the first click; indeterminate bars pulse
- TLS-relaxation URI params (`tlsAllowInvalidCertificates`, `tlsInsecure`, `tlsAllowInvalidHostnames`) are stripped and passed to mongodump/mongorestore as `--tlsInsecure` — the tools ignore them in connection strings and otherwise hang failing certificate validation against internal-CA clusters
