### PR TITLE
feat: Cluster Health monitor — replica-set status and replication lag (#114)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -950,6 +950,14 @@ async fn current_ops(
 }
 
 #[tauri::command]
+async fn repl_set_status(
+    state: tauri::State<'_, AppState>,
+    id: String,
+) -> Result<monitoring::ReplSetStatus, String> {
+    monitoring::repl_set_status_impl(&state, &id).await
+}
+
+#[tauri::command]
 async fn kill_op(state: tauri::State<'_, AppState>, id: String, opid: i64) -> Result<(), String> {
     monitoring::kill_op_impl(&state, &id, opid).await
 }
@@ -1876,6 +1884,7 @@ pub fn run() {
             queries::list_all_saved_queries,
             server_status,
             current_ops,
+            repl_set_status,
             kill_op,
             list_users,
             create_user,

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -227,6 +227,91 @@ pub fn curate_profile_entry(d: &Document) -> ProfileEntry {
     }
 }
 
+// ── Replica-set health (issue #114) ──────────────────────────────────────────
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplSetMember {
+    pub name: String,
+    pub state_str: String,
+    pub health: i64,
+    #[serde(rename = "self")]
+    pub self_member: bool,
+    pub uptime_secs: i64,
+    pub optime_date_ms: i64,
+    pub ping_ms: Option<i64>,
+    pub sync_source: String,
+    /// Seconds behind the primary; None for the primary itself and whenever
+    /// the set has no primary (election in progress).
+    pub lag_secs: Option<f64>,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplSetStatus {
+    /// false = standalone server (replSetGetStatus said NoReplicationEnabled).
+    pub is_replica_set: bool,
+    pub set: String,
+    pub my_state_str: String,
+    pub mongo_version: String,
+    pub members: Vec<ReplSetMember>,
+}
+
+/// Curate a raw `replSetGetStatus` document. Lag per non-primary member is
+/// primary optimeDate − member optimeDate (clamped at 0); without a primary
+/// there is no reference point, so lag stays None.
+pub fn curate_repl_set_status(raw: &Document, mongo_version: &str) -> ReplSetStatus {
+    let raw_members: Vec<&Document> = raw
+        .get_array("members")
+        .map(|a| a.iter().filter_map(|b| b.as_document()).collect())
+        .unwrap_or_default();
+    let optime_ms = |m: &Document| match m.get("optimeDate") {
+        Some(Bson::DateTime(dt)) => dt.timestamp_millis(),
+        _ => 0,
+    };
+    let primary_optime_ms = raw_members
+        .iter()
+        .find(|m| m.get_str("stateStr").ok() == Some("PRIMARY"))
+        .map(|m| optime_ms(m));
+
+    let members: Vec<ReplSetMember> = raw_members
+        .iter()
+        .map(|m| {
+            let state_str = m.get_str("stateStr").unwrap_or_default().to_string();
+            let optime_date_ms = optime_ms(m);
+            let lag_secs = if state_str == "PRIMARY" {
+                None
+            } else {
+                primary_optime_ms.map(|p| ((p - optime_date_ms).max(0)) as f64 / 1000.0)
+            };
+            ReplSetMember {
+                name: m.get_str("name").unwrap_or_default().to_string(),
+                health: num(m, "health"),
+                self_member: m.get_bool("self").unwrap_or(false),
+                uptime_secs: num(m, "uptime"),
+                optime_date_ms,
+                ping_ms: m.get("pingMs").map(|_| num(m, "pingMs")),
+                sync_source: m.get_str("syncSourceHost").unwrap_or_default().to_string(),
+                state_str,
+                lag_secs,
+            }
+        })
+        .collect();
+    let my_state_str = members
+        .iter()
+        .find(|m| m.self_member)
+        .map(|m| m.state_str.clone())
+        .unwrap_or_default();
+
+    ReplSetStatus {
+        is_replica_set: true,
+        set: raw.get_str("set").unwrap_or_default().to_string(),
+        my_state_str,
+        mongo_version: mongo_version.to_string(),
+        members,
+    }
+}
+
 // ── Mock data (demo connections) ──────────────────────────────────────────────
 
 fn mock_server_status() -> ServerStatus {
@@ -240,6 +325,32 @@ fn mock_server_status() -> ServerStatus {
         network: Network { bytes_in: 8_400_000, bytes_out: 19_200_000, num_requests: 64_000 },
         cache: Some(CacheStats { bytes_in_cache: 268_435_456, max_bytes: 536_870_912, dirty_bytes: 12_582_912 }),
         repl_set: None,
+    }
+}
+
+fn mock_repl_set_status() -> ReplSetStatus {
+    let now = 1_749_427_200_000i64;
+    let member = |name: &str, state: &str, self_m: bool, uptime: i64, optime: i64, ping: Option<i64>, sync: &str, lag: Option<f64>| ReplSetMember {
+        name: name.into(),
+        state_str: state.into(),
+        health: 1,
+        self_member: self_m,
+        uptime_secs: uptime,
+        optime_date_ms: optime,
+        ping_ms: ping,
+        sync_source: sync.into(),
+        lag_secs: lag,
+    };
+    ReplSetStatus {
+        is_replica_set: true,
+        set: "rs0".into(),
+        my_state_str: "PRIMARY".into(),
+        mongo_version: "7.0.0".into(),
+        members: vec![
+            member("mqlens-demo:27017", "PRIMARY", true, 86_400, now, None, "", None),
+            member("mqlens-demo-2:27017", "SECONDARY", false, 86_300, now - 800, Some(1), "mqlens-demo:27017", Some(0.8)),
+            member("mqlens-demo-3:27017", "SECONDARY", false, 4_200, now - 42_000, Some(3), "mqlens-demo:27017", Some(42.0)),
+        ],
     }
 }
 
@@ -372,6 +483,34 @@ pub async fn read_profile_impl(
     Ok(out)
 }
 
+pub async fn repl_set_status_impl(state: &AppState, id: &str) -> Result<ReplSetStatus, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(mock_repl_set_status());
+    }
+    let client = require_real_client(state, id)?;
+    let admin = client.database("admin");
+    let raw = match admin.run_command(doc! { "replSetGetStatus": 1 }).await {
+        Ok(raw) => raw,
+        Err(e) => {
+            // Standalone servers answer NoReplicationEnabled (code 76): a
+            // valid "not a replica set" state, not an error.
+            if let mongodb::error::ErrorKind::Command(ref ce) = *e.kind {
+                if ce.code == 76 {
+                    return Ok(ReplSetStatus { is_replica_set: false, ..Default::default() });
+                }
+            }
+            return Err(format!("replSetGetStatus failed: {}", e));
+        }
+    };
+    // rs.status() carries no server version; buildInfo is a cheap admin call
+    // and only runs while the Cluster tab is actively polling.
+    let version = match admin.run_command(doc! { "buildInfo": 1 }).await {
+        Ok(b) => b.get_str("version").unwrap_or_default().to_string(),
+        Err(_) => String::new(),
+    };
+    Ok(curate_repl_set_status(&raw, &version))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -459,5 +598,84 @@ mod tests {
         assert_eq!(p.millis, 142);
         assert_eq!(p.ts_ms, 1_700_000_000_000);
         assert_eq!(p.plan_summary, "COLLSCAN");
+    }
+
+    fn repl_status_doc() -> Document {
+        doc! {
+            "set": "rs0",
+            "myState": 1i32,
+            "members": [
+                { "name": "db1:27017", "stateStr": "PRIMARY", "health": 1.0, "self": true,
+                  "uptime": 1_209_600i64, "optimeDate": DateTime::from_millis(1_700_000_042_000) },
+                { "name": "db2:27017", "stateStr": "SECONDARY", "health": 1.0,
+                  "uptime": 86_400i64, "optimeDate": DateTime::from_millis(1_700_000_041_200),
+                  "pingMs": 1i64, "syncSourceHost": "db1:27017" },
+                { "name": "db3:27017", "stateStr": "(not reachable/healthy)", "health": 0.0,
+                  "uptime": 0i64, "optimeDate": DateTime::from_millis(1_700_000_000_000),
+                  "pingMs": 3i64, "syncSourceHost": "" },
+            ],
+        }
+    }
+
+    #[test]
+    fn curates_repl_set_status_with_lag() {
+        let s = curate_repl_set_status(&repl_status_doc(), "7.0.5");
+        assert!(s.is_replica_set);
+        assert_eq!(s.set, "rs0");
+        assert_eq!(s.my_state_str, "PRIMARY", "role comes from the self member");
+        assert_eq!(s.mongo_version, "7.0.5");
+        assert_eq!(s.members.len(), 3);
+
+        let primary = &s.members[0];
+        assert!(primary.self_member);
+        assert_eq!(primary.lag_secs, None, "primary carries no lag");
+        assert_eq!(primary.ping_ms, None, "self member has no pingMs");
+
+        let healthy = &s.members[1];
+        assert_eq!(healthy.lag_secs, Some(0.8));
+        assert_eq!(healthy.ping_ms, Some(1));
+        assert_eq!(healthy.sync_source, "db1:27017");
+
+        let down = &s.members[2];
+        assert_eq!(down.health, 0);
+        assert_eq!(down.state_str, "(not reachable/healthy)");
+        assert_eq!(down.lag_secs, Some(42.0));
+    }
+
+    #[test]
+    fn repl_set_lag_is_none_without_primary() {
+        let d = doc! {
+            "set": "rs0",
+            "members": [
+                { "name": "db2:27017", "stateStr": "SECONDARY", "health": 1.0, "self": true,
+                  "uptime": 5i64, "optimeDate": DateTime::from_millis(1_700_000_000_000) },
+                { "name": "db3:27017", "stateStr": "SECONDARY", "health": 1.0,
+                  "uptime": 5i64, "optimeDate": DateTime::from_millis(1_699_999_000_000) },
+            ],
+        };
+        let s = curate_repl_set_status(&d, "7.0.5");
+        assert!(s.members.iter().all(|m| m.lag_secs.is_none()), "no primary -> no lag numbers");
+        assert_eq!(s.my_state_str, "SECONDARY");
+    }
+
+    #[test]
+    fn repl_set_lag_clamps_ahead_of_primary_to_zero() {
+        let d = doc! {
+            "set": "rs0",
+            "members": [
+                { "name": "p:1", "stateStr": "PRIMARY", "health": 1.0, "optimeDate": DateTime::from_millis(1_000) },
+                { "name": "s:1", "stateStr": "SECONDARY", "health": 1.0, "optimeDate": DateTime::from_millis(2_000) },
+            ],
+        };
+        let s = curate_repl_set_status(&d, "x");
+        assert_eq!(s.members[1].lag_secs, Some(0.0));
+    }
+
+    #[test]
+    fn repl_set_status_is_resilient_to_empty_doc() {
+        let s = curate_repl_set_status(&doc! {}, "");
+        assert!(s.is_replica_set);
+        assert!(s.members.is_empty());
+        assert_eq!(s.my_state_str, "");
     }
 }

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -279,14 +279,15 @@ pub fn curate_repl_set_status(raw: &Document, mongo_version: &str) -> ReplSetSta
         .map(|m| {
             let state_str = m.get_str("stateStr").unwrap_or_default().to_string();
             let optime_date_ms = optime_ms(m);
-            let lag_secs = if state_str == "PRIMARY" {
+            let health = num(m, "health");
+            let lag_secs = if state_str == "PRIMARY" || health != 1 || optime_date_ms == 0 {
                 None
             } else {
                 primary_optime_ms.map(|p| ((p - optime_date_ms).max(0)) as f64 / 1000.0)
             };
             ReplSetMember {
                 name: m.get_str("name").unwrap_or_default().to_string(),
-                health: num(m, "health"),
+                health,
                 self_member: m.get_bool("self").unwrap_or(false),
                 uptime_secs: num(m, "uptime"),
                 optime_date_ms,
@@ -498,6 +499,9 @@ pub async fn repl_set_status_impl(state: &AppState, id: &str) -> Result<ReplSetS
                 if ce.code == 76 {
                     return Ok(ReplSetStatus { is_replica_set: false, ..Default::default() });
                 }
+                if ce.code == 13 {
+                    return Err("Not authorized to run replSetGetStatus — the connection's user needs the clusterMonitor role.".to_string());
+                }
             }
             return Err(format!("replSetGetStatus failed: {}", e));
         }
@@ -639,7 +643,7 @@ mod tests {
         let down = &s.members[2];
         assert_eq!(down.health, 0);
         assert_eq!(down.state_str, "(not reachable/healthy)");
-        assert_eq!(down.lag_secs, Some(42.0));
+        assert_eq!(down.lag_secs, None, "unhealthy members report no lag, even with a real optimeDate");
     }
 
     #[test]
@@ -677,5 +681,20 @@ mod tests {
         assert!(s.is_replica_set);
         assert!(s.members.is_empty());
         assert_eq!(s.my_state_str, "");
+    }
+
+    #[test]
+    fn repl_set_down_member_gets_no_lag_not_a_bogus_epoch_delta() {
+        let d = doc! {
+            "set": "rs0",
+            "members": [
+                { "name": "p:1", "stateStr": "PRIMARY", "health": 1.0, "optimeDate": DateTime::from_millis(1_700_000_000_000) },
+                { "name": "down:1", "stateStr": "(not reachable/healthy)", "health": 0.0, "optimeDate": DateTime::from_millis(0) },
+                { "name": "gone:1", "stateStr": "(not reachable/healthy)", "health": 0.0 },
+            ],
+        };
+        let s = curate_repl_set_status(&d, "x");
+        assert_eq!(s.members[1].lag_secs, None, "epoch-0 optime must not become a multi-year lag");
+        assert_eq!(s.members[2].lag_secs, None, "missing optime must not become a lag");
     }
 }

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -510,10 +510,16 @@ pub async fn repl_set_status_impl(state: &AppState, id: &str) -> Result<ReplSetS
         .run_command(doc! { "hello": 1 })
         .await
         .map_err(|e| format!("hello failed: {}", e))?;
+    // Server version applies to every topology; buildInfo needs no privileges.
+    let version = match admin.run_command(doc! { "buildInfo": 1 }).await {
+        Ok(b) => b.get_str("version").unwrap_or_default().to_string(),
+        Err(_) => String::new(),
+    };
     let cluster_type = classify_topology(&hello);
     if cluster_type != "replicaSet" {
         return Ok(ReplSetStatus {
             cluster_type: cluster_type.to_string(),
+            mongo_version: version,
             ..Default::default()
         });
     }
@@ -537,12 +543,6 @@ pub async fn repl_set_status_impl(state: &AppState, id: &str) -> Result<ReplSetS
             }
             return Err(format!("replSetGetStatus failed: {}", e));
         }
-    };
-    // rs.status() carries no server version; buildInfo is a cheap admin call
-    // and only runs while the Cluster tab is actively polling.
-    let version = match admin.run_command(doc! { "buildInfo": 1 }).await {
-        Ok(b) => b.get_str("version").unwrap_or_default().to_string(),
-        Err(_) => String::new(),
     };
     Ok(curate_repl_set_status(&raw, &version))
 }

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -251,10 +251,24 @@ pub struct ReplSetMember {
 pub struct ReplSetStatus {
     /// false = standalone server (replSetGetStatus said NoReplicationEnabled).
     pub is_replica_set: bool,
+    /// "replicaSet" | "sharded" | "standalone"
+    pub cluster_type: String,
     pub set: String,
     pub my_state_str: String,
     pub mongo_version: String,
     pub members: Vec<ReplSetMember>,
+}
+
+/// Classify a `hello` response: mongos advertises msg "isdbgrid", replica-set
+/// members carry setName, anything else is a standalone server.
+pub fn classify_topology(hello: &Document) -> &'static str {
+    if hello.get_str("msg").ok() == Some("isdbgrid") {
+        return "sharded";
+    }
+    if hello.get_str("setName").is_ok() {
+        return "replicaSet";
+    }
+    "standalone"
 }
 
 /// Curate a raw `replSetGetStatus` document. Lag per non-primary member is
@@ -306,6 +320,7 @@ pub fn curate_repl_set_status(raw: &Document, mongo_version: &str) -> ReplSetSta
 
     ReplSetStatus {
         is_replica_set: true,
+        cluster_type: "replicaSet".to_string(),
         set: raw.get_str("set").unwrap_or_default().to_string(),
         my_state_str,
         mongo_version: mongo_version.to_string(),
@@ -344,6 +359,7 @@ fn mock_repl_set_status() -> ReplSetStatus {
     };
     ReplSetStatus {
         is_replica_set: true,
+        cluster_type: "replicaSet".into(),
         set: "rs0".into(),
         my_state_str: "PRIMARY".into(),
         mongo_version: "7.0.0".into(),
@@ -490,14 +506,30 @@ pub async fn repl_set_status_impl(state: &AppState, id: &str) -> Result<ReplSetS
     }
     let client = require_real_client(state, id)?;
     let admin = client.database("admin");
+    let hello = admin
+        .run_command(doc! { "hello": 1 })
+        .await
+        .map_err(|e| format!("hello failed: {}", e))?;
+    let cluster_type = classify_topology(&hello);
+    if cluster_type != "replicaSet" {
+        return Ok(ReplSetStatus {
+            cluster_type: cluster_type.to_string(),
+            ..Default::default()
+        });
+    }
     let raw = match admin.run_command(doc! { "replSetGetStatus": 1 }).await {
         Ok(raw) => raw,
         Err(e) => {
             // Standalone servers answer NoReplicationEnabled (code 76): a
-            // valid "not a replica set" state, not an error.
+            // valid "not a replica set" state, not an error. Kept as a safety
+            // net even though hello now classifies standalones up front.
             if let mongodb::error::ErrorKind::Command(ref ce) = *e.kind {
                 if ce.code == 76 {
-                    return Ok(ReplSetStatus { is_replica_set: false, ..Default::default() });
+                    return Ok(ReplSetStatus {
+                        is_replica_set: false,
+                        cluster_type: "standalone".to_string(),
+                        ..Default::default()
+                    });
                 }
                 if ce.code == 13 {
                     return Err("Not authorized to run replSetGetStatus — the connection's user needs the clusterMonitor role.".to_string());
@@ -622,12 +654,20 @@ mod tests {
     }
 
     #[test]
+    fn classifies_topology_from_hello() {
+        assert_eq!(classify_topology(&doc! { "msg": "isdbgrid", "ok": 1.0 }), "sharded");
+        assert_eq!(classify_topology(&doc! { "setName": "rs0", "ok": 1.0 }), "replicaSet");
+        assert_eq!(classify_topology(&doc! { "ok": 1.0 }), "standalone");
+    }
+
+    #[test]
     fn curates_repl_set_status_with_lag() {
         let s = curate_repl_set_status(&repl_status_doc(), "7.0.5");
         assert!(s.is_replica_set);
         assert_eq!(s.set, "rs0");
         assert_eq!(s.my_state_str, "PRIMARY", "role comes from the self member");
         assert_eq!(s.mongo_version, "7.0.5");
+        assert_eq!(s.cluster_type, "replicaSet");
         assert_eq!(s.members.len(), 3);
 
         let primary = &s.members[0];

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -224,6 +224,7 @@ mod tests {
         let s = crate::monitoring::repl_set_status_impl(&state, &conn_id).await.unwrap();
         assert!(s.is_replica_set);
         assert_eq!(s.set, "rs0");
+        assert_eq!(s.cluster_type, "replicaSet");
         assert_eq!(s.members.len(), 3);
         assert_eq!(s.members.iter().filter(|m| m.state_str == "PRIMARY").count(), 1);
         assert!(

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -214,6 +214,24 @@ mod tests {
         assert_eq!(customers.collection_type, "collection");
     }
 
+    // Issue #114: demo mode returns a synthetic replica set so the Cluster
+    // tab is populated without a live cluster — including a lagging
+    // secondary so the warning styling is visible.
+    #[tokio::test]
+    async fn test_mock_repl_set_status_returns_synthetic_set() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+        let s = crate::monitoring::repl_set_status_impl(&state, &conn_id).await.unwrap();
+        assert!(s.is_replica_set);
+        assert_eq!(s.set, "rs0");
+        assert_eq!(s.members.len(), 3);
+        assert_eq!(s.members.iter().filter(|m| m.state_str == "PRIMARY").count(), 1);
+        assert!(
+            s.members.iter().any(|m| m.lag_secs.map(|l| l >= 10.0).unwrap_or(false)),
+            "demo set includes a lagging secondary"
+        );
+    }
+
     #[tokio::test]
     async fn test_conn_uris_stored_for_real_and_absent_for_mock() {
         use crate::db::mongotools::resolve_conn_uri;

--- a/src/components/ClusterHealthCard.tsx
+++ b/src/components/ClusterHealthCard.tsx
@@ -32,7 +32,12 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({ connection
     <div className="flex w-64 flex-col gap-1.5 text-xs" data-testid="cluster-health-card">
       {err && <div className="text-destructive">{err}</div>}
       {!err && !data && <div className="text-muted-foreground">Loading cluster health…</div>}
-      {!err && data && !data.isReplicaSet && (
+      {!err && data && !data.isReplicaSet && data.clusterType === 'sharded' && (
+        <div className="text-muted-foreground" data-testid="cluster-card-sharded">
+          Sharded cluster (mongos).
+        </div>
+      )}
+      {!err && data && !data.isReplicaSet && data.clusterType !== 'sharded' && (
         <div className="text-muted-foreground" data-testid="cluster-card-standalone">
           Standalone server — no replica set.
         </div>
@@ -40,7 +45,7 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({ connection
       {!err && data && data.isReplicaSet && (
         <>
           <div className="text-muted-foreground">
-            <span className="font-semibold text-foreground">{data.set}</span>
+            Replica set <span className="font-semibold text-foreground">{data.set}</span>
             {data.myStateStr && <> · you: {data.myStateStr}</>}
           </div>
           <div className="flex flex-col gap-1">

--- a/src/components/ClusterHealthCard.tsx
+++ b/src/components/ClusterHealthCard.tsx
@@ -30,7 +30,7 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({ connection
 
   return (
     <div className="flex w-64 flex-col gap-1.5 text-xs" data-testid="cluster-health-card">
-      {err && <div className="text-red-500">{err}</div>}
+      {err && <div className="text-destructive">{err}</div>}
       {!err && !data && <div className="text-muted-foreground">Loading cluster health…</div>}
       {!err && data && !data.isReplicaSet && (
         <div className="text-muted-foreground" data-testid="cluster-card-standalone">

--- a/src/components/ClusterHealthCard.tsx
+++ b/src/components/ClusterHealthCard.tsx
@@ -43,7 +43,7 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({
   const readPref = connectionUri ? uriReadPreference(connectionUri) : null;
 
   return (
-    <div className="flex w-64 flex-col gap-1.5 text-xs" data-testid="cluster-health-card">
+    <div className="flex w-max min-w-64 max-w-96 flex-col gap-1.5 text-xs" data-testid="cluster-health-card">
       {err && <div className="text-destructive">{err}</div>}
       {!err && !data && <div className="text-muted-foreground">Loading cluster health…</div>}
       {(data || err) && connectionName && (
@@ -78,12 +78,12 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({
               return (
                 <div
                   key={m.name}
-                  className={cn('flex items-center gap-1.5', unhealthy && 'text-destructive')}
+                  className={cn('flex flex-wrap items-center gap-x-1.5', unhealthy && 'text-destructive')}
                   data-testid={`cluster-card-member-${m.name}`}
                 >
                   <span className={cn('h-2 w-2 shrink-0 rounded-full', memberDotClass(m))} />
-                  <span className="min-w-0 flex-1 truncate font-mono">{m.name}</span>
-                  <span className="shrink-0 text-muted-foreground">
+                  <span className="whitespace-nowrap font-mono">{m.name}</span>
+                  <span className="whitespace-nowrap text-muted-foreground">
                     {unhealthy ? (
                       '— Offline [(not reachable/healthy)]'
                     ) : isPrimary ? (

--- a/src/components/ClusterHealthCard.tsx
+++ b/src/components/ClusterHealthCard.tsx
@@ -1,18 +1,29 @@
 import React, { useEffect, useState } from 'react';
 import { replSetStatus, type ReplSetStatus } from '@/lib/monitoringApi';
-import { lagText, lagClass, memberDotClass, memberUnhealthy } from '@/lib/clusterHealth';
+import { lagText, lagClass, memberDotClass, memberUnhealthy, uriUser, uriReadPreference } from '@/lib/clusterHealth';
 import { cn } from '@/lib/utils';
 
 interface ClusterHealthCardProps {
   connectionId: string;
+  connectionName?: string;
+  connectionUri?: string;
   onOpenMonitoring?: (connectionId: string) => void;
 }
 
+const capitalize = (s: string): string => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
 /** Compact replica-set health summary. Fetches once on mount — i.e. once per
- *  popover open — so there is no background polling cost. */
-export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({ connectionId, onOpenMonitoring }) => {
+ *  popover open — so there is no background polling cost. Refresh re-runs
+ *  the fetch in place via the `nonce` bump below. */
+export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({
+  connectionId,
+  connectionName,
+  connectionUri,
+  onOpenMonitoring,
+}) => {
   const [data, setData] = useState<ReplSetStatus | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
 
   useEffect(() => {
     let alive = true;
@@ -26,12 +37,27 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({ connection
     return () => {
       alive = false;
     };
-  }, [connectionId]);
+  }, [connectionId, nonce]);
+
+  const user = connectionUri ? uriUser(connectionUri) : null;
+  const readPref = connectionUri ? uriReadPreference(connectionUri) : null;
 
   return (
     <div className="flex w-64 flex-col gap-1.5 text-xs" data-testid="cluster-health-card">
       {err && <div className="text-destructive">{err}</div>}
       {!err && !data && <div className="text-muted-foreground">Loading cluster health…</div>}
+      {(data || err) && connectionName && (
+        <div data-testid="cluster-card-connection">
+          Connection: <span className="font-semibold text-foreground">{connectionName}</span>
+          {data?.isReplicaSet && (
+            <>
+              {' '}
+              [replica set: <span>{data.set}</span>]
+            </>
+          )}
+        </div>
+      )}
+      {(data || err) && user && <div data-testid="cluster-card-user">User: {user}</div>}
       {!err && data && !data.isReplicaSet && data.clusterType === 'sharded' && (
         <div className="text-muted-foreground" data-testid="cluster-card-sharded">
           Sharded cluster (mongos).
@@ -44,42 +70,67 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({ connection
       )}
       {!err && data && data.isReplicaSet && (
         <>
-          <div className="text-muted-foreground">
-            Replica set <span className="font-semibold text-foreground">{data.set}</span>
-            {data.myStateStr && <> · you: {data.myStateStr}</>}
-          </div>
+          <div className="text-muted-foreground">Server(s):</div>
           <div className="flex flex-col gap-1">
-            {data.members.map((m) => (
-              <div
-                key={m.name}
-                className={cn('flex items-center gap-1.5', memberUnhealthy(m) && 'text-destructive')}
-                data-testid={`cluster-card-member-${m.name}`}
-              >
-                <span className={cn('h-2 w-2 shrink-0 rounded-full', memberDotClass(m))} />
-                <span className="min-w-0 flex-1 truncate font-mono">{m.name}</span>
-                <span
-                  className={cn('shrink-0', m.stateStr === 'PRIMARY' ? 'text-muted-foreground' : lagClass(m.lagSecs))}
+            {data.members.map((m) => {
+              const unhealthy = memberUnhealthy(m);
+              const isPrimary = m.stateStr === 'PRIMARY';
+              return (
+                <div
+                  key={m.name}
+                  className={cn('flex items-center gap-1.5', unhealthy && 'text-destructive')}
+                  data-testid={`cluster-card-member-${m.name}`}
                 >
-                  {m.stateStr === 'PRIMARY'
-                    ? 'PRIMARY'
-                    : memberUnhealthy(m)
-                      ? m.stateStr
-                      : `lag ${lagText(m.lagSecs)}`}
-                </span>
-              </div>
-            ))}
+                  <span className={cn('h-2 w-2 shrink-0 rounded-full', memberDotClass(m))} />
+                  <span className="min-w-0 flex-1 truncate font-mono">{m.name}</span>
+                  <span className="shrink-0 text-muted-foreground">
+                    {unhealthy ? (
+                      '— Offline [(not reachable/healthy)]'
+                    ) : isPrimary ? (
+                      '— Online [PRIMARY]'
+                    ) : (
+                      <>
+                        — Online [SECONDARY] · <span className={lagClass(m.lagSecs)}>lag {lagText(m.lagSecs)}</span>
+                      </>
+                    )}
+                  </span>
+                </div>
+              );
+            })}
           </div>
+          {readPref && (
+            <div data-testid="cluster-card-read-pref">Read preference mode: {capitalize(readPref)}</div>
+          )}
+        </>
+      )}
+      {!err && data && data.mongoVersion && (
+        <div data-testid="cluster-card-version">Server version: {data.mongoVersion}</div>
+      )}
+      {!err && data && data.isReplicaSet && (
+        <div className="mt-0.5 flex items-center gap-2">
+          <button
+            type="button"
+            className="self-start text-primary underline-offset-2 hover:underline"
+            onClick={() => {
+              setErr(null);
+              setData(null);
+              setNonce((n) => n + 1);
+            }}
+            data-testid="cluster-card-refresh"
+          >
+            Refresh
+          </button>
           {onOpenMonitoring && (
             <button
               type="button"
-              className="mt-0.5 self-start text-primary underline-offset-2 hover:underline"
+              className="self-start text-primary underline-offset-2 hover:underline"
               onClick={() => onOpenMonitoring(connectionId)}
               data-testid="cluster-card-open-monitoring"
             >
               Open Monitoring →
             </button>
           )}
-        </>
+        </div>
       )}
     </div>
   );

--- a/src/components/ClusterHealthCard.tsx
+++ b/src/components/ClusterHealthCard.tsx
@@ -43,7 +43,7 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({
   const readPref = connectionUri ? uriReadPreference(connectionUri) : null;
 
   return (
-    <div className="flex w-max min-w-64 max-w-96 flex-col gap-1.5 text-xs" data-testid="cluster-health-card">
+    <div className="flex w-max min-w-72 max-w-[28rem] flex-col gap-1.5 text-xs" data-testid="cluster-health-card">
       {err && <div className="text-destructive">{err}</div>}
       {!err && !data && <div className="text-muted-foreground">Loading cluster health…</div>}
       {(data || err) && connectionName && (

--- a/src/components/ClusterHealthCard.tsx
+++ b/src/components/ClusterHealthCard.tsx
@@ -52,7 +52,7 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({
           {data?.isReplicaSet && (
             <>
               {' '}
-              [replica set: <span>{data.set}</span>]
+              [replica set: <span className="font-semibold text-foreground">{data.set}</span>]
             </>
           )}
         </div>
@@ -78,7 +78,7 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({
               return (
                 <div
                   key={m.name}
-                  className={cn('flex flex-wrap items-center gap-x-1.5', unhealthy && 'text-destructive')}
+                  className={cn('flex flex-wrap items-center gap-x-1.5 gap-y-0.5', unhealthy && 'text-destructive')}
                   data-testid={`cluster-card-member-${m.name}`}
                 >
                   <span className={cn('h-2 w-2 shrink-0 rounded-full', memberDotClass(m))} />
@@ -90,7 +90,7 @@ export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({
                       '— Online [PRIMARY]'
                     ) : (
                       <>
-                        — Online [SECONDARY] · <span className={lagClass(m.lagSecs)}>lag {lagText(m.lagSecs)}</span>
+                        — Online [{m.stateStr}] · <span className={lagClass(m.lagSecs)}>lag {lagText(m.lagSecs)}</span>
                       </>
                     )}
                   </span>

--- a/src/components/ClusterHealthCard.tsx
+++ b/src/components/ClusterHealthCard.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { replSetStatus, type ReplSetStatus } from '@/lib/monitoringApi';
+import { lagText, lagClass, memberDotClass, memberUnhealthy } from '@/lib/clusterHealth';
+import { cn } from '@/lib/utils';
+
+interface ClusterHealthCardProps {
+  connectionId: string;
+  onOpenMonitoring?: (connectionId: string) => void;
+}
+
+/** Compact replica-set health summary. Fetches once on mount — i.e. once per
+ *  popover open — so there is no background polling cost. */
+export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({ connectionId, onOpenMonitoring }) => {
+  const [data, setData] = useState<ReplSetStatus | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    replSetStatus(connectionId)
+      .then((s) => {
+        if (alive) setData(s);
+      })
+      .catch((e: unknown) => {
+        if (alive) setErr(String((e as Error)?.message || e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [connectionId]);
+
+  return (
+    <div className="flex w-64 flex-col gap-1.5 text-xs" data-testid="cluster-health-card">
+      {err && <div className="text-red-500">{err}</div>}
+      {!err && !data && <div className="text-muted-foreground">Loading cluster health…</div>}
+      {!err && data && !data.isReplicaSet && (
+        <div className="text-muted-foreground" data-testid="cluster-card-standalone">
+          Standalone server — no replica set.
+        </div>
+      )}
+      {!err && data && data.isReplicaSet && (
+        <>
+          <div className="text-muted-foreground">
+            <span className="font-semibold text-foreground">{data.set}</span>
+            {data.myStateStr && <> · you: {data.myStateStr}</>}
+          </div>
+          <div className="flex flex-col gap-1">
+            {data.members.map((m) => (
+              <div
+                key={m.name}
+                className={cn('flex items-center gap-1.5', memberUnhealthy(m) && 'text-destructive')}
+                data-testid={`cluster-card-member-${m.name}`}
+              >
+                <span className={cn('h-2 w-2 shrink-0 rounded-full', memberDotClass(m))} />
+                <span className="min-w-0 flex-1 truncate font-mono">{m.name}</span>
+                <span
+                  className={cn('shrink-0', m.stateStr === 'PRIMARY' ? 'text-muted-foreground' : lagClass(m.lagSecs))}
+                >
+                  {m.stateStr === 'PRIMARY'
+                    ? 'PRIMARY'
+                    : memberUnhealthy(m)
+                      ? m.stateStr
+                      : `lag ${lagText(m.lagSecs)}`}
+                </span>
+              </div>
+            ))}
+          </div>
+          {onOpenMonitoring && (
+            <button
+              type="button"
+              className="mt-0.5 self-start text-primary underline-offset-2 hover:underline"
+              onClick={() => onOpenMonitoring(connectionId)}
+              data-testid="cluster-card-open-monitoring"
+            >
+              Open Monitoring →
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -41,10 +41,12 @@ import {
   getProfilingStatus,
   setProfilingLevel,
   readProfile,
+  replSetStatus,
   type ServerStatus,
   type CurrentOp,
   type ProfilingStatus,
   type ProfileEntry,
+  type ReplSetStatus,
 } from '../lib/monitoringApi';
 
 interface MonitoringViewProps {
@@ -62,7 +64,7 @@ const DEFAULT_POLL_MS = 10000;
 const MAX_SAMPLES = 30;
 const TABLE_CMD_CHARS = 120;
 
-type Section = 'ops' | 'profiler';
+type Section = 'ops' | 'profiler' | 'cluster';
 
 /** Lean time-series point — avoids retaining full ServerStatus per sample. */
 interface MetricSample {
@@ -532,6 +534,32 @@ const ProfileFilterBar: React.FC<{
   </div>
 );
 
+const lagText = (lagSecs: number | null | undefined): string =>
+  lagSecs == null ? 'n/a' : `${lagSecs < 10 ? lagSecs.toFixed(1) : Math.round(lagSecs)}s`;
+
+const lagClass = (lagSecs: number | null | undefined): string => {
+  if (lagSecs == null) return 'text-muted-foreground';
+  if (lagSecs >= 60) return 'font-semibold text-red-500';
+  if (lagSecs >= 10) return 'font-semibold text-amber-500';
+  return 'text-muted-foreground';
+};
+
+const memberUnhealthy = (m: { health: number; stateStr: string }): boolean =>
+  m.health !== 1 || /not reachable|DOWN|UNKNOWN/i.test(m.stateStr);
+
+const memberDotClass = (m: { health: number; stateStr: string }): string => {
+  if (memberUnhealthy(m)) return 'bg-red-500';
+  if (m.stateStr === 'PRIMARY') return 'bg-emerald-500';
+  if (m.stateStr === 'SECONDARY') return 'bg-sky-500';
+  return 'bg-amber-500';
+};
+
+const fmtMemberUptime = (secs: number): string => {
+  const d = Math.floor(secs / 86_400);
+  const h = Math.floor((secs % 86_400) / 3_600);
+  return d > 0 ? `${d}d ${h}h` : `${h}h ${Math.floor((secs % 3_600) / 60)}m`;
+};
+
 export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) => {
   const [status, setStatus] = useState<ServerStatus | null>(null);
   const [ops, setOps] = useState<CurrentOp[]>([]);
@@ -559,12 +587,26 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
   const [profileLoading, setProfileLoading] = useState(false);
   const profilerLoadedRef = useRef(false);
 
+  const [cluster, setCluster] = useState<ReplSetStatus | null>(null);
+  const [clusterErr, setClusterErr] = useState<string | null>(null);
+
   const [pollMs, setPollMs] = useState(DEFAULT_POLL_MS);
   const aliveRef = useRef(true);
 
+  // Read by pollOnce so its identity stays stable across tab switches (the
+  // interval effect resets the samples history whenever pollOnce changes).
+  const sectionRef = useRef(section);
+  useEffect(() => {
+    sectionRef.current = section;
+  }, [section]);
+
   const pollOnce = useCallback(async () => {
     if (typeof document !== 'undefined' && document.hidden) return;
-    const [sRes, oRes] = await Promise.allSettled([serverStatus(connectionId), currentOps(connectionId)]);
+    const [sRes, oRes, cRes] = await Promise.allSettled([
+      serverStatus(connectionId),
+      currentOps(connectionId),
+      sectionRef.current === 'cluster' ? replSetStatus(connectionId) : Promise.resolve(null),
+    ]);
     if (!aliveRef.current) return;
     if (sRes.status === 'fulfilled') {
       const s = sRes.value;
@@ -579,6 +621,14 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
       setOpsErr(null);
     } else {
       setOpsErr(String((oRes.reason as Error)?.message || oRes.reason));
+    }
+    if (cRes.status === 'fulfilled') {
+      if (cRes.value) {
+        setCluster(cRes.value);
+        setClusterErr(null);
+      }
+    } else {
+      setClusterErr(String((cRes.reason as Error)?.message || cRes.reason));
     }
   }, [connectionId]);
 
@@ -597,6 +647,12 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
       clearInterval(iv);
     };
   }, [pollOnce, pollMs, connectionId]);
+
+  // Entering the Cluster tab fetches right away; pollOnce reads the section
+  // from a ref, so this does not disturb the interval or the sample history.
+  useEffect(() => {
+    if (section === 'cluster') void pollOnce();
+  }, [section, pollOnce]);
 
   const refreshProfiler = useCallback(async () => {
     if (!profilerDb) return;
@@ -742,6 +798,14 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
               onClick={() => setSection('profiler')}
             >
               Profiler
+            </TabsTrigger>
+            <TabsTrigger
+              value="cluster"
+              className="h-7 px-3 text-xs"
+              data-testid="mon-tab-cluster"
+              onClick={() => setSection('cluster')}
+            >
+              Cluster
             </TabsTrigger>
           </TabsList>
         </Tabs>
@@ -973,6 +1037,78 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
             )}
           </div>
         )}
+
+      {section === 'cluster' && (
+        <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-auto p-3" data-testid="mon-panel-cluster">
+          {clusterErr && <div className="text-xs text-red-500">{clusterErr}</div>}
+          {!clusterErr && cluster && !cluster.isReplicaSet && (
+            <div
+              className="rounded-lg border border-border bg-muted/30 p-4 text-xs text-muted-foreground"
+              data-testid="cluster-not-replset"
+            >
+              This connection is a standalone MongoDB server — replica-set health does not apply here.
+            </div>
+          )}
+          {!clusterErr && cluster && cluster.isReplicaSet && (
+            <>
+              <div className="text-xs text-muted-foreground" data-testid="cluster-summary">
+                Replica set <span className="font-semibold text-foreground">{cluster.set}</span>
+                {' · '}
+                {cluster.members.length} members
+                {cluster.mongoVersion && <> · MongoDB {cluster.mongoVersion}</>}
+                {cluster.myStateStr && <> · you: {cluster.myStateStr}</>}
+              </div>
+              <div className="overflow-x-auto rounded-lg border border-border">
+                <table className="w-full text-xs" data-testid="cluster-members-table">
+                  <thead className="bg-muted/50 text-left text-muted-foreground">
+                    <tr>
+                      <th className="px-3 py-1.5 font-medium">Member</th>
+                      <th className="px-3 py-1.5 font-medium">State</th>
+                      <th className="px-3 py-1.5 font-medium">Uptime</th>
+                      <th className="px-3 py-1.5 font-medium">Ping</th>
+                      <th className="px-3 py-1.5 font-medium">Sync source</th>
+                      <th className="px-3 py-1.5 font-medium">Lag</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cluster.members.map((m) => (
+                      <tr
+                        key={m.name}
+                        data-testid={`cluster-member-${m.name}`}
+                        className={cn(
+                          'border-t border-border/50',
+                          memberUnhealthy(m) && 'bg-destructive/10 text-destructive',
+                        )}
+                      >
+                        <td className="px-3 py-1.5">
+                          <span className="flex items-center gap-1.5">
+                            <span className={cn('h-2 w-2 shrink-0 rounded-full', memberDotClass(m))} />
+                            <span className="font-mono">{m.name}</span>
+                            {m.self && <span className="text-[10px] text-muted-foreground">(you)</span>}
+                          </span>
+                        </td>
+                        <td className="px-3 py-1.5">{m.stateStr}</td>
+                        <td className="px-3 py-1.5">{fmtMemberUptime(m.uptimeSecs)}</td>
+                        <td className="px-3 py-1.5">{m.pingMs == null ? '—' : `${m.pingMs}ms`}</td>
+                        <td className="px-3 py-1.5 font-mono">{m.syncSource || '—'}</td>
+                        <td
+                          className={cn('px-3 py-1.5', m.stateStr === 'PRIMARY' ? 'text-muted-foreground' : lagClass(m.lagSecs))}
+                          data-testid={`cluster-lag-${m.name}`}
+                        >
+                          {m.stateStr === 'PRIMARY' ? '—' : lagText(m.lagSecs)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+          {!clusterErr && !cluster && (
+            <div className="text-xs text-muted-foreground">Loading replica-set status…</div>
+          )}
+        </div>
+      )}
 
       {detail && <MonitoringDetail detail={detail} onClose={() => setDetail(null)} />}
     </div>

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1016,7 +1016,16 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
       {section === 'cluster' && (
         <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-auto p-3" data-testid="mon-panel-cluster">
           {clusterErr && <div className="text-xs text-red-500">{clusterErr}</div>}
-          {!clusterErr && cluster && !cluster.isReplicaSet && (
+          {!clusterErr && cluster && !cluster.isReplicaSet && cluster.clusterType === 'sharded' && (
+            <div
+              className="rounded-lg border border-border bg-muted/30 p-4 text-xs text-muted-foreground"
+              data-testid="cluster-sharded"
+            >
+              Sharded cluster — member-level health isn&apos;t available through mongos. Connect directly to a
+              shard&apos;s replica set to inspect its members.
+            </div>
+          )}
+          {!clusterErr && cluster && !cluster.isReplicaSet && cluster.clusterType !== 'sharded' && (
             <div
               className="rounded-lg border border-border bg-muted/30 p-4 text-xs text-muted-foreground"
               data-testid="cluster-not-replset"

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1075,6 +1075,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                       <tr
                         key={m.name}
                         data-testid={`cluster-member-${m.name}`}
+                        title={m.optimeDateMs > 0 ? `optime: ${new Date(m.optimeDateMs).toISOString()}` : undefined}
                         className={cn(
                           'border-t border-border/50',
                           memberUnhealthy(m) && 'bg-destructive/10 text-destructive',
@@ -1084,7 +1085,7 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
                           <span className="flex items-center gap-1.5">
                             <span className={cn('h-2 w-2 shrink-0 rounded-full', memberDotClass(m))} />
                             <span className="font-mono">{m.name}</span>
-                            {m.self && <span className="text-[10px] text-muted-foreground">(you)</span>}
+                            {m.self && <span className="text-ui-2xs text-muted-foreground">(you)</span>}
                           </span>
                         </td>
                         <td className="px-3 py-1.5">{m.stateStr}</td>

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -48,6 +48,7 @@ import {
   type ProfileEntry,
   type ReplSetStatus,
 } from '../lib/monitoringApi';
+import { lagText, lagClass, memberUnhealthy, memberDotClass, fmtMemberUptime } from '@/lib/clusterHealth';
 
 interface MonitoringViewProps {
   connectionId: string;
@@ -533,32 +534,6 @@ const ProfileFilterBar: React.FC<{
     <FilterCount shown={shown} total={total} />
   </div>
 );
-
-const lagText = (lagSecs: number | null | undefined): string =>
-  lagSecs == null ? 'n/a' : `${lagSecs < 10 ? lagSecs.toFixed(1) : Math.round(lagSecs)}s`;
-
-const lagClass = (lagSecs: number | null | undefined): string => {
-  if (lagSecs == null) return 'text-muted-foreground';
-  if (lagSecs >= 60) return 'font-semibold text-red-500';
-  if (lagSecs >= 10) return 'font-semibold text-amber-500';
-  return 'text-muted-foreground';
-};
-
-const memberUnhealthy = (m: { health: number; stateStr: string }): boolean =>
-  m.health !== 1 || /not reachable|DOWN|UNKNOWN/i.test(m.stateStr);
-
-const memberDotClass = (m: { health: number; stateStr: string }): string => {
-  if (memberUnhealthy(m)) return 'bg-red-500';
-  if (m.stateStr === 'PRIMARY') return 'bg-emerald-500';
-  if (m.stateStr === 'SECONDARY') return 'bg-sky-500';
-  return 'bg-amber-500';
-};
-
-const fmtMemberUptime = (secs: number): string => {
-  const d = Math.floor(secs / 86_400);
-  const h = Math.floor((secs % 86_400) / 3_600);
-  return d > 0 ? `${d}d ${h}h` : `${h}h ${Math.floor((secs % 3_600) / 60)}m`;
-};
 
 export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) => {
   const [status, setStatus] = useState<ServerStatus | null>(null);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -56,6 +56,8 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+import { ClusterHealthCard } from '@/components/ClusterHealthCard';
 import { ThemePicker } from '@/components/theme/ThemePicker';
 import {
   Database,
@@ -189,6 +191,8 @@ interface SidebarProps {
   refreshTarget?: { connectionId: string; db?: string; expand: boolean } | null;
   /** Bumped by the parent to fire a refresh of `refreshTarget`. */
   refreshTargetNonce?: number;
+  /** Hover delay before the connection cluster-health popover opens (ms). */
+  clusterHoverDelayMs?: number;
 }
 
 const treeRowClass = (active?: boolean) =>
@@ -297,10 +301,32 @@ export const Sidebar: React.FC<SidebarProps> = ({
   canPaste,
   refreshTarget,
   refreshTargetNonce,
+  clusterHoverDelayMs = 400,
 }) => {
   const { toast, confirm, prompt } = useDialogs();
   const [filterQuery, setFilterQuery] = useState('');
   const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Cluster-health hover popover: which connection's card is open, plus
+  // open-delay and grace-close timers so the pointer can travel into the card.
+  const [healthPopoverConn, setHealthPopoverConn] = useState<string | null>(null);
+  const healthOpenTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const healthCloseTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelHealthTimers = () => {
+    if (healthOpenTimer.current) clearTimeout(healthOpenTimer.current);
+    if (healthCloseTimer.current) clearTimeout(healthCloseTimer.current);
+    healthOpenTimer.current = null;
+    healthCloseTimer.current = null;
+  };
+  const scheduleHealthOpen = (connId: string) => {
+    cancelHealthTimers();
+    healthOpenTimer.current = setTimeout(() => setHealthPopoverConn(connId), clusterHoverDelayMs);
+  };
+  const scheduleHealthClose = () => {
+    if (healthOpenTimer.current) clearTimeout(healthOpenTimer.current);
+    healthCloseTimer.current = setTimeout(() => setHealthPopoverConn(null), 150);
+  };
+  useEffect(() => cancelHealthTimers, []);
 
   // Mock connections (the bundled sample data, or ids/URIs marked as such) never
   // reach a real mongodump/mongorestore binary — the backend rejects them outright
@@ -1417,8 +1443,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
           return (
             <div key={conn.id}>
+              <Popover open={healthPopoverConn === conn.id}>
               <ContextMenu>
                 <ContextMenuTrigger asChild>
+                  <PopoverAnchor asChild>
                   <div
                     className={cn(
                       'group flex h-7 cursor-pointer items-center gap-1 rounded-sm px-2 text-xs hover:bg-accent/80',
@@ -1429,6 +1457,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     aria-expanded={isConnExpanded}
                     aria-label={`Connection ${conn.name}`}
                     onClick={() => setExpandedConnections((prev) => ({ ...prev, [conn.id]: !prev[conn.id] }))}
+                    onMouseEnter={() => scheduleHealthOpen(conn.id)}
+                    onMouseLeave={scheduleHealthClose}
                   >
                     <div className="flex min-w-0 flex-1 items-center gap-1">
                       <ChevronRight
@@ -1476,6 +1506,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                       <LogOut className="size-3" />
                     </Button>
                   </div>
+                  </PopoverAnchor>
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                   <ContextMenuItem className={ctxItemClass} onClick={() => handleAddDatabase(conn.id)}>
@@ -1573,6 +1604,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   </ContextMenuItem>
                 </ContextMenuContent>
               </ContextMenu>
+                <PopoverContent
+                  side="right"
+                  align="start"
+                  onOpenAutoFocus={(e) => e.preventDefault()}
+                  onMouseEnter={cancelHealthTimers}
+                  onMouseLeave={scheduleHealthClose}
+                >
+                  <ClusterHealthCard connectionId={conn.id} onOpenMonitoring={onOpenMonitoring} />
+                </PopoverContent>
+              </Popover>
 
               {isConnExpanded && (
                 <div className="ml-3 border-l border-border/50 pl-1">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -312,6 +312,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const [healthPopoverConn, setHealthPopoverConn] = useState<string | null>(null);
   const healthOpenTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const healthCloseTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The popover opens at the mouse cursor, not beside the row: a virtual
+  // anchor reports a zero-size rect at the last pointer position (updated
+  // until the popover opens, then frozen so the card doesn't chase the mouse).
+  const healthAnchorPoint = React.useRef({ x: 0, y: 0 });
+  const healthVirtualAnchor = React.useRef({
+    getBoundingClientRect: () => {
+      const { x, y } = healthAnchorPoint.current;
+      return { width: 0, height: 0, x, y, top: y, bottom: y, left: x, right: x, toJSON: () => ({}) } as DOMRect;
+    },
+  });
   const cancelHealthTimers = () => {
     if (healthOpenTimer.current) clearTimeout(healthOpenTimer.current);
     if (healthCloseTimer.current) clearTimeout(healthCloseTimer.current);
@@ -1457,7 +1467,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
               >
               <ContextMenu>
                 <ContextMenuTrigger asChild>
-                  <PopoverAnchor asChild>
                   <div
                     className={cn(
                       'group flex h-7 cursor-pointer items-center gap-1 rounded-sm px-2 text-xs hover:bg-accent/80',
@@ -1468,7 +1477,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     aria-expanded={isConnExpanded}
                     aria-label={`Connection ${conn.name}`}
                     onClick={() => setExpandedConnections((prev) => ({ ...prev, [conn.id]: !prev[conn.id] }))}
-                    onMouseEnter={() => scheduleHealthOpen(conn.id)}
+                    onMouseEnter={(e) => {
+                      healthAnchorPoint.current = { x: e.clientX, y: e.clientY };
+                      scheduleHealthOpen(conn.id);
+                    }}
+                    onMouseMove={(e) => {
+                      // Track the pointer until the popover opens so the card
+                      // appears where the cursor is, not where it entered.
+                      if (healthPopoverConn !== conn.id) {
+                        healthAnchorPoint.current = { x: e.clientX, y: e.clientY };
+                      }
+                    }}
                     onMouseLeave={scheduleHealthClose}
                   >
                     <div className="flex min-w-0 flex-1 items-center gap-1">
@@ -1517,7 +1536,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                       <LogOut className="size-3" />
                     </Button>
                   </div>
-                  </PopoverAnchor>
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                   <ContextMenuItem className={ctxItemClass} onClick={() => handleAddDatabase(conn.id)}>
@@ -1615,9 +1633,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   </ContextMenuItem>
                 </ContextMenuContent>
               </ContextMenu>
+                <PopoverAnchor virtualRef={healthVirtualAnchor} />
                 <PopoverContent
-                  side="right"
+                  side="bottom"
                   align="start"
+                  sideOffset={8}
                   onOpenAutoFocus={(e) => e.preventDefault()}
                   onMouseEnter={cancelHealthTimers}
                   onMouseLeave={scheduleHealthClose}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1642,7 +1642,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   onMouseEnter={cancelHealthTimers}
                   onMouseLeave={scheduleHealthClose}
                 >
-                  <ClusterHealthCard connectionId={conn.id} onOpenMonitoring={onOpenMonitoring} />
+                  <ClusterHealthCard
+                    connectionId={conn.id}
+                    connectionName={conn.name}
+                    connectionUri={conn.uri}
+                    onOpenMonitoring={onOpenMonitoring}
+                  />
                 </PopoverContent>
               </Popover>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -320,6 +320,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
   const scheduleHealthOpen = (connId: string) => {
     cancelHealthTimers();
+    // Moving to a different row: close the previous popover immediately
+    // instead of letting it linger for the open delay.
+    setHealthPopoverConn((cur) => (cur !== null && cur !== connId ? null : cur));
     healthOpenTimer.current = setTimeout(() => setHealthPopoverConn(connId), clusterHoverDelayMs);
   };
   const scheduleHealthClose = () => {
@@ -1443,7 +1446,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
           return (
             <div key={conn.id}>
-              <Popover open={healthPopoverConn === conn.id}>
+              <Popover
+                open={healthPopoverConn === conn.id}
+                onOpenChange={(open) => {
+                  if (!open) {
+                    cancelHealthTimers();
+                    setHealthPopoverConn(null);
+                  }
+                }}
+              >
               <ContextMenu>
                 <ContextMenuTrigger asChild>
                   <PopoverAnchor asChild>

--- a/src/components/__tests__/ClusterHealthCard.test.tsx
+++ b/src/components/__tests__/ClusterHealthCard.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => mockInvoke(...a) }));
+
+import { ClusterHealthCard } from '../ClusterHealthCard';
+
+const CLUSTER = {
+  isReplicaSet: true,
+  set: 'rs0',
+  myStateStr: 'PRIMARY',
+  mongoVersion: '7.0.0',
+  members: [
+    { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 86400, optimeDateMs: 1749427200000, pingMs: null, syncSource: '', lagSecs: null },
+    { name: 'db2:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 86300, optimeDateMs: 1749427199200, pingMs: 1, syncSource: 'db1:27017', lagSecs: 0.8 },
+    { name: 'db3:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 4200, optimeDateMs: 1749427158000, pingMs: 3, syncSource: 'db1:27017', lagSecs: 42 },
+    { name: 'db4:27017', stateStr: '(not reachable/healthy)', health: 0, self: false, uptimeSecs: 0, optimeDateMs: 0, pingMs: null, syncSource: '', lagSecs: null },
+  ],
+};
+
+beforeEach(() => mockInvoke.mockReset());
+
+describe('ClusterHealthCard', () => {
+  it('renders the set summary and members with lag styling', async () => {
+    mockInvoke.mockResolvedValue(CLUSTER);
+    render(<ClusterHealthCard connectionId="conn-1" />);
+    const card = await screen.findByTestId('cluster-health-card');
+    expect(card).toHaveTextContent('rs0');
+    expect(card).toHaveTextContent('you: PRIMARY');
+    expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
+    expect(screen.getByTestId('cluster-card-member-db1:27017')).toHaveTextContent('PRIMARY');
+    expect(screen.getByTestId('cluster-card-member-db2:27017')).toHaveTextContent('lag 0.8s');
+    // 42s >= 10s threshold: amber class somewhere inside the row.
+    expect(screen.getByTestId('cluster-card-member-db3:27017').innerHTML).toMatch(/amber/);
+    // Unhealthy member: destructive styling + stateStr instead of lag.
+    const down = screen.getByTestId('cluster-card-member-db4:27017');
+    expect(down.className).toMatch(/destructive/);
+    expect(down).toHaveTextContent('(not reachable/healthy)');
+  });
+
+  it('shows the standalone one-liner for non-replica-set servers', async () => {
+    mockInvoke.mockResolvedValue({ isReplicaSet: false, set: '', myStateStr: '', mongoVersion: '', members: [] });
+    render(<ClusterHealthCard connectionId="conn-1" />);
+    expect(await screen.findByTestId('cluster-card-standalone')).toBeInTheDocument();
+  });
+
+  it('renders errors quietly and fires onOpenMonitoring from the footer link', async () => {
+    mockInvoke.mockRejectedValueOnce('Not authorized to run replSetGetStatus');
+    const { unmount } = render(<ClusterHealthCard connectionId="conn-1" />);
+    expect(await screen.findByText(/not authorized/i)).toBeInTheDocument();
+    unmount();
+
+    mockInvoke.mockResolvedValue(CLUSTER);
+    const onOpen = vi.fn();
+    render(<ClusterHealthCard connectionId="conn-2" onOpenMonitoring={onOpen} />);
+    (await screen.findByTestId('cluster-card-open-monitoring')).click();
+    expect(onOpen).toHaveBeenCalledWith('conn-2');
+  });
+});

--- a/src/components/__tests__/ClusterHealthCard.test.tsx
+++ b/src/components/__tests__/ClusterHealthCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 const mockInvoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => mockInvoke(...a) }));
@@ -23,28 +23,55 @@ const CLUSTER = {
 beforeEach(() => mockInvoke.mockReset());
 
 describe('ClusterHealthCard', () => {
-  it('renders the set summary and members with lag styling', async () => {
+  it('renders the connection header, member rows, read-pref and version', async () => {
     mockInvoke.mockResolvedValue(CLUSTER);
-    render(<ClusterHealthCard connectionId="conn-1" />);
+    render(
+      <ClusterHealthCard
+        connectionId="conn-1"
+        connectionName="Mock DB"
+        connectionUri="mongodb://root:pw@h1:27017,h2:27017/?readPreference=primary"
+      />
+    );
     const card = await screen.findByTestId('cluster-health-card');
-    expect(card).toHaveTextContent('Replica set');
-    expect(card).toHaveTextContent('rs0');
-    expect(card).toHaveTextContent('you: PRIMARY');
     expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
+
+    expect(screen.getByTestId('cluster-card-connection')).toHaveTextContent('Mock DB');
+    expect(screen.getByTestId('cluster-card-connection')).toHaveTextContent('replica set: rs0');
+    expect(screen.getByTestId('cluster-card-user')).toHaveTextContent('root');
+    expect(screen.getByTestId('cluster-card-read-pref')).toHaveTextContent('Primary');
+    expect(screen.getByTestId('cluster-card-version')).toHaveTextContent('7.0.0');
+
     expect(screen.getByTestId('cluster-card-member-db1:27017')).toHaveTextContent('PRIMARY');
+    expect(screen.getByTestId('cluster-card-member-db2:27017')).toHaveTextContent('Online [SECONDARY]');
     expect(screen.getByTestId('cluster-card-member-db2:27017')).toHaveTextContent('lag 0.8s');
     // 42s >= 10s threshold: amber class somewhere inside the row.
     expect(screen.getByTestId('cluster-card-member-db3:27017').innerHTML).toMatch(/amber/);
-    // Unhealthy member: destructive styling + stateStr instead of lag.
+    // Unhealthy member: destructive styling + Offline instead of lag.
     const down = screen.getByTestId('cluster-card-member-db4:27017');
     expect(down.className).toMatch(/destructive/);
+    expect(down).toHaveTextContent('Offline');
     expect(down).toHaveTextContent('(not reachable/healthy)');
+    expect(card).toBeInTheDocument();
   });
 
-  it('shows the standalone one-liner for non-replica-set servers', async () => {
+  it('refetches when Refresh is clicked', async () => {
+    mockInvoke.mockResolvedValue(CLUSTER);
+    render(<ClusterHealthCard connectionId="conn-1" />);
+    await screen.findByTestId('cluster-health-card');
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+
+    screen.getByTestId('cluster-card-refresh').click();
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledTimes(2));
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'repl_set_status', { id: 'conn-1' });
+  });
+
+  it('shows the standalone one-liner for non-replica-set servers, without header lines when props are omitted', async () => {
     mockInvoke.mockResolvedValue({ isReplicaSet: false, clusterType: 'standalone', set: '', myStateStr: '', mongoVersion: '', members: [] });
     render(<ClusterHealthCard connectionId="conn-1" />);
     expect(await screen.findByTestId('cluster-card-standalone')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-card-connection')).toBeNull();
+    expect(screen.queryByTestId('cluster-card-user')).toBeNull();
+    expect(screen.queryByTestId('cluster-card-read-pref')).toBeNull();
   });
 
   it('shows the sharded one-liner for mongos connections', async () => {

--- a/src/components/__tests__/ClusterHealthCard.test.tsx
+++ b/src/components/__tests__/ClusterHealthCard.test.tsx
@@ -8,6 +8,7 @@ import { ClusterHealthCard } from '../ClusterHealthCard';
 
 const CLUSTER = {
   isReplicaSet: true,
+  clusterType: 'replicaSet',
   set: 'rs0',
   myStateStr: 'PRIMARY',
   mongoVersion: '7.0.0',
@@ -26,6 +27,7 @@ describe('ClusterHealthCard', () => {
     mockInvoke.mockResolvedValue(CLUSTER);
     render(<ClusterHealthCard connectionId="conn-1" />);
     const card = await screen.findByTestId('cluster-health-card');
+    expect(card).toHaveTextContent('Replica set');
     expect(card).toHaveTextContent('rs0');
     expect(card).toHaveTextContent('you: PRIMARY');
     expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
@@ -40,9 +42,16 @@ describe('ClusterHealthCard', () => {
   });
 
   it('shows the standalone one-liner for non-replica-set servers', async () => {
-    mockInvoke.mockResolvedValue({ isReplicaSet: false, set: '', myStateStr: '', mongoVersion: '', members: [] });
+    mockInvoke.mockResolvedValue({ isReplicaSet: false, clusterType: 'standalone', set: '', myStateStr: '', mongoVersion: '', members: [] });
     render(<ClusterHealthCard connectionId="conn-1" />);
     expect(await screen.findByTestId('cluster-card-standalone')).toBeInTheDocument();
+  });
+
+  it('shows the sharded one-liner for mongos connections', async () => {
+    mockInvoke.mockResolvedValue({ isReplicaSet: false, clusterType: 'sharded', set: '', myStateStr: '', mongoVersion: '', members: [] });
+    render(<ClusterHealthCard connectionId="conn-1" />);
+    expect(await screen.findByTestId('cluster-card-sharded')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-card-standalone')).toBeNull();
   });
 
   it('renders errors quietly and fires onOpenMonitoring from the footer link', async () => {

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -17,6 +17,7 @@ const STATUS = {
 
 const CLUSTER = {
   isReplicaSet: true,
+  clusterType: 'replicaSet',
   set: 'rs0',
   myStateStr: 'PRIMARY',
   mongoVersion: '7.0.0',
@@ -186,12 +187,27 @@ describe('MonitoringView', () => {
       if (cmd === 'server_status') return Promise.resolve(STATUS);
       if (cmd === 'current_ops') return Promise.resolve([]);
       if (cmd === 'repl_set_status')
-        return Promise.resolve({ isReplicaSet: false, set: '', myStateStr: '', mongoVersion: '', members: [] });
+        return Promise.resolve({ isReplicaSet: false, clusterType: 'standalone', set: '', myStateStr: '', mongoVersion: '', members: [] });
       return Promise.resolve(null);
     });
     render(<MonitoringView connectionId="conn-1" />);
     fireEvent.click(await screen.findByTestId('mon-tab-cluster'));
     expect(await screen.findByTestId('cluster-not-replset')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-members-table')).toBeNull();
+  });
+
+  it('shows a sharded-cluster notice for mongos connections', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'server_status') return Promise.resolve(STATUS);
+      if (cmd === 'current_ops') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({ isReplicaSet: false, clusterType: 'sharded', set: '', myStateStr: '', mongoVersion: '', members: [] });
+      return Promise.resolve(null);
+    });
+    render(<MonitoringView connectionId="conn-1" />);
+    fireEvent.click(await screen.findByTestId('mon-tab-cluster'));
+    expect(await screen.findByTestId('cluster-sharded')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-not-replset')).toBeNull();
     expect(screen.queryByTestId('cluster-members-table')).toBeNull();
   });
 });

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -15,6 +15,18 @@ const STATUS = {
   cache: { bytesInCache: 1024, maxBytes: 4096, dirtyBytes: 0 },
 };
 
+const CLUSTER = {
+  isReplicaSet: true,
+  set: 'rs0',
+  myStateStr: 'PRIMARY',
+  mongoVersion: '7.0.0',
+  members: [
+    { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 86400, optimeDateMs: 1749427200000, pingMs: null, syncSource: '', lagSecs: null },
+    { name: 'db2:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 86300, optimeDateMs: 1749427199200, pingMs: 1, syncSource: 'db1:27017', lagSecs: 0.8 },
+    { name: 'db3:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 4200, optimeDateMs: 1749427158000, pingMs: 3, syncSource: 'db1:27017', lagSecs: 42 },
+  ],
+};
+
 beforeEach(() => {
   mockInvoke.mockReset();
   mockInvoke.mockImplementation((cmd: string) => {
@@ -26,6 +38,7 @@ beforeEach(() => {
       case 'list_databases': return Promise.resolve(['admin', 'sales_db']);
       case 'get_profiling_status': return Promise.resolve({ level: 0, slowMs: 100 });
       case 'read_profile': return Promise.resolve([]);
+      case 'repl_set_status': return Promise.resolve(CLUSTER);
       case 'kill_op': return Promise.resolve();
       default: return Promise.resolve(null);
     }
@@ -130,5 +143,51 @@ describe('MonitoringView', () => {
     await waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith('set_profiling_level', expect.objectContaining({ id: 'conn-1', level: 1 }));
     });
+  });
+
+  it('does not fetch replica-set status until the Cluster tab is active', async () => {
+    render(<MonitoringView connectionId="conn-1" />);
+    expect(await screen.findByTestId('current-ops-table')).toBeInTheDocument();
+    expect(mockInvoke).not.toHaveBeenCalledWith('repl_set_status', expect.anything());
+    fireEvent.click(screen.getByTestId('mon-tab-cluster'));
+    expect(await screen.findByTestId('mon-panel-cluster')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
+    });
+  });
+
+  it('renders replica-set members with roles and lag warning styling', async () => {
+    render(<MonitoringView connectionId="conn-1" />);
+    fireEvent.click(await screen.findByTestId('mon-tab-cluster'));
+
+    const summary = await screen.findByTestId('cluster-summary');
+    expect(summary).toHaveTextContent('rs0');
+    expect(summary).toHaveTextContent('3 members');
+    expect(summary).toHaveTextContent('7.0.0');
+    expect(summary).toHaveTextContent('PRIMARY');
+
+    expect(screen.getByTestId('cluster-member-db1:27017')).toHaveTextContent('PRIMARY');
+    // Healthy secondary: sub-threshold lag, no warning class.
+    const okLag = screen.getByTestId('cluster-lag-db2:27017');
+    expect(okLag).toHaveTextContent('0.8s');
+    expect(okLag.className).not.toMatch(/amber|red/);
+    // Lagging secondary (42s >= 10s): amber warning.
+    const warnLag = screen.getByTestId('cluster-lag-db3:27017');
+    expect(warnLag).toHaveTextContent('42');
+    expect(warnLag.className).toMatch(/amber/);
+  });
+
+  it('shows a friendly empty state for standalone (non-replica-set) servers', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'server_status') return Promise.resolve(STATUS);
+      if (cmd === 'current_ops') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({ isReplicaSet: false, set: '', myStateStr: '', mongoVersion: '', members: [] });
+      return Promise.resolve(null);
+    });
+    render(<MonitoringView connectionId="conn-1" />);
+    fireEvent.click(await screen.findByTestId('mon-tab-cluster'));
+    expect(await screen.findByTestId('cluster-not-replset')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-members-table')).toBeNull();
   });
 });

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -24,6 +24,7 @@ const CLUSTER = {
     { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 86400, optimeDateMs: 1749427200000, pingMs: null, syncSource: '', lagSecs: null },
     { name: 'db2:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 86300, optimeDateMs: 1749427199200, pingMs: 1, syncSource: 'db1:27017', lagSecs: 0.8 },
     { name: 'db3:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 4200, optimeDateMs: 1749427158000, pingMs: 3, syncSource: 'db1:27017', lagSecs: 42 },
+    { name: 'db4:27017', stateStr: '(not reachable/healthy)', health: 0, self: false, uptimeSecs: 0, optimeDateMs: 0, pingMs: null, syncSource: '', lagSecs: null },
   ],
 };
 
@@ -162,7 +163,7 @@ describe('MonitoringView', () => {
 
     const summary = await screen.findByTestId('cluster-summary');
     expect(summary).toHaveTextContent('rs0');
-    expect(summary).toHaveTextContent('3 members');
+    expect(summary).toHaveTextContent('4 members');
     expect(summary).toHaveTextContent('7.0.0');
     expect(summary).toHaveTextContent('PRIMARY');
 
@@ -175,6 +176,9 @@ describe('MonitoringView', () => {
     const warnLag = screen.getByTestId('cluster-lag-db3:27017');
     expect(warnLag).toHaveTextContent('42');
     expect(warnLag.className).toMatch(/amber/);
+    // Down/unreachable member: unhealthy styling and no bogus lag.
+    expect(screen.getByTestId('cluster-member-db4:27017').className).toMatch(/destructive/);
+    expect(screen.getByTestId('cluster-lag-db4:27017')).toHaveTextContent('n/a');
   });
 
   it('shows a friendly empty state for standalone (non-replica-set) servers', async () => {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -300,7 +300,7 @@ describe('Sidebar Component', () => {
       if (cmd === 'list_collections') return Promise.resolve([]);
       if (cmd === 'repl_set_status')
         return Promise.resolve({
-          isReplicaSet: true, set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          isReplicaSet: true, clusterType: 'replicaSet', set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
           members: [
             { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
           ],
@@ -333,7 +333,7 @@ describe('Sidebar Component', () => {
       if (cmd === 'list_collections') return Promise.resolve([]);
       if (cmd === 'repl_set_status')
         return Promise.resolve({
-          isReplicaSet: true, set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          isReplicaSet: true, clusterType: 'replicaSet', set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
           members: [
             { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
           ],
@@ -367,7 +367,7 @@ describe('Sidebar Component', () => {
       if (cmd === 'list_collections') return Promise.resolve([]);
       if (cmd === 'repl_set_status')
         return Promise.resolve({
-          isReplicaSet: true, set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          isReplicaSet: true, clusterType: 'replicaSet', set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
           members: [
             { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
           ],

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -327,6 +327,81 @@ describe('Sidebar Component', () => {
     expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
   });
 
+  it('closes the cluster-health popover on Escape (#114)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({
+          isReplicaSet: true, set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          members: [
+            { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
+          ],
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+    const row = await screen.findByLabelText('Connection Mock DB');
+    fireEvent.mouseEnter(row);
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByTestId('cluster-health-card')).toBeNull());
+  });
+
+  it('refetches cluster health once per open when closed then reopened (#114)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({
+          isReplicaSet: true, set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          members: [
+            { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
+          ],
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+    const row = await screen.findByLabelText('Connection Mock DB');
+
+    fireEvent.mouseEnter(row);
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(row);
+    // Grace close is 150ms of real time before the popover actually closes.
+    await waitFor(() => expect(screen.queryByTestId('cluster-health-card')).toBeNull());
+
+    fireEvent.mouseEnter(row);
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
+
+    const replSetStatusCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === 'repl_set_status');
+    expect(replSetStatusCalls).toHaveLength(2);
+  });
+
   it('sorts collections by name before rendering', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -325,6 +325,10 @@ describe('Sidebar Component', () => {
     expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
     expect(await screen.findByText('rs0')).toBeInTheDocument();
     expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
+    // #114 follow-up: connection name is passed through; the fixture's
+    // auth-less uri ('mongodb://mock') means no user line.
+    expect(screen.getByTestId('cluster-card-connection')).toHaveTextContent('Mock DB');
+    expect(screen.queryByTestId('cluster-card-user')).toBeNull();
   });
 
   it('closes the cluster-health popover on Escape (#114)', async () => {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -294,6 +294,39 @@ describe('Sidebar Component', () => {
     expect(tsIcons[0].closest('div')).toHaveTextContent('sensor_readings');
   });
 
+  it('shows a cluster-health popover when hovering a connection (#114)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({
+          isReplicaSet: true, set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          members: [
+            { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
+          ],
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+    const row = await screen.findByLabelText('Connection Mock DB');
+    expect(mockInvoke).not.toHaveBeenCalledWith('repl_set_status', expect.anything());
+    fireEvent.mouseEnter(row);
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
+    expect(await screen.findByText('rs0')).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
+  });
+
   it('sorts collections by name before rendering', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { cn } from '@/lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 rounded-md border border-border bg-popover p-3 text-popover-foreground shadow-md outline-none',
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };

--- a/src/lib/__tests__/clusterHealth.test.ts
+++ b/src/lib/__tests__/clusterHealth.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { uriUser, uriReadPreference } from '../clusterHealth';
+
+describe('uriUser', () => {
+  it('extracts the user from a user+pass URI', () => {
+    expect(uriUser('mongodb://root:pw@h1:27017,h2:27017/db')).toBe('root');
+  });
+
+  it('extracts the user from a user-only URI', () => {
+    expect(uriUser('mongodb://root@h1:27017/db')).toBe('root');
+  });
+
+  it('returns null for an auth-less URI', () => {
+    expect(uriUser('mongodb://h1:27017,h2:27017/db')).toBeNull();
+  });
+
+  it('decodes a percent-encoded user in a mongodb+srv URI', () => {
+    expect(uriUser('mongodb+srv://user%40corp:pw@cluster0.example.mongodb.net/db')).toBe('user@corp');
+  });
+});
+
+describe('uriReadPreference', () => {
+  it('defaults to primary when absent', () => {
+    expect(uriReadPreference('mongodb://h1:27017/db')).toBe('primary');
+  });
+
+  it('reads readPreference from the query string', () => {
+    expect(uriReadPreference('mongodb://h1:27017/db?readPreference=secondaryPreferred')).toBe('secondaryPreferred');
+  });
+
+  it('reads readPreference when other params are present', () => {
+    expect(
+      uriReadPreference('mongodb://h1:27017/db?retryWrites=true&readPreference=secondaryPreferred&w=majority')
+    ).toBe('secondaryPreferred');
+  });
+});

--- a/src/lib/clusterHealth.ts
+++ b/src/lib/clusterHealth.ts
@@ -1,0 +1,25 @@
+export const lagText = (lagSecs: number | null | undefined): string =>
+  lagSecs == null ? 'n/a' : `${lagSecs < 10 ? lagSecs.toFixed(1) : Math.round(lagSecs)}s`;
+
+export const lagClass = (lagSecs: number | null | undefined): string => {
+  if (lagSecs == null) return 'text-muted-foreground';
+  if (lagSecs >= 60) return 'font-semibold text-red-500';
+  if (lagSecs >= 10) return 'font-semibold text-amber-500';
+  return 'text-muted-foreground';
+};
+
+export const memberUnhealthy = (m: { health: number; stateStr: string }): boolean =>
+  m.health !== 1 || /not reachable|DOWN|UNKNOWN/i.test(m.stateStr);
+
+export const memberDotClass = (m: { health: number; stateStr: string }): string => {
+  if (memberUnhealthy(m)) return 'bg-red-500';
+  if (m.stateStr === 'PRIMARY') return 'bg-emerald-500';
+  if (m.stateStr === 'SECONDARY') return 'bg-sky-500';
+  return 'bg-amber-500';
+};
+
+export const fmtMemberUptime = (secs: number): string => {
+  const d = Math.floor(secs / 86_400);
+  const h = Math.floor((secs % 86_400) / 3_600);
+  return d > 0 ? `${d}d ${h}h` : `${h}h ${Math.floor((secs % 3_600) / 60)}m`;
+};

--- a/src/lib/clusterHealth.ts
+++ b/src/lib/clusterHealth.ts
@@ -23,3 +23,17 @@ export const fmtMemberUptime = (secs: number): string => {
   const h = Math.floor((secs % 86_400) / 3_600);
   return d > 0 ? `${d}d ${h}h` : `${h}h ${Math.floor((secs % 3_600) / 60)}m`;
 };
+
+/** Username from a mongodb:// or mongodb+srv:// URI, or null when auth-less.
+ *  Multi-host URIs (mongodb://u:p@h1:27017,h2:27017/db) break `new URL`, so
+ *  this is regex-based rather than parsed via the URL API. */
+export const uriUser = (uri: string): string | null => {
+  const m = /^mongodb(?:\+srv)?:\/\/([^:@/]+)(?::[^@/]*)?@/.exec(uri);
+  return m ? decodeURIComponent(m[1]) : null;
+};
+
+/** readPreference from the URI query string; MongoDB's default is "primary". */
+export const uriReadPreference = (uri: string): string => {
+  const m = /[?&]readPreference=([^&]+)/i.exec(uri);
+  return m ? decodeURIComponent(m[1]) : 'primary';
+};

--- a/src/lib/monitoringApi.ts
+++ b/src/lib/monitoringApi.ts
@@ -45,3 +45,25 @@ export const setProfilingLevel = (id: string, database: string, level: number, s
   invoke<ProfilingStatus>('set_profiling_level', { id, database, level, slowMs });
 export const readProfile = (id: string, database: string, limit: number) =>
   invoke<ProfileEntry[]>('read_profile', { id, database, limit });
+
+export interface ReplSetMember {
+  name: string;
+  stateStr: string;
+  health: number;
+  self: boolean;
+  uptimeSecs: number;
+  optimeDateMs: number;
+  pingMs?: number | null;
+  syncSource: string;
+  lagSecs?: number | null;
+}
+
+export interface ReplSetStatus {
+  isReplicaSet: boolean;
+  set: string;
+  myStateStr: string;
+  mongoVersion: string;
+  members: ReplSetMember[];
+}
+
+export const replSetStatus = (id: string) => invoke<ReplSetStatus>('repl_set_status', { id });

--- a/src/lib/monitoringApi.ts
+++ b/src/lib/monitoringApi.ts
@@ -60,6 +60,7 @@ export interface ReplSetMember {
 
 export interface ReplSetStatus {
   isReplicaSet: boolean;
+  clusterType: string;
   set: string;
   myStateStr: string;
   mongoVersion: string;


### PR DESCRIPTION
Closes #114.

- New **Cluster** tab in Monitoring: replica-set summary (set name, member count, MongoDB version, your role) and per-member rows (state dot, host, state, uptime, ping, sync source). Each row's tooltip carries the member's raw optimeDate.
- **Replication lag** per secondary (primary optimeDate − member optimeDate): amber ≥ 10s, red ≥ 60s. Down/unreachable members render destructively with **n/a** lag — an unhealthy member's stale optime would otherwise read as an epoch-sized number.
- Standalone servers get a friendly "not a replica set" empty state (replSetGetStatus code 76 mapped, not errored); missing clusterMonitor role gets a readable authorization message (code 13).
- Fetches only while the Cluster tab is active, riding the existing refresh-interval selector without disturbing the metrics chart history.
- Demo mode returns a synthetic 3-member rs0 (including a 42s-lagged secondary) so the tab works without a live cluster.

Verification: cargo 239/239, vitest 680/680 (with coverage), tsc clean.