### PR TITLE
fix: unbounded memory growth in the resource monitor on Linux (#165)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,8 +106,15 @@ pub fn resource_usage_impl(state: &AppState) -> ResourceUsage {
         pids.is_empty() || tree_at.elapsed().as_secs() >= RESOURCE_TREE_REFRESH_SECS
     };
 
+    // Only memory + CPU are read below. The default refresh kind would also
+    // collect disk usage, exe paths, and (Linux) one entry per THREAD via
+    // with_tasks — and with remove_dead_processes=false the retained System
+    // kept every process/thread that ever existed, growing RSS without bound
+    // on busy hosts (issue #165). Refresh minimally and always purge the dead.
+    let refresh_kind = sysinfo::ProcessRefreshKind::nothing().with_memory().with_cpu();
+
     if rebuild_tree {
-        sys.refresh_processes(sysinfo::ProcessesToUpdate::All, false);
+        sys.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, refresh_kind);
         let mut tree: HashSet<sysinfo::Pid> = HashSet::new();
         tree.insert(pid);
         loop {
@@ -135,7 +142,7 @@ pub fn resource_usage_impl(state: &AppState) -> ResourceUsage {
     } else {
         let pids = state.resource_pids.lock().unwrap_or_else(|p| p.into_inner());
         if !pids.is_empty() {
-            sys.refresh_processes(sysinfo::ProcessesToUpdate::Some(&pids), false);
+            sys.refresh_processes_specifics(sysinfo::ProcessesToUpdate::Some(&pids), true, refresh_kind);
         }
     }
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -50,6 +50,51 @@ mod tests {
         assert!(usage.cpu_percent >= 0.0);
     }
 
+    /// The retained sysinfo System must not accumulate dead processes across
+    /// tree rebuilds — with `remove_dead_processes: false` every process (and,
+    /// on Linux, every thread) that ever existed while the app ran stayed in
+    /// the map forever, growing RSS without bound on busy hosts (issue #165).
+    #[cfg(unix)]
+    #[test]
+    fn test_resource_usage_purges_dead_processes_on_rebuild() {
+        use std::time::{Duration, Instant};
+
+        let state = AppState::new();
+        crate::resource_usage_impl(&state); // initial tree build
+
+        // A child of this process, alive across the next rebuild.
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .stdout(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let child_pid = sysinfo::Pid::from_u32(child.id());
+
+        let force_rebuild = |state: &AppState| {
+            *state.resource_tree_at.lock().unwrap() = Instant::now()
+                .checked_sub(Duration::from_secs(
+                    crate::limits::RESOURCE_TREE_REFRESH_SECS + 1,
+                ))
+                .expect("system clock supports back-dating");
+            crate::resource_usage_impl(state);
+        };
+
+        force_rebuild(&state);
+        assert!(
+            state.sys.lock().unwrap().process(child_pid).is_some(),
+            "live child should be captured in the retained System"
+        );
+
+        child.kill().expect("kill child");
+        child.wait().expect("reap child");
+
+        force_rebuild(&state);
+        assert!(
+            state.sys.lock().unwrap().process(child_pid).is_none(),
+            "dead child must be purged from the retained System on rebuild"
+        );
+    }
+
     #[tokio::test]
     async fn test_mock_connection_lifecycle() {
         let state = AppState::new();


### PR DESCRIPTION
Fixes #165.

## Root cause

The status bar polls `get_resource_usage` every 5s; every 10s it rebuilds the process tree with `refresh_processes(ProcessesToUpdate::All, false)` against the `sysinfo::System` retained for the app's lifetime in `AppState` (kept for CPU delta sampling). Two compounding problems:

1. **`remove_dead_processes: false`** — every process that ever existed while MQLens ran stayed in the retained map forever.
2. The convenience `refresh_processes` uses a refresh kind that includes **`with_tasks()`**, which on Linux adds one map entry per **thread** of every process (plus disk-usage counters and exe paths nobody reads).

On a Linux host with continuous workload (constant process/thread churn), the retained map grows without bound — consistent with the reported 8+ GB RSS after ~2h. The per-thread entries also inflate the status bar's memory figure on Linux by summing each thread's RSS into the process-tree total. macOS is far less affected (`with_tasks` is Linux-only, lower PID churn), matching the Linux-only report.

## Fix

`refresh_processes_specifics` with `ProcessRefreshKind::nothing().with_memory().with_cpu()` (the only fields the status bar reads) and `remove_dead_processes: true` on both the full rebuild and the per-tree refresh.

## Test plan
- [x] New test `test_resource_usage_purges_dead_processes_on_rebuild`: a child process captured in the retained System while alive must be gone after it dies and the tree rebuilds — fails on the previous code, passes now
- [x] Existing `test_resource_usage_sums_process_tree` still passes (CPU delta sampling and tree summing intact)
- [x] Full backend suite: 225 passed
- [ ] Reporter verification on Linux over a multi-hour run (asked in #165)