### PR TITLE
feat: connection URI import/export with secret redaction (#115)

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { invoke, Channel } from '@tauri-apps/api/core';
-import { open } from '@tauri-apps/plugin-dialog';
+import { open, save } from '@tauri-apps/plugin-dialog';
+import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
+import { buildExportUri, findMongoUriInText } from '@/lib/connection';
 import { useDialogs } from './dialogs/DialogProvider';
 import { PasswordInput } from './PasswordInput';
 import { useEscapeClose } from '../lib/useEscapeClose';
@@ -25,6 +27,13 @@ import {
   DialogOverlay,
 } from '@/components/ui/dialog';
 import { DraggableDialogContent } from '@/components/ui/draggable-dialog-content';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Switch } from '@/components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -387,6 +396,15 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
   // Editor Dialog nested modal states
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [editMode, setEditMode] = useState<'new' | 'edit' | 'duplicate'>('new');
+
+  // URI import (clipboard/file) error — shown inline next to the Import menu,
+  // since those sources fail without a dialog of their own to host a message.
+  const [importError, setImportError] = useState<string | null>(null);
+  // Export-URI dialog: the URI being exported and whether the source profile
+  // has an SSH tunnel (which can't be represented in a mongodb:// URI).
+  const [exportDialog, setExportDialog] = useState<{ uri: string; hasSsh: boolean } | null>(null);
+  const [exportIncludePassword, setExportIncludePassword] = useState(false);
+  const [exportIncludeSettings, setExportIncludeSettings] = useState(true);
   const [editorState, setEditorState] = useState<typeof BLANK_CONN>(BLANK_CONN);
   const [activeEditorTab, setActiveEditorTab] = useState('server');
   const [showPassword, setShowPassword] = useState(false);
@@ -670,7 +688,41 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
     }
   };
 
