### PR TITLE
feat: distinct sidebar icon for time-series collections (#137)

### DIFF
--- a/src-tauri/src/db/copy.rs
+++ b/src-tauri/src/db/copy.rs
@@ -775,8 +775,8 @@ mod tests {
         ).await.unwrap();
         let tasks = state.tasks.lock().unwrap();
         let s = tasks.get(&task.id).unwrap().summary.as_ref().unwrap();
-        // sales_db mock has customers, transactions, products -> 3 collections.
-        assert_eq!(s.collections_copied, 3);
+        // sales_db mock has customers, transactions, products, sensor_readings -> 4 collections.
+        assert_eq!(s.collections_copied, 4);
     }
 
     #[tokio::test]

--- a/src-tauri/src/db/metadata.rs
+++ b/src-tauri/src/db/metadata.rs
@@ -52,9 +52,9 @@ pub async fn list_collections_impl(
     if is_mock {
         return Ok(mock_db::get_mock_collections(db)
             .into_iter()
-            .map(|name| CollectionInfo {
+            .map(|(name, collection_type)| CollectionInfo {
                 name,
-                collection_type: "collection".to_string(),
+                collection_type: collection_type.to_string(),
             })
             .collect());
     }

--- a/src-tauri/src/mock_db.rs
+++ b/src-tauri/src/mock_db.rs
@@ -1,14 +1,23 @@
 use serde_json::Value;
 
-pub fn get_mock_collections(db: &str) -> Vec<String> {
+// (name, type) pairs — type is "collection" or "timeseries", matching the
+// strings list_collections_impl reports for real clusters.
+pub fn get_mock_collections(db: &str) -> Vec<(String, &'static str)> {
     match db {
         "sales_db" => vec![
-            "customers".to_string(),
-            "transactions".to_string(),
-            "products".to_string(),
+            ("customers".to_string(), "collection"),
+            ("transactions".to_string(), "collection"),
+            ("products".to_string(), "collection"),
+            ("sensor_readings".to_string(), "timeseries"),
         ],
-        "user_analytics" => vec!["events".to_string(), "sessions".to_string()],
-        "admin" => vec!["system.users".to_string(), "system.version".to_string()],
+        "user_analytics" => vec![
+            ("events".to_string(), "collection"),
+            ("sessions".to_string(), "collection"),
+        ],
+        "admin" => vec![
+            ("system.users".to_string(), "collection"),
+            ("system.version".to_string(), "collection"),
+        ],
         _ => vec![],
     }
 }
@@ -276,6 +285,31 @@ fn get_mock_data(database: &str, collection: &str) -> Vec<Value> {
                 }),
             ]
         }
+        ("sales_db", "sensor_readings") => {
+            vec![
+                serde_json::json!({
+                    "_id": { "$oid": "603d779f4f102e3a105c3320" },
+                    "timestamp": "2026-07-10T08:00:00Z",
+                    "sensor_id": "temp-01",
+                    "value": 21.4,
+                    "unit": "C"
+                }),
+                serde_json::json!({
+                    "_id": { "$oid": "603d779f4f102e3a105c3321" },
+                    "timestamp": "2026-07-10T08:05:00Z",
+                    "sensor_id": "temp-01",
+                    "value": 21.9,
+                    "unit": "C"
+                }),
+                serde_json::json!({
+                    "_id": { "$oid": "603d779f4f102e3a105c3322" },
+                    "timestamp": "2026-07-10T08:10:00Z",
+                    "sensor_id": "hum-02",
+                    "value": 44.0,
+                    "unit": "%"
+                }),
+            ]
+        }
         _ => vec![],
     }
 }
