### PR TITLE
feat: guided mongosh detection on shell failure (#124)

### DIFF
--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -1883,8 +1883,9 @@ mod tests {
         let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out5");
         let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
         // Wait until the task has finished AND its cancel flag is gone (the
-        // flag is removed just after the status flips; poll both).
-        for _ in 0..250 {
+        // flag is removed just after the status flips; poll both). Generous
+        // budget — under full-suite load process spawns can be slow.
+        for _ in 0..750 {
             let finished = state.tasks.lock().unwrap().get(&task.id).map(|t| t.status != "running").unwrap_or(false);
             let flag_gone = state.cancels.lock().unwrap().get(&task.id).is_none();
             if finished && flag_gone {
@@ -1892,7 +1893,11 @@ mod tests {
             }
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
-        assert!(state.cancels.lock().unwrap().get(&task.id).is_none(), "flag cleaned up");
+        let snapshot = state.tasks.lock().unwrap().get(&task.id).cloned();
+        assert!(
+            state.cancels.lock().unwrap().get(&task.id).is_none(),
+            "flag cleaned up (task snapshot: {snapshot:?})"
+        );
 
         assert!(state.cancel_or_ack(&task.id).is_ok(), "cancel after finish should be a quiet no-op");
         assert!(state.cancel_or_ack("no-such-task").is_err(), "unknown task ids still error");

--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -736,6 +736,10 @@ async fn run_tool_process(
     let mut tail: VecDeque<String> = VecDeque::with_capacity(STDERR_TAIL_LINES);
     let mut processed: u64 = 0;
     let mut poll = tokio::time::interval(Duration::from_millis(250));
+    // Set once the child has exited while the pipe is still open — a
+    // grandchild that inherited the stderr write end would otherwise delay
+    // EOF (and so task completion) until IT exits.
+    let mut exited: Option<(std::process::ExitStatus, std::time::Instant)> = None;
 
     let cancelled = loop {
         tokio::select! {
@@ -806,6 +810,18 @@ async fn run_tool_process(
                         });
                     }
                 }
+                // Detect the child exiting while the pipe stays open; after a
+                // short grace for buffered output, stop reading — EOF may
+                // never come if something else inherited the write end.
+                match exited {
+                    None => {
+                        if let Ok(Some(status)) = child.try_wait() {
+                            exited = Some((status, std::time::Instant::now()));
+                        }
+                    }
+                    Some((_, at)) if at.elapsed() >= Duration::from_millis(500) => break false,
+                    Some(_) => {}
+                }
             }
         }
     };
@@ -817,17 +833,22 @@ async fn run_tool_process(
 
     // The tool can close stderr while still running; a bare wait() here would
     // leave the task uncancellable from that point on. Keep polling the
-    // cancel flag (killing on cancel) until the process actually exits.
-    let status = loop {
-        tokio::select! {
-            status = child.wait() => {
-                break status.map_err(|e| format!("Failed to wait for {}: {}", tool_path, e))?;
-            }
-            _ = poll.tick() => {
-                if cancel.load(Ordering::SeqCst) {
-                    let _ = child.kill().await;
-                    let _ = child.wait().await;
-                    return Ok(ToolOutcome::Cancelled);
+    // cancel flag (killing on cancel) until the process actually exits —
+    // unless the exit was already observed above.
+    let status = if let Some((status, _)) = exited {
+        status
+    } else {
+        loop {
+            tokio::select! {
+                status = child.wait() => {
+                    break status.map_err(|e| format!("Failed to wait for {}: {}", tool_path, e))?;
+                }
+                _ = poll.tick() => {
+                    if cancel.load(Ordering::SeqCst) {
+                        let _ = child.kill().await;
+                        let _ = child.wait().await;
+                        return Ok(ToolOutcome::Cancelled);
+                    }
                 }
             }
         }
@@ -1638,13 +1659,61 @@ mod tests {
     }
 
     async fn wait_for_task(state: &AppState, task_id: &str) {
-        for _ in 0..50 {
+        // Generous budget: under full-suite process-spawn load even a trivial
+        // task can take a while end to end. Returns as soon as it settles.
+        for _ in 0..500 {
             let status = state.tasks.lock().unwrap().get(task_id).map(|t| t.status.clone());
             if status.as_deref() != Some("running") {
                 return;
             }
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
+    }
+
+    /// Start a dump task and wait for proof the tool actually launched,
+    /// riding out the classic fork/exec ETXTBSY race (under parallel test
+    /// load a concurrently forked child can briefly hold the just-written
+    /// fake tool's fd, failing the spawn with "Failed to start").
+    ///
+    /// "Launched" is detected via the runner's own post-spawn signal — the
+    /// task message flips to "<tool> started — connecting…" — or any terminal
+    /// state. A "Failed to start" failure retries with a fresh task; every
+    /// other outcome is the test's real behavior and is returned as-is.
+    async fn start_dump_task_retrying(
+        state: &AppState,
+        tool: &std::path::Path,
+        out: &str,
+    ) -> TaskInfo {
+        for attempt in 0..10 {
+            let task = start_dump_task_impl(
+                state,
+                "c1",
+                tool.to_str().unwrap(),
+                dump_server_folder_opts(out),
+            )
+            .await
+            .unwrap();
+            for _ in 0..500 {
+                let snap = state.tasks.lock().unwrap().get(&task.id).cloned();
+                if let Some(t) = snap {
+                    if t.status == "failed"
+                        && t.error.as_deref().unwrap_or("").contains("Failed to start")
+                    {
+                        break; // transient spawn race — retry with a fresh task
+                    }
+                    let spawned = t.status != "running"
+                        || t.processed > 0
+                        || t.message.contains("started")
+                        || t.message.contains("running");
+                    if spawned {
+                        return task;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            eprintln!("fake-tool spawn raced (attempt {attempt}); retrying");
+        }
+        panic!("fake tool could not be spawned after retries");
     }
 
     #[cfg(unix)]
@@ -1658,8 +1727,7 @@ mod tests {
              echo 'ts\tdone dumping a.y (7 documents)' 1>&2\n\
              exit 0\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out").await;
         assert_eq!(task.kind, "dump");
         wait_for_task(&state, &task.id).await;
         let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
@@ -1680,8 +1748,7 @@ mod tests {
              echo 'cannot connect to mongodb://u:sekrit@h:27017/db' 1>&2\n\
              exit 3\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out2");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out2").await;
         wait_for_task(&state, &task.id).await;
         let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
         assert_eq!(t.status, "failed");
@@ -1703,8 +1770,7 @@ mod tests {
         let tool = crate::db::mongotools::test_support::write_fake_tool(
             "echo 'ts\tdone dumping a.x (1 documents)' 1>&2\nsleep 30\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out3");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out3").await;
 
         // Wait until the fake tool has reported at least one namespace done.
         for _ in 0..100 {
@@ -1737,8 +1803,7 @@ mod tests {
         let state = AppState::new();
         state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
         let tool = crate::db::mongotools::test_support::write_fake_tool("sleep 30\n");
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out4");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out4").await;
         assert_ne!(task.message, "Queued", "initial message should say the tool is starting");
 
         // Shortly after spawn the message must reflect a live process.
@@ -1786,8 +1851,7 @@ mod tests {
              echo 'ts\tdone dumping a.x (5 documents)' 1>&2\n\
              exit 0\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out7");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out7").await;
         wait_for_task(&state, &task.id).await;
         let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
         assert_eq!(t.status, "completed");
@@ -1807,8 +1871,7 @@ mod tests {
         let tool = crate::db::mongotools::test_support::write_fake_tool(
             "echo 'ts\tdone dumping a.x (1 documents)' 1>&2\nexec 2>&-\nsleep 30\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out8");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out8").await;
 
         // Wait until the stderr line was consumed, then a beat for the EOF.
         for _ in 0..100 {
@@ -1831,6 +1894,35 @@ mod tests {
         let _ = std::fs::remove_file(&tool);
     }
 
+    /// A grandchild that inherits the tool's stderr write end must not wedge
+    /// the task after the tool itself exits: without exit detection the read
+    /// loop waits for a pipe EOF that only arrives when the grandchild dies.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_lingering_grandchild_does_not_wedge_task_completion() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        // The backgrounded sleep inherits stderr and holds the pipe open for
+        // 20s; the tool itself exits immediately.
+        let tool = crate::db::mongotools::test_support::write_fake_tool(
+            "echo 'ts\tdone dumping a.x (3 documents)' 1>&2\nsleep 20 &\nexit 0\n",
+        );
+        let started = std::time::Instant::now();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out9").await;
+        wait_for_task(&state, &task.id).await;
+        let elapsed = started.elapsed();
+
+        let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(t.status, "completed", "task: {t:?}");
+        assert_eq!(t.processed, 1);
+        assert!(
+            elapsed.as_secs() < 5,
+            "task must complete shortly after the tool exits, took {elapsed:?}"
+        );
+        let _ = std::fs::remove_file(&tool);
+    }
+
     /// Before the first parsable progress event, raw stderr lines (driver
     /// warnings, connection errors) must reach the task message instead of
     /// being dropped — they're the only clue when a tool can't connect. The
@@ -1844,8 +1936,7 @@ mod tests {
         let tool = crate::db::mongotools::test_support::write_fake_tool(
             "echo 'ts\tconnection warning: cluster unreachable' 1>&2\nsleep 30\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out6");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out6").await;
 
         let mut snapshot: Option<TaskInfo> = None;
         for _ in 0..250 {
@@ -1880,8 +1971,7 @@ mod tests {
         let state = AppState::new();
         state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
         let tool = crate::db::mongotools::test_support::write_fake_tool("exit 0\n");
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out5");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out5").await;
         // Wait until the task has finished AND its cancel flag is gone (the
         // flag is removed just after the status flips; poll both). Generous
         // budget — under full-suite load process spawns can be slow.

--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -1701,10 +1701,12 @@ mod tests {
                     {
                         break; // transient spawn race — retry with a fresh task
                     }
+                    // Any message past the initial "Starting <tool>…" means the
+                    // runner got beyond spawn — matching specific phrases races
+                    // against surfaced stderr overwriting the message.
                     let spawned = t.status != "running"
                         || t.processed > 0
-                        || t.message.contains("started")
-                        || t.message.contains("running");
+                        || !t.message.starts_with("Starting");
                     if spawned {
                         return task;
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -673,6 +673,23 @@ async fn detect_mongo_tools(
     Ok(db::mongotools::detect_mongo_tools(configured_dir.as_deref(), managed_dir.as_deref()))
 }
 
+/// Find a working mongosh for the shell's guided-setup card: configured path,
+/// managed install, PATH, then well-known install locations. Probing spawns
+/// several `--version` children, so it runs off the async runtime.
+#[tauri::command]
+async fn detect_mongosh_binary(
+    app_handle: tauri::AppHandle,
+    configured: String,
+) -> Result<Option<toolsetup::MongoshDetection>, String> {
+    use tauri::Manager;
+    let app_data_dir = app_handle.path().app_data_dir().ok();
+    tokio::task::spawn_blocking(move || {
+        toolsetup::detect_mongosh(&configured, app_data_dir.as_deref(), &[])
+    })
+    .await
+    .map_err(|e| format!("mongosh detection failed: {}", e))
+}
+
 #[tauri::command]
 async fn start_dump_task(
     state: tauri::State<'_, AppState>,
@@ -1779,6 +1796,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             connect_db,
             detect_mongo_tools,
+            detect_mongosh_binary,
             start_dump_task,
             start_restore_task,
             start_tool_install_task,

--- a/src-tauri/src/toolsetup.rs
+++ b/src-tauri/src/toolsetup.rs
@@ -342,6 +342,116 @@ pub fn resolve_mongosh_executable(configured: &str, app_data_dir: Option<&Path>)
     "mongosh".to_string()
 }
 
+/// One working mongosh binary found by [`detect_mongosh`], with where it came
+/// from so the UI can phrase the offer ("found on PATH", "managed install").
+#[derive(serde::Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MongoshDetection {
+    pub path: String,
+    pub version: String,
+    /// "configured" | "managed" | "path" | "common"
+    pub source: String,
+}
+
+/// Run `path --version` and return the first output line, or `None` when the
+/// binary is missing, not executable, or exits non-zero.
+fn probe_version(path: &Path) -> Option<String> {
+    let out = std::process::Command::new(path)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let line = text.lines().next()?.trim();
+    if line.is_empty() {
+        None
+    } else {
+        Some(line.to_string())
+    }
+}
+
+/// Well-known install locations probed after PATH — covers packaged-app
+/// launches where the login-shell PATH merge didn't help (notably Windows,
+/// which has no `path_env` equivalent).
+fn common_mongosh_dirs() -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    #[cfg(windows)]
+    {
+        if let Ok(pf) = std::env::var("ProgramFiles") {
+            dirs.push(PathBuf::from(pf).join("mongosh"));
+        }
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            dirs.push(PathBuf::from(local).join("Programs").join("mongosh"));
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        dirs.extend(
+            ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/snap/bin"]
+                .iter()
+                .map(PathBuf::from),
+        );
+        if let Some(home) = std::env::var_os("HOME") {
+            dirs.push(PathBuf::from(home).join(".local/bin"));
+        }
+    }
+    dirs
+}
+
+/// Find a working mongosh, probing (in order) the configured path, the
+/// managed install, every PATH entry, and finally `common_mongosh_dirs()`
+/// plus `extra_dirs` (tests inject temp dirs there). Unlike
+/// [`resolve_mongosh_executable`] — which decides what to *spawn* — this
+/// verifies each candidate actually runs, for the shell's guided-setup card.
+pub fn detect_mongosh(
+    configured: &str,
+    app_data_dir: Option<&Path>,
+    extra_dirs: &[PathBuf],
+) -> Option<MongoshDetection> {
+    let hit = |path: &Path, source: &str| -> Option<MongoshDetection> {
+        probe_version(path).map(|version| MongoshDetection {
+            path: path.to_string_lossy().into_owned(),
+            version,
+            source: source.to_string(),
+        })
+    };
+
+    let trimmed = configured.trim();
+    if !trimmed.is_empty() {
+        if let Some(found) = hit(Path::new(trimmed), "configured") {
+            return Some(found);
+        }
+    }
+
+    let bin_name = binary_file_name("mongosh");
+    if let Some(app_data_dir) = app_data_dir {
+        if let Ok(tool) = find_pinned_tool("mongosh") {
+            if let Some(found) = hit(&managed_bin_dir(app_data_dir, tool).join(&bin_name), "managed") {
+                return Some(found);
+            }
+        }
+    }
+
+    if let Some(path_var) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            if let Some(found) = hit(&dir.join(&bin_name), "path") {
+                return Some(found);
+            }
+        }
+    }
+
+    for dir in common_mongosh_dirs().iter().chain(extra_dirs) {
+        if let Some(found) = hit(&dir.join(&bin_name), "common") {
+            return Some(found);
+        }
+    }
+
+    None
+}
+
 /// Runs `path --version`, treating any spawn failure or non-zero exit as
 /// "not usable" — the safety net after extraction, and the check
 /// `managed_tools_status` uses to decide `installed`.
@@ -1054,6 +1164,71 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[cfg(unix)]
+    fn write_fake_mongosh(dir: &Path, version_line: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::create_dir_all(dir).unwrap();
+        let path = dir.join("mongosh");
+        std::fs::write(&path, format!("#!/bin/sh\necho '{version_line}'\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    /// `detect_mongosh` probes configured → managed → PATH → common locations
+    /// and reports where the working binary came from, so the shell's failure
+    /// card can offer "use this path" for binaries outside the configured one.
+    #[cfg(unix)]
+    #[test]
+    fn detect_mongosh_probes_in_order_and_reports_source() {
+        let base = test_app_data("detect-mongosh");
+
+        // Nothing anywhere -> None (empty extra dirs keep PATH from mattering:
+        // a real mongosh on the test machine's PATH would be reported as
+        // source "path", which the assertions below tolerate).
+        let empty = detect_mongosh("", None, &[base.join("nowhere")]);
+        assert!(
+            empty.is_none() || empty.as_ref().unwrap().source == "path",
+            "unexpected detection: {empty:?}"
+        );
+
+        // A working binary in a "common" dir is found with its version.
+        let common_dir = base.join("common-bin");
+        write_fake_mongosh(&common_dir, "2.9.9");
+        let found = detect_mongosh("", None, &[common_dir.clone()]).expect("common dir hit");
+        assert!(found.source == "common" || found.source == "path");
+        if found.source == "common" {
+            assert_eq!(found.version, "2.9.9");
+            assert_eq!(found.path, common_dir.join("mongosh").to_string_lossy());
+        }
+
+        // A configured binary wins over everything else.
+        let configured_dir = base.join("configured-bin");
+        let configured = write_fake_mongosh(&configured_dir, "3.0.0");
+        let found = detect_mongosh(configured.to_str().unwrap(), None, &[common_dir.clone()])
+            .expect("configured hit");
+        assert_eq!(found.source, "configured");
+        assert_eq!(found.version, "3.0.0");
+
+        // A broken configured path falls through to the next tier.
+        let found = detect_mongosh(
+            base.join("missing/mongosh").to_str().unwrap(),
+            None,
+            &[common_dir.clone()],
+        )
+        .expect("fallback hit");
+        assert_ne!(found.source, "configured");
+
+        // The managed install beats common dirs.
+        let tool = find_pinned_tool("mongosh").unwrap();
+        let managed = managed_bin_dir(&base, tool);
+        write_fake_mongosh(&managed, "2.9.2");
+        let found = detect_mongosh("", Some(&base), &[common_dir]).expect("managed hit");
+        assert_eq!(found.source, "managed");
+        assert_eq!(found.version, "2.9.2");
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// Polls the task map until `task_id` leaves "running", returning its

--- a/src-tauri/src/toolsetup.rs
+++ b/src-tauri/src/toolsetup.rs
@@ -353,18 +353,50 @@ pub struct MongoshDetection {
     pub source: String,
 }
 
+/// Per-candidate budget for [`probe_version`]. Detection probes many
+/// locations sequentially (configured, managed, every PATH entry, common
+/// dirs), so one wedged binary must not stall the shell's guided-setup card —
+/// same rationale as [`PROBE_TIMEOUT`] in the install flow, but shorter since
+/// several candidates may be probed back to back.
+const DETECT_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Run `path --version` and return the first output line, or `None` when the
-/// binary is missing, not executable, or exits non-zero.
+/// binary is missing, not executable, exits non-zero, or hangs past
+/// [`DETECT_PROBE_TIMEOUT`].
 fn probe_version(path: &Path) -> Option<String> {
-    let out = std::process::Command::new(path)
+    probe_version_with_timeout(path, DETECT_PROBE_TIMEOUT)
+}
+
+fn probe_version_with_timeout(path: &Path, timeout: Duration) -> Option<String> {
+    use std::io::Read;
+    let mut child = std::process::Command::new(path)
         .arg("--version")
         .stdin(std::process::Stdio::null())
-        .output()
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
         .ok()?;
-    if !out.status.success() {
+    let deadline = std::time::Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    };
+    if !status.success() {
         return None;
     }
-    let text = String::from_utf8_lossy(&out.stdout);
+    // Safe post-exit: `--version` output is one short line, far below the
+    // pipe buffer, so the child cannot have blocked on a full pipe.
+    let mut text = String::new();
+    child.stdout.take()?.read_to_string(&mut text).ok()?;
     let line = text.lines().next()?.trim();
     if line.is_empty() {
         None
@@ -1227,6 +1259,31 @@ mod tests {
         let found = detect_mongosh("", Some(&base), &[common_dir]).expect("managed hit");
         assert_eq!(found.source, "managed");
         assert_eq!(found.version, "2.9.2");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// A wedged candidate (hangs on `--version`) must not stall detection:
+    /// the probe is killed at its deadline and the candidate reported as
+    /// unusable — same rationale as [`PROBE_TIMEOUT`] in the install flow.
+    #[cfg(unix)]
+    #[test]
+    fn probe_version_kills_wedged_binary_at_deadline() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = test_app_data("probe-wedged");
+        std::fs::create_dir_all(&base).unwrap();
+        let path = base.join("mongosh");
+        std::fs::write(&path, "#!/bin/sh\nsleep 30\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let started = std::time::Instant::now();
+        let probed = probe_version_with_timeout(&path, Duration::from_millis(300));
+        let elapsed = started.elapsed();
+        assert!(probed.is_none(), "wedged binary must be reported unusable");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "probe must be bounded by its deadline, took {elapsed:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -415,8 +415,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     };
   }, [sessionAttempted, sessionId, mongoshPath, retryNonce]);
 
-  // Persist a newly chosen mongosh path; updating `mongoshPath` re-attempts
-  // the session (it's a dependency of the session effect above).
+  // Persist a newly chosen mongosh path and re-attempt the session. The
+  // retry-nonce bump matters when the picked path equals the current one
+  // (setMongoshPath alone would be a no-op state update, so no re-attempt).
   const saveMongoshPath = async (path: string) => {
     try {
       const current = await invoke<AppSettings>('load_app_settings').catch(() => ({} as AppSettings));
@@ -428,6 +429,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     }
     setDetectedMongosh(null);
     setMongoshPath(path);
+    setRetryNonce((n) => n + 1);
   };
 
   const browseForMongosh = async () => {

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Editor from '@monaco-editor/react';
 import { invoke } from '@tauri-apps/api/core';
+import { open as openFileDialog } from '@tauri-apps/plugin-dialog';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { AlertCircle, Braces, CornerDownLeft, Eraser, Play, Sparkles, Terminal } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -236,6 +238,11 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [sessionAttempted, setSessionAttempted] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
+  // Guided setup on session failure: a working mongosh found outside the
+  // configured path (offered as one click), or null when nothing was found.
+  const [detectedMongosh, setDetectedMongosh] = useState<
+    { path: string; version: string; source: string } | null
+  >(null);
   // Reuses the retry-nonce mechanism above: when a parent-driven reconnect signal
   // changes (e.g. the guided tool-install dialog finished), re-attempt the session
   // the same way the gate's own Retry button does.
@@ -384,6 +391,62 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [entries, tab]);
+
+  // When the session failed to attach, probe for a usable mongosh (managed
+  // install, PATH, well-known locations) so the gate can offer a one-click
+  // fix instead of only pointing at Settings.
+  useEffect(() => {
+    if (!sessionAttempted || sessionId !== null || mongoshPath === null) return;
+    let alive = true;
+    invoke<{ path: string; version: string; source: string } | null>('detect_mongosh_binary', {
+      configured: mongoshPath || '',
+    })
+      .then((found) => {
+        if (!alive) return;
+        // A hit at the configured path means the session failure has some
+        // other cause — offering "use this path" would be a no-op.
+        setDetectedMongosh(found && found.source !== 'configured' ? found : null);
+      })
+      .catch(() => {
+        if (alive) setDetectedMongosh(null);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [sessionAttempted, sessionId, mongoshPath, retryNonce]);
+
+  // Persist a newly chosen mongosh path; updating `mongoshPath` re-attempts
+  // the session (it's a dependency of the session effect above).
+  const saveMongoshPath = async (path: string) => {
+    try {
+      const current = await invoke<AppSettings>('load_app_settings').catch(() => ({} as AppSettings));
+      await invoke('save_app_settings', {
+        settings: { ...current, mongosh_path: path },
+      });
+    } catch {
+      /* settings persistence is best-effort — still try the new path below */
+    }
+    setDetectedMongosh(null);
+    setMongoshPath(path);
+  };
+
+  const browseForMongosh = async () => {
+    try {
+      const picked = await openFileDialog({ multiple: false, title: 'Locate the mongosh binary' });
+      if (typeof picked === 'string' && picked) await saveMongoshPath(picked);
+    } catch {
+      /* user cancelled */
+    }
+  };
+
+  // OS-specific manual install hint for the gate card.
+  const installHint = useMemo(() => {
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    if (/mac/i.test(ua)) return 'brew install mongosh';
+    if (/win/i.test(ua)) return 'winget install MongoDB.Shell (or the MSI from mongodb.com)';
+    if (/linux/i.test(ua)) return 'sudo apt install mongodb-mongosh (or your distro’s package)';
+    return 'install mongosh from mongodb.com';
+  }, []);
 
   const executeFind = async (
     collName: string,
@@ -635,26 +698,57 @@ export const MongoShell: React.FC<MongoShellProps> = ({
               <div className="text-sm font-semibold text-foreground">MongoShell requires mongosh</div>
               <div className="max-w-sm text-xs leading-relaxed text-muted-foreground">
                 A live mongosh session is required to run queries and scripts here.
-                Install mongosh and set its path in Settings, then retry.
               </div>
+              {detectedMongosh && (
+                <div
+                  className="max-w-sm rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs"
+                  data-testid="shell-detected-mongosh"
+                >
+                  <div className="text-foreground">
+                    Found <span className="font-semibold">mongosh {detectedMongosh.version}</span>
+                  </div>
+                  <div className="truncate font-mono text-ui-2xs text-muted-foreground" title={detectedMongosh.path}>
+                    {detectedMongosh.path}
+                  </div>
+                  <Button
+                    size="sm"
+                    className="mt-1.5"
+                    onClick={() => void saveMongoshPath(detectedMongosh.path)}
+                    data-testid="shell-use-detected-btn"
+                  >
+                    Use this binary
+                  </Button>
+                </div>
+              )}
               <div className="mt-1 flex items-center gap-2">
-                {onOpenSettings && (
-                  <Button onClick={onOpenSettings} data-testid="gate-open-settings">
-                    Open Settings
+                {onInstallTools && (
+                  <Button onClick={onInstallTools} data-testid="shell-install-tools-btn">
+                    Install tools…
                   </Button>
                 )}
-                {onInstallTools && (
-                  <Button
-                    variant="outline"
-                    onClick={onInstallTools}
-                    data-testid="shell-install-tools-btn"
-                  >
-                    Install tools…
+                <Button variant="outline" onClick={() => void browseForMongosh()} data-testid="shell-browse-mongosh-btn">
+                  Browse for binary…
+                </Button>
+                {onOpenSettings && (
+                  <Button variant="outline" onClick={onOpenSettings} data-testid="gate-open-settings">
+                    Open Settings
                   </Button>
                 )}
                 <Button variant="outline" onClick={() => setRetryNonce((n) => n + 1)} data-testid="gate-retry">
                   Retry
                 </Button>
+              </div>
+              <div className="max-w-sm text-ui-2xs text-muted-foreground" data-testid="shell-install-hint">
+                Or install it yourself: <code className="font-mono">{installHint}</code> — see the{' '}
+                <button
+                  type="button"
+                  className="text-primary underline-offset-2 hover:underline"
+                  onClick={() => void openUrl('https://www.mongodb.com/docs/mongodb-shell/install/')}
+                  data-testid="shell-mongosh-docs-link"
+                >
+                  mongosh install docs
+                </button>
+                .
               </div>
             </>
           )}

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -7,6 +7,15 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: any[]) => mockInvoke(...args),
 }));
 
+const mockOpenDialog = vi.fn();
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: (...args: any[]) => mockOpenDialog(...args),
+}));
+const mockOpenUrl = vi.fn();
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: (...args: any[]) => mockOpenUrl(...args),
+}));
+
 vi.mock('@monaco-editor/react', () => ({
   default: ({ value, onChange }: any) => (
     <textarea
@@ -543,5 +552,86 @@ describe('MongoShell Component', () => {
       'run_mongosh_command',
       expect.objectContaining({ command: script })
     );
+  });
+
+  describe('guided mongosh setup on session failure', () => {
+    const renderFailedShell = (overrides: Record<string, (args: any) => any> = {}) => {
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        if (overrides[cmd]) return overrides[cmd](args);
+        if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+        if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '' });
+        if (cmd === 'test_mongosh_path') return Promise.reject(new Error('Failed to run mongosh'));
+        if (cmd === 'start_mongosh_session')
+          return Promise.reject(new Error('Failed to start mongosh'));
+        if (cmd === 'detect_mongosh_binary') return Promise.resolve(null);
+        if (cmd === 'save_app_settings') return Promise.resolve();
+        return Promise.resolve([]);
+      });
+      render(
+        <MongoShell
+          connectionId="conn-1"
+          connectionName="mock"
+          connectionUri="mongodb://prod-replica-set"
+          databaseName="sales_db"
+        />
+      );
+    };
+
+    it('offers a detected mongosh and saves it on confirmation', async () => {
+      renderFailedShell({
+        detect_mongosh_binary: () =>
+          Promise.resolve({ path: '/opt/homebrew/bin/mongosh', version: '2.9.9', source: 'path' }),
+      });
+
+      expect(await screen.findByTestId('shell-detected-mongosh')).toHaveTextContent(
+        /2\.9\.9.*\/opt\/homebrew\/bin\/mongosh|\/opt\/homebrew\/bin\/mongosh.*2\.9\.9/
+      );
+      fireEvent.click(screen.getByTestId('shell-use-detected-btn'));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith(
+          'save_app_settings',
+          expect.objectContaining({
+            settings: expect.objectContaining({ mongosh_path: '/opt/homebrew/bin/mongosh' }),
+          })
+        );
+      });
+      // Saving retries the session.
+      const sessionAttempts = mockInvoke.mock.calls.filter(([cmd]) => cmd === 'start_mongosh_session');
+      await waitFor(() => {
+        expect(
+          mockInvoke.mock.calls.filter(([cmd]) => cmd === 'start_mongosh_session').length
+        ).toBeGreaterThan(sessionAttempts.length - 1);
+      });
+    });
+
+    it('lets the user browse for a binary and saves the pick', async () => {
+      mockOpenDialog.mockResolvedValue('/custom/tools/mongosh');
+      renderFailedShell();
+
+      fireEvent.click(await screen.findByTestId('shell-browse-mongosh-btn'));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith(
+          'save_app_settings',
+          expect.objectContaining({
+            settings: expect.objectContaining({ mongosh_path: '/custom/tools/mongosh' }),
+          })
+        );
+      });
+    });
+
+    it('shows install instructions and a MongoDB docs link when nothing is found', async () => {
+      renderFailedShell();
+
+      expect(await screen.findByTestId('shell-install-hint')).toBeInTheDocument();
+      const docsLink = screen.getByTestId('shell-mongosh-docs-link');
+      fireEvent.click(docsLink);
+      await waitFor(() => {
+        expect(mockOpenUrl).toHaveBeenCalledWith(
+          expect.stringContaining('mongodb.com/docs/mongodb-shell')
+        );
+      });
+    });
   });
 });

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -621,6 +621,27 @@ describe('MongoShell Component', () => {
       });
     });
 
+    it('re-attempts the session even when the picked binary equals the configured path', async () => {
+      // Same path as already configured: without an explicit retry, the state
+      // update is a no-op and the session would never be re-attempted.
+      mockOpenDialog.mockResolvedValue('/already/configured/mongosh');
+      renderFailedShell({
+        load_app_settings: () => Promise.resolve({ mongosh_path: '/already/configured/mongosh' }),
+      });
+
+      const browseBtn = await screen.findByTestId('shell-browse-mongosh-btn');
+      const attemptsBefore = mockInvoke.mock.calls.filter(
+        ([cmd]) => cmd === 'start_mongosh_session'
+      ).length;
+      fireEvent.click(browseBtn);
+
+      await waitFor(() => {
+        expect(
+          mockInvoke.mock.calls.filter(([cmd]) => cmd === 'start_mongosh_session').length
+        ).toBeGreaterThan(attemptsBefore);
+      });
+    });
+
     it('shows install instructions and a MongoDB docs link when nothing is found', async () => {
       renderFailedShell();
 


### PR DESCRIPTION
Closes #124.

## Summary

The 0.10.0 managed-tools work already gave the shell's failure gate an "Install tools…" path; this fills the remaining acceptance criteria:

- **Probe on failure**: new `detect_mongosh` (backend) checks the configured path, the managed install, every PATH entry, and well-known install locations — including `%ProgramFiles%\mongosh` / `%LOCALAPPDATA%\Programs\mongosh` on Windows, which has no login-shell PATH merge like Unix's `path_env`
- **Auto-save with confirmation**: a found binary shows as "Found mongosh 2.x at …" with a one-click **Use this binary** that saves it to settings and re-attempts the session
- **Browse for binary…** file picker on the card, same save-and-retry flow
- **OS-specific install hint** (brew / winget-MSI / apt) plus a link to the mongosh install docs

A configured path that still probes OK is deliberately not offered — the session failure then has a different cause and "use this path" would be a no-op.

## Test plan
- [x] Rust: `detect_mongosh_probes_in_order_and_reports_source` (probe order, source labels, broken-configured fallback, managed-beats-common) — 226 backend tests green
- [x] Frontend: 3 new MongoShell gate tests (detected-offer saves + retries; browse saves the pick; hint + docs link) — 671 tests across 59 files green, typecheck clean