### PR TITLE
release: v0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ npm install
 npm run tauri dev      # run the desktop app with hot reload
 ```
 
+For something to point the app at, seed the
+[local demo database](docs/demo-database.md) — synthetic collections, indexes,
+a view, and GridFS files that exercise every major workflow (and match the
+screenshots above).
+
 Other useful commands:
 
 ```bash

--- a/docs/demo-database.md
+++ b/docs/demo-database.md
@@ -1,0 +1,77 @@
+# Local demo database
+
+A seeded MongoDB database for developing MQLens, reproducing the README
+screenshots, and exercising every major workflow — browsing, querying,
+aggregations, indexes and explain plans, views, import/export, dump/restore,
+and GridFS — without touching real data.
+
+Everything here runs locally against a throwaway server. **Never use real
+secrets or production data for screenshots or test runs** — the seed data is
+entirely synthetic, and connection strings in captures should point at
+`localhost` only.
+
+## 1. Start MongoDB locally
+
+Any local MongoDB ≥ 6.0 works. The quickest option is Docker:
+
+```bash
+docker run -d --rm --name mqlens-demo -p 27017:27017 mongo:7
+```
+
+(Or use an existing local `mongod`; nothing in the seed requires a replica set
+or auth.)
+
+## 2. Seed the demo data
+
+From the repository root:
+
+```bash
+mongosh mongodb://localhost:27017 -f scripts/seed-demo-data.js
+```
+
+The script drops and recreates a single database, **`mqlens_demo`**, and prints
+a document-count summary when it finishes:
+
+| Collection | Docs | What it's for |
+|---|---|---|
+| `products` | 5 | Small flat collection — quick browsing, editing, schema view |
+| `customers` | 36 | Unique index (`email_1`), tags array, lifecycle facets |
+| `orders` | 180 | Nested `items` array + `shipping` subdocument, three secondary indexes — the main collection for queries, aggregations, and explain plans |
+| `events` | 260 | Time-series-ish audit log with a compound index |
+| `active_customer_revenue` | view | Aggregation view over `orders` (revenue by region) |
+| `fs.files` / `fs.chunks` | 2 files | Real GridFS files with consistent chunks — list, download, and delete all work |
+
+Re-running the script is safe: it drops `mqlens_demo` first and reseeds from
+scratch, so it doubles as a reset button after destructive experiments.
+
+## 3. Connect from MQLens
+
+Add a connection with the URI `mongodb://localhost:27017` (name it something
+like `Local demo`), connect, and open `mqlens_demo`.
+
+## 4. Suggested test flows
+
+- **Query bar** — on `orders`: `{ status: "shipped", region: "Europe" }`, or a
+  range like `{ total: { $gt: 300 } }`.
+- **Explain plans** — the query above uses `status_1_createdAt_-1` /
+  `region_1_total_-1`; drop the filter to compare against a COLLSCAN. Sorting
+  by `createdAt` shows index-backed sorts.
+- **Aggregation** — group revenue by region on `orders`, then compare with the
+  prebuilt `active_customer_revenue` view.
+- **Indexes** — `customers.email_1` is unique: inserting a duplicate email
+  demonstrates constraint errors safely.
+- **Import/export** — export `orders` as NDJSON/BSON/CSV, reimport into a new
+  collection; the `events` collection is good for filtered exports.
+- **Dump & restore** — a database-scope dump of `mqlens_demo` is small and
+  fast; restoring with renames exercises the namespace mapping.
+- **GridFS** — the two seeded files have real chunk data, so download and
+  delete flows work end to end; upload something to round-trip.
+
+## 5. Cleaning up
+
+```bash
+docker stop mqlens-demo    # container was started with --rm
+```
+
+Or, to remove just the data while keeping the server:
+`mongosh mongodb://localhost:27017 --eval 'db.getSiblingDB("mqlens_demo").dropDatabase()'`.

--- a/scripts/seed-demo-data.js
+++ b/scripts/seed-demo-data.js
@@ -101,15 +101,15 @@ const events = Array.from({ length: 260 }, (_, index) => ({
     rowsReturned: (index * 13) % 500,
   },
 }));
-db.events.insertMany(events);
+demoDb.events.insertMany(events);
 
-db.orders.createIndex({ status: 1, createdAt: -1 });
-db.orders.createIndex({ region: 1, total: -1 });
-db.orders.createIndex({ customerId: 1 });
-db.customers.createIndex({ email: 1 }, { unique: true });
-db.events.createIndex({ type: 1, createdAt: -1 });
+demoDb.orders.createIndex({ status: 1, createdAt: -1 });
+demoDb.orders.createIndex({ region: 1, total: -1 });
+demoDb.orders.createIndex({ customerId: 1 });
+demoDb.customers.createIndex({ email: 1 }, { unique: true });
+demoDb.events.createIndex({ type: 1, createdAt: -1 });
 