@@ -307,6 +341,7 @@ pub fn get_mock_indexes(db: &str, collection: &str) -> Vec<crate::IndexInfo> {
         ("sales_db", "customers") => vec!["_id_", "email_1", "tier_1"],
         ("sales_db", "transactions") => vec!["_id_", "timestamp_-1", "customer_name_1"],
         ("sales_db", "products") => vec!["_id_", "price_1", "category_1"],
+        ("sales_db", "sensor_readings") => vec!["_id_", "timestamp_-1"],
         ("user_analytics", "events") => vec!["_id_", "event_type_1", "timestamp_-1"],
         ("user_analytics", "sessions") => vec!["_id_", "session_id_1"],
         ("admin", "system.users") => vec!["_id_", "user_1_db_1"],

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -128,6 +128,7 @@ mod tests {
         assert!(collection_names.contains(&"transactions".to_string()));
         assert!(collections
             .iter()
+            .filter(|c| c.name != "sensor_readings")
             .all(|c| c.collection_type == "collection"));
 
         // 3b. Test list indexes
@@ -184,6 +185,32 @@ mod tests {
             let mocks = state.mocks.lock().unwrap();
             assert!(!mocks.contains_key(&conn_id));
         }
+    }
+
+    // Issue #137: demo mode must surface a time-series collection so the
+    // sidebar's distinct icon is visible without a live cluster.
+    #[tokio::test]
+    async fn test_mock_collections_report_timeseries_type() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let collections = list_collections_impl(&state, &conn_id, "sales_db")
+            .await
+            .expect("list mock collections");
+
+        let sensor = collections
+            .iter()
+            .find(|c| c.name == "sensor_readings")
+            .expect("sales_db should include sensor_readings");
+        assert_eq!(sensor.collection_type, "timeseries");
+
+        let customers = collections
+            .iter()
+            .find(|c| c.name == "customers")
+            .expect("customers still listed");
+        assert_eq!(customers.collection_type, "collection");
     }
 
     #[tokio::test]
@@ -2878,12 +2905,21 @@ mod tests {
         };
 
         // Collections per database, plus the empty fallback for an unknown db.
-        assert!(get_mock_collections("sales_db").contains(&"transactions".to_string()));
+        let sales_names: Vec<String> = get_mock_collections("sales_db")
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert!(sales_names.contains(&"transactions".to_string()));
         assert_eq!(
             get_mock_collections("user_analytics"),
-            vec!["events".to_string(), "sessions".to_string()]
+            vec![
+                ("events".to_string(), "collection"),
+                ("sessions".to_string(), "collection"),
+            ]
         );
-        assert!(get_mock_collections("admin").contains(&"system.users".to_string()));
+        assert!(get_mock_collections("admin")
+            .iter()
+            .any(|(name, _)| name == "system.users"));
         assert!(get_mock_collections("nope").is_empty());
 
         // Query + count across the non-products datasets (each hits a distinct match arm).

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -126,6 +126,7 @@ mod tests {
         let collection_names: Vec<String> = collections.iter().map(|c| c.name.clone()).collect();
         assert!(collection_names.contains(&"customers".to_string()));
         assert!(collection_names.contains(&"transactions".to_string()));
+        // sensor_readings is timeseries; its type is asserted in test_mock_collections_report_timeseries_type
         assert!(collections
             .iter()
             .filter(|c| c.name != "sensor_readings")

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -91,6 +91,7 @@ import {
   ClipboardPaste,
   DatabaseBackup,
   DatabaseZap,
+  ChartLine,
 } from 'lucide-react';
 
 const REPO_URL = 'https://github.com/mqlens/mqlens-mongodb';
@@ -1118,6 +1119,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     const collKey = `${connId}/${dbName}/${collName}`;
     const isCollExpanded = expandedCollections[collKey];
     const collIndexes = indexes[collKey] || [];
+    const collType = (collections[`${connId}/${dbName}`] || []).find((c) => c.name === collName)?.type;
     const isActive =
       activeCollection?.connectionId === connId &&
       activeCollection?.db === dbName &&
@@ -1146,7 +1148,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 size={10}
                 className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isCollExpanded && 'rotate-90')}
               />
-              <Layers size={11} className={cn('shrink-0', isActive ? 'text-primary' : 'text-emerald-500')} />
+              {collType === 'timeseries' ? (
+                <span
+                  title="Time-series collection"
+                  data-testid="coll-icon-timeseries"
+                  className="flex shrink-0 items-center"
+                >
+                  <ChartLine size={11} className={cn('shrink-0', isActive ? 'text-primary' : 'text-emerald-500')} />
+                </span>
+              ) : (
+                <Layers size={11} className={cn('shrink-0', isActive ? 'text-primary' : 'text-emerald-500')} />
+              )}
               <span className="min-w-0 truncate" title={collName}>
                 {collName}
               </span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -87,11 +87,11 @@ import {
   X,
   Pin,
   Heart,
-  Copy,
+  ChartLine,
   ClipboardPaste,
+  Copy,
   DatabaseBackup,
   DatabaseZap,
-  ChartLine,
 } from 'lucide-react';
 
 const REPO_URL = 'https://github.com/mqlens/mqlens-mongodb';

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -280,8 +280,14 @@ describe('Sidebar Component', () => {
     await screen.findByText('sensor_readings');
     expect(screen.getByText('customers')).toBeInTheDocument();
 
+    // Views live in their own folder — expand it so the view row is actually
+    // rendered; otherwise the "views unaffected" check below is vacuous.
+    fireEvent.click(screen.getByText('Views'));
+    await screen.findByText('active_users');
+
     // Exactly one row gets the time-series icon — the regular collection
-    // (and anything else in the tree) keeps the generic Layers icon.
+    // (and anything else in the tree, including the view row) keeps the
+    // generic Layers icon.
     const tsIcons = screen.getAllByTestId('coll-icon-timeseries');
     expect(tsIcons).toHaveLength(1);
     expect(tsIcons[0]).toHaveAttribute('title', 'Time-series collection');

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -250,6 +250,43 @@ describe('Sidebar Component', () => {
     expect(handleDisconnect).toHaveBeenCalledWith('conn-1');
   });
 
+  it('renders a distinct icon for time-series collections (#137)', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections' && args.db === 'sales_db') {
+        return Promise.resolve([
+          { name: 'customers', type: 'collection' },
+          { name: 'sensor_readings', type: 'timeseries' },
+        ]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('sales_db'));
+    fireEvent.click(await screen.findByText('Collections'));
+    await screen.findByText('sensor_readings');
+    expect(screen.getByText('customers')).toBeInTheDocument();
+
+    // Exactly one row gets the time-series icon — the regular collection
+    // (and anything else in the tree) keeps the generic Layers icon.
+    const tsIcons = screen.getAllByTestId('coll-icon-timeseries');
+    expect(tsIcons).toHaveLength(1);
+    expect(tsIcons[0]).toHaveAttribute('title', 'Time-series collection');
+    expect(tsIcons[0].closest('div')).toHaveTextContent('sensor_readings');
+  });
+
   it('sorts collections by name before rendering', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -257,6 +257,7 @@ describe('Sidebar Component', () => {
         return Promise.resolve([
           { name: 'customers', type: 'collection' },
           { name: 'sensor_readings', type: 'timeseries' },
+          { name: 'active_users', type: 'view' },
         ]);
       }
       return Promise.reject(new Error(`Unhandled mock: ${cmd}`));


### PR DESCRIPTION
Closes #137.

- Collections with `type === 'timeseries'` render a ChartLine icon with a "Time-series collection" tooltip in the sidebar tree; regular collections and views are unchanged (covered by tests, including a view-row case).
- Demo mode (`mongodb://mock`) now includes a `sensor_readings` time-series collection with sample documents and indexes so the icon is visible without a live cluster.
- Backend: `get_mock_collections` returns (name, type) pairs; the real-cluster path already reported `timeseries`. The mock database-copy test was updated for the fourth `sales_db` collection.

Verification: cargo 233/233, vitest 677/677 (with coverage), tsc clean.