-  // Paste a connection string → auto-detect protocol, hosts, auth, and topology.
+  // Apply an imported connection string → auto-detect protocol, hosts, auth,
+  // and topology. Accepts free-form text (a .env line, a note) and extracts
+  // the first mongodb:// / mongodb+srv:// URI from it.
+  const applyImportedUri = (raw: string | null | undefined, sourceHint: string) => {
+    const found = raw ? findMongoUriInText(raw) : null;
+    if (!found) {
+      setImportError(`No mongodb:// or mongodb+srv:// connection string found ${sourceHint}.`);
+      return;
+    }
+    setImportError(null);
+    setEditorState(prev => ({ ...prev, uri: found, ...parseUriIntoFields(found) }));
+    setActiveEditorTab('server');
+  };
+
+  const handleImportFromClipboard = async () => {
+    try {
+      const text = await navigator.clipboard?.readText?.();
+      applyImportedUri(text, 'in the clipboard');
+    } catch {
+      setImportError('Could not read the clipboard.');
+    }
+  };
+
+  const handleImportFromFile = async () => {
+    try {
+      const path = await open({ multiple: false, title: 'Import connection URI from file' });
+      if (typeof path !== 'string') return;
+      const text = await readTextFile(path);
+      applyImportedUri(text, `in ${path.split(/[\\/]/).pop()}`);
+    } catch {
+      setImportError('Could not read the selected file.');
+    }
+  };
+
+  // Manual paste fallback (the original Import URI dialog).
   const handleImportUri = async () => {
     const uri = await prompt({
       title: 'Import Connection URI',
@@ -681,9 +733,37 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       validate: (v) => (/^mongodb(\+srv)?:\/\//i.test(v.trim()) ? null : 'Enter a mongodb:// or mongodb+srv:// URI'),
     });
     if (!uri || !uri.trim()) return;
+    setImportError(null);
     const clean = uri.trim();
     setEditorState(prev => ({ ...prev, uri: clean, ...parseUriIntoFields(clean) }));
     setActiveEditorTab('server');
+  };
+
+  // Export a URI with the password stripped by default (SSH/proxy secrets too);
+  // the toggles opt back into secrets or drop the settings query entirely.
+  const openExportDialog = (uri: string, hasSsh: boolean) => {
+    setExportIncludePassword(false);
+    setExportIncludeSettings(true);
+    setExportDialog({ uri, hasSsh });
+  };
+
+  const exportPreview = exportDialog
+    ? buildExportUri(exportDialog.uri, {
+        includePassword: exportIncludePassword,
+        includeSettings: exportIncludeSettings,
+      })
+    : '';
+
+  const handleExportSave = async () => {
+    if (!exportDialog) return;
+    try {
+      const path = await save({ defaultPath: 'connection-uri.txt', title: 'Save connection URI' });
+      if (!path) return;
+      await writeTextFile(path, `${exportPreview}\n`);
+      setExportDialog(null);
+    } catch {
+      /* user cancelled or write failed — keep the dialog open */
+    }
   };
 
   const runTestStepSequence = async () => {
@@ -818,11 +898,11 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                 <Trash2 size={12} />
                 <span>Delete</span>
               </Button>
-              <Button variant="outline" size="sm" className="h-8 gap-1.5 text-ui-xs" onClick={() => {
-                if (selectedProfile) navigator.clipboard?.writeText(selectedProfile.uri);
+              <Button variant="outline" size="sm" className="h-8 gap-1.5 text-ui-xs" data-testid="export-uri-btn" onClick={() => {
+                if (selectedProfile) openExportDialog(selectedProfile.uri, !!selectedProfile.ssh?.enabled);
               }}>
                 <ExternalLink size={12} />
-                <span>Copy URI</span>
+                <span>Export URI</span>
               </Button>
             </>
           )}
@@ -1212,9 +1292,9 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
               <div className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2">
                 <Badge variant="secondary" className="shrink-0 text-ui-2xs">URI</Badge>
                 <code className="min-w-0 flex-1 truncate font-mono text-ui-2xs text-muted-foreground">{maskUriPassword(buildUri(editorState))}</code>
-                <Button type="button" variant="ghost" size="sm" className="h-7 shrink-0 gap-1 text-ui-2xs" onClick={() => navigator.clipboard?.writeText(buildUri(editorState))}>
+                <Button type="button" variant="ghost" size="sm" className="h-7 shrink-0 gap-1 text-ui-2xs" data-testid="editor-export-uri-btn" onClick={() => openExportDialog(buildUri(editorState), editorState.sshEnabled)}>
                   <Copy size={12} />
-                  <span>Copy</span>
+                  <span>Export…</span>
                 </Button>
               </div>
             </section>
@@ -1842,10 +1922,30 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                   <RefreshCw size={11} className={testing ? 'animate-spin' : ''} />
                   <span>Test Connection</span>
                 </Button>
-                <Button variant="outline" size="sm" onClick={handleImportUri} data-testid="import-uri-btn">
-                  <ClipboardPaste size={11} />
-                  <span>Import URI</span>
-                </Button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" size="sm" data-testid="import-uri-btn">
+                      <ClipboardPaste size={11} />
+                      <span>Import URI</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start">
+                    <DropdownMenuItem onClick={handleImportFromClipboard} data-testid="import-from-clipboard">
+                      From clipboard
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleImportFromFile} data-testid="import-from-file">
+                      From a file…
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleImportUri} data-testid="import-paste-manually">
+                      Paste manually…
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                {importError && (
+                  <span className="self-center text-ui-2xs text-destructive" data-testid="import-uri-error">
+                    {importError}
+                  </span>
+                )}
               </div>
               <div className="flex gap-2">
                 <Button variant="outline" size="sm" onClick={() => setShowEditDialog(false)}>Cancel</Button>
@@ -1858,6 +1958,73 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
             </div>
             </div>
         </DraggableDialogContent>
+      </Dialog>
+
+      <Dialog open={!!exportDialog} onOpenChange={(o) => !o && setExportDialog(null)}>
+        <DialogContent className="max-w-lg" data-testid="export-uri-dialog">
+          <DialogHeader>
+            <DialogTitle>Export connection URI</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <code
+              className="block break-all rounded-lg border border-border bg-muted/30 px-3 py-2 font-mono text-ui-2xs"
+              data-testid="export-uri-preview"
+            >
+              {exportPreview}
+            </code>
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <Label htmlFor="export-include-password" className="text-ui-xs">Include password</Label>
+                <p className="text-ui-2xs text-muted-foreground">
+                  Off strips the auth password and proxy/token secrets so the URI is safe to share.
+                </p>
+              </div>
+              <Switch
+                id="export-include-password"
+                checked={exportIncludePassword}
+                onCheckedChange={setExportIncludePassword}
+                data-testid="export-include-password"
+              />
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <Label htmlFor="export-include-settings" className="text-ui-xs">Include connection settings</Label>
+                <p className="text-ui-2xs text-muted-foreground">
+                  TLS files, replica set, auth mechanism, appName, proxy, and timeouts.
+                </p>
+              </div>
+              <Switch
+                id="export-include-settings"
+                checked={exportIncludeSettings}
+                onCheckedChange={setExportIncludeSettings}
+                data-testid="export-include-settings"
+              />
+            </div>
+            {exportDialog?.hasSsh && (
+              <p className="text-ui-2xs text-muted-foreground" data-testid="export-ssh-note">
+                This connection uses an SSH tunnel. Tunnel settings can’t be represented in a
+                MongoDB URI and are not exported.
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="export-save-btn"
+              onClick={handleExportSave}
+            >
+              Save to file…
+            </Button>
+            <Button
+              size="sm"
+              data-testid="export-copy-btn"
+              onClick={() => navigator.clipboard?.writeText(exportPreview)}
+            >
+              Copy to clipboard
+            </Button>
+          </DialogFooter>
+        </DialogContent>
       </Dialog>
     </>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -385,7 +385,19 @@ export const Sidebar: React.FC<SidebarProps> = ({
     const existing = connectionIdForName(connectionName);
     if (existing) return existing;
 
-    const profile = connectionProfiles.find((p) => p.name === connectionName);
+    // The mount-time profile load may not have landed yet — clicking a pinned
+    // item right after launch used to dead-end on the empty list with a
+    // "no saved connection" error. Fall back to a fresh on-demand load.
+    let profile = connectionProfiles.find((p) => p.name === connectionName);
+    if (!profile) {
+      try {
+        const fresh = (await invoke<ConnectionProfile[]>('load_connection_profiles')) ?? [];
+        setConnectionProfiles(fresh);
+        profile = fresh.find((p) => p.name === connectionName);
+      } catch {
+        /* fall through to the error toast below */
+      }
+    }
     if (!profile || !onConnectProfile) {
       toast(
         `No saved connection "${connectionName}". Add it in Connection Manager, then try again.`,

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -25,6 +25,20 @@ vi.mock('@tauri-apps/api/core', () => ({
   },
 }));
 
+// File dialogs and text-file IO used by URI import/export.
+const mockOpenDialog = vi.fn();
+const mockSaveDialog = vi.fn();
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: (...args: any[]) => mockOpenDialog(...args),
+  save: (...args: any[]) => mockSaveDialog(...args),
+}));
+const mockReadTextFile = vi.fn();
+const mockWriteTextFile = vi.fn();
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  readTextFile: (...args: any[]) => mockReadTextFile(...args),
+  writeTextFile: (...args: any[]) => mockWriteTextFile(...args),
+}));
+
 const baseConn = {
   topology: 'standalone',
   hosts: [{ host: 'db.example.com', port: '27017' }],
@@ -847,6 +861,135 @@ describe('ConnectionManager Component', () => {
         id: 'p1',
         color_tag: null,
       });
+    });
+  });
+});
+
+describe('URI import and export', () => {
+  const prodProfile = {
+    id: 'p1',
+    name: 'Prod',
+    uri: 'mongodb://alice:pw@db1:27017/sales?tls=true&proxyHost=p&proxyPassword=ppw',
+    ssh: { enabled: true, host: 'jump', port: 22, user: 'ops', auth: { type: 'password', password: 'sp' } },
+    color_tag: null,
+  };
+  const redacted = 'mongodb://alice@db1:27017/sales?tls=true&proxyHost=p';
+
+  const setupClipboard = () => {
+    const readText = vi.fn();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { readText, writeText },
+      configurable: true,
+    });
+    return { readText, writeText };
+  };
+
+  const renderManager = (profiles: any[] = []) => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve(profiles);
+      return Promise.resolve([]);
+    });
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+  };
+
+  const openImportMenu = async () => {
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+    fireEvent.pointerDown(screen.getByTestId('import-uri-btn'), { button: 0, ctrlKey: false });
+  };
+
+  beforeEach(() => {
+    mockOpenDialog.mockReset();
+    mockSaveDialog.mockReset();
+    mockReadTextFile.mockReset();
+    mockWriteTextFile.mockReset();
+  });
+
+  it('imports a URI from the clipboard into the editor form', async () => {
+    const { readText } = setupClipboard();
+    readText.mockResolvedValue('MONGO_URL="mongodb://u:p@db.imported.example:27017/app"');
+    renderManager();
+
+    await openImportMenu();
+    fireEvent.click(await screen.findByTestId('import-from-clipboard'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/db\.imported\.example/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an inline error when the clipboard has no mongodb URI', async () => {
+    const { readText } = setupClipboard();
+    readText.mockResolvedValue('postgres://u:p@host/db');
+    renderManager();
+
+    await openImportMenu();
+    fireEvent.click(await screen.findByTestId('import-from-clipboard'));
+
+    expect(await screen.findByTestId('import-uri-error')).toHaveTextContent(/no mongodb/i);
+  });
+
+  it('imports the first URI found in a picked file', async () => {
+    setupClipboard();
+    mockOpenDialog.mockResolvedValue('/tmp/creds.env');
+    mockReadTextFile.mockResolvedValue('A=1\nURL=mongodb+srv://u@cluster.file.example/app\n');
+    renderManager();
+
+    await openImportMenu();
+    fireEvent.click(await screen.findByTestId('import-from-file'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/cluster\.file\.example/)).toBeInTheDocument();
+    });
+  });
+
+  it('exports a redacted URI by default, notes the SSH tunnel, and includes the password on demand', async () => {
+    const { writeText } = setupClipboard();
+    renderManager([prodProfile]);
+
+    fireEvent.click((await screen.findAllByText('Prod'))[0]);
+    fireEvent.click(screen.getByTestId('export-uri-btn'));
+
+    const preview = await screen.findByTestId('export-uri-preview');
+    expect(preview).toHaveTextContent(redacted);
+    expect(preview).not.toHaveTextContent('pw');
+    expect(screen.getByTestId('export-ssh-note')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('export-copy-btn'));
+    expect(writeText).toHaveBeenCalledWith(redacted);
+
+    fireEvent.click(screen.getByTestId('export-include-password'));
+    await waitFor(() => expect(preview).toHaveTextContent('alice:pw@'));
+
+    fireEvent.click(screen.getByTestId('export-copy-btn'));
+    expect(writeText).toHaveBeenLastCalledWith(prodProfile.uri);
+  });
+
+  it('drops the query string when connection settings are excluded', async () => {
+    setupClipboard();
+    renderManager([prodProfile]);
+
+    fireEvent.click((await screen.findAllByText('Prod'))[0]);
+    fireEvent.click(screen.getByTestId('export-uri-btn'));
+
+    const preview = await screen.findByTestId('export-uri-preview');
+    fireEvent.click(screen.getByTestId('export-include-settings'));
+    await waitFor(() => expect(preview).toHaveTextContent(/^mongodb:\/\/alice@db1:27017\/sales$/));
+  });
+
+  it('saves the export to a file via the save dialog', async () => {
+    setupClipboard();
+    mockSaveDialog.mockResolvedValue('/tmp/conn.txt');
+    mockWriteTextFile.mockResolvedValue(undefined);
+    renderManager([prodProfile]);
+
+    fireEvent.click((await screen.findAllByText('Prod'))[0]);
+    fireEvent.click(screen.getByTestId('export-uri-btn'));
+    await screen.findByTestId('export-uri-preview');
+    fireEvent.click(screen.getByTestId('export-save-btn'));
+
+    await waitFor(() => {
+      expect(mockWriteTextFile).toHaveBeenCalledWith('/tmp/conn.txt', `${redacted}\n`);
     });
   });
 });

--- a/src/lib/__tests__/connection.test.ts
+++ b/src/lib/__tests__/connection.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { buildExportUri, findMongoUriInText, stripUriSecrets } from '../connection';
+
+describe('stripUriSecrets', () => {
+  it('removes the auth password but keeps the username', () => {
+    expect(stripUriSecrets('mongodb://alice:s3cr%40t@db1:27017,db2:27017/sales?tls=true')).toBe(
+      'mongodb://alice@db1:27017,db2:27017/sales?tls=true'
+    );
+  });
+
+  it('leaves URIs without credentials untouched', () => {
+    expect(stripUriSecrets('mongodb://db:27017/app?replicaSet=rs0')).toBe(
+      'mongodb://db:27017/app?replicaSet=rs0'
+    );
+    expect(stripUriSecrets('mongodb+srv://cluster.example.com/app')).toBe(
+      'mongodb+srv://cluster.example.com/app'
+    );
+  });
+
+  it('keeps a username-only userinfo (no password) intact', () => {
+    expect(stripUriSecrets('mongodb://alice@db:27017/?authMechanism=MONGODB-X509')).toBe(
+      'mongodb://alice@db:27017/?authMechanism=MONGODB-X509'
+    );
+  });
+
+  it('removes the SOCKS5 proxy password but keeps the proxy username', () => {
+    expect(
+      stripUriSecrets('mongodb://db:27017/?proxyHost=p&proxyPort=1080&proxyUsername=u&proxyPassword=pw&tls=true')
+    ).toBe('mongodb://db:27017/?proxyHost=p&proxyPort=1080&proxyUsername=u&tls=true');
+  });
+
+  it('removes an AWS session token but keeps other mechanism properties', () => {
+    expect(
+      stripUriSecrets(
+        'mongodb://u:p@db/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:tok123&appName=x'
+      )
+    ).toBe('mongodb://u@db/?authMechanism=MONGODB-AWS&appName=x');
+  });
+
+  it('removes a client-key password and cleans a now-empty query', () => {
+    expect(stripUriSecrets('mongodb://db:27017/app?tlsCertificateKeyFilePassword=kp')).toBe(
+      'mongodb://db:27017/app'
+    );
+  });
+
+  it('does not touch password-shaped text inside query values', () => {
+    expect(stripUriSecrets('mongodb://db/?appName=user:pass%40host')).toBe(
+      'mongodb://db/?appName=user:pass%40host'
+    );
+  });
+});
+
+describe('buildExportUri', () => {
+  const uri =
+    'mongodb://alice:pw@db1:27017,db2:27017/sales?replicaSet=rs0&tls=true&proxyHost=p&proxyPassword=ppw&appName=MQLens';
+
+  it('defaults are applied by the caller — full round trip keeps everything', () => {
+    expect(buildExportUri(uri, { includePassword: true, includeSettings: true })).toBe(uri);
+  });
+
+  it('strips all secrets when the password is excluded', () => {
+    expect(buildExportUri(uri, { includePassword: false, includeSettings: true })).toBe(
+      'mongodb://alice@db1:27017,db2:27017/sales?replicaSet=rs0&tls=true&proxyHost=p&appName=MQLens'
+    );
+  });
+
+  it('drops the query string but keeps hosts and default db when settings are excluded', () => {
+    expect(buildExportUri(uri, { includePassword: true, includeSettings: false })).toBe(
+      'mongodb://alice:pw@db1:27017,db2:27017/sales'
+    );
+    expect(buildExportUri(uri, { includePassword: false, includeSettings: false })).toBe(
+      'mongodb://alice@db1:27017,db2:27017/sales'
+    );
+  });
+});
+
+describe('findMongoUriInText', () => {
+  it('finds the first mongodb URI in .env-style content', () => {
+    const env = '# config\nAPP_ENV=prod\nMONGO_URL="mongodb+srv://u:p@cluster.example.com/app?retryWrites=true"\nOTHER=1\n';
+    expect(findMongoUriInText(env)).toBe('mongodb+srv://u:p@cluster.example.com/app?retryWrites=true');
+  });
+
+  it('accepts a bare URI with surrounding whitespace', () => {
+    expect(findMongoUriInText('  mongodb://localhost:27017/test \n')).toBe('mongodb://localhost:27017/test');
+  });
+
+  it('returns null when no mongodb URI is present', () => {
+    expect(findMongoUriInText('postgres://u:p@host/db')).toBeNull();
+    expect(findMongoUriInText('')).toBeNull();
+  });
+});

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -8,3 +8,60 @@ export interface ConnectionProfile {
   color_tag?: string | null;
   ssh?: SshConfig | null;
 }
+
+/** Options for exporting a connection URI for sharing. */
+export interface ExportUriOptions {
+  /** Keep the auth password and other secret-bearing params. Default callers to false. */
+  includePassword: boolean;
+  /** Keep the query string (TLS files, replicaSet, appName, proxy, timeouts…). */
+  includeSettings: boolean;
+}
+
+// Query params whose values are secrets in their own right.
+const SECRET_PARAM_KEYS = /^(proxyPassword|tlsCertificateKeyFilePassword|sslClientCertificateKeyPassword)$/i;
+
+const isSecretParam = (param: string): boolean => {
+  const key = param.split('=')[0];
+  if (SECRET_PARAM_KEYS.test(key)) return true;
+  // AWS session tokens travel inside authMechanismProperties.
+  return /^authMechanismProperties$/i.test(key) && /AWS_SESSION_TOKEN/i.test(param);
+};
+
+/**
+ * Remove every secret a mongodb:// URI can carry: the userinfo password (the
+ * username is kept), the SOCKS5 proxy password, client-key passwords, and AWS
+ * session tokens. Unlike `maskUriPassword` (a display mask), the result is a
+ * valid, shareable URI. SSH tunnel secrets never live in the URI itself.
+ */
+export const stripUriSecrets = (uri: string): string => {
+  // Userinfo password: anchored to the scheme so query values can't match.
+  let out = uri.replace(/^(mongodb(?:\+srv)?:\/\/[^:/@?#]+):[^@/?#]*@/i, '$1@');
+
+  const qIdx = out.indexOf('?');
+  if (qIdx === -1) return out;
+  const kept = out
+    .slice(qIdx + 1)
+    .split('&')
+    .filter((p) => p !== '' && !isSecretParam(p));
+  return kept.length ? `${out.slice(0, qIdx)}?${kept.join('&')}` : out.slice(0, qIdx);
+};
+
+/**
+ * Build the URI string an Export action writes to the clipboard or a file.
+ * Excluding settings drops the whole query string (hosts and the default db
+ * stay — they are the address, not settings); excluding the password strips
+ * all secrets via `stripUriSecrets`.
+ */
+export const buildExportUri = (uri: string, opts: ExportUriOptions): string => {
+  let out = opts.includeSettings ? uri : uri.split(/[?#]/)[0];
+  if (!opts.includePassword) out = stripUriSecrets(out);
+  return out;
+};
+
+/**
+ * Find the first mongodb:// / mongodb+srv:// connection string in free-form
+ * text (a .env file, a note, a pasted config). Quotes and whitespace end the
+ * match so `MONGO_URL="mongodb://…"` yields just the URI.
+ */
+export const findMongoUriInText = (text: string): string | null =>
+  text.match(/mongodb(?:\+srv)?:\/\/[^\s"'`;]+/i)?.[0] ?? null;


### PR DESCRIPTION
Closes #115.

## Summary

Connection URIs can now move in and out of the Connection Manager without hand-editing strings, and exports are safe to share by default.

### Import (editor footer, now a menu)
- **From clipboard** — reads the clipboard and extracts the first `mongodb://` / `mongodb+srv://` string (an `.env`-style line like `MONGO_URL="mongodb://…"` works)
- **From a file…** — file picker + text read, same extraction
- **Paste manually…** — the original dialog, kept as fallback
- No connection string found → clear inline error instead of silently doing nothing

### Export (replaces the raw copy actions that leaked passwords silently)
- New **Export URI** on a saved connection and **Export…** in the editor's URI preview row, opening a dialog with a live preview of exactly what will be shared
- **Include password** toggle — **off by default**; off strips the auth password *and* SOCKS5 proxy passwords, TLS client-key passwords, and AWS session tokens (`stripUriSecrets` is a true strip producing a valid URI, not a display mask)
- **Include connection settings** toggle — off drops the whole query string, keeping scheme/hosts/default db
- Copy to clipboard or save to a file; SSH-tunneled profiles get a note that tunnel settings can't be represented in a MongoDB URI

## Test plan
- [x] 13 new unit tests for `stripUriSecrets` / `buildExportUri` / `findMongoUriInText` (userinfo edge cases, secret query params, empty-query cleanup, .env extraction)
- [x] 6 new ConnectionManager component tests: clipboard/file import, inline error, redacted-by-default export, toggle behavior, save-to-file
- [x] Full frontend suite: 668 tests across 59 files, typecheck clean