### PR TITLE
feat: SSH tunnel authentication via the system ssh-agent (#130)

### DIFF
--- a/src-tauri/src/ssh_tunnel.rs
+++ b/src-tauri/src/ssh_tunnel.rs
@@ -7,6 +7,7 @@ fn default_ssh_port() -> u16 {
 /// SSH authentication method. Frontend-shaped, internally tagged:
 ///   {"type":"password","password":"..."}
 ///   {"type":"key","path":"...","passphrase":"..."}
+///   {"type":"agent"}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum SshAuth {
@@ -18,6 +19,8 @@ pub enum SshAuth {
         #[serde(default)]
         passphrase: Option<String>,
     },
+    /// Delegate signing to the system ssh-agent; no key material is stored.
+    Agent,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -104,10 +107,64 @@ pub fn rewrite_uri_hosts(uri: &str, local_host: &str, local_port: u16) -> String
 // ── Live SSH tunnel (russh) ────────────────────────────────────────────────
 use std::sync::{Arc, Mutex as StdMutex};
 use russh::client::{self, Config};
+use russh::keys::agent::client::{AgentClient, AgentStream};
+use russh::keys::agent::AgentIdentity;
 use russh::keys::{check_known_hosts, load_secret_key, ssh_key, PrivateKeyWithHashAlg};
 use russh::{ChannelMsg, Disconnect};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+
+/// An ssh-agent connection over whatever transport the platform uses
+/// (unix socket, Windows named pipe).
+pub(crate) type BoxedAgentClient = AgentClient<Box<dyn AgentStream + Send + Unpin>>;
+
+/// Connect to the system ssh-agent. `sock` is the value of `SSH_AUTH_SOCK`
+/// (passed explicitly so tests don't depend on the ambient environment).
+/// Errors are user-readable and actionable.
+#[cfg(unix)]
+pub(crate) async fn connect_agent_at(sock: Option<String>) -> Result<BoxedAgentClient, String> {
+    let sock = match sock.filter(|s| !s.is_empty()) {
+        Some(s) => s,
+        None => {
+            return Err(
+                "SSH agent not reachable (SSH_AUTH_SOCK is not set). Start an ssh-agent and load your key with ssh-add."
+                    .to_string(),
+            )
+        }
+    };
+    AgentClient::connect_uds(&sock)
+        .await
+        .map(|c| c.dynamic())
+        .map_err(|e| {
+            format!(
+                "SSH agent not reachable at '{}': {}. Is your ssh-agent running?",
+                sock, e
+            )
+        })
+}
+
+/// Windows: the OpenSSH agent service listens on a well-known named pipe;
+/// `SSH_AUTH_SOCK`, when set, may point at an alternative pipe.
+#[cfg(windows)]
+pub(crate) async fn connect_agent_at(sock: Option<String>) -> Result<BoxedAgentClient, String> {
+    let pipe = sock
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| r"\\.\pipe\openssh-ssh-agent".to_string());
+    AgentClient::connect_named_pipe(&pipe)
+        .await
+        .map(|c| c.dynamic())
+        .map_err(|e| {
+            format!(
+                "SSH agent not reachable at '{}': {}. Is the 'OpenSSH Authentication Agent' service running?",
+                pipe, e
+            )
+        })
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) async fn connect_agent_at(_sock: Option<String>) -> Result<BoxedAgentClient, String> {
+    Err("ssh-agent is not supported on this platform yet".to_string())
+}
 
 // russh client handler that verifies the server host key against ~/.ssh/known_hosts.
 struct TunnelClient {
@@ -209,6 +266,66 @@ pub async fn open_tunnel(
                 .await
                 .map_err(|e| format!("SSH public-key authentication error: {}", e))?
                 .success()
+        }
+        SshAuth::Agent => {
+            let mut agent = connect_agent_at(std::env::var("SSH_AUTH_SOCK").ok()).await?;
+            let identities = agent
+                .request_identities()
+                .await
+                .map_err(|e| format!("Failed to list SSH agent identities: {}", e))?;
+            if identities.is_empty() {
+                return Err(
+                    "SSH agent has no identities loaded — add one with ssh-add.".to_string()
+                );
+            }
+            let hash = session
+                .best_supported_rsa_hash()
+                .await
+                .map_err(|e| format!("SSH key hash negotiation failed: {}", e))?
+                .flatten();
+            // Try every identity the agent holds; signing stays in the agent.
+            let mut authed = false;
+            let mut last_err: Option<String> = None;
+            for identity in identities {
+                let result = match identity {
+                    AgentIdentity::PublicKey { key, .. } => {
+                        session
+                            .authenticate_publickey_with(cfg.user.clone(), key, hash, &mut agent)
+                            .await
+                    }
+                    AgentIdentity::Certificate { certificate, .. } => {
+                        session
+                            .authenticate_certificate_with(
+                                cfg.user.clone(),
+                                certificate,
+                                hash,
+                                &mut agent,
+                            )
+                            .await
+                    }
+                };
+                match result {
+                    Ok(r) if r.success() => {
+                        authed = true;
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(e) => last_err = Some(e.to_string()),
+                }
+            }
+            if !authed {
+                return Err(match last_err {
+                    Some(e) => format!(
+                        "SSH agent identities were rejected by the server for user '{}' (last agent error: {})",
+                        cfg.user, e
+                    ),
+                    None => format!(
+                        "SSH agent identities were rejected by the server for user '{}'.",
+                        cfg.user
+                    ),
+                });
+            }
+            true
         }
     };
     if !authed {

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1048,6 +1048,139 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_ssh_auth_agent_serde_roundtrip() {
+        use crate::ssh_tunnel::{SshAuth, SshConfig};
+        let cfg = SshConfig {
+            enabled: true,
+            host: "bastion".into(),
+            port: 22,
+            user: "ops".into(),
+            auth: SshAuth::Agent,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(
+            json.contains(r#""auth":{"type":"agent"}"#),
+            "agent auth must serialize frontend-shaped, got: {}",
+            json
+        );
+        let back: SshConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.auth, SshAuth::Agent);
+
+        // agent variant from frontend-shaped JSON
+        let fe: SshConfig = serde_json::from_str(
+            r#"{"enabled":true,"host":"h","port":22,"user":"u","auth":{"type":"agent"}}"#,
+        )
+        .unwrap();
+        assert_eq!(fe.auth, SshAuth::Agent);
+    }
+
+    // Agent auth must fail with an actionable message when SSH_AUTH_SOCK is not
+    // set. The helper takes the socket path as a parameter so this test does not
+    // depend on (or mutate) the ambient environment.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_agent_connect_error_when_sock_unset() {
+        let err = crate::ssh_tunnel::connect_agent_at(None)
+            .await
+            .err()
+            .expect("connecting without SSH_AUTH_SOCK must fail");
+        assert!(
+            err.contains("SSH_AUTH_SOCK is not set"),
+            "error should name the missing env var, got: {}",
+            err
+        );
+        assert!(err.contains("SSH agent not reachable"), "got: {}", err);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_agent_connect_error_when_sock_missing() {
+        let err = crate::ssh_tunnel::connect_agent_at(Some(
+            "/nonexistent/mqlens-test-agent.sock".to_string(),
+        ))
+        .await
+        .err()
+        .expect("connecting to a missing socket must fail");
+        assert!(
+            err.contains("SSH agent not reachable") && err.contains("/nonexistent/mqlens-test-agent.sock"),
+            "error should name the socket path, got: {}",
+            err
+        );
+    }
+
+    // Live agent integration: spawn a real ssh-agent, add a throwaway ed25519
+    // key, and list identities through the russh agent client. Skips (does not
+    // fail) when ssh-agent/ssh-keygen/ssh-add are unavailable on this machine.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_agent_lists_identities_via_live_agent() {
+        use std::process::Command;
+
+        let agent_out = match Command::new("ssh-agent").arg("-s").output() {
+            Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
+            _ => {
+                eprintln!("skipping: ssh-agent not available");
+                return;
+            }
+        };
+        // Parse `SSH_AUTH_SOCK=/path; export SSH_AUTH_SOCK;` / `SSH_AGENT_PID=123; ...`
+        let parse_var = |name: &str| -> Option<String> {
+            agent_out.lines().find_map(|l| {
+                let rest = l.trim().strip_prefix(&format!("{}=", name))?;
+                Some(rest.split(';').next()?.to_string())
+            })
+        };
+        let sock = parse_var("SSH_AUTH_SOCK").expect("ssh-agent output has SSH_AUTH_SOCK");
+        let pid = parse_var("SSH_AGENT_PID");
+        // Ensure the agent is killed even if assertions below fail.
+        struct KillAgent(Option<String>);
+        impl Drop for KillAgent {
+            fn drop(&mut self) {
+                if let Some(pid) = self.0.take() {
+                    let _ = std::process::Command::new("kill").arg(pid).status();
+                }
+            }
+        }
+        let _kill = KillAgent(pid);
+
+        let dir = std::env::temp_dir().join(format!("mqlens-agent-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp key dir");
+        let key_path = dir.join("id_ed25519");
+        let keygen = Command::new("ssh-keygen")
+            .args(["-t", "ed25519", "-N", "", "-q", "-f"])
+            .arg(&key_path)
+            .status();
+        if !matches!(keygen, Ok(s) if s.success()) {
+            eprintln!("skipping: ssh-keygen not available");
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
+        let added = Command::new("ssh-add")
+            .arg(&key_path)
+            .env("SSH_AUTH_SOCK", &sock)
+            .status();
+        if !matches!(added, Ok(s) if s.success()) {
+            eprintln!("skipping: ssh-add not available or failed");
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
+
+        let mut agent = crate::ssh_tunnel::connect_agent_at(Some(sock))
+            .await
+            .expect("connect to live ssh-agent");
+        let identities = agent
+            .request_identities()
+            .await
+            .expect("list identities from live ssh-agent");
+        assert!(
+            !identities.is_empty(),
+            "agent should hold the key we just added"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     // GO-LIVE H2: count must reflect the true match count, not the page size.
     #[tokio::test]
     async fn test_mock_count_documents() {

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -57,7 +57,8 @@ export type SshConfig = {
   user: string;
   auth:
     | { type: 'password'; password: string }
-    | { type: 'key'; path: string; passphrase?: string };
+    | { type: 'key'; path: string; passphrase?: string }
+    | { type: 'agent' };
 };
 
 interface ConnectionProfile {
@@ -363,7 +364,9 @@ export const buildSshConfig = (s: typeof BLANK_CONN): SshConfig | null => {
   const auth =
     s.sshAuth === 'password'
       ? { type: 'password' as const, password: s.sshPass }
-      : { type: 'key' as const, path: s.sshKey, passphrase: s.sshPass || undefined };
+      : s.sshAuth === 'agent'
+        ? { type: 'agent' as const }
+        : { type: 'key' as const, path: s.sshKey, passphrase: s.sshPass || undefined };
   return {
     enabled: true,
     host: s.sshHost,
@@ -503,12 +506,14 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
           sshHost: ssh.host,
           sshPort: String(ssh.port),
           sshUser: ssh.user,
-          sshAuth: ssh.auth.type === 'password' ? 'password' : 'key',
+          sshAuth: ssh.auth.type,
           sshKey: ssh.auth.type === 'key' ? ssh.auth.path : '',
           sshPass:
             ssh.auth.type === 'password'
               ? ssh.auth.password
-              : ssh.auth.passphrase || '',
+              : ssh.auth.type === 'key'
+                ? ssh.auth.passphrase || ''
+                : '',
         }
       : {};
 
@@ -1680,18 +1685,19 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                         <div className="flex flex-1 flex-col gap-1">
                           <Label>Auth Method</Label>
                           <Select value={editorState.sshAuth} onValueChange={(v) => setEditorState(prev => ({ ...prev, sshAuth: v }))}>
-                            <SelectTrigger className="h-8 text-xs">
+                            <SelectTrigger className="h-8 text-xs" data-testid="ssh-auth-select">
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent className={NESTED_SELECT_Z}>
                               <SelectItem value="key">Private Key</SelectItem>
                               <SelectItem value="password">Password</SelectItem>
+                              <SelectItem value="agent">SSH Agent</SelectItem>
                             </SelectContent>
                           </Select>
                         </div>
                       </div>
 
-                      {editorState.sshAuth === 'key' ? (
+                      {editorState.sshAuth === 'key' && (
                         <>
                           <div className="flex flex-col gap-1">
                             <Label>Private Key Path</Label>
@@ -1713,7 +1719,8 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                             />
                           </div>
                         </>
-                      ) : (
+                      )}
+                      {editorState.sshAuth === 'password' && (
                         <div className="flex flex-col gap-1">
                           <Label>SSH Password</Label>
                           <PasswordInput
@@ -1722,6 +1729,15 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                             placeholder="••••••••"
                             className="font-mono"
                           />
+                        </div>
+                      )}
+                      {editorState.sshAuth === 'agent' && (
+                        <div
+                          data-testid="ssh-agent-note"
+                          className="rounded border border-border bg-muted/40 px-2 py-1.5 text-[10.5px] leading-relaxed text-muted-foreground"
+                        >
+                          Authentication uses your system ssh-agent (SSH_AUTH_SOCK). Keys and
+                          passphrases stay in the agent and never touch MQLens or the saved profile.
                         </div>
                       )}
 

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -371,6 +371,111 @@ describe('buildSshConfig (C7)', () => {
     });
     expect(cfg?.auth).toEqual({ type: 'password', password: 'pw' });
   });
+
+  it('builds an agent-auth config without any secret material', () => {
+    const cfg = buildSshConfig({
+      ...sshBase,
+      sshEnabled: true,
+      sshHost: 'h',
+      sshUser: 'u',
+      sshAuth: 'agent',
+      sshKey: '~/.ssh/id_ed25519', // stale form state must not leak into the config
+      sshPass: 'leftover',
+    });
+    expect(cfg?.auth).toEqual({ type: 'agent' });
+  });
+});
+
+describe('SSH agent auth in the editor (issue #130)', () => {
+  const agentProfile = {
+    id: 'p-agent',
+    name: 'Bastion',
+    uri: 'mongodb://db.internal:27017',
+    ssh: { enabled: true, host: 'jump.example.com', port: 22, user: 'ops', auth: { type: 'agent' } },
+    color_tag: null,
+  };
+
+  const renderWithProfiles = (profiles: any[], onSave: (p: any) => void = () => {}) => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve(profiles);
+      if (cmd === 'save_connection_profile') {
+        onSave(args.profile);
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+  };
+
+  const openSshTab = async () => {
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+    fireEvent.click(screen.getByRole('button', { name: /ssh tunnel/i }));
+    fireEvent.click(screen.getByLabelText(/enable ssh tunnel/i));
+  };
+
+  it('selecting "SSH agent" hides key/password inputs, shows the security note, and saves auth {type: agent}', async () => {
+    let savedProfile: any = null;
+    renderWithProfiles([], (p) => { savedProfile = p; });
+
+    await openSshTab();
+    fireEvent.change(screen.getByPlaceholderText('ssh.server.com'), { target: { value: 'jump.example.com' } });
+    fireEvent.change(screen.getByPlaceholderText('deploy'), { target: { value: 'ops' } });
+
+    await pickSelectOption('ssh-auth-select', /ssh agent/i);
+
+    // Key/password inputs are hidden; the security note is shown instead.
+    expect(screen.queryByPlaceholderText('~/.ssh/id_ed25519')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('••••••••')).not.toBeInTheDocument();
+    const note = screen.getByTestId('ssh-agent-note');
+    expect(note).toHaveTextContent(/SSH_AUTH_SOCK/);
+    expect(note).toHaveTextContent(/never/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => {
+      expect(savedProfile?.ssh).toEqual({
+        enabled: true,
+        host: 'jump.example.com',
+        port: 22,
+        user: 'ops',
+        auth: { type: 'agent' },
+      });
+    });
+  });
+
+  it('switching back from agent to key/password restores those inputs', async () => {
+    renderWithProfiles([]);
+    await openSshTab();
+
+    await pickSelectOption('ssh-auth-select', /ssh agent/i);
+    expect(screen.getByTestId('ssh-agent-note')).toBeInTheDocument();
+
+    await pickSelectOption('ssh-auth-select', /private key/i);
+    expect(screen.queryByTestId('ssh-agent-note')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('~/.ssh/id_ed25519')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/leave blank if the key is unencrypted/i)).toBeInTheDocument();
+
+    await pickSelectOption('ssh-auth-select', /^password$/i);
+    expect(screen.queryByTestId('ssh-agent-note')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('••••••••')).toBeInTheDocument();
+  });
+
+  it('round-trips a saved profile with agent auth through edit and save', async () => {
+    let savedProfile: any = null;
+    renderWithProfiles([agentProfile], (p) => { savedProfile = p; });
+
+    fireEvent.click((await screen.findAllByText('Bastion'))[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    // The SSH tab reflects the persisted agent auth without touching anything.
+    fireEvent.click(screen.getByRole('button', { name: /ssh tunnel/i }));
+    expect(screen.getByTestId('ssh-agent-note')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('~/.ssh/id_ed25519')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => {
+      expect(savedProfile?.ssh).toEqual(agentProfile.ssh);
+    });
+  });
 });
 
 describe('ConnectionManager Component', () => {


### PR DESCRIPTION
Closes #130.

## Summary

Adds **SSH agent** as a third tunnel auth mode alongside password and key file — for enterprise setups where key passphrases must not be stored in desktop apps.

- `SshAuth::Agent` (`{"type":"agent"}`): connects to the system agent, lists its identities, and tries each via agent-side signing (`authenticate_publickey_with`); **certificate identities are supported** via `authenticate_certificate_with` — key material and passphrases never touch MQLens or the saved profile
- Unix: `SSH_AUTH_SOCK` (passed explicitly through a testable helper); **Windows: the OpenSSH agent named pipe** (`\\.\pipe\openssh-ssh-agent`, or `SSH_AUTH_SOCK` as an alternate pipe path) — russh 0.61 supports both transports
- Actionable errors for every failure mode: agent socket unset, agent unreachable, no identities loaded (points at `ssh-add`), all identities rejected (names the user, includes the last agent error)
- Connection dialog: "SSH Agent" auth option hides the key/password inputs and shows a security note; agent profiles round-trip through edit/save

## Test plan
- [x] Rust: serde round-trip, socket-unset and socket-missing error paths, plus a live-agent integration test (spawns a real `ssh-agent`, generates + adds an ed25519 key, lists identities through the russh agent client; skips gracefully where the tools are missing) — 229 backend tests green
- [x] Frontend: 4 new ConnectionManager tests (agent config carries no secret material; selecting agent hides inputs + shows the note; switching back restores inputs; saved-profile round-trip) — 672 frontend tests green, typecheck clean
- [ ] Manual: tunnel to a real host with the local ssh-agent (macOS Keychain agent) holding the key