### PR TITLE
feat: stats popovers for databases, collections, and indexes (#178)

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -11,6 +11,7 @@ pub mod metadata;
 pub mod mongotools;
 pub mod query;
 pub mod schema;
+pub mod stats;
 pub mod tasks;
 pub mod users;
 pub mod version;

--- a/src-tauri/src/db/stats.rs
+++ b/src-tauri/src/db/stats.rs
@@ -1,0 +1,294 @@
+//! Database / collection / index statistics for the sidebar stats popovers
+//! (#178). Same shape as monitoring.rs: pure curation functions (unit-tested)
+//! + async `*_impl` wrappers with mock branches for demo mode.
+
+use crate::{connection_is_mock, require_real_client, AppState};
+use mongodb::bson::{doc, Bson, Document};
+use serde::Serialize;
+
+fn num(d: &Document, key: &str) -> i64 {
+    match d.get(key) {
+        Some(Bson::Int32(v)) => *v as i64,
+        Some(Bson::Int64(v)) => *v,
+        Some(Bson::Double(v)) => *v as i64,
+        _ => 0,
+    }
+}
+fn fnum(d: &Document, key: &str) -> f64 {
+    match d.get(key) {
+        Some(Bson::Int32(v)) => *v as f64,
+        Some(Bson::Int64(v)) => *v as f64,
+        Some(Bson::Double(v)) => *v,
+        _ => 0.0,
+    }
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DbStatsUi {
+    pub collections: i64,
+    pub views: i64,
+    pub objects: i64,
+    pub avg_obj_size: f64,
+    pub data_size: i64,
+    pub storage_size: i64,
+    pub indexes: i64,
+    pub total_index_size: i64,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CollStatsUi {
+    pub count: i64,
+    pub avg_obj_size: f64,
+    pub size: i64,
+    pub storage_size: i64,
+    pub nindexes: i64,
+    pub total_index_size: i64,
+    pub capped: bool,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexStatUi {
+    pub name: String,
+    pub size_bytes: i64,
+    /// Accesses since the counter started ($indexStats); 0 when unavailable.
+    pub ops: i64,
+    pub since_ms: i64,
+}
+
+/// Curate a raw `dbStats` command reply.
+pub fn curate_db_stats(raw: &Document) -> DbStatsUi {
+    DbStatsUi {
+        collections: num(raw, "collections"),
+        views: num(raw, "views"),
+        objects: num(raw, "objects"),
+        avg_obj_size: fnum(raw, "avgObjSize"),
+        data_size: num(raw, "dataSize"),
+        storage_size: num(raw, "storageSize"),
+        indexes: num(raw, "indexes"),
+        total_index_size: num(raw, "totalIndexSize"),
+    }
+}
+
+/// Curate the `storageStats` subdocument of a `$collStats` aggregation result.
+pub fn curate_coll_stats(storage: &Document) -> CollStatsUi {
+    CollStatsUi {
+        count: num(storage, "count"),
+        avg_obj_size: fnum(storage, "avgObjSize"),
+        size: num(storage, "size"),
+        storage_size: num(storage, "storageSize"),
+        nindexes: num(storage, "nindexes"),
+        total_index_size: num(storage, "totalIndexSize"),
+        capped: storage.get_bool("capped").unwrap_or(false),
+    }
+}
+
+/// Join `$collStats.storageStats.indexSizes` (authoritative index list) with
+/// `$indexStats` usage docs; indexes missing from `$indexStats` report zero
+/// usage. Sorted by on-disk size, largest first.
+pub fn curate_index_stats(index_sizes: &Document, stats_docs: &[Document]) -> Vec<IndexStatUi> {
+    let usage = |name: &str| -> (i64, i64) {
+        stats_docs
+            .iter()
+            .find(|d| d.get_str("name").ok() == Some(name))
+            .and_then(|d| d.get_document("accesses").ok())
+            .map(|a| {
+                let since = match a.get("since") {
+                    Some(Bson::DateTime(dt)) => dt.timestamp_millis(),
+                    _ => 0,
+                };
+                (num(a, "ops"), since)
+            })
+            .unwrap_or((0, 0))
+    };
+    let mut out: Vec<IndexStatUi> = index_sizes
+        .iter()
+        .map(|(name, size)| {
+            let (ops, since_ms) = usage(name);
+            IndexStatUi {
+                name: name.clone(),
+                size_bytes: match size {
+                    Bson::Int32(v) => *v as i64,
+                    Bson::Int64(v) => *v,
+                    Bson::Double(v) => *v as i64,
+                    _ => 0,
+                },
+                ops,
+                since_ms,
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes));
+    out
+}
+
+// ── Mock data (demo connections) ─────────────────────────────────────────────
+
+fn mock_db_stats(db: &str) -> DbStatsUi {
+    match db {
+        "sales_db" => DbStatsUi { collections: 4, views: 0, objects: 12, avg_obj_size: 512.0, data_size: 6_144, storage_size: 24_576, indexes: 10, total_index_size: 40_960 },
+        "user_analytics" => DbStatsUi { collections: 2, views: 0, objects: 6, avg_obj_size: 384.0, data_size: 2_304, storage_size: 12_288, indexes: 5, total_index_size: 20_480 },
+        _ => DbStatsUi { collections: 2, views: 0, objects: 2, avg_obj_size: 128.0, data_size: 256, storage_size: 8_192, indexes: 2, total_index_size: 8_192 },
+    }
+}
+
+fn mock_coll_stats() -> CollStatsUi {
+    CollStatsUi { count: 3, avg_obj_size: 512.0, size: 1_536, storage_size: 8_192, nindexes: 3, total_index_size: 12_288, capped: false }
+}
+
+fn mock_index_stats(db: &str, coll: &str) -> Vec<IndexStatUi> {
+    crate::mock_db::get_mock_indexes(db, coll)
+        .into_iter()
+        .enumerate()
+        .map(|(i, info)| IndexStatUi {
+            name: info.name.clone(),
+            size_bytes: 36_864 - (i as i64) * 8_192,
+            ops: if info.name == "_id_" { 10_500 } else { 42 * (i as i64 + 1) },
+            since_ms: 1_749_427_200_000,
+        })
+        .collect()
+}
+
+// ── Async command impls ──────────────────────────────────────────────────────
+
+pub async fn db_stats_impl(state: &AppState, id: &str, db: &str) -> Result<DbStatsUi, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(mock_db_stats(db));
+    }
+    let client = require_real_client(state, id)?;
+    let raw = client
+        .database(db)
+        .run_command(doc! { "dbStats": 1 })
+        .await
+        .map_err(|e| format!("dbStats failed: {}", e))?;
+    Ok(curate_db_stats(&raw))
+}
+
+/// Run `$collStats {storageStats}` and return the first result's storageStats.
+async fn coll_storage_stats(
+    client: &mongodb::Client,
+    db: &str,
+    coll: &str,
+) -> Result<Document, String> {
+    use futures::stream::StreamExt;
+    let mut cursor = client
+        .database(db)
+        .collection::<Document>(coll)
+        .aggregate(vec![doc! { "$collStats": { "storageStats": {} } }])
+        .await
+        .map_err(|e| format!("collStats failed: {}", e))?;
+    match cursor.next().await {
+        Some(Ok(d)) => Ok(d.get_document("storageStats").cloned().unwrap_or_default()),
+        Some(Err(e)) => Err(format!("collStats cursor error: {}", e)),
+        None => Ok(Document::new()),
+    }
+}
+
+pub async fn coll_stats_impl(state: &AppState, id: &str, db: &str, coll: &str) -> Result<CollStatsUi, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(mock_coll_stats());
+    }
+    let client = require_real_client(state, id)?;
+    let storage = coll_storage_stats(&client, db, coll).await?;
+    Ok(curate_coll_stats(&storage))
+}
+
+pub async fn index_stats_impl(state: &AppState, id: &str, db: &str, coll: &str) -> Result<Vec<IndexStatUi>, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(mock_index_stats(db, coll));
+    }
+    let client = require_real_client(state, id)?;
+    let storage = coll_storage_stats(&client, db, coll).await?;
+    let index_sizes = storage.get_document("indexSizes").cloned().unwrap_or_default();
+    use futures::stream::StreamExt;
+    let mut stats_docs: Vec<Document> = Vec::new();
+    // $indexStats can fail on views / old servers — degrade to zero usage.
+    if let Ok(mut cursor) = client
+        .database(db)
+        .collection::<Document>(coll)
+        .aggregate(vec![doc! { "$indexStats": {} }])
+        .await
+    {
+        while let Some(Ok(d)) = cursor.next().await {
+            stats_docs.push(d);
+        }
+    }
+    Ok(curate_index_stats(&index_sizes, &stats_docs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mongodb::bson::{doc, DateTime};
+
+    #[test]
+    fn curates_db_stats_subset() {
+        let raw = doc! {
+            "db": "sales_db", "collections": 4i32, "views": 1i32, "objects": 12_345i64,
+            "avgObjSize": 512.5, "dataSize": 6_324_712i64, "storageSize": 2_502_656i64,
+            "indexes": 9i32, "totalIndexSize": 1_105_920i64, "ok": 1.0,
+        };
+        let s = curate_db_stats(&raw);
+        assert_eq!(s.collections, 4);
+        assert_eq!(s.views, 1);
+        assert_eq!(s.objects, 12_345);
+        assert_eq!(s.avg_obj_size, 512.5);
+        assert_eq!(s.data_size, 6_324_712);
+        assert_eq!(s.storage_size, 2_502_656);
+        assert_eq!(s.indexes, 9);
+        assert_eq!(s.total_index_size, 1_105_920);
+    }
+
+    #[test]
+    fn db_stats_resilient_to_missing_fields() {
+        let s = curate_db_stats(&doc! { "db": "x" });
+        assert_eq!(s, DbStatsUi::default());
+    }
+
+    #[test]
+    fn curates_coll_stats_from_storage_stats() {
+        let storage = doc! {
+            "count": 5_000i64, "avgObjSize": 256i32, "size": 1_280_000i64,
+            "storageSize": 540_672i64, "nindexes": 3i32, "totalIndexSize": 122_880i64,
+            "capped": false,
+        };
+        let s = curate_coll_stats(&storage);
+        assert_eq!(s.count, 5_000);
+        assert_eq!(s.avg_obj_size, 256.0);
+        assert_eq!(s.size, 1_280_000);
+        assert_eq!(s.storage_size, 540_672);
+        assert_eq!(s.nindexes, 3);
+        assert_eq!(s.total_index_size, 122_880);
+        assert!(!s.capped);
+    }
+
+    #[test]
+    fn curates_index_stats_joining_sizes_and_usage() {
+        let sizes = doc! { "_id_": 36_864i64, "email_1": 20_480i64, "unused_1": 8_192i64 };
+        let stats = vec![
+            doc! { "name": "_id_", "accesses": { "ops": 10_500i64, "since": DateTime::from_millis(1_700_000_000_000) } },
+            doc! { "name": "email_1", "accesses": { "ops": 42i64, "since": DateTime::from_millis(1_700_000_000_000) } },
+            // "unused_1" intentionally absent from $indexStats output.
+        ];
+        let out = curate_index_stats(&sizes, &stats);
+        assert_eq!(out.len(), 3);
+        let id = out.iter().find(|i| i.name == "_id_").unwrap();
+        assert_eq!(id.size_bytes, 36_864);
+        assert_eq!(id.ops, 10_500);
+        assert_eq!(id.since_ms, 1_700_000_000_000);
+        let unused = out.iter().find(|i| i.name == "unused_1").unwrap();
+        assert_eq!(unused.size_bytes, 8_192);
+        assert_eq!(unused.ops, 0, "index absent from $indexStats reports zero usage");
+        assert_eq!(unused.since_ms, 0);
+    }
+
+    #[test]
+    fn index_stats_sorted_by_size_desc() {
+        let sizes = doc! { "small_1": 100i64, "big_1": 900i64 };
+        let out = curate_index_stats(&sizes, &[]);
+        assert_eq!(out[0].name, "big_1");
+        assert_eq!(out[1].name, "small_1");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,7 @@ pub use db::metadata::{
     create_index_impl, delete_index_impl, list_collections_impl, list_databases_impl,
     list_indexes_impl,
 };
+pub use db::stats::{db_stats_impl, coll_stats_impl, index_stats_impl};
 pub use db::query::{count_documents_impl, execute_mql_query_impl, explain_mql_query_impl};
 pub use db::schema::{analyze_schema_impl, infer_schema, FieldStat, SchemaReport, TypeCount};
 pub use db::users::{
@@ -929,6 +930,35 @@ async fn list_indexes(
     collection: String,
 ) -> Result<Vec<IndexInfo>, String> {
     list_indexes_impl(&state, &id, &db, &collection).await
+}
+
+#[tauri::command]
+async fn db_stats(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    db: String,
+) -> Result<db::stats::DbStatsUi, String> {
+    db::stats::db_stats_impl(&state, &id, &db).await
+}
+
+#[tauri::command]
+async fn coll_stats(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    db: String,
+    collection: String,
+) -> Result<db::stats::CollStatsUi, String> {
+    db::stats::coll_stats_impl(&state, &id, &db, &collection).await
+}
+
+#[tauri::command]
+async fn index_stats(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    db: String,
+    collection: String,
+) -> Result<Vec<db::stats::IndexStatUi>, String> {
+    db::stats::index_stats_impl(&state, &id, &db, &collection).await
 }
 
 // ── Cluster monitoring ────────────────────────────────────────────────────────
@@ -1823,6 +1853,9 @@ pub fn run() {
             list_databases,
             list_collections,
             list_indexes,
+            db_stats,
+            coll_stats,
+            index_stats,
             create_index,
             delete_index,
             delete_document,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -233,6 +233,33 @@ mod tests {
         );
     }
 
+    // Issue #178: demo mode returns believable stats so all three popovers
+    // render without a live server.
+    #[tokio::test]
+    async fn test_mock_stats_impls_return_demo_numbers() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+
+        let db = crate::db::stats::db_stats_impl(&state, &conn_id, "sales_db").await.unwrap();
+        assert!(db.collections >= 4);
+        assert!(db.objects > 0);
+        assert!(db.data_size > 0);
+
+        let coll = crate::db::stats::coll_stats_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .unwrap();
+        assert!(coll.count > 0);
+        assert!(coll.size > 0);
+        assert!(coll.nindexes >= 1);
+
+        let idx = crate::db::stats::index_stats_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .unwrap();
+        assert!(!idx.is_empty());
+        assert!(idx.iter().any(|i| i.name == "_id_"));
+        assert!(idx.iter().all(|i| i.size_bytes > 0));
+    }
+
     #[tokio::test]
     async fn test_conn_uris_stored_for_real_and_absent_for_mock() {
         use crate::db::mongotools::resolve_conn_uri;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -58,6 +58,7 @@ import {
 } from '@/components/ui/context-menu';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { ClusterHealthCard } from '@/components/ClusterHealthCard';
+import { DbStatsCard, CollStatsCard, IndexStatsCard } from '@/components/StatsCards';
 import { ThemePicker } from '@/components/theme/ThemePicker';
 import {
   Database,
@@ -118,6 +119,27 @@ export interface IndexInfo {
   unique: boolean;
   sparse: boolean;
 }
+
+// Discriminated target for the row-hover stats popover (issue #178):
+// connection → cluster health, database/collection/index → their stats cards.
+type StatsPopoverTarget =
+  | { kind: 'connection'; connId: string }
+  | { kind: 'database'; connId: string; db: string }
+  | { kind: 'collection'; connId: string; db: string; coll: string }
+  | { kind: 'index'; connId: string; db: string; coll: string; index: string };
+
+const targetKey = (t: StatsPopoverTarget): string => {
+  switch (t.kind) {
+    case 'connection':
+      return `connection:${t.connId}`;
+    case 'database':
+      return `database:${t.connId}/${t.db}`;
+    case 'collection':
+      return `collection:${t.connId}/${t.db}/${t.coll}`;
+    case 'index':
+      return `index:${t.connId}/${t.db}/${t.coll}/${t.index}`;
+  }
+};
 
 const compareCollectionNames = (a: string, b: string) =>
   a.localeCompare(b, undefined, { sensitivity: 'base', numeric: true });
@@ -307,39 +329,57 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const [filterQuery, setFilterQuery] = useState('');
   const searchInputRef = React.useRef<HTMLInputElement>(null);
 
-  // Cluster-health hover popover: which connection's card is open, plus
-  // open-delay and grace-close timers so the pointer can travel into the card.
-  const [healthPopoverConn, setHealthPopoverConn] = useState<string | null>(null);
-  const healthOpenTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-  const healthCloseTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Stats hover popover: which row's card is open (connection → cluster
+  // health, database/collection/index → their stats cards), plus open-delay
+  // and grace-close timers so the pointer can travel into the card.
+  const [statsPopover, setStatsPopover] = useState<StatsPopoverTarget | null>(null);
+  const statsOpenTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const statsCloseTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   // The popover opens at the mouse cursor, not beside the row: a virtual
   // anchor reports a zero-size rect at the last pointer position (updated
   // until the popover opens, then frozen so the card doesn't chase the mouse).
-  const healthAnchorPoint = React.useRef({ x: 0, y: 0 });
-  const healthVirtualAnchor = React.useRef({
+  const statsAnchorPoint = React.useRef({ x: 0, y: 0 });
+  const statsVirtualAnchor = React.useRef({
     getBoundingClientRect: () => {
-      const { x, y } = healthAnchorPoint.current;
+      const { x, y } = statsAnchorPoint.current;
       return { width: 0, height: 0, x, y, top: y, bottom: y, left: x, right: x, toJSON: () => ({}) } as DOMRect;
     },
   });
-  const cancelHealthTimers = () => {
-    if (healthOpenTimer.current) clearTimeout(healthOpenTimer.current);
-    if (healthCloseTimer.current) clearTimeout(healthCloseTimer.current);
-    healthOpenTimer.current = null;
-    healthCloseTimer.current = null;
+  const cancelStatsTimers = () => {
+    if (statsOpenTimer.current) clearTimeout(statsOpenTimer.current);
+    if (statsCloseTimer.current) clearTimeout(statsCloseTimer.current);
+    statsOpenTimer.current = null;
+    statsCloseTimer.current = null;
   };
-  const scheduleHealthOpen = (connId: string) => {
-    cancelHealthTimers();
+  const scheduleStatsOpen = (target: StatsPopoverTarget) => {
+    cancelStatsTimers();
     // Moving to a different row: close the previous popover immediately
     // instead of letting it linger for the open delay.
-    setHealthPopoverConn((cur) => (cur !== null && cur !== connId ? null : cur));
-    healthOpenTimer.current = setTimeout(() => setHealthPopoverConn(connId), clusterHoverDelayMs);
+    setStatsPopover((cur) => (cur !== null && targetKey(cur) !== targetKey(target) ? null : cur));
+    statsOpenTimer.current = setTimeout(() => setStatsPopover(target), clusterHoverDelayMs);
   };
-  const scheduleHealthClose = () => {
-    if (healthOpenTimer.current) clearTimeout(healthOpenTimer.current);
-    healthCloseTimer.current = setTimeout(() => setHealthPopoverConn(null), 150);
+  const scheduleStatsClose = () => {
+    if (statsOpenTimer.current) clearTimeout(statsOpenTimer.current);
+    statsCloseTimer.current = setTimeout(() => setStatsPopover(null), 150);
   };
-  useEffect(() => cancelHealthTimers, []);
+  useEffect(() => cancelStatsTimers, []);
+
+  // Hover props for a stats-popover row: capture the cursor position on
+  // enter and schedule the open; keep tracking the pointer until this row's
+  // popover actually opens; grace-close on leave so the pointer can travel
+  // into the card without it disappearing.
+  const statsHoverHandlers = (target: StatsPopoverTarget) => ({
+    onMouseEnter: (e: React.MouseEvent) => {
+      statsAnchorPoint.current = { x: e.clientX, y: e.clientY };
+      scheduleStatsOpen(target);
+    },
+    onMouseMove: (e: React.MouseEvent) => {
+      if (statsPopover === null || targetKey(statsPopover) !== targetKey(target)) {
+        statsAnchorPoint.current = { x: e.clientX, y: e.clientY };
+      }
+    },
+    onMouseLeave: scheduleStatsClose,
+  });
 
   // Mock connections (the bundled sample data, or ids/URIs marked as such) never
   // reach a real mongodump/mongorestore binary — the backend rejects them outright
@@ -1182,6 +1222,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 }
               }}
               className={cn(treeRowClass(isActive), isSelected && 'bg-accent')}
+              {...statsHoverHandlers({ kind: 'collection', connId, db: dbName, coll: collName })}
             >
               <ChevronRight
                 size={10}
@@ -1385,6 +1426,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                             onSelectIndex(connId, dbName, collName, indexName);
                           }}
                           className={treeRowClass(isIndexActive)}
+                          {...statsHoverHandlers({ kind: 'index', connId, db: dbName, coll: collName, index: indexName })}
                         >
                           <KeyRound
                             size={10}
@@ -1456,15 +1498,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
           return (
             <div key={conn.id}>
-              <Popover
-                open={healthPopoverConn === conn.id}
-                onOpenChange={(open) => {
-                  if (!open) {
-                    cancelHealthTimers();
-                    setHealthPopoverConn(null);
-                  }
-                }}
-              >
               <ContextMenu>
                 <ContextMenuTrigger asChild>
                   <div
@@ -1477,18 +1510,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     aria-expanded={isConnExpanded}
                     aria-label={`Connection ${conn.name}`}
                     onClick={() => setExpandedConnections((prev) => ({ ...prev, [conn.id]: !prev[conn.id] }))}
-                    onMouseEnter={(e) => {
-                      healthAnchorPoint.current = { x: e.clientX, y: e.clientY };
-                      scheduleHealthOpen(conn.id);
-                    }}
-                    onMouseMove={(e) => {
-                      // Track the pointer until the popover opens so the card
-                      // appears where the cursor is, not where it entered.
-                      if (healthPopoverConn !== conn.id) {
-                        healthAnchorPoint.current = { x: e.clientX, y: e.clientY };
-                      }
-                    }}
-                    onMouseLeave={scheduleHealthClose}
+                    {...statsHoverHandlers({ kind: 'connection', connId: conn.id })}
                   >
                     <div className="flex min-w-0 flex-1 items-center gap-1">
                       <ChevronRight
@@ -1633,23 +1655,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   </ContextMenuItem>
                 </ContextMenuContent>
               </ContextMenu>
-                <PopoverAnchor virtualRef={healthVirtualAnchor} />
-                <PopoverContent
-                  side="bottom"
-                  align="start"
-                  sideOffset={8}
-                  onOpenAutoFocus={(e) => e.preventDefault()}
-                  onMouseEnter={cancelHealthTimers}
-                  onMouseLeave={scheduleHealthClose}
-                >
-                  <ClusterHealthCard
-                    connectionId={conn.id}
-                    connectionName={conn.name}
-                    connectionUri={conn.uri}
-                    onOpenMonitoring={onOpenMonitoring}
-                  />
-                </PopoverContent>
-              </Popover>
 
               {isConnExpanded && (
                 <div className="ml-3 border-l border-border/50 pl-1">
@@ -1698,6 +1703,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                               aria-expanded={isDbExpanded}
                               aria-label={`Database ${dbName}`}
                               onClick={() => toggleDb(conn.id, dbName)}
+                              {...statsHoverHandlers({ kind: 'database', connId: conn.id, db: dbName })}
                             >
                               <ChevronRight
                                 size={11}
@@ -2385,6 +2391,56 @@ export const Sidebar: React.FC<SidebarProps> = ({
         <ThemePicker />
         <span className="text-[10px] text-muted-foreground">Theme</span>
       </footer>
+
+      {/* Single root-level stats popover shared by connection/database/collection/index
+          rows (issue #178) — the virtual anchor positions it at the cursor regardless
+          of which row triggered it, so it doesn't need to live inside the tree map. */}
+      <Popover
+        open={statsPopover !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            cancelStatsTimers();
+            setStatsPopover(null);
+          }
+        }}
+      >
+        <PopoverAnchor virtualRef={statsVirtualAnchor} />
+        <PopoverContent
+          side="bottom"
+          align="start"
+          sideOffset={8}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onMouseEnter={cancelStatsTimers}
+          onMouseLeave={scheduleStatsClose}
+        >
+          {statsPopover?.kind === 'connection' &&
+            (() => {
+              const conn = activeConnections.find((c) => c.id === statsPopover.connId);
+              return (
+                <ClusterHealthCard
+                  connectionId={statsPopover.connId}
+                  connectionName={conn?.name}
+                  connectionUri={conn?.uri}
+                  onOpenMonitoring={onOpenMonitoring}
+                />
+              );
+            })()}
+          {statsPopover?.kind === 'database' && (
+            <DbStatsCard connectionId={statsPopover.connId} db={statsPopover.db} />
+          )}
+          {statsPopover?.kind === 'collection' && (
+            <CollStatsCard connectionId={statsPopover.connId} db={statsPopover.db} collection={statsPopover.coll} />
+          )}
+          {statsPopover?.kind === 'index' && (
+            <IndexStatsCard
+              connectionId={statsPopover.connId}
+              db={statsPopover.db}
+              collection={statsPopover.coll}
+              indexName={statsPopover.index}
+            />
+          )}
+        </PopoverContent>
+      </Popover>
     </aside>
     </EmptySpaceContextMenu>
   );

--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { formatBytes } from '@/lib/clusterHealth';
+import { formatBytes } from '@/lib/format';
 
 interface DbStatsUi {
   collections: number;

--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -1,0 +1,238 @@
+import React, { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { formatBytes } from '@/lib/clusterHealth';
+
+interface DbStatsUi {
+  collections: number;
+  views: number;
+  objects: number;
+  avgObjSize: number;
+  dataSize: number;
+  storageSize: number;
+  indexes: number;
+  totalIndexSize: number;
+}
+
+interface CollStatsUi {
+  count: number;
+  avgObjSize: number;
+  size: number;
+  storageSize: number;
+  nindexes: number;
+  totalIndexSize: number;
+  capped: boolean;
+}
+
+interface IndexStatUi {
+  name: string;
+  sizeBytes: number;
+  ops: number;
+  sinceMs: number;
+}
+
+const CARD_CLASS = 'flex w-max min-w-72 max-w-[28rem] flex-col gap-1.5 text-xs';
+
+const Row: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+  <div>
+    <span className="text-muted-foreground">{label}:</span> {value}
+  </div>
+);
+
+const RefreshLink: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+  <button
+    type="button"
+    className="mt-0.5 self-start text-primary underline-offset-2 hover:underline"
+    onClick={onClick}
+    data-testid="stats-refresh"
+  >
+    Refresh
+  </button>
+);
+
+interface DbStatsCardProps {
+  connectionId: string;
+  db: string;
+}
+
+/** Compact database-level stats summary (issue #178). Fetches once on mount
+ *  — i.e. once per popover open — so there is no background polling cost.
+ *  Refresh re-runs the fetch in place via the `nonce` bump below. */
+export const DbStatsCard: React.FC<DbStatsCardProps> = ({ connectionId, db }) => {
+  const [data, setData] = useState<DbStatsUi | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    let alive = true;
+    invoke<DbStatsUi>('db_stats', { id: connectionId, db })
+      .then((s) => {
+        if (alive) setData(s);
+      })
+      .catch((e: unknown) => {
+        if (alive) setErr(String((e as Error)?.message || e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [connectionId, db, nonce]);
+
+  const refresh = () => {
+    setErr(null);
+    setData(null);
+    setNonce((n) => n + 1);
+  };
+
+  return (
+    <div className={CARD_CLASS} data-testid="db-stats-card">
+      {err && <div className="text-destructive">{err}</div>}
+      {!err && !data && <div className="text-muted-foreground">Loading database stats…</div>}
+      {!err && data && (
+        <>
+          <div>
+            Database: <span className="font-semibold text-foreground">{db}</span>
+          </div>
+          <Row label="Collections" value={data.collections.toLocaleString()} />
+          <Row label="Views" value={data.views.toLocaleString()} />
+          <Row label="Objects" value={data.objects.toLocaleString()} />
+          <Row label="Avg. object size" value={formatBytes(data.avgObjSize)} />
+          <Row label="Data size" value={formatBytes(data.dataSize)} />
+          <Row label="Storage size" value={formatBytes(data.storageSize)} />
+          <Row label="Indexes" value={data.indexes.toLocaleString()} />
+          <Row label="Total index size" value={formatBytes(data.totalIndexSize)} />
+        </>
+      )}
+      {(data || err) && <RefreshLink onClick={refresh} />}
+    </div>
+  );
+};
+
+interface CollStatsCardProps {
+  connectionId: string;
+  db: string;
+  collection: string;
+}
+
+/** Compact collection-level stats summary (issue #178). Same fetch-once +
+ *  nonce-refresh pattern as DbStatsCard. */
+export const CollStatsCard: React.FC<CollStatsCardProps> = ({ connectionId, db, collection }) => {
+  const [data, setData] = useState<CollStatsUi | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    let alive = true;
+    invoke<CollStatsUi>('coll_stats', { id: connectionId, db, collection })
+      .then((s) => {
+        if (alive) setData(s);
+      })
+      .catch((e: unknown) => {
+        if (alive) setErr(String((e as Error)?.message || e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [connectionId, db, collection, nonce]);
+
+  const refresh = () => {
+    setErr(null);
+    setData(null);
+    setNonce((n) => n + 1);
+  };
+
+  return (
+    <div className={CARD_CLASS} data-testid="coll-stats-card">
+      {err && <div className="text-destructive">{err}</div>}
+      {!err && !data && <div className="text-muted-foreground">Loading collection stats…</div>}
+      {!err && data && (
+        <>
+          <div>
+            Collection:{' '}
+            <span className="font-semibold text-foreground">
+              {db}.{collection}
+            </span>
+          </div>
+          <Row label="Documents" value={data.count.toLocaleString()} />
+          <Row label="Avg. object size" value={formatBytes(data.avgObjSize)} />
+          <Row label="Data size" value={formatBytes(data.size)} />
+          <Row label="Storage size" value={formatBytes(data.storageSize)} />
+          <Row label="Indexes" value={data.nindexes.toLocaleString()} />
+          <Row label="Total index size" value={formatBytes(data.totalIndexSize)} />
+          {data.capped && <Row label="Capped" value="yes" />}
+        </>
+      )}
+      {(data || err) && <RefreshLink onClick={refresh} />}
+    </div>
+  );
+};
+
+interface IndexStatsCardProps {
+  connectionId: string;
+  db: string;
+  collection: string;
+  indexName: string;
+}
+
+/** Compact single-index stats summary (issue #178). `index_stats` returns
+ *  every index on the collection; this card picks the one matching
+ *  `indexName` out of that array. */
+export const IndexStatsCard: React.FC<IndexStatsCardProps> = ({ connectionId, db, collection, indexName }) => {
+  const [data, setData] = useState<IndexStatUi[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    let alive = true;
+    invoke<IndexStatUi[]>('index_stats', { id: connectionId, db, collection })
+      .then((s) => {
+        if (alive) setData(s);
+      })
+      .catch((e: unknown) => {
+        if (alive) setErr(String((e as Error)?.message || e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [connectionId, db, collection, nonce]);
+
+  const refresh = () => {
+    setErr(null);
+    setData(null);
+    setNonce((n) => n + 1);
+  };
+
+  const entry = data?.find((i) => i.name === indexName) ?? null;
+
+  return (
+    <div className={CARD_CLASS} data-testid="index-stats-card">
+      {err && <div className="text-destructive">{err}</div>}
+      {!err && !data && <div className="text-muted-foreground">Loading index stats…</div>}
+      {!err && data && (
+        <>
+          <div>
+            Index:{' '}
+            <span className="font-semibold text-foreground">
+              {indexName} on {db}.{collection}
+            </span>
+          </div>
+          {!entry && <div className="text-muted-foreground">No stats for this index.</div>}
+          {entry && (
+            <>
+              <Row label="Size" value={formatBytes(entry.sizeBytes)} />
+              {entry.sinceMs > 0 ? (
+                <>
+                  <Row label="Usage" value={`${entry.ops.toLocaleString()} ops`} />
+                  <Row label="Since" value={new Date(entry.sinceMs).toLocaleDateString()} />
+                </>
+              ) : entry.ops === 0 ? (
+                <Row label="Usage" value="n/a (no data since restart)" />
+              ) : (
+                <Row label="Usage" value={`${entry.ops.toLocaleString()} ops`} />
+              )}
+            </>
+          )}
+        </>
+      )}
+      {(data || err) && <RefreshLink onClick={refresh} />}
+    </div>
+  );
+};

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -406,6 +406,166 @@ describe('Sidebar Component', () => {
     expect(replSetStatusCalls).toHaveLength(2);
   });
 
+  it('shows a database stats popover when hovering a database row (#178)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'db_stats')
+        return Promise.resolve({
+          collections: 3, views: 0, objects: 100, avgObjSize: 128,
+          dataSize: 12800, storageSize: 20000, indexes: 4, totalIndexSize: 4096,
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+
+    const dbRow = await screen.findByLabelText('Database sales_db');
+    fireEvent.mouseEnter(dbRow);
+    expect(await screen.findByTestId('db-stats-card')).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith('db_stats', { id: 'conn-1', db: 'sales_db' });
+  });
+
+  it('shows a collection stats popover when hovering a collection row (#178)', async () => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections' && args.db === 'sales_db') {
+        return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      }
+      if (cmd === 'coll_stats')
+        return Promise.resolve({
+          count: 500, avgObjSize: 256, size: 128000, storageSize: 150000,
+          nindexes: 2, totalIndexSize: 8192, capped: false,
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+
+    const dbNode = await screen.findByText('sales_db');
+    fireEvent.click(dbNode);
+    const collectionsFolder = await screen.findByText('Collections');
+    fireEvent.click(collectionsFolder);
+    const collText = await screen.findByText('customers');
+    const collRow = collText.closest('div')!;
+    fireEvent.mouseEnter(collRow);
+    expect(await screen.findByTestId('coll-stats-card')).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith('coll_stats', { id: 'conn-1', db: 'sales_db', collection: 'customers' });
+  });
+
+  it('shows an index stats popover when hovering an index row (#178)', async () => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections' && args.db === 'sales_db') {
+        return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      }
+      if (cmd === 'list_indexes') {
+        return Promise.resolve([
+          { name: '_id_', keys: '{"_id":1}', unique: true, sparse: false },
+          { name: 'email_1', keys: '{"email":1}', unique: false, sparse: false },
+        ]);
+      }
+      if (cmd === 'index_stats')
+        return Promise.resolve([
+          { name: '_id_', sizeBytes: 4096, ops: 10, sinceMs: 0 },
+          { name: 'email_1', sizeBytes: 2048, ops: 5, sinceMs: 0 },
+        ]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+
+    const dbNode = await screen.findByText('sales_db');
+    fireEvent.click(dbNode);
+    const collectionsFolder = await screen.findByText('Collections');
+    fireEvent.click(collectionsFolder);
+    const collNode = await screen.findByText('customers');
+    fireEvent.click(collNode);
+    const indexesFolder = await screen.findByText('indexes');
+    fireEvent.click(indexesFolder);
+    const indexText = await screen.findByText('email_1');
+    const indexRow = indexText.closest('div')!;
+    fireEvent.mouseEnter(indexRow);
+    expect(await screen.findByTestId('index-stats-card')).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith('index_stats', { id: 'conn-1', db: 'sales_db', collection: 'customers' });
+  });
+
+  it('closes the db popover and opens the health popover moving from a database row to the connection row (#178)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'db_stats')
+        return Promise.resolve({
+          collections: 1, views: 0, objects: 1, avgObjSize: 1,
+          dataSize: 1, storageSize: 1, indexes: 1, totalIndexSize: 1,
+        });
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({
+          isReplicaSet: true, clusterType: 'replicaSet', set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          members: [
+            { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
+          ],
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+
+    const connRow = await screen.findByLabelText('Connection Mock DB');
+    const dbRow = await screen.findByLabelText('Database sales_db');
+
+    fireEvent.mouseEnter(dbRow);
+    expect(await screen.findByTestId('db-stats-card')).toBeInTheDocument();
+
+    fireEvent.mouseEnter(connRow);
+    await waitFor(() => expect(screen.queryByTestId('db-stats-card')).toBeNull());
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
+  });
+
   it('sorts collections by name before rendering', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {

--- a/src/components/__tests__/StatsCards.test.tsx
+++ b/src/components/__tests__/StatsCards.test.tsx
@@ -47,7 +47,7 @@ describe('DbStatsCard', () => {
     expect(card).toHaveTextContent('Database:');
     expect(card).toHaveTextContent('sales_db');
     expect(card).toHaveTextContent('12,345');
-    expect(card).toHaveTextContent('6.0 MB'); // dataSize
+    expect(card).toHaveTextContent('6 MB'); // dataSize
     expect(card).toHaveTextContent('9'); // indexes
   });
 
@@ -99,7 +99,7 @@ describe('IndexStatsCard', () => {
 
     expect(card).toHaveTextContent('Index:');
     expect(card).toHaveTextContent('email_1 on sales_db.orders');
-    expect(card).toHaveTextContent('20.0 KB');
+    expect(card).toHaveTextContent('20 KB');
     expect(card).toHaveTextContent('42 ops');
     expect(card).toHaveTextContent(new Date(1_749_427_200_000).toLocaleDateString());
   });

--- a/src/components/__tests__/StatsCards.test.tsx
+++ b/src/components/__tests__/StatsCards.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => mockInvoke(...a) }));
+
+import { DbStatsCard, CollStatsCard, IndexStatsCard } from '../StatsCards';
+
+const DB_STATS = {
+  collections: 4,
+  views: 1,
+  objects: 12345,
+  avgObjSize: 512.5,
+  dataSize: 6324712,
+  storageSize: 2502656,
+  indexes: 9,
+  totalIndexSize: 1105920,
+};
+
+const COLL_STATS = {
+  count: 42123,
+  avgObjSize: 256,
+  size: 10_768_000,
+  storageSize: 4_194_304,
+  nindexes: 3,
+  totalIndexSize: 98_304,
+  capped: false,
+};
+
+const CAPPED_COLL_STATS = { ...COLL_STATS, capped: true };
+
+const INDEX_STATS = [
+  { name: '_id_', sizeBytes: 36_864, ops: 10_500, sinceMs: 1_749_427_200_000 },
+  { name: 'email_1', sizeBytes: 20_480, ops: 42, sinceMs: 1_749_427_200_000 },
+  { name: 'unused_1', sizeBytes: 8_192, ops: 0, sinceMs: 0 },
+];
+
+beforeEach(() => mockInvoke.mockReset());
+
+describe('DbStatsCard', () => {
+  it('renders labeled values with human sizes', async () => {
+    mockInvoke.mockResolvedValue(DB_STATS);
+    render(<DbStatsCard connectionId="conn-1" db="sales_db" />);
+    const card = await screen.findByTestId('db-stats-card');
+    expect(mockInvoke).toHaveBeenCalledWith('db_stats', { id: 'conn-1', db: 'sales_db' });
+
+    expect(card).toHaveTextContent('Database:');
+    expect(card).toHaveTextContent('sales_db');
+    expect(card).toHaveTextContent('12,345');
+    expect(card).toHaveTextContent('6.0 MB'); // dataSize
+    expect(card).toHaveTextContent('9'); // indexes
+  });
+
+  it('refetches when Refresh is clicked', async () => {
+    mockInvoke.mockResolvedValue(DB_STATS);
+    render(<DbStatsCard connectionId="conn-1" db="sales_db" />);
+    await screen.findByTestId('db-stats-card');
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+
+    screen.getByTestId('stats-refresh').click();
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledTimes(2));
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'db_stats', { id: 'conn-1', db: 'sales_db' });
+  });
+
+  it('renders the error text quietly', async () => {
+    mockInvoke.mockRejectedValueOnce('dbStats failed: not authorized');
+    render(<DbStatsCard connectionId="conn-1" db="sales_db" />);
+    expect(await screen.findByText(/not authorized/i)).toBeInTheDocument();
+  });
+});
+
+describe('CollStatsCard', () => {
+  it('renders the document count with locale formatting and hides Capped when false', async () => {
+    mockInvoke.mockResolvedValue(COLL_STATS);
+    render(<CollStatsCard connectionId="conn-1" db="sales_db" collection="orders" />);
+    const card = await screen.findByTestId('coll-stats-card');
+    expect(mockInvoke).toHaveBeenCalledWith('coll_stats', { id: 'conn-1', db: 'sales_db', collection: 'orders' });
+
+    expect(card).toHaveTextContent('Collection:');
+    expect(card).toHaveTextContent('sales_db.orders');
+    expect(card).toHaveTextContent('42,123');
+    expect(card.textContent).not.toMatch(/Capped/);
+  });
+
+  it('shows Capped: yes when the collection is capped', async () => {
+    mockInvoke.mockResolvedValue(CAPPED_COLL_STATS);
+    render(<CollStatsCard connectionId="conn-1" db="sales_db" collection="logs" />);
+    const card = await screen.findByTestId('coll-stats-card');
+    expect(card).toHaveTextContent('Capped: yes');
+  });
+});
+
+describe('IndexStatsCard', () => {
+  it('picks the matching index from the array and renders usage + since', async () => {
+    mockInvoke.mockResolvedValue(INDEX_STATS);
+    render(<IndexStatsCard connectionId="conn-1" db="sales_db" collection="orders" indexName="email_1" />);
+    const card = await screen.findByTestId('index-stats-card');
+    expect(mockInvoke).toHaveBeenCalledWith('index_stats', { id: 'conn-1', db: 'sales_db', collection: 'orders' });
+
+    expect(card).toHaveTextContent('Index:');
+    expect(card).toHaveTextContent('email_1 on sales_db.orders');
+    expect(card).toHaveTextContent('20.0 KB');
+    expect(card).toHaveTextContent('42 ops');
+    expect(card).toHaveTextContent(new Date(1_749_427_200_000).toLocaleDateString());
+  });
+
+  it('shows the no-data-since-restart line when ops and sinceMs are both zero', async () => {
+    mockInvoke.mockResolvedValue(INDEX_STATS);
+    render(<IndexStatsCard connectionId="conn-1" db="sales_db" collection="orders" indexName="unused_1" />);
+    const card = await screen.findByTestId('index-stats-card');
+    expect(card).toHaveTextContent('Usage: n/a (no data since restart)');
+    expect(card.textContent).not.toMatch(/Since:/);
+  });
+
+  it('shows a fallback message when the index is missing from the response', async () => {
+    mockInvoke.mockResolvedValue(INDEX_STATS);
+    render(<IndexStatsCard connectionId="conn-1" db="sales_db" collection="orders" indexName="ghost_1" />);
+    const card = await screen.findByTestId('index-stats-card');
+    expect(card).toHaveTextContent('No stats for this index.');
+  });
+});

--- a/src/lib/__tests__/clusterHealth.test.ts
+++ b/src/lib/__tests__/clusterHealth.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { uriUser, uriReadPreference } from '../clusterHealth';
+import { uriUser, uriReadPreference, formatBytes } from '../clusterHealth';
+
+describe('formatBytes', () => {
+  it('shows raw bytes with no decimal below 1 KB', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(999)).toBe('999 B');
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('formats KB with one decimal', () => {
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('formats MB with one decimal', () => {
+    expect(formatBytes(24_576_000)).toBe('23.4 MB');
+  });
+
+  it('formats GB with one decimal', () => {
+    expect(formatBytes(1_288_490_189)).toBe('1.2 GB');
+  });
+});
 
 describe('uriUser', () => {
   it('extracts the user from a user+pass URI', () => {

--- a/src/lib/__tests__/clusterHealth.test.ts
+++ b/src/lib/__tests__/clusterHealth.test.ts
@@ -1,25 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { uriUser, uriReadPreference, formatBytes } from '../clusterHealth';
-
-describe('formatBytes', () => {
-  it('shows raw bytes with no decimal below 1 KB', () => {
-    expect(formatBytes(0)).toBe('0 B');
-    expect(formatBytes(999)).toBe('999 B');
-    expect(formatBytes(512)).toBe('512 B');
-  });
-
-  it('formats KB with one decimal', () => {
-    expect(formatBytes(1536)).toBe('1.5 KB');
-  });
-
-  it('formats MB with one decimal', () => {
-    expect(formatBytes(24_576_000)).toBe('23.4 MB');
-  });
-
-  it('formats GB with one decimal', () => {
-    expect(formatBytes(1_288_490_189)).toBe('1.2 GB');
-  });
-});
+import { uriUser, uriReadPreference } from '../clusterHealth';
 
 describe('uriUser', () => {
   it('extracts the user from a user+pass URI', () => {

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -15,4 +15,8 @@ describe('formatBytes', () => {
     expect(formatBytes(150 * 1024 * 1024)).toBe('150 MB');
     expect(formatBytes(2 * 1024 * 1024 * 1024)).toBe('2 GB');
   });
+
+  it('scales past TB into PB', () => {
+    expect(formatBytes(2 * 1024 ** 5)).toBe('2 PB');
+  });
 });

--- a/src/lib/clusterHealth.ts
+++ b/src/lib/clusterHealth.ts
@@ -37,3 +37,17 @@ export const uriReadPreference = (uri: string): string => {
   const m = /[?&]readPreference=([^&]+)/i.exec(uri);
   return m ? decodeURIComponent(m[1]) : 'primary';
 };
+
+/** Human-readable byte size for the stats popovers: raw bytes below 1 KB,
+ *  one decimal place for KB/MB/GB/TB (divisor 1024). */
+export const formatBytes = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes < 1024) return `${Math.round(bytes)} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes / 1024;
+  let i = 0;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i++;
+  }
+  return `${value.toFixed(1)} ${units[i]}`;
+};

--- a/src/lib/clusterHealth.ts
+++ b/src/lib/clusterHealth.ts
@@ -38,16 +38,3 @@ export const uriReadPreference = (uri: string): string => {
   return m ? decodeURIComponent(m[1]) : 'primary';
 };
 
-/** Human-readable byte size for the stats popovers: raw bytes below 1 KB,
- *  one decimal place for KB/MB/GB/TB (divisor 1024). */
-export const formatBytes = (bytes: number): string => {
-  if (!Number.isFinite(bytes) || bytes < 1024) return `${Math.round(bytes)} B`;
-  const units = ['KB', 'MB', 'GB', 'TB'];
-  let value = bytes / 1024;
-  let i = 0;
-  while (value >= 1024 && i < units.length - 1) {
-    value /= 1024;
-    i++;
-  }
-  return `${value.toFixed(1)} ${units[i]}`;
-};

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,7 +1,7 @@
 // Format a byte count into a compact human-readable string (e.g. 145 MB).
 export function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
-  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
   const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
   const value = bytes / Math.pow(1024, i);
   // No decimals for bytes; one decimal otherwise, trimmed.


### PR DESCRIPTION
Closes #178. Implements the stats half of #90 (per-index size + usage).

- Hovering a database / collection / index row in the sidebar opens a compact stats popover — same interaction as the connection cluster-health card (#114): cursor-anchored, fetch once per open, Refresh link, Escape/outside-click dismissal.
- Databases: dbStats (collections, views, objects, sizes, indexes). Collections: $collStats storageStats (count, sizes, nindexes, capped). Indexes: on-disk size + $indexStats usage (ops, since), gracefully zero when $indexStats is unavailable.
- Sidebar popover machinery generalized from connection-only to all four row kinds; connection behavior unchanged (existing tests untouched).
- Sizes use the shared formatBytes helper (now scales past TB). Demo mode returns believable stats for all three popovers.

Verification: cargo 246/246, vitest 709/709 (with coverage), tsc clean.