-db.createCollection('active_customer_revenue', {
+demoDb.createCollection('active_customer_revenue', {
   viewOn: 'orders',
   pipeline: [
     { $match: { status: { $in: ['shipped', 'delivered'] } } },
@@ -118,32 +118,71 @@ db.createCollection('active_customer_revenue', {
   ],
 });
 
-db.fs.files.insertMany([
+// GridFS files with real chunk data (lengths match the chunks), so listing,
+// downloading, and deleting in the GridFS view all work against them.
+const gridFsFiles = [
   {
-    _id: ObjectId(),
     filename: 'orders-q2-export.csv',
-    length: NumberLong('184320'),
-    chunkSize: 261120,
-    uploadDate: new Date(Date.UTC(2026, 5, 1, 10, 30)),
     contentType: 'text/csv',
+    uploadDate: new Date(Date.UTC(2026, 5, 1, 10, 30)),
     metadata: { owner: 'analytics', source: 'scheduled-export' },
+    content:
+      'orderNo,region,status,total\n' +
+      orders.slice(0, 25).map((o) => `${o.orderNo},${o.region},${o.status},${o.total}`).join('\n') +
+      '\n',
   },
   {
-    _id: ObjectId(),
     filename: 'customer-schema-snapshot.json',
-    length: NumberLong('32768'),
-    chunkSize: 261120,
-    uploadDate: new Date(Date.UTC(2026, 5, 2, 14, 15)),
     contentType: 'application/json',
+    uploadDate: new Date(Date.UTC(2026, 5, 2, 14, 15)),
     metadata: { owner: 'data-platform', source: 'schema-analysis' },
+    content: JSON.stringify(
+      {
+        collection: 'customers',
+        sampledAt: '2026-06-02T14:15:00Z',
+        fields: {
+          customerId: 'string',
+          name: 'string',
+          email: 'string',
+          region: 'string',
+          plan: 'string',
+          lifecycle: 'string',
+          seats: 'int',
+          spendToDate: 'int',
+          tags: 'array<string>',
+          createdAt: 'date',
+        },
+      },
+      null,
+      2,
+    ),
   },
-]);
+];
+
+for (const file of gridFsFiles) {
+  const bytes = Buffer.from(file.content, 'utf8');
+  const fileId = new ObjectId();
+  demoDb.fs.files.insertOne({
+    _id: fileId,
+    filename: file.filename,
+    length: Long.fromNumber(bytes.length),
+    chunkSize: 261120,
+    uploadDate: file.uploadDate,
+    contentType: file.contentType,
+    metadata: file.metadata,
+  });
+  demoDb.fs.chunks.insertOne({
+    files_id: fileId,
+    n: 0,
+    data: BinData(0, bytes.toString('base64')),
+  });
+}
 
 printjson({
   database: dbName,
-  products: db.products.countDocuments(),
-  customers: db.customers.countDocuments(),
-  orders: db.orders.countDocuments(),
-  events: db.events.countDocuments(),
-  gridFsFiles: db.fs.files.countDocuments(),
+  products: demoDb.products.countDocuments(),
+  customers: demoDb.customers.countDocuments(),
+  orders: demoDb.orders.countDocuments(),
+  events: demoDb.events.countDocuments(),
+  gridFsFiles: demoDb.fs.files.countDocuments(),
 });

--- a/src-tauri/src/db/copy.rs
+++ b/src-tauri/src/db/copy.rs
@@ -775,8 +775,8 @@ mod tests {
         ).await.unwrap();
         let tasks = state.tasks.lock().unwrap();
         let s = tasks.get(&task.id).unwrap().summary.as_ref().unwrap();
-        // sales_db mock has customers, transactions, products -> 3 collections.
-        assert_eq!(s.collections_copied, 3);
+        // sales_db mock has customers, transactions, products, sensor_readings -> 4 collections.
+        assert_eq!(s.collections_copied, 4);
     }
 
     #[tokio::test]

--- a/src-tauri/src/db/metadata.rs
+++ b/src-tauri/src/db/metadata.rs
@@ -52,9 +52,9 @@ pub async fn list_collections_impl(
     if is_mock {
         return Ok(mock_db::get_mock_collections(db)
             .into_iter()
-            .map(|name| CollectionInfo {
+            .map(|(name, collection_type)| CollectionInfo {
                 name,
-                collection_type: "collection".to_string(),
+                collection_type: collection_type.to_string(),
             })
             .collect());
     }

--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -1883,8 +1883,9 @@ mod tests {
         let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out5");
         let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
         // Wait until the task has finished AND its cancel flag is gone (the
-        // flag is removed just after the status flips; poll both).
-        for _ in 0..250 {
+        // flag is removed just after the status flips; poll both). Generous
+        // budget — under full-suite load process spawns can be slow.
+        for _ in 0..750 {
             let finished = state.tasks.lock().unwrap().get(&task.id).map(|t| t.status != "running").unwrap_or(false);
             let flag_gone = state.cancels.lock().unwrap().get(&task.id).is_none();
             if finished && flag_gone {
@@ -1892,7 +1893,11 @@ mod tests {
             }
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
-        assert!(state.cancels.lock().unwrap().get(&task.id).is_none(), "flag cleaned up");
+        let snapshot = state.tasks.lock().unwrap().get(&task.id).cloned();
+        assert!(
+            state.cancels.lock().unwrap().get(&task.id).is_none(),
+            "flag cleaned up (task snapshot: {snapshot:?})"
+        );
 
         assert!(state.cancel_or_ack(&task.id).is_ok(), "cancel after finish should be a quiet no-op");
         assert!(state.cancel_or_ack("no-such-task").is_err(), "unknown task ids still error");

--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -736,6 +736,10 @@ async fn run_tool_process(
     let mut tail: VecDeque<String> = VecDeque::with_capacity(STDERR_TAIL_LINES);
     let mut processed: u64 = 0;
     let mut poll = tokio::time::interval(Duration::from_millis(250));
+    // Set once the child has exited while the pipe is still open — a
+    // grandchild that inherited the stderr write end would otherwise delay
+    // EOF (and so task completion) until IT exits.
+    let mut exited: Option<(std::process::ExitStatus, std::time::Instant)> = None;
 
     let cancelled = loop {
         tokio::select! {
@@ -806,6 +810,18 @@ async fn run_tool_process(
                         });
                     }
                 }
+                // Detect the child exiting while the pipe stays open; after a
+                // short grace for buffered output, stop reading — EOF may
+                // never come if something else inherited the write end.
+                match exited {
+                    None => {
+                        if let Ok(Some(status)) = child.try_wait() {
+                            exited = Some((status, std::time::Instant::now()));
+                        }
+                    }
+                    Some((_, at)) if at.elapsed() >= Duration::from_millis(500) => break false,
+                    Some(_) => {}
+                }
             }
         }
     };
@@ -817,17 +833,22 @@ async fn run_tool_process(
 
     // The tool can close stderr while still running; a bare wait() here would
     // leave the task uncancellable from that point on. Keep polling the
-    // cancel flag (killing on cancel) until the process actually exits.
-    let status = loop {
-        tokio::select! {
-            status = child.wait() => {
-                break status.map_err(|e| format!("Failed to wait for {}: {}", tool_path, e))?;
-            }
-            _ = poll.tick() => {
-                if cancel.load(Ordering::SeqCst) {
-                    let _ = child.kill().await;
-                    let _ = child.wait().await;
-                    return Ok(ToolOutcome::Cancelled);
+    // cancel flag (killing on cancel) until the process actually exits —
+    // unless the exit was already observed above.
+    let status = if let Some((status, _)) = exited {
+        status
+    } else {
+        loop {
+            tokio::select! {
+                status = child.wait() => {
+                    break status.map_err(|e| format!("Failed to wait for {}: {}", tool_path, e))?;
+                }
+                _ = poll.tick() => {
+                    if cancel.load(Ordering::SeqCst) {
+                        let _ = child.kill().await;
+                        let _ = child.wait().await;
+                        return Ok(ToolOutcome::Cancelled);
+                    }
                 }
             }
         }
@@ -1638,13 +1659,61 @@ mod tests {
     }
 
     async fn wait_for_task(state: &AppState, task_id: &str) {
-        for _ in 0..50 {
+        // Generous budget: under full-suite process-spawn load even a trivial
+        // task can take a while end to end. Returns as soon as it settles.
+        for _ in 0..500 {
             let status = state.tasks.lock().unwrap().get(task_id).map(|t| t.status.clone());
             if status.as_deref() != Some("running") {
                 return;
             }
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
+    }
+
+    /// Start a dump task and wait for proof the tool actually launched,
+    /// riding out the classic fork/exec ETXTBSY race (under parallel test
+    /// load a concurrently forked child can briefly hold the just-written
+    /// fake tool's fd, failing the spawn with "Failed to start").
+    ///
+    /// "Launched" is detected via the runner's own post-spawn signal — the
+    /// task message flips to "<tool> started — connecting…" — or any terminal
+    /// state. A "Failed to start" failure retries with a fresh task; every
+    /// other outcome is the test's real behavior and is returned as-is.
+    async fn start_dump_task_retrying(
+        state: &AppState,
+        tool: &std::path::Path,
+        out: &str,
+    ) -> TaskInfo {
+        for attempt in 0..10 {
+            let task = start_dump_task_impl(
+                state,
+                "c1",
+                tool.to_str().unwrap(),
+                dump_server_folder_opts(out),
+            )
+            .await
+            .unwrap();
+            for _ in 0..500 {
+                let snap = state.tasks.lock().unwrap().get(&task.id).cloned();
+                if let Some(t) = snap {
+                    if t.status == "failed"
+                        && t.error.as_deref().unwrap_or("").contains("Failed to start")
+                    {
+                        break; // transient spawn race — retry with a fresh task
+                    }
+                    let spawned = t.status != "running"
+                        || t.processed > 0
+                        || t.message.contains("started")
+                        || t.message.contains("running");
+                    if spawned {
+                        return task;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            eprintln!("fake-tool spawn raced (attempt {attempt}); retrying");
+        }
+        panic!("fake tool could not be spawned after retries");
     }
 
     #[cfg(unix)]
@@ -1658,8 +1727,7 @@ mod tests {
              echo 'ts\tdone dumping a.y (7 documents)' 1>&2\n\
              exit 0\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out").await;
         assert_eq!(task.kind, "dump");
         wait_for_task(&state, &task.id).await;
         let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
@@ -1680,8 +1748,7 @@ mod tests {
              echo 'cannot connect to mongodb://u:sekrit@h:27017/db' 1>&2\n\
              exit 3\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out2");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out2").await;
         wait_for_task(&state, &task.id).await;
         let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
         assert_eq!(t.status, "failed");
@@ -1703,8 +1770,7 @@ mod tests {
         let tool = crate::db::mongotools::test_support::write_fake_tool(
             "echo 'ts\tdone dumping a.x (1 documents)' 1>&2\nsleep 30\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out3");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out3").await;
 
         // Wait until the fake tool has reported at least one namespace done.
         for _ in 0..100 {
@@ -1737,8 +1803,7 @@ mod tests {
         let state = AppState::new();
         state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
         let tool = crate::db::mongotools::test_support::write_fake_tool("sleep 30\n");
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out4");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out4").await;
         assert_ne!(task.message, "Queued", "initial message should say the tool is starting");
 
         // Shortly after spawn the message must reflect a live process.
@@ -1786,8 +1851,7 @@ mod tests {
              echo 'ts\tdone dumping a.x (5 documents)' 1>&2\n\
              exit 0\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out7");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out7").await;
         wait_for_task(&state, &task.id).await;
         let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
         assert_eq!(t.status, "completed");
@@ -1807,8 +1871,7 @@ mod tests {
         let tool = crate::db::mongotools::test_support::write_fake_tool(
             "echo 'ts\tdone dumping a.x (1 documents)' 1>&2\nexec 2>&-\nsleep 30\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out8");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out8").await;
 
         // Wait until the stderr line was consumed, then a beat for the EOF.
         for _ in 0..100 {
@@ -1831,6 +1894,35 @@ mod tests {
         let _ = std::fs::remove_file(&tool);
     }
 
+    /// A grandchild that inherits the tool's stderr write end must not wedge
+    /// the task after the tool itself exits: without exit detection the read
+    /// loop waits for a pipe EOF that only arrives when the grandchild dies.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_lingering_grandchild_does_not_wedge_task_completion() {
+        use crate::db::mongotools::*;
+        let state = AppState::new();
+        state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
+        // The backgrounded sleep inherits stderr and holds the pipe open for
+        // 20s; the tool itself exits immediately.
+        let tool = crate::db::mongotools::test_support::write_fake_tool(
+            "echo 'ts\tdone dumping a.x (3 documents)' 1>&2\nsleep 20 &\nexit 0\n",
+        );
+        let started = std::time::Instant::now();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out9").await;
+        wait_for_task(&state, &task.id).await;
+        let elapsed = started.elapsed();
+
+        let t = state.tasks.lock().unwrap().get(&task.id).cloned().unwrap();
+        assert_eq!(t.status, "completed", "task: {t:?}");
+        assert_eq!(t.processed, 1);
+        assert!(
+            elapsed.as_secs() < 5,
+            "task must complete shortly after the tool exits, took {elapsed:?}"
+        );
+        let _ = std::fs::remove_file(&tool);
+    }
+
     /// Before the first parsable progress event, raw stderr lines (driver
     /// warnings, connection errors) must reach the task message instead of
     /// being dropped — they're the only clue when a tool can't connect. The
@@ -1844,8 +1936,7 @@ mod tests {
         let tool = crate::db::mongotools::test_support::write_fake_tool(
             "echo 'ts\tconnection warning: cluster unreachable' 1>&2\nsleep 30\n",
         );
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out6");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out6").await;
 
         let mut snapshot: Option<TaskInfo> = None;
         for _ in 0..250 {
@@ -1880,8 +1971,7 @@ mod tests {
         let state = AppState::new();
         state.conn_uris.lock().unwrap().insert("c1".into(), "mongodb://u:pw@localhost:27017".into());
         let tool = crate::db::mongotools::test_support::write_fake_tool("exit 0\n");
-        let opts = dump_server_folder_opts("/tmp/mqlens-dump-test-out5");
-        let task = start_dump_task_impl(&state, "c1", tool.to_str().unwrap(), opts).await.unwrap();
+        let task = start_dump_task_retrying(&state, &tool, "/tmp/mqlens-dump-test-out5").await;
         // Wait until the task has finished AND its cancel flag is gone (the
         // flag is removed just after the status flips; poll both). Generous
         // budget — under full-suite load process spawns can be slow.

--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -1701,10 +1701,12 @@ mod tests {
                     {
                         break; // transient spawn race — retry with a fresh task
                     }
+                    // Any message past the initial "Starting <tool>…" means the
+                    // runner got beyond spawn — matching specific phrases races
+                    // against surfaced stderr overwriting the message.
                     let spawned = t.status != "running"
                         || t.processed > 0
-                        || t.message.contains("started")
-                        || t.message.contains("running");
+                        || !t.message.starts_with("Starting");
                     if spawned {
                         return task;
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -673,6 +673,23 @@ async fn detect_mongo_tools(
     Ok(db::mongotools::detect_mongo_tools(configured_dir.as_deref(), managed_dir.as_deref()))
 }
 
+/// Find a working mongosh for the shell's guided-setup card: configured path,
+/// managed install, PATH, then well-known install locations. Probing spawns
+/// several `--version` children, so it runs off the async runtime.
+#[tauri::command]
+async fn detect_mongosh_binary(
+    app_handle: tauri::AppHandle,
+    configured: String,
+) -> Result<Option<toolsetup::MongoshDetection>, String> {
+    use tauri::Manager;
+    let app_data_dir = app_handle.path().app_data_dir().ok();
+    tokio::task::spawn_blocking(move || {
+        toolsetup::detect_mongosh(&configured, app_data_dir.as_deref(), &[])
+    })
+    .await
+    .map_err(|e| format!("mongosh detection failed: {}", e))
+}
+
 #[tauri::command]
 async fn start_dump_task(
     state: tauri::State<'_, AppState>,
@@ -1779,6 +1796,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             connect_db,
             detect_mongo_tools,
+            detect_mongosh_binary,
             start_dump_task,
             start_restore_task,
             start_tool_install_task,

--- a/src-tauri/src/mock_db.rs
+++ b/src-tauri/src/mock_db.rs
@@ -1,14 +1,23 @@
 use serde_json::Value;
 
-pub fn get_mock_collections(db: &str) -> Vec<String> {
+// (name, type) pairs — type is "collection" or "timeseries", matching the
+// strings list_collections_impl reports for real clusters.
+pub fn get_mock_collections(db: &str) -> Vec<(String, &'static str)> {
     match db {
         "sales_db" => vec![
-            "customers".to_string(),
-            "transactions".to_string(),
-            "products".to_string(),
+            ("customers".to_string(), "collection"),
+            ("transactions".to_string(), "collection"),
+            ("products".to_string(), "collection"),
+            ("sensor_readings".to_string(), "timeseries"),
         ],
-        "user_analytics" => vec!["events".to_string(), "sessions".to_string()],
-        "admin" => vec!["system.users".to_string(), "system.version".to_string()],
+        "user_analytics" => vec![
+            ("events".to_string(), "collection"),
+            ("sessions".to_string(), "collection"),
+        ],
+        "admin" => vec![
+            ("system.users".to_string(), "collection"),
+            ("system.version".to_string(), "collection"),
+        ],
         _ => vec![],
     }
 }
@@ -276,6 +285,31 @@ fn get_mock_data(database: &str, collection: &str) -> Vec<Value> {
                 }),
             ]
         }
+        ("sales_db", "sensor_readings") => {
+            vec![
+                serde_json::json!({
+                    "_id": { "$oid": "603d779f4f102e3a105c3320" },
+                    "timestamp": "2026-07-10T08:00:00Z",
+                    "sensor_id": "temp-01",
+                    "value": 21.4,
+                    "unit": "C"
+                }),
+                serde_json::json!({
+                    "_id": { "$oid": "603d779f4f102e3a105c3321" },
+                    "timestamp": "2026-07-10T08:05:00Z",
+                    "sensor_id": "temp-01",
+                    "value": 21.9,
+                    "unit": "C"
+                }),
+                serde_json::json!({
+                    "_id": { "$oid": "603d779f4f102e3a105c3322" },
+                    "timestamp": "2026-07-10T08:10:00Z",
+                    "sensor_id": "hum-02",
+                    "value": 44.0,
+                    "unit": "%"
+                }),
+            ]
+        }
         _ => vec![],
     }
 }
@@ -307,6 +341,7 @@ pub fn get_mock_indexes(db: &str, collection: &str) -> Vec<crate::IndexInfo> {
         ("sales_db", "customers") => vec!["_id_", "email_1", "tier_1"],
         ("sales_db", "transactions") => vec!["_id_", "timestamp_-1", "customer_name_1"],
         ("sales_db", "products") => vec!["_id_", "price_1", "category_1"],
+        ("sales_db", "sensor_readings") => vec!["_id_", "timestamp_-1"],
         ("user_analytics", "events") => vec!["_id_", "event_type_1", "timestamp_-1"],
         ("user_analytics", "sessions") => vec!["_id_", "session_id_1"],
         ("admin", "system.users") => vec!["_id_", "user_1_db_1"],

--- a/src-tauri/src/ssh_tunnel.rs
+++ b/src-tauri/src/ssh_tunnel.rs
@@ -7,6 +7,7 @@ fn default_ssh_port() -> u16 {
 /// SSH authentication method. Frontend-shaped, internally tagged:
 ///   {"type":"password","password":"..."}
 ///   {"type":"key","path":"...","passphrase":"..."}
+///   {"type":"agent"}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum SshAuth {
@@ -18,6 +19,8 @@ pub enum SshAuth {
         #[serde(default)]
         passphrase: Option<String>,
     },
+    /// Delegate signing to the system ssh-agent; no key material is stored.
+    Agent,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -104,10 +107,64 @@ pub fn rewrite_uri_hosts(uri: &str, local_host: &str, local_port: u16) -> String
 // ── Live SSH tunnel (russh) ────────────────────────────────────────────────
 use std::sync::{Arc, Mutex as StdMutex};
 use russh::client::{self, Config};
+use russh::keys::agent::client::{AgentClient, AgentStream};
+use russh::keys::agent::AgentIdentity;
 use russh::keys::{check_known_hosts, load_secret_key, ssh_key, PrivateKeyWithHashAlg};
 use russh::{ChannelMsg, Disconnect};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+
+/// An ssh-agent connection over whatever transport the platform uses
+/// (unix socket, Windows named pipe).
+pub(crate) type BoxedAgentClient = AgentClient<Box<dyn AgentStream + Send + Unpin>>;
+
+/// Connect to the system ssh-agent. `sock` is the value of `SSH_AUTH_SOCK`
+/// (passed explicitly so tests don't depend on the ambient environment).
+/// Errors are user-readable and actionable.
+#[cfg(unix)]
+pub(crate) async fn connect_agent_at(sock: Option<String>) -> Result<BoxedAgentClient, String> {
+    let sock = match sock.filter(|s| !s.is_empty()) {
+        Some(s) => s,
+        None => {
+            return Err(
+                "SSH agent not reachable (SSH_AUTH_SOCK is not set). Start an ssh-agent and load your key with ssh-add."
+                    .to_string(),
+            )
+        }
+    };
+    AgentClient::connect_uds(&sock)
+        .await
+        .map(|c| c.dynamic())
+        .map_err(|e| {
+            format!(
+                "SSH agent not reachable at '{}': {}. Is your ssh-agent running?",
+                sock, e
+            )
+        })
+}
+
+/// Windows: the OpenSSH agent service listens on a well-known named pipe;
+/// `SSH_AUTH_SOCK`, when set, may point at an alternative pipe.
+#[cfg(windows)]
+pub(crate) async fn connect_agent_at(sock: Option<String>) -> Result<BoxedAgentClient, String> {
+    let pipe = sock
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| r"\\.\pipe\openssh-ssh-agent".to_string());
+    AgentClient::connect_named_pipe(&pipe)
+        .await
+        .map(|c| c.dynamic())
+        .map_err(|e| {
+            format!(
+                "SSH agent not reachable at '{}': {}. Is the 'OpenSSH Authentication Agent' service running?",
+                pipe, e
+            )
+        })
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) async fn connect_agent_at(_sock: Option<String>) -> Result<BoxedAgentClient, String> {
+    Err("ssh-agent is not supported on this platform yet".to_string())
+}
 
 // russh client handler that verifies the server host key against ~/.ssh/known_hosts.
 struct TunnelClient {
@@ -209,6 +266,66 @@ pub async fn open_tunnel(
                 .await
                 .map_err(|e| format!("SSH public-key authentication error: {}", e))?
                 .success()
+        }
+        SshAuth::Agent => {
+            let mut agent = connect_agent_at(std::env::var("SSH_AUTH_SOCK").ok()).await?;
+            let identities = agent
+                .request_identities()
+                .await
+                .map_err(|e| format!("Failed to list SSH agent identities: {}", e))?;
+            if identities.is_empty() {
+                return Err(
+                    "SSH agent has no identities loaded — add one with ssh-add.".to_string()
+                );
+            }
+            let hash = session
+                .best_supported_rsa_hash()
+                .await
+                .map_err(|e| format!("SSH key hash negotiation failed: {}", e))?
+                .flatten();
+            // Try every identity the agent holds; signing stays in the agent.
+            let mut authed = false;
+            let mut last_err: Option<String> = None;
+            for identity in identities {
+                let result = match identity {
+                    AgentIdentity::PublicKey { key, .. } => {
+                        session
+                            .authenticate_publickey_with(cfg.user.clone(), key, hash, &mut agent)
+                            .await
+                    }
+                    AgentIdentity::Certificate { certificate, .. } => {
+                        session
+                            .authenticate_certificate_with(
+                                cfg.user.clone(),
+                                certificate,
+                                hash,
+                                &mut agent,
+                            )
+                            .await
+                    }
+                };
+                match result {
+                    Ok(r) if r.success() => {
+                        authed = true;
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(e) => last_err = Some(e.to_string()),
+                }
+            }
+            if !authed {
+                return Err(match last_err {
+                    Some(e) => format!(
+                        "SSH agent identities were rejected by the server for user '{}' (last agent error: {})",
+                        cfg.user, e
+                    ),
+                    None => format!(
+                        "SSH agent identities were rejected by the server for user '{}'.",
+                        cfg.user
+                    ),
+                });
+            }
+            true
         }
     };
     if !authed {

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1048,6 +1048,139 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_ssh_auth_agent_serde_roundtrip() {
+        use crate::ssh_tunnel::{SshAuth, SshConfig};
+        let cfg = SshConfig {
+            enabled: true,
+            host: "bastion".into(),
+            port: 22,
+            user: "ops".into(),
+            auth: SshAuth::Agent,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(
+            json.contains(r#""auth":{"type":"agent"}"#),
+            "agent auth must serialize frontend-shaped, got: {}",
+            json
+        );
+        let back: SshConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.auth, SshAuth::Agent);
+
+        // agent variant from frontend-shaped JSON
+        let fe: SshConfig = serde_json::from_str(
+            r#"{"enabled":true,"host":"h","port":22,"user":"u","auth":{"type":"agent"}}"#,
+        )
+        .unwrap();
+        assert_eq!(fe.auth, SshAuth::Agent);
+    }
+
+    // Agent auth must fail with an actionable message when SSH_AUTH_SOCK is not
+    // set. The helper takes the socket path as a parameter so this test does not
+    // depend on (or mutate) the ambient environment.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_agent_connect_error_when_sock_unset() {
+        let err = crate::ssh_tunnel::connect_agent_at(None)
+            .await
+            .err()
+            .expect("connecting without SSH_AUTH_SOCK must fail");
+        assert!(
+            err.contains("SSH_AUTH_SOCK is not set"),
+            "error should name the missing env var, got: {}",
+            err
+        );
+        assert!(err.contains("SSH agent not reachable"), "got: {}", err);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_agent_connect_error_when_sock_missing() {
+        let err = crate::ssh_tunnel::connect_agent_at(Some(
+            "/nonexistent/mqlens-test-agent.sock".to_string(),
+        ))
+        .await
+        .err()
+        .expect("connecting to a missing socket must fail");
+        assert!(
+            err.contains("SSH agent not reachable") && err.contains("/nonexistent/mqlens-test-agent.sock"),
+            "error should name the socket path, got: {}",
+            err
+        );
+    }
+
+    // Live agent integration: spawn a real ssh-agent, add a throwaway ed25519
+    // key, and list identities through the russh agent client. Skips (does not
+    // fail) when ssh-agent/ssh-keygen/ssh-add are unavailable on this machine.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_agent_lists_identities_via_live_agent() {
+        use std::process::Command;
+
+        let agent_out = match Command::new("ssh-agent").arg("-s").output() {
+            Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
+            _ => {
+                eprintln!("skipping: ssh-agent not available");
+                return;
+            }
+        };
+        // Parse `SSH_AUTH_SOCK=/path; export SSH_AUTH_SOCK;` / `SSH_AGENT_PID=123; ...`
+        let parse_var = |name: &str| -> Option<String> {
+            agent_out.lines().find_map(|l| {
+                let rest = l.trim().strip_prefix(&format!("{}=", name))?;
+                Some(rest.split(';').next()?.to_string())
+            })
+        };
+        let sock = parse_var("SSH_AUTH_SOCK").expect("ssh-agent output has SSH_AUTH_SOCK");
+        let pid = parse_var("SSH_AGENT_PID");
+        // Ensure the agent is killed even if assertions below fail.
+        struct KillAgent(Option<String>);
+        impl Drop for KillAgent {
+            fn drop(&mut self) {
+                if let Some(pid) = self.0.take() {
+                    let _ = std::process::Command::new("kill").arg(pid).status();
+                }
+            }
+        }
+        let _kill = KillAgent(pid);
+
+        let dir = std::env::temp_dir().join(format!("mqlens-agent-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp key dir");
+        let key_path = dir.join("id_ed25519");
+        let keygen = Command::new("ssh-keygen")
+            .args(["-t", "ed25519", "-N", "", "-q", "-f"])
+            .arg(&key_path)
+            .status();
+        if !matches!(keygen, Ok(s) if s.success()) {
+            eprintln!("skipping: ssh-keygen not available");
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
+        let added = Command::new("ssh-add")
+            .arg(&key_path)
+            .env("SSH_AUTH_SOCK", &sock)
+            .status();
+        if !matches!(added, Ok(s) if s.success()) {
+            eprintln!("skipping: ssh-add not available or failed");
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
+
+        let mut agent = crate::ssh_tunnel::connect_agent_at(Some(sock))
+            .await
+            .expect("connect to live ssh-agent");
+        let identities = agent
+            .request_identities()
+            .await
+            .expect("list identities from live ssh-agent");
+        assert!(
+            !identities.is_empty(),
+            "agent should hold the key we just added"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     // GO-LIVE H2: count must reflect the true match count, not the page size.
     #[tokio::test]
     async fn test_mock_count_documents() {

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -126,8 +126,10 @@ mod tests {
         let collection_names: Vec<String> = collections.iter().map(|c| c.name.clone()).collect();
         assert!(collection_names.contains(&"customers".to_string()));
         assert!(collection_names.contains(&"transactions".to_string()));
+        // sensor_readings is timeseries; its type is asserted in test_mock_collections_report_timeseries_type
         assert!(collections
             .iter()
+            .filter(|c| c.name != "sensor_readings")
             .all(|c| c.collection_type == "collection"));
 
         // 3b. Test list indexes
@@ -184,6 +186,32 @@ mod tests {
             let mocks = state.mocks.lock().unwrap();
             assert!(!mocks.contains_key(&conn_id));
         }
+    }
+
+    // Issue #137: demo mode must surface a time-series collection so the
+    // sidebar's distinct icon is visible without a live cluster.
+    #[tokio::test]
+    async fn test_mock_collections_report_timeseries_type() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let collections = list_collections_impl(&state, &conn_id, "sales_db")
+            .await
+            .expect("list mock collections");
+
+        let sensor = collections
+            .iter()
+            .find(|c| c.name == "sensor_readings")
+            .expect("sales_db should include sensor_readings");
+        assert_eq!(sensor.collection_type, "timeseries");
+
+        let customers = collections
+            .iter()
+            .find(|c| c.name == "customers")
+            .expect("customers still listed");
+        assert_eq!(customers.collection_type, "collection");
     }
 
     #[tokio::test]
@@ -2878,12 +2906,21 @@ mod tests {
         };
 
         // Collections per database, plus the empty fallback for an unknown db.
-        assert!(get_mock_collections("sales_db").contains(&"transactions".to_string()));
+        let sales_names: Vec<String> = get_mock_collections("sales_db")
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert!(sales_names.contains(&"transactions".to_string()));
         assert_eq!(
             get_mock_collections("user_analytics"),
-            vec!["events".to_string(), "sessions".to_string()]
+            vec![
+                ("events".to_string(), "collection"),
+                ("sessions".to_string(), "collection"),
+            ]
         );
-        assert!(get_mock_collections("admin").contains(&"system.users".to_string()));
+        assert!(get_mock_collections("admin")
+            .iter()
+            .any(|(name, _)| name == "system.users"));
         assert!(get_mock_collections("nope").is_empty());
 
         // Query + count across the non-products datasets (each hits a distinct match arm).

--- a/src-tauri/src/toolsetup.rs
+++ b/src-tauri/src/toolsetup.rs
@@ -342,6 +342,116 @@ pub fn resolve_mongosh_executable(configured: &str, app_data_dir: Option<&Path>)
     "mongosh".to_string()
 }
 
+/// One working mongosh binary found by [`detect_mongosh`], with where it came
+/// from so the UI can phrase the offer ("found on PATH", "managed install").
+#[derive(serde::Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MongoshDetection {
+    pub path: String,
+    pub version: String,
+    /// "configured" | "managed" | "path" | "common"
+    pub source: String,
+}
+
+/// Run `path --version` and return the first output line, or `None` when the
+/// binary is missing, not executable, or exits non-zero.
+fn probe_version(path: &Path) -> Option<String> {
+    let out = std::process::Command::new(path)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let line = text.lines().next()?.trim();
+    if line.is_empty() {
+        None
+    } else {
+        Some(line.to_string())
+    }
+}
+
+/// Well-known install locations probed after PATH — covers packaged-app
+/// launches where the login-shell PATH merge didn't help (notably Windows,
+/// which has no `path_env` equivalent).
+fn common_mongosh_dirs() -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    #[cfg(windows)]
+    {
+        if let Ok(pf) = std::env::var("ProgramFiles") {
+            dirs.push(PathBuf::from(pf).join("mongosh"));
+        }
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            dirs.push(PathBuf::from(local).join("Programs").join("mongosh"));
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        dirs.extend(
+            ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/snap/bin"]
+                .iter()
+                .map(PathBuf::from),
+        );
+        if let Some(home) = std::env::var_os("HOME") {
+            dirs.push(PathBuf::from(home).join(".local/bin"));
+        }
+    }
+    dirs
+}
+
+/// Find a working mongosh, probing (in order) the configured path, the
+/// managed install, every PATH entry, and finally `common_mongosh_dirs()`
+/// plus `extra_dirs` (tests inject temp dirs there). Unlike
+/// [`resolve_mongosh_executable`] — which decides what to *spawn* — this
+/// verifies each candidate actually runs, for the shell's guided-setup card.
+pub fn detect_mongosh(
+    configured: &str,
+    app_data_dir: Option<&Path>,
+    extra_dirs: &[PathBuf],
+) -> Option<MongoshDetection> {
+    let hit = |path: &Path, source: &str| -> Option<MongoshDetection> {
+        probe_version(path).map(|version| MongoshDetection {
+            path: path.to_string_lossy().into_owned(),
+            version,
+            source: source.to_string(),
+        })
+    };
+
+    let trimmed = configured.trim();
+    if !trimmed.is_empty() {
+        if let Some(found) = hit(Path::new(trimmed), "configured") {
+            return Some(found);
+        }
+    }
+
+    let bin_name = binary_file_name("mongosh");
+    if let Some(app_data_dir) = app_data_dir {
+        if let Ok(tool) = find_pinned_tool("mongosh") {
+            if let Some(found) = hit(&managed_bin_dir(app_data_dir, tool).join(&bin_name), "managed") {
+                return Some(found);
+            }
+        }
+    }
+
+    if let Some(path_var) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            if let Some(found) = hit(&dir.join(&bin_name), "path") {
+                return Some(found);
+            }
+        }
+    }
+
+    for dir in common_mongosh_dirs().iter().chain(extra_dirs) {
+        if let Some(found) = hit(&dir.join(&bin_name), "common") {
+            return Some(found);
+        }
+    }
+
+    None
+}
+
 /// Runs `path --version`, treating any spawn failure or non-zero exit as
 /// "not usable" — the safety net after extraction, and the check
 /// `managed_tools_status` uses to decide `installed`.
@@ -1054,6 +1164,71 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[cfg(unix)]
+    fn write_fake_mongosh(dir: &Path, version_line: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::create_dir_all(dir).unwrap();
+        let path = dir.join("mongosh");
+        std::fs::write(&path, format!("#!/bin/sh\necho '{version_line}'\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    /// `detect_mongosh` probes configured → managed → PATH → common locations
+    /// and reports where the working binary came from, so the shell's failure
+    /// card can offer "use this path" for binaries outside the configured one.
+    #[cfg(unix)]
+    #[test]
+    fn detect_mongosh_probes_in_order_and_reports_source() {
+        let base = test_app_data("detect-mongosh");
+
+        // Nothing anywhere -> None (empty extra dirs keep PATH from mattering:
+        // a real mongosh on the test machine's PATH would be reported as
+        // source "path", which the assertions below tolerate).
+        let empty = detect_mongosh("", None, &[base.join("nowhere")]);
+        assert!(
+            empty.is_none() || empty.as_ref().unwrap().source == "path",
+            "unexpected detection: {empty:?}"
+        );
+
+        // A working binary in a "common" dir is found with its version.
+        let common_dir = base.join("common-bin");
+        write_fake_mongosh(&common_dir, "2.9.9");
+        let found = detect_mongosh("", None, &[common_dir.clone()]).expect("common dir hit");
+        assert!(found.source == "common" || found.source == "path");
+        if found.source == "common" {
+            assert_eq!(found.version, "2.9.9");
+            assert_eq!(found.path, common_dir.join("mongosh").to_string_lossy());
+        }
+
+        // A configured binary wins over everything else.
+        let configured_dir = base.join("configured-bin");
+        let configured = write_fake_mongosh(&configured_dir, "3.0.0");
+        let found = detect_mongosh(configured.to_str().unwrap(), None, &[common_dir.clone()])
+            .expect("configured hit");
+        assert_eq!(found.source, "configured");
+        assert_eq!(found.version, "3.0.0");
+
+        // A broken configured path falls through to the next tier.
+        let found = detect_mongosh(
+            base.join("missing/mongosh").to_str().unwrap(),
+            None,
+            &[common_dir.clone()],
+        )
+        .expect("fallback hit");
+        assert_ne!(found.source, "configured");
+
+        // The managed install beats common dirs.
+        let tool = find_pinned_tool("mongosh").unwrap();
+        let managed = managed_bin_dir(&base, tool);
+        write_fake_mongosh(&managed, "2.9.2");
+        let found = detect_mongosh("", Some(&base), &[common_dir]).expect("managed hit");
+        assert_eq!(found.source, "managed");
+        assert_eq!(found.version, "2.9.2");
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// Polls the task map until `task_id` leaves "running", returning its

--- a/src-tauri/src/toolsetup.rs
+++ b/src-tauri/src/toolsetup.rs
@@ -353,18 +353,50 @@ pub struct MongoshDetection {
     pub source: String,
 }
 
+/// Per-candidate budget for [`probe_version`]. Detection probes many
+/// locations sequentially (configured, managed, every PATH entry, common
+/// dirs), so one wedged binary must not stall the shell's guided-setup card —
+/// same rationale as [`PROBE_TIMEOUT`] in the install flow, but shorter since
+/// several candidates may be probed back to back.
+const DETECT_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Run `path --version` and return the first output line, or `None` when the
-/// binary is missing, not executable, or exits non-zero.
+/// binary is missing, not executable, exits non-zero, or hangs past
+/// [`DETECT_PROBE_TIMEOUT`].
 fn probe_version(path: &Path) -> Option<String> {
-    let out = std::process::Command::new(path)
+    probe_version_with_timeout(path, DETECT_PROBE_TIMEOUT)
+}
+
+fn probe_version_with_timeout(path: &Path, timeout: Duration) -> Option<String> {
+    use std::io::Read;
+    let mut child = std::process::Command::new(path)
         .arg("--version")
         .stdin(std::process::Stdio::null())
-        .output()
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
         .ok()?;
-    if !out.status.success() {
+    let deadline = std::time::Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    };
+    if !status.success() {
         return None;
     }
-    let text = String::from_utf8_lossy(&out.stdout);
+    // Safe post-exit: `--version` output is one short line, far below the
+    // pipe buffer, so the child cannot have blocked on a full pipe.
+    let mut text = String::new();
+    child.stdout.take()?.read_to_string(&mut text).ok()?;
     let line = text.lines().next()?.trim();
     if line.is_empty() {
         None
@@ -1227,6 +1259,31 @@ mod tests {
         let found = detect_mongosh("", Some(&base), &[common_dir]).expect("managed hit");
         assert_eq!(found.source, "managed");
         assert_eq!(found.version, "2.9.2");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// A wedged candidate (hangs on `--version`) must not stall detection:
+    /// the probe is killed at its deadline and the candidate reported as
+    /// unusable — same rationale as [`PROBE_TIMEOUT`] in the install flow.
+    #[cfg(unix)]
+    #[test]
+    fn probe_version_kills_wedged_binary_at_deadline() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = test_app_data("probe-wedged");
+        std::fs::create_dir_all(&base).unwrap();
+        let path = base.join("mongosh");
+        std::fs::write(&path, "#!/bin/sh\nsleep 30\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let started = std::time::Instant::now();
+        let probed = probe_version_with_timeout(&path, Duration::from_millis(300));
+        let elapsed = started.elapsed();
+        assert!(probed.is_none(), "wedged binary must be reported unusable");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "probe must be bounded by its deadline, took {elapsed:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -57,7 +57,8 @@ export type SshConfig = {
   user: string;
   auth:
     | { type: 'password'; password: string }
-    | { type: 'key'; path: string; passphrase?: string };
+    | { type: 'key'; path: string; passphrase?: string }
+    | { type: 'agent' };
 };
 
 interface ConnectionProfile {
@@ -363,7 +364,9 @@ export const buildSshConfig = (s: typeof BLANK_CONN): SshConfig | null => {
   const auth =
     s.sshAuth === 'password'
       ? { type: 'password' as const, password: s.sshPass }
-      : { type: 'key' as const, path: s.sshKey, passphrase: s.sshPass || undefined };
+      : s.sshAuth === 'agent'
+        ? { type: 'agent' as const }
+        : { type: 'key' as const, path: s.sshKey, passphrase: s.sshPass || undefined };
   return {
     enabled: true,
     host: s.sshHost,
@@ -503,12 +506,14 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
           sshHost: ssh.host,
           sshPort: String(ssh.port),
           sshUser: ssh.user,
-          sshAuth: ssh.auth.type === 'password' ? 'password' : 'key',
+          sshAuth: ssh.auth.type,
           sshKey: ssh.auth.type === 'key' ? ssh.auth.path : '',
           sshPass:
             ssh.auth.type === 'password'
               ? ssh.auth.password
-              : ssh.auth.passphrase || '',
+              : ssh.auth.type === 'key'
+                ? ssh.auth.passphrase || ''
+                : '',
         }
       : {};
 
@@ -1680,18 +1685,19 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                         <div className="flex flex-1 flex-col gap-1">
                           <Label>Auth Method</Label>
                           <Select value={editorState.sshAuth} onValueChange={(v) => setEditorState(prev => ({ ...prev, sshAuth: v }))}>
-                            <SelectTrigger className="h-8 text-xs">
+                            <SelectTrigger className="h-8 text-xs" data-testid="ssh-auth-select">
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent className={NESTED_SELECT_Z}>
                               <SelectItem value="key">Private Key</SelectItem>
                               <SelectItem value="password">Password</SelectItem>
+                              <SelectItem value="agent">SSH Agent</SelectItem>
                             </SelectContent>
                           </Select>
                         </div>
                       </div>
 
-                      {editorState.sshAuth === 'key' ? (
+                      {editorState.sshAuth === 'key' && (
                         <>
                           <div className="flex flex-col gap-1">
                             <Label>Private Key Path</Label>
@@ -1713,7 +1719,8 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                             />
                           </div>
                         </>
-                      ) : (
+                      )}
+                      {editorState.sshAuth === 'password' && (
                         <div className="flex flex-col gap-1">
                           <Label>SSH Password</Label>
                           <PasswordInput
@@ -1722,6 +1729,15 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                             placeholder="••••••••"
                             className="font-mono"
                           />
+                        </div>
+                      )}
+                      {editorState.sshAuth === 'agent' && (
+                        <div
+                          data-testid="ssh-agent-note"
+                          className="rounded border border-border bg-muted/40 px-2 py-1.5 text-[10.5px] leading-relaxed text-muted-foreground"
+                        >
+                          Authentication uses your system ssh-agent (SSH_AUTH_SOCK). Keys and
+                          passphrases stay in the agent and never touch MQLens or the saved profile.
                         </div>
                       )}
 

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -415,8 +415,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     };
   }, [sessionAttempted, sessionId, mongoshPath, retryNonce]);
 
-  // Persist a newly chosen mongosh path; updating `mongoshPath` re-attempts
-  // the session (it's a dependency of the session effect above).
+  // Persist a newly chosen mongosh path and re-attempt the session. The
+  // retry-nonce bump matters when the picked path equals the current one
+  // (setMongoshPath alone would be a no-op state update, so no re-attempt).
   const saveMongoshPath = async (path: string) => {
     try {
       const current = await invoke<AppSettings>('load_app_settings').catch(() => ({} as AppSettings));
@@ -428,6 +429,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     }
     setDetectedMongosh(null);
     setMongoshPath(path);
+    setRetryNonce((n) => n + 1);
   };
 
   const browseForMongosh = async () => {

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Editor from '@monaco-editor/react';
 import { invoke } from '@tauri-apps/api/core';
+import { open as openFileDialog } from '@tauri-apps/plugin-dialog';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { AlertCircle, Braces, CornerDownLeft, Eraser, Play, Sparkles, Terminal } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -236,6 +238,11 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [sessionAttempted, setSessionAttempted] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
+  // Guided setup on session failure: a working mongosh found outside the
+  // configured path (offered as one click), or null when nothing was found.
+  const [detectedMongosh, setDetectedMongosh] = useState<
+    { path: string; version: string; source: string } | null
+  >(null);
   // Reuses the retry-nonce mechanism above: when a parent-driven reconnect signal
   // changes (e.g. the guided tool-install dialog finished), re-attempt the session
   // the same way the gate's own Retry button does.
@@ -384,6 +391,62 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [entries, tab]);
+
+  // When the session failed to attach, probe for a usable mongosh (managed
+  // install, PATH, well-known locations) so the gate can offer a one-click
+  // fix instead of only pointing at Settings.
+  useEffect(() => {
+    if (!sessionAttempted || sessionId !== null || mongoshPath === null) return;
+    let alive = true;
+    invoke<{ path: string; version: string; source: string } | null>('detect_mongosh_binary', {
+      configured: mongoshPath || '',
+    })
+      .then((found) => {
+        if (!alive) return;
+        // A hit at the configured path means the session failure has some
+        // other cause — offering "use this path" would be a no-op.
+        setDetectedMongosh(found && found.source !== 'configured' ? found : null);
+      })
+      .catch(() => {
+        if (alive) setDetectedMongosh(null);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [sessionAttempted, sessionId, mongoshPath, retryNonce]);
+
+  // Persist a newly chosen mongosh path; updating `mongoshPath` re-attempts
+  // the session (it's a dependency of the session effect above).
+  const saveMongoshPath = async (path: string) => {
+    try {
+      const current = await invoke<AppSettings>('load_app_settings').catch(() => ({} as AppSettings));
+      await invoke('save_app_settings', {
+        settings: { ...current, mongosh_path: path },
+      });
+    } catch {
+      /* settings persistence is best-effort — still try the new path below */
+    }
+    setDetectedMongosh(null);
+    setMongoshPath(path);
+  };
+
+  const browseForMongosh = async () => {
+    try {
+      const picked = await openFileDialog({ multiple: false, title: 'Locate the mongosh binary' });
+      if (typeof picked === 'string' && picked) await saveMongoshPath(picked);
+    } catch {
+      /* user cancelled */
+    }
+  };
+
+  // OS-specific manual install hint for the gate card.
+  const installHint = useMemo(() => {
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    if (/mac/i.test(ua)) return 'brew install mongosh';
+    if (/win/i.test(ua)) return 'winget install MongoDB.Shell (or the MSI from mongodb.com)';
+    if (/linux/i.test(ua)) return 'sudo apt install mongodb-mongosh (or your distro’s package)';
+    return 'install mongosh from mongodb.com';
+  }, []);
 
   const executeFind = async (
     collName: string,
@@ -635,26 +698,57 @@ export const MongoShell: React.FC<MongoShellProps> = ({
               <div className="text-sm font-semibold text-foreground">MongoShell requires mongosh</div>
               <div className="max-w-sm text-xs leading-relaxed text-muted-foreground">
                 A live mongosh session is required to run queries and scripts here.
-                Install mongosh and set its path in Settings, then retry.
               </div>
+              {detectedMongosh && (
+                <div
+                  className="max-w-sm rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs"
+                  data-testid="shell-detected-mongosh"
+                >
+                  <div className="text-foreground">
+                    Found <span className="font-semibold">mongosh {detectedMongosh.version}</span>
+                  </div>
+                  <div className="truncate font-mono text-ui-2xs text-muted-foreground" title={detectedMongosh.path}>
+                    {detectedMongosh.path}
+                  </div>
+                  <Button
+                    size="sm"
+                    className="mt-1.5"
+                    onClick={() => void saveMongoshPath(detectedMongosh.path)}
+                    data-testid="shell-use-detected-btn"
+                  >
+                    Use this binary
+                  </Button>
+                </div>
+              )}
               <div className="mt-1 flex items-center gap-2">
-                {onOpenSettings && (
-                  <Button onClick={onOpenSettings} data-testid="gate-open-settings">
-                    Open Settings
+                {onInstallTools && (
+                  <Button onClick={onInstallTools} data-testid="shell-install-tools-btn">
+                    Install tools…
                   </Button>
                 )}
-                {onInstallTools && (
-                  <Button
-                    variant="outline"
-                    onClick={onInstallTools}
-                    data-testid="shell-install-tools-btn"
-                  >
-                    Install tools…
+                <Button variant="outline" onClick={() => void browseForMongosh()} data-testid="shell-browse-mongosh-btn">
+                  Browse for binary…
+                </Button>
+                {onOpenSettings && (
+                  <Button variant="outline" onClick={onOpenSettings} data-testid="gate-open-settings">
+                    Open Settings
                   </Button>
                 )}
                 <Button variant="outline" onClick={() => setRetryNonce((n) => n + 1)} data-testid="gate-retry">
                   Retry
                 </Button>
+              </div>
+              <div className="max-w-sm text-ui-2xs text-muted-foreground" data-testid="shell-install-hint">
+                Or install it yourself: <code className="font-mono">{installHint}</code> — see the{' '}
+                <button
+                  type="button"
+                  className="text-primary underline-offset-2 hover:underline"
+                  onClick={() => void openUrl('https://www.mongodb.com/docs/mongodb-shell/install/')}
+                  data-testid="shell-mongosh-docs-link"
+                >
+                  mongosh install docs
+                </button>
+                .
               </div>
             </>
           )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -87,8 +87,9 @@ import {
   X,
   Pin,
   Heart,
-  Copy,
+  ChartLine,
   ClipboardPaste,
+  Copy,
   DatabaseBackup,
   DatabaseZap,
 } from 'lucide-react';
@@ -1118,6 +1119,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     const collKey = `${connId}/${dbName}/${collName}`;
     const isCollExpanded = expandedCollections[collKey];
     const collIndexes = indexes[collKey] || [];
+    const collType = (collections[`${connId}/${dbName}`] || []).find((c) => c.name === collName)?.type;
     const isActive =
       activeCollection?.connectionId === connId &&
       activeCollection?.db === dbName &&
@@ -1146,7 +1148,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 size={10}
                 className={cn('shrink-0 text-muted-foreground transition-transform duration-150', isCollExpanded && 'rotate-90')}
               />
-              <Layers size={11} className={cn('shrink-0', isActive ? 'text-primary' : 'text-emerald-500')} />
+              {collType === 'timeseries' ? (
+                <span
+                  title="Time-series collection"
+                  data-testid="coll-icon-timeseries"
+                  className="flex shrink-0 items-center"
+                >
+                  <ChartLine size={11} className={cn('shrink-0', isActive ? 'text-primary' : 'text-emerald-500')} />
+                </span>
+              ) : (
+                <Layers size={11} className={cn('shrink-0', isActive ? 'text-primary' : 'text-emerald-500')} />
+              )}
               <span className="min-w-0 truncate" title={collName}>
                 {collName}
               </span>

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -371,6 +371,111 @@ describe('buildSshConfig (C7)', () => {
     });
     expect(cfg?.auth).toEqual({ type: 'password', password: 'pw' });
   });
+
+  it('builds an agent-auth config without any secret material', () => {
+    const cfg = buildSshConfig({
+      ...sshBase,
+      sshEnabled: true,
+      sshHost: 'h',
+      sshUser: 'u',
+      sshAuth: 'agent',
+      sshKey: '~/.ssh/id_ed25519', // stale form state must not leak into the config
+      sshPass: 'leftover',
+    });
+    expect(cfg?.auth).toEqual({ type: 'agent' });
+  });
+});
+
+describe('SSH agent auth in the editor (issue #130)', () => {
+  const agentProfile = {
+    id: 'p-agent',
+    name: 'Bastion',
+    uri: 'mongodb://db.internal:27017',
+    ssh: { enabled: true, host: 'jump.example.com', port: 22, user: 'ops', auth: { type: 'agent' } },
+    color_tag: null,
+  };
+
+  const renderWithProfiles = (profiles: any[], onSave: (p: any) => void = () => {}) => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve(profiles);
+      if (cmd === 'save_connection_profile') {
+        onSave(args.profile);
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+  };
+
+  const openSshTab = async () => {
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+    fireEvent.click(screen.getByRole('button', { name: /ssh tunnel/i }));
+    fireEvent.click(screen.getByLabelText(/enable ssh tunnel/i));
+  };
+
+  it('selecting "SSH agent" hides key/password inputs, shows the security note, and saves auth {type: agent}', async () => {
+    let savedProfile: any = null;
+    renderWithProfiles([], (p) => { savedProfile = p; });
+
+    await openSshTab();
+    fireEvent.change(screen.getByPlaceholderText('ssh.server.com'), { target: { value: 'jump.example.com' } });
+    fireEvent.change(screen.getByPlaceholderText('deploy'), { target: { value: 'ops' } });
+
+    await pickSelectOption('ssh-auth-select', /ssh agent/i);
+
+    // Key/password inputs are hidden; the security note is shown instead.
+    expect(screen.queryByPlaceholderText('~/.ssh/id_ed25519')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('••••••••')).not.toBeInTheDocument();
+    const note = screen.getByTestId('ssh-agent-note');
+    expect(note).toHaveTextContent(/SSH_AUTH_SOCK/);
+    expect(note).toHaveTextContent(/never/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => {
+      expect(savedProfile?.ssh).toEqual({
+        enabled: true,
+        host: 'jump.example.com',
+        port: 22,
+        user: 'ops',
+        auth: { type: 'agent' },
+      });
+    });
+  });
+
+  it('switching back from agent to key/password restores those inputs', async () => {
+    renderWithProfiles([]);
+    await openSshTab();
+
+    await pickSelectOption('ssh-auth-select', /ssh agent/i);
+    expect(screen.getByTestId('ssh-agent-note')).toBeInTheDocument();
+
+    await pickSelectOption('ssh-auth-select', /private key/i);
+    expect(screen.queryByTestId('ssh-agent-note')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('~/.ssh/id_ed25519')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/leave blank if the key is unencrypted/i)).toBeInTheDocument();
+
+    await pickSelectOption('ssh-auth-select', /^password$/i);
+    expect(screen.queryByTestId('ssh-agent-note')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('••••••••')).toBeInTheDocument();
+  });
+
+  it('round-trips a saved profile with agent auth through edit and save', async () => {
+    let savedProfile: any = null;
+    renderWithProfiles([agentProfile], (p) => { savedProfile = p; });
+
+    fireEvent.click((await screen.findAllByText('Bastion'))[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    // The SSH tab reflects the persisted agent auth without touching anything.
+    fireEvent.click(screen.getByRole('button', { name: /ssh tunnel/i }));
+    expect(screen.getByTestId('ssh-agent-note')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('~/.ssh/id_ed25519')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => {
+      expect(savedProfile?.ssh).toEqual(agentProfile.ssh);
+    });
+  });
 });
 
 describe('ConnectionManager Component', () => {

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -7,6 +7,15 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: any[]) => mockInvoke(...args),
 }));
 
+const mockOpenDialog = vi.fn();
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: (...args: any[]) => mockOpenDialog(...args),
+}));
+const mockOpenUrl = vi.fn();
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: (...args: any[]) => mockOpenUrl(...args),
+}));
+
 vi.mock('@monaco-editor/react', () => ({
   default: ({ value, onChange }: any) => (
     <textarea
@@ -543,5 +552,86 @@ describe('MongoShell Component', () => {
       'run_mongosh_command',
       expect.objectContaining({ command: script })
     );
+  });
+
+  describe('guided mongosh setup on session failure', () => {
+    const renderFailedShell = (overrides: Record<string, (args: any) => any> = {}) => {
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        if (overrides[cmd]) return overrides[cmd](args);
+        if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+        if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '' });
+        if (cmd === 'test_mongosh_path') return Promise.reject(new Error('Failed to run mongosh'));
+        if (cmd === 'start_mongosh_session')
+          return Promise.reject(new Error('Failed to start mongosh'));
+        if (cmd === 'detect_mongosh_binary') return Promise.resolve(null);
+        if (cmd === 'save_app_settings') return Promise.resolve();
+        return Promise.resolve([]);
+      });
+      render(
+        <MongoShell
+          connectionId="conn-1"
+          connectionName="mock"
+          connectionUri="mongodb://prod-replica-set"
+          databaseName="sales_db"
+        />
+      );
+    };
+
+    it('offers a detected mongosh and saves it on confirmation', async () => {
+      renderFailedShell({
+        detect_mongosh_binary: () =>
+          Promise.resolve({ path: '/opt/homebrew/bin/mongosh', version: '2.9.9', source: 'path' }),
+      });
+
+      expect(await screen.findByTestId('shell-detected-mongosh')).toHaveTextContent(
+        /2\.9\.9.*\/opt\/homebrew\/bin\/mongosh|\/opt\/homebrew\/bin\/mongosh.*2\.9\.9/
+      );
+      fireEvent.click(screen.getByTestId('shell-use-detected-btn'));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith(
+          'save_app_settings',
+          expect.objectContaining({
+            settings: expect.objectContaining({ mongosh_path: '/opt/homebrew/bin/mongosh' }),
+          })
+        );
+      });
+      // Saving retries the session.
+      const sessionAttempts = mockInvoke.mock.calls.filter(([cmd]) => cmd === 'start_mongosh_session');
+      await waitFor(() => {
+        expect(
+          mockInvoke.mock.calls.filter(([cmd]) => cmd === 'start_mongosh_session').length
+        ).toBeGreaterThan(sessionAttempts.length - 1);
+      });
+    });
+
+    it('lets the user browse for a binary and saves the pick', async () => {
+      mockOpenDialog.mockResolvedValue('/custom/tools/mongosh');
+      renderFailedShell();
+
+      fireEvent.click(await screen.findByTestId('shell-browse-mongosh-btn'));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith(
+          'save_app_settings',
+          expect.objectContaining({
+            settings: expect.objectContaining({ mongosh_path: '/custom/tools/mongosh' }),
+          })
+        );
+      });
+    });
+
+    it('shows install instructions and a MongoDB docs link when nothing is found', async () => {
+      renderFailedShell();
+
+      expect(await screen.findByTestId('shell-install-hint')).toBeInTheDocument();
+      const docsLink = screen.getByTestId('shell-mongosh-docs-link');
+      fireEvent.click(docsLink);
+      await waitFor(() => {
+        expect(mockOpenUrl).toHaveBeenCalledWith(
+          expect.stringContaining('mongodb.com/docs/mongodb-shell')
+        );
+      });
+    });
   });
 });

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -621,6 +621,27 @@ describe('MongoShell Component', () => {
       });
     });
 
+    it('re-attempts the session even when the picked binary equals the configured path', async () => {
+      // Same path as already configured: without an explicit retry, the state
+      // update is a no-op and the session would never be re-attempted.
+      mockOpenDialog.mockResolvedValue('/already/configured/mongosh');
+      renderFailedShell({
+        load_app_settings: () => Promise.resolve({ mongosh_path: '/already/configured/mongosh' }),
+      });
+
+      const browseBtn = await screen.findByTestId('shell-browse-mongosh-btn');
+      const attemptsBefore = mockInvoke.mock.calls.filter(
+        ([cmd]) => cmd === 'start_mongosh_session'
+      ).length;
+      fireEvent.click(browseBtn);
+
+      await waitFor(() => {
+        expect(
+          mockInvoke.mock.calls.filter(([cmd]) => cmd === 'start_mongosh_session').length
+        ).toBeGreaterThan(attemptsBefore);
+      });
+    });
+
     it('shows install instructions and a MongoDB docs link when nothing is found', async () => {
       renderFailedShell();
 

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -250,6 +250,50 @@ describe('Sidebar Component', () => {
     expect(handleDisconnect).toHaveBeenCalledWith('conn-1');
   });
 
+  it('renders a distinct icon for time-series collections (#137)', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections' && args.db === 'sales_db') {
+        return Promise.resolve([
+          { name: 'customers', type: 'collection' },
+          { name: 'sensor_readings', type: 'timeseries' },
+          { name: 'active_users', type: 'view' },
+        ]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('sales_db'));
+    fireEvent.click(await screen.findByText('Collections'));
+    await screen.findByText('sensor_readings');
+    expect(screen.getByText('customers')).toBeInTheDocument();
+
+    // Views live in their own folder — expand it so the view row is actually
+    // rendered; otherwise the "views unaffected" check below is vacuous.
+    fireEvent.click(screen.getByText('Views'));
+    await screen.findByText('active_users');
+
+    // Exactly one row gets the time-series icon — the regular collection
+    // (and anything else in the tree, including the view row) keeps the
+    // generic Layers icon.
+    const tsIcons = screen.getAllByTestId('coll-icon-timeseries');
+    expect(tsIcons).toHaveLength(1);
+    expect(tsIcons[0]).toHaveAttribute('title', 'Time-series collection');
+    expect(tsIcons[0].closest('div')).toHaveTextContent('sensor_readings');
+  });
+
   it('sorts collections by name before rendering', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {


### PR DESCRIPTION
Promotes dev to main; the release workflow will compute v0.11.0 from Conventional Commits, bump version files, tag `mqlens-v0.11.0`, and publish builds.

## Since v0.10.0

### Features
- SSH tunnel authentication via the system ssh-agent (#130)
- Guided mongosh detection on the shell's failure card (#124)
- Distinct sidebar icon for time-series collections (#137)

### Fixes
- Tool tasks complete promptly when a grandchild holds the stderr pipe
- mongosh detection cannot hang on a wedged binary; re-picking the configured path retries the session
- Fake-tool spawn detection made robust in tests