### PR TITLE
docs: local demo database guide (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ npm install
 npm run tauri dev      # run the desktop app with hot reload
 ```
 
+For something to point the app at, seed the
+[local demo database](docs/demo-database.md) — synthetic collections, indexes,
+a view, and GridFS files that exercise every major workflow (and match the
+screenshots above).
+
 Other useful commands:
 
 ```bash

--- a/docs/demo-database.md
+++ b/docs/demo-database.md
@@ -1,0 +1,77 @@
+# Local demo database
+
+A seeded MongoDB database for developing MQLens, reproducing the README
+screenshots, and exercising every major workflow — browsing, querying,
+aggregations, indexes and explain plans, views, import/export, dump/restore,
+and GridFS — without touching real data.
+
+Everything here runs locally against a throwaway server. **Never use real
+secrets or production data for screenshots or test runs** — the seed data is
+entirely synthetic, and connection strings in captures should point at
+`localhost` only.
+
+## 1. Start MongoDB locally
+
+Any local MongoDB ≥ 6.0 works. The quickest option is Docker:
+
+```bash
+docker run -d --rm --name mqlens-demo -p 27017:27017 mongo:7
+```
+
+(Or use an existing local `mongod`; nothing in the seed requires a replica set
+or auth.)
+
+## 2. Seed the demo data
+
+From the repository root:
+
+```bash
+mongosh mongodb://localhost:27017 -f scripts/seed-demo-data.js
+```
+
+The script drops and recreates a single database, **`mqlens_demo`**, and prints
+a document-count summary when it finishes:
+
+| Collection | Docs | What it's for |
+|---|---|---|
+| `products` | 5 | Small flat collection — quick browsing, editing, schema view |
+| `customers` | 36 | Unique index (`email_1`), tags array, lifecycle facets |
+| `orders` | 180 | Nested `items` array + `shipping` subdocument, three secondary indexes — the main collection for queries, aggregations, and explain plans |
+| `events` | 260 | Time-series-ish audit log with a compound index |
+| `active_customer_revenue` | view | Aggregation view over `orders` (revenue by region) |
+| `fs.files` / `fs.chunks` | 2 files | Real GridFS files with consistent chunks — list, download, and delete all work |
+
+Re-running the script is safe: it drops `mqlens_demo` first and reseeds from
+scratch, so it doubles as a reset button after destructive experiments.
+
+## 3. Connect from MQLens
+
+Add a connection with the URI `mongodb://localhost:27017` (name it something
+like `Local demo`), connect, and open `mqlens_demo`.
+
+## 4. Suggested test flows
+
+- **Query bar** — on `orders`: `{ status: "shipped", region: "Europe" }`, or a
+  range like `{ total: { $gt: 300 } }`.
+- **Explain plans** — the query above uses `status_1_createdAt_-1` /
+  `region_1_total_-1`; drop the filter to compare against a COLLSCAN. Sorting
+  by `createdAt` shows index-backed sorts.
+- **Aggregation** — group revenue by region on `orders`, then compare with the
+  prebuilt `active_customer_revenue` view.
+- **Indexes** — `customers.email_1` is unique: inserting a duplicate email
+  demonstrates constraint errors safely.
+- **Import/export** — export `orders` as NDJSON/BSON/CSV, reimport into a new
+  collection; the `events` collection is good for filtered exports.
+- **Dump & restore** — a database-scope dump of `mqlens_demo` is small and
+  fast; restoring with renames exercises the namespace mapping.
+- **GridFS** — the two seeded files have real chunk data, so download and
+  delete flows work end to end; upload something to round-trip.
+
+## 5. Cleaning up
+
+```bash
+docker stop mqlens-demo    # container was started with --rm
+```
+
+Or, to remove just the data while keeping the server:
+`mongosh mongodb://localhost:27017 --eval 'db.getSiblingDB("mqlens_demo").dropDatabase()'`.

--- a/scripts/seed-demo-data.js
+++ b/scripts/seed-demo-data.js
@@ -101,15 +101,15 @@ const events = Array.from({ length: 260 }, (_, index) => ({
     rowsReturned: (index * 13) % 500,
   },
 }));
-db.events.insertMany(events);
+demoDb.events.insertMany(events);
 
-db.orders.createIndex({ status: 1, createdAt: -1 });
-db.orders.createIndex({ region: 1, total: -1 });
-db.orders.createIndex({ customerId: 1 });
-db.customers.createIndex({ email: 1 }, { unique: true });
-db.events.createIndex({ type: 1, createdAt: -1 });
+demoDb.orders.createIndex({ status: 1, createdAt: -1 });
+demoDb.orders.createIndex({ region: 1, total: -1 });
+demoDb.orders.createIndex({ customerId: 1 });
+demoDb.customers.createIndex({ email: 1 }, { unique: true });
+demoDb.events.createIndex({ type: 1, createdAt: -1 });
 
-db.createCollection('active_customer_revenue', {
+demoDb.createCollection('active_customer_revenue', {
   viewOn: 'orders',
   pipeline: [
     { $match: { status: { $in: ['shipped', 'delivered'] } } },
@@ -118,32 +118,71 @@ db.createCollection('active_customer_revenue', {
   ],
 });
 
-db.fs.files.insertMany([
+// GridFS files with real chunk data (lengths match the chunks), so listing,
+// downloading, and deleting in the GridFS view all work against them.
+const gridFsFiles = [
   {
-    _id: ObjectId(),
     filename: 'orders-q2-export.csv',
-    length: NumberLong('184320'),
-    chunkSize: 261120,
-    uploadDate: new Date(Date.UTC(2026, 5, 1, 10, 30)),
     contentType: 'text/csv',
+    uploadDate: new Date(Date.UTC(2026, 5, 1, 10, 30)),
     metadata: { owner: 'analytics', source: 'scheduled-export' },
+    content:
+      'orderNo,region,status,total\n' +
+      orders.slice(0, 25).map((o) => `${o.orderNo},${o.region},${o.status},${o.total}`).join('\n') +
+      '\n',
   },
   {
-    _id: ObjectId(),
     filename: 'customer-schema-snapshot.json',
-    length: NumberLong('32768'),
-    chunkSize: 261120,
-    uploadDate: new Date(Date.UTC(2026, 5, 2, 14, 15)),
     contentType: 'application/json',
+    uploadDate: new Date(Date.UTC(2026, 5, 2, 14, 15)),
     metadata: { owner: 'data-platform', source: 'schema-analysis' },
+    content: JSON.stringify(
+      {
+        collection: 'customers',
+        sampledAt: '2026-06-02T14:15:00Z',
+        fields: {
+          customerId: 'string',
+          name: 'string',
+          email: 'string',
+          region: 'string',
+          plan: 'string',
+          lifecycle: 'string',
+          seats: 'int',
+          spendToDate: 'int',
+          tags: 'array<string>',
+          createdAt: 'date',
+        },
+      },
+      null,
+      2,
+    ),
   },
-]);
+];
+
+for (const file of gridFsFiles) {
+  const bytes = Buffer.from(file.content, 'utf8');
+  const fileId = new ObjectId();
+  demoDb.fs.files.insertOne({
+    _id: fileId,
+    filename: file.filename,
+    length: Long.fromNumber(bytes.length),
+    chunkSize: 261120,
+    uploadDate: file.uploadDate,
+    contentType: file.contentType,
+    metadata: file.metadata,
+  });
+  demoDb.fs.chunks.insertOne({
+    files_id: fileId,
+    n: 0,
+    data: BinData(0, bytes.toString('base64')),
+  });
+}
 
 printjson({
   database: dbName,
-  products: db.products.countDocuments(),
-  customers: db.customers.countDocuments(),
-  orders: db.orders.countDocuments(),
-  events: db.events.countDocuments(),
-  gridFsFiles: db.fs.files.countDocuments(),
+  products: demoDb.products.countDocuments(),
+  customers: demoDb.customers.countDocuments(),
+  orders: demoDb.orders.countDocuments(),
+  events: demoDb.events.countDocuments(),
+  gridFsFiles: demoDb.fs.files.countDocuments(),
 });


### PR DESCRIPTION
Closes #31.

## Summary

- **`docs/demo-database.md`** — how to start a local MongoDB (Docker one-liner), seed it with `mongosh -f scripts/seed-demo-data.js`, and which collection exercises which MQLens workflow: queries and explain plans (`orders` + its three indexes), aggregation views (`active_customer_revenue`), unique-index errors (`customers.email_1`), import/export and dump/restore, and GridFS. Includes the no-real-secrets note for screenshots, and the script doubles as a reset button (drop-and-reseed). Linked from the README's Development section.
- **Fixed `scripts/seed-demo-data.js`** — everything below the customers insert wrote to the *session default db* instead of `mqlens_demo`, so run as `mongosh -f` (no db argument) the events, all five indexes, the view, and the GridFS files landed in `test`. Also the GridFS entries were `fs.files` metadata with no `fs.chunks`, so downloads failed. All writes now target `mqlens_demo`, and both GridFS files carry real chunk data with lengths matching their chunks.

## Verification

Ran end to end against a throwaway `mongo:7` container exactly as the guide instructs:
- Seed prints `products: 5, customers: 36, orders: 180, events: 260, gridFsFiles: 2`
- `test` database stays empty; all five secondary indexes and the view (4 region rows) exist in `mqlens_demo`
- Both GridFS files' chunk bytes exactly match their declared lengths (843 and 334 bytes)