### PR TITLE
feat: index usage stats and ESR index suggestions (#90)

### DIFF
--- a/src-tauri/src/mock_db.rs
+++ b/src-tauri/src/mock_db.rs
@@ -145,19 +145,38 @@ pub fn execute_mock_query(
 }
 
 pub fn get_mock_explain(database: &str, collection: &str, filter: &str) -> String {
+    // Only sales_db.transactions returns a COLLSCAN plan, so the index-suggestion
+    // banner has somewhere to demo without a real server. Every other namespace
+    // keeps the pre-existing IXSCAN shape.
+    let winning_plan = if database == "sales_db" && collection == "transactions" {
+        serde_json::json!({
+            "stage": "SORT",
+            "sortPattern": { "timestamp": -1 },
+            "inputStage": { "stage": "COLLSCAN" }
+        })
+    } else {
+        serde_json::json!({
+            "stage": "IXSCAN",
+            "keyPattern": { "category": 1 },
+            "indexName": "category_1",
+            "isMultiKey": false,
+            "direction": "forward"
+        })
+    };
+
+    let parsed_query = if database == "sales_db" && collection == "transactions" {
+        serde_json::json!({ "$and": [ { "customer_name": { "$eq": "Alice Smith" } } ] })
+    } else {
+        serde_json::from_str::<serde_json::Value>(filter).unwrap_or_default()
+    };
+
     let plan = serde_json::json!({
         "explainVersion": "1",
         "queryPlanner": {
             "namespace": format!("{}.{}", database, collection),
             "indexFilterSet": false,
-            "parsedQuery": serde_json::from_str::<serde_json::Value>(filter).unwrap_or_default(),
-            "winningPlan": {
-                "stage": "IXSCAN",
-                "keyPattern": { "category": 1 },
-                "indexName": "category_1",
-                "isMultiKey": false,
-                "direction": "forward"
-            }
+            "parsedQuery": parsed_query,
+            "winningPlan": winning_plan
         },
         "executionStats": {
             "executionSuccess": true,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2992,6 +2992,23 @@ mod tests {
         // Explain renders a plan namespaced to the requested collection.
         let explain = get_mock_explain("user_analytics", "events", "{}");
         assert!(explain.contains("user_analytics.events"));
+        assert!(explain.contains("IXSCAN"));
+
+        // sales_db.transactions is the one namespace that demos a COLLSCAN plan,
+        // so the index-suggestion banner is reachable without a real server.
+        let tx_explain = get_mock_explain("sales_db", "transactions", "{}");
+        assert!(tx_explain.contains("COLLSCAN"));
+        assert!(!tx_explain.contains("IXSCAN"));
+        let tx_plan: serde_json::Value = serde_json::from_str(&tx_explain).unwrap();
+        assert_eq!(
+            tx_plan["queryPlanner"]["parsedQuery"]["$and"][0]["customer_name"]["$eq"],
+            "Alice Smith"
+        );
+
+        // Every other namespace (e.g. sales_db.products) keeps the original IXSCAN shape.
+        let products_explain = get_mock_explain("sales_db", "products", "{}");
+        assert!(products_explain.contains("IXSCAN"));
+        assert!(!products_explain.contains("COLLSCAN"));
 
         // Index sets for each collection, including the admin and unknown fallbacks.
         let idx = |db, coll| -> Vec<String> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import { UpdatePrompt } from './components/UpdatePrompt';
 import { DialogProvider, useDialogs } from './components/dialogs/DialogProvider';
 import { formatBytes } from './lib/format';
 import type { QueryCodeSpec } from './lib/queryCodeGen';
+import type { IndexSuggestion } from './lib/indexSuggestions';
 import { docToShell } from './lib/shellDoc';
 import { recordHistory, loadCollectionQueries, type SavedQueryBody } from './lib/queryStore';
 import { clearNamespaceIndex, loadNamespaceIndex, matchesNamespaceScope } from './lib/paletteIndex';
@@ -320,6 +321,10 @@ function Workspace() {
       keys: Record<string, number>;
       unique: boolean;
       sparse: boolean;
+    } | null;
+    prefill?: {
+      name: string;
+      keys: Record<string, number>;
     } | null;
   } | null>(null);
   const [indexMutationTrigger, setIndexMutationTrigger] = useState(0);
@@ -1171,6 +1176,24 @@ function Workspace() {
       db: dbName,
       collection: collName,
       initialData: null,
+    });
+    setIsIndexModalOpen(true);
+  };
+
+  // Fired by the DataGrid COLLSCAN suggestion banner: opens the create-index
+  // flow pre-filled with the ESR-ordered keys, scoped to the active tab's own
+  // connection/db/collection (preferred over parsing the explain namespace).
+  const handleCreateSuggestedIndex = (suggestion: IndexSuggestion) => {
+    if (!activeTab || activeTab.type !== 'collection') return;
+    setIndexModalTarget({
+      connectionId: activeTab.connectionId,
+      db: activeTab.db,
+      collection: activeTab.collection,
+      initialData: null,
+      prefill: {
+        name: suggestion.suggestedName,
+        keys: suggestion.keys,
+      },
     });
     setIsIndexModalOpen(true);
   };
@@ -2058,6 +2081,7 @@ function Workspace() {
             collectionName={indexModalTarget?.collection}
             availableFields={availableFields}
             initialData={indexModalTarget?.initialData}
+            prefill={indexModalTarget?.prefill}
           />
 
           <DocumentEditModal
@@ -2236,6 +2260,7 @@ function Workspace() {
                           countLoading={activeTab.countLoading}
                           skip={activeTab.lastQuery?.skip ?? 0}
                           limit={activeTab.lastQuery?.limit ?? 50}
+                          onCreateSuggestedIndex={handleCreateSuggestedIndex}
                           {...(!activeTab.lastAggregate ? {
                             onPageChange: handlePageChange,
                             onPageSizeChange: handlePageSizeChange,

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo, useEffect, useContext } from 'react';
 import { DocumentViewerContext } from './DocumentViewer';
 import { List } from 'react-window';
-import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3 } from 'lucide-react';
+import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3, Lightbulb } from 'lucide-react';
 import { ChartView } from './ChartView';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import Editor from '@monaco-editor/react';
 import { generateQueryCode, CODE_LANGUAGES, CODE_LANGUAGE_MONACO_IDS, type CodeLanguage, type QueryCodeSpec } from '../lib/queryCodeGen';
+import { suggestESRIndex, type IndexSuggestion } from '../lib/indexSuggestions';
 import { useMonacoTheme } from '../lib/useMonacoTheme';
 import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
 import { Button } from '@/components/ui/button';
@@ -36,6 +37,8 @@ interface DataGridProps {
   limit?: number;
   onPageChange?: (newSkip: number) => void;
   onPageSizeChange?: (newLimit: number) => void;
+  // Fired when the user accepts the COLLSCAN suggestion banner's "Create Index" CTA.
+  onCreateSuggestedIndex?: (suggestion: IndexSuggestion) => void;
 }
 
 type ViewMode = 'table' | 'tree' | 'json' | 'chart';
@@ -445,10 +448,17 @@ export const DataGrid: React.FC<DataGridProps> = ({
   limit,
   onPageChange,
   onPageSizeChange,
+  onCreateSuggestedIndex,
 }) => {
   const themeCtx = useThemeOptional();
   const density: SpacingDensity =
     densityProp ?? themeCtx?.config.spacingDensity ?? 'cozy';
+
+  // ESR-rule suggestion derived from the current explain plan (null unless it's a COLLSCAN).
+  const indexSuggestion = useMemo(
+    () => (explainResult ? suggestESRIndex(explainResult) : null),
+    [explainResult]
+  );
 
   // Right-click context menu shared by all result views (Table / Tree / JSON).
   const [ctxMenu, setCtxMenu] = useState<
@@ -1479,6 +1489,29 @@ export const DataGrid: React.FC<DataGridProps> = ({
                   </button>
                 </div>
               </div>
+
+              {indexSuggestion && (
+                <div
+                  className="mx-3 mt-3 flex shrink-0 items-start gap-2.5 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2.5"
+                  data-testid="index-suggestion-banner"
+                >
+                  <Lightbulb size={16} className="mt-0.5 shrink-0 text-warning" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                    <p className="text-xs leading-relaxed text-foreground">{indexSuggestion.reason}</p>
+                    <code className="w-fit rounded bg-background/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+                      {JSON.stringify(indexSuggestion.keys)}
+                    </code>
+                  </div>
+                  <Button
+                    size="sm"
+                    className="h-7 shrink-0 gap-1.5 text-[11px] font-semibold"
+                    onClick={() => onCreateSuggestedIndex?.(indexSuggestion)}
+                    data-testid="create-suggested-index-btn"
+                  >
+                    Create Index
+                  </Button>
+                </div>
+              )}
 
               {explainView === 'visual' ? (
                 <div

--- a/src/components/IndexModal.tsx
+++ b/src/components/IndexModal.tsx
@@ -48,6 +48,12 @@ interface IndexModalProps {
     unique: boolean;
     sparse: boolean;
   } | null;
+  // Pre-fills the create-mode form (e.g. from a COLLSCAN index suggestion).
+  // Ignored when initialData is set (edit mode) — unique/sparse always start false.
+  prefill?: {
+    name: string;
+    keys: Record<string, number>;
+  } | null;
 }
 
 const defaultIndexName = (json: string): string => {
@@ -77,6 +83,7 @@ export const IndexModal: React.FC<IndexModalProps> = ({
   databaseName,
   collectionName,
   initialData,
+  prefill,
 }) => {
   const [indexName, setIndexName] = useState('');
   const [nameTouched, setNameTouched] = useState(false);
@@ -120,6 +127,15 @@ export const IndexModal: React.FC<IndexModalProps> = ({
         );
         setKeysList(list.length > 0 ? list : [newKeyRule()]);
         setRawKeysJson(JSON.stringify(initialData.keys, null, 2));
+      } else if (prefill && Object.keys(prefill.keys).length > 0) {
+        setIndexName(prefill.name);
+        setUnique(false);
+        setSparse(false);
+        const list: IndexKeyRule[] = Object.entries(prefill.keys).map(([field, dir]) =>
+          newKeyRule(field, dir === -1 ? -1 : 1)
+        );
+        setKeysList(list);
+        setRawKeysJson(JSON.stringify(prefill.keys, null, 2));
       } else {
         setIndexName('');
         setUnique(false);
@@ -131,7 +147,7 @@ export const IndexModal: React.FC<IndexModalProps> = ({
       setIsRawMode(false);
       setNameTouched(false);
     }
-  }, [isOpen, initialData]);
+  }, [isOpen, initialData, prefill]);
 
   useEffect(() => {
     if (!isOpen || initialData || nameTouched) return;

--- a/src/components/IndexModal.tsx
+++ b/src/components/IndexModal.tsx
@@ -150,9 +150,9 @@ export const IndexModal: React.FC<IndexModalProps> = ({
   }, [isOpen, initialData, prefill]);
 
   useEffect(() => {
-    if (!isOpen || initialData || nameTouched) return;
+    if (!isOpen || initialData || prefill || nameTouched) return;
     setIndexName(defaultIndexName(rawKeysJson));
-  }, [isOpen, initialData, nameTouched, rawKeysJson]);
+  }, [isOpen, initialData, prefill, nameTouched, rawKeysJson]);
 
   useEffect(() => {
     if (!isRawMode) {

--- a/src/components/IndexViewer.tsx
+++ b/src/components/IndexViewer.tsx
@@ -357,7 +357,7 @@ export const IndexViewer: React.FC<IndexViewerProps> = ({
               </CardHeader>
               <CardContent>
                 <div className="flex items-center gap-2">
-                  <div className="text-lg font-semibold text-foreground">{statEntry.ops.toLocaleString()} ops</div>
+                  <div className="text-lg font-semibold text-foreground">{statEntry.ops.toLocaleString('en-US')} ops</div>
                   {statEntry.ops === 0 && (
                     <Badge variant="outline" data-testid="index-unused-badge">
                       Unused

--- a/src/components/IndexViewer.tsx
+++ b/src/components/IndexViewer.tsx
@@ -13,13 +13,17 @@ import {
   Edit,
   Trash2,
   Loader2,
+  HardDrive,
+  Activity,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
+import { formatBytes } from '@/lib/format';
 import type { IndexInfo } from './Sidebar';
+import type { IndexStatUi } from './StatsCards';
 import { useDialogs } from './dialogs/DialogProvider';
 
 interface IndexViewerProps {
@@ -44,12 +48,14 @@ export const IndexViewer: React.FC<IndexViewerProps> = ({
   const [info, setInfo] = useState<IndexInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<IndexStatUi[] | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
     setInfo(null);
+    setStats(null);
 
     (async () => {
       try {
@@ -72,10 +78,27 @@ export const IndexViewer: React.FC<IndexViewerProps> = ({
       }
     })();
 
+    // Fetched independently, in its own try/catch: a stats failure must
+    // never block rendering the index definition above.
+    (async () => {
+      try {
+        const s = await invoke<IndexStatUi[]>('index_stats', {
+          id: connectionId,
+          db: databaseName,
+          collection: collectionName,
+        });
+        if (!cancelled) setStats(s);
+      } catch {
+        // Usage/size stats are a nice-to-have; ignore failures silently.
+      }
+    })();
+
     return () => {
       cancelled = true;
     };
   }, [connectionId, databaseName, collectionName, indexName]);
+
+  const statEntry = useMemo(() => stats?.find((s) => s.name === indexName) ?? null, [stats, indexName]);
 
   const indexSpecs = useMemo(() => {
     let keyPattern: Record<string, number | string> = {};
@@ -308,6 +331,43 @@ export const IndexViewer: React.FC<IndexViewerProps> = ({
               </p>
             </CardContent>
           </Card>
+
+          {statEntry && (
+            <Card className="relative overflow-hidden" data-testid="index-size-card">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <HardDrive size={12} className="text-primary" />
+                  Size
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-lg font-semibold text-foreground">{formatBytes(statEntry.sizeBytes)}</div>
+                <p className="mt-1 text-[11px] text-muted-foreground">On-disk index size</p>
+              </CardContent>
+            </Card>
+          )}
+
+          {statEntry && (
+            <Card className="relative overflow-hidden" data-testid="index-usage-card">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <Activity size={12} className="text-success" />
+                  Usage
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-2">
+                  <div className="text-lg font-semibold text-foreground">{statEntry.ops.toLocaleString()} ops</div>
+                  {statEntry.ops === 0 && (
+                    <Badge variant="outline" data-testid="index-unused-badge">
+                      Unused
+                    </Badge>
+                  )}
+                </div>
+                <p className="mt-1 text-[11px] text-muted-foreground">Index accesses since last restart</p>
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         <div className="grid gap-4 lg:grid-cols-2">

--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -23,7 +23,7 @@ interface CollStatsUi {
   capped: boolean;
 }
 
-interface IndexStatUi {
+export interface IndexStatUi {
   name: string;
   sizeBytes: number;
   ops: number;

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -224,6 +224,44 @@ describe('DataGrid Component', () => {
     expect(screen.getByText(/"David Miller"/)).toBeInTheDocument();
   });
 
+  it('shows a COLLSCAN suggestion banner in the explain panel and fires onCreateSuggestedIndex', () => {
+    const collscanExplain = JSON.stringify({
+      queryPlanner: {
+        namespace: 'shop.orders',
+        parsedQuery: { status: { $eq: 'open' } },
+        winningPlan: { stage: 'COLLSCAN' },
+      },
+    });
+    const onCreateSuggestedIndex = vi.fn();
+    render(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={collscanExplain}
+        onCreateSuggestedIndex={onCreateSuggestedIndex}
+      />
+    );
+
+    const btn = screen.getByTestId('create-suggested-index-btn');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+
+    expect(onCreateSuggestedIndex).toHaveBeenCalledTimes(1);
+    const suggestion = onCreateSuggestedIndex.mock.calls[0][0];
+    expect(suggestion.namespace).toBe('shop.orders');
+    expect(suggestion.keys).toEqual({ status: 1 });
+  });
+
+  it('does not show a suggestion banner when the plan already uses an index', () => {
+    const ixscanExplain = JSON.stringify({
+      queryPlanner: {
+        namespace: 'shop.orders',
+        winningPlan: { stage: 'FETCH', inputStage: { stage: 'IXSCAN', indexName: 'status_1' } },
+      },
+    });
+    render(<DataGrid documents={mockDocuments} explainResult={ixscanExplain} />);
+    expect(screen.queryByTestId('create-suggested-index-btn')).not.toBeInTheDocument();
+  });
+
   it('shows a Query Code tab rendering the query spec in the selected language', () => {
     const spec = {
       db: 'shop',

--- a/src/components/__tests__/IndexViewer.test.tsx
+++ b/src/components/__tests__/IndexViewer.test.tsx
@@ -22,10 +22,22 @@ describe('IndexViewer (T2)', () => {
     indexName: 'city_1',
   };
 
+  const CITY_INDEX = { name: 'city_1', keys: '{"city":1}', unique: true, sparse: false };
+
+  // Routes invoke calls by command name so list_indexes and index_stats can
+  // each return their own shape (a single mockResolvedValue would make
+  // index_stats resolve with the list_indexes payload and vice versa).
+  const mockInvokeByCommand = (handlers: Record<string, any>) => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      const handler = handlers[cmd];
+      if (handler === undefined) return Promise.resolve([]);
+      if (handler instanceof Error || handler === 'reject') return Promise.reject(handler);
+      return Promise.resolve(handler);
+    });
+  };
+
   it('renders the REAL index spec from list_indexes (C3/H4)', async () => {
-    mockInvoke.mockResolvedValue([
-      { name: 'city_1', keys: '{"city":1}', unique: true, sparse: false },
-    ]);
+    mockInvokeByCommand({ list_indexes: [CITY_INDEX], index_stats: [] });
     render(<IndexViewer {...baseProps} />);
 
     // Real key field + unique/sparse flags (not guessed from the name).
@@ -46,9 +58,7 @@ describe('IndexViewer (T2)', () => {
   });
 
   it('deletes the index after the in-app confirm', async () => {
-    mockInvoke.mockResolvedValue([
-      { name: 'city_1', keys: '{"city":1}', unique: false, sparse: false },
-    ]);
+    mockInvokeByCommand({ list_indexes: [{ ...CITY_INDEX, unique: false }], index_stats: [] });
     const onDeleteIndex = vi.fn();
     render(<IndexViewer {...baseProps} onDeleteIndex={onDeleteIndex} />);
 
@@ -56,5 +66,50 @@ describe('IndexViewer (T2)', () => {
     fireEvent.click(await screen.findByTestId('dialog-confirm'));
 
     await waitFor(() => expect(onDeleteIndex).toHaveBeenCalledWith('city_1'));
+  });
+
+  it('fetches index_stats and renders Size + Usage cards for the matching index', async () => {
+    mockInvokeByCommand({
+      list_indexes: [CITY_INDEX],
+      index_stats: [
+        { name: 'city_1', sizeBytes: 16_384, ops: 4_200, sinceMs: 1_749_427_200_000 },
+        { name: 'other_1', sizeBytes: 999, ops: 1, sinceMs: 1_749_427_200_000 },
+      ],
+    });
+    render(<IndexViewer {...baseProps} />);
+
+    expect(mockInvoke).toHaveBeenCalledWith('index_stats', {
+      id: 'c1',
+      db: 'shop',
+      collection: 'products',
+    });
+
+    const sizeCard = await screen.findByTestId('index-size-card');
+    expect(sizeCard).toHaveTextContent('16 KB');
+
+    const usageCard = await screen.findByTestId('index-usage-card');
+    expect(usageCard).toHaveTextContent('4,200');
+    expect(usageCard).not.toHaveTextContent(/unused/i);
+  });
+
+  it('shows an "unused" badge when the matching index has zero ops', async () => {
+    mockInvokeByCommand({
+      list_indexes: [CITY_INDEX],
+      index_stats: [{ name: 'city_1', sizeBytes: 8_192, ops: 0, sinceMs: 0 }],
+    });
+    render(<IndexViewer {...baseProps} />);
+
+    const usageCard = await screen.findByTestId('index-usage-card');
+    expect(usageCard).toHaveTextContent('0');
+    expect(usageCard).toHaveTextContent(/unused/i);
+  });
+
+  it('still renders the definition when index_stats fails', async () => {
+    mockInvokeByCommand({ list_indexes: [CITY_INDEX], index_stats: new Error('stats down') });
+    render(<IndexViewer {...baseProps} />);
+
+    expect(await screen.findByText('city')).toBeInTheDocument();
+    expect(screen.queryByTestId('index-size-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('index-usage-card')).not.toBeInTheDocument();
   });
 });

--- a/src/lib/__tests__/indexSuggestions.test.ts
+++ b/src/lib/__tests__/indexSuggestions.test.ts
@@ -39,4 +39,77 @@ describe('suggestESRIndex (ESR rule)', () => {
     const s = suggestESRIndex(collscan)!;
     expect(s.keys).toEqual({ status: 1 });
   });
+
+  it('returns null for an IDHACK plan (index-served find-by-_id, no COLLSCAN)', () => {
+    const idhack = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { _id: { $eq: 1 } },
+      winningPlan: { stage: 'IDHACK' },
+    } });
+    expect(suggestESRIndex(idhack)).toBeNull();
+  });
+
+  it('returns null for a COUNT_SCAN plan (index-served, no COLLSCAN)', () => {
+    const countScan = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'COUNT_SCAN' },
+    } });
+    expect(suggestESRIndex(countScan)).toBeNull();
+  });
+
+  it('returns null for a DISTINCT_SCAN plan (index-served, no COLLSCAN)', () => {
+    const distinctScan = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'DISTINCT_SCAN' },
+    } });
+    expect(suggestESRIndex(distinctScan)).toBeNull();
+  });
+
+  it('returns null for a CLUSTERED_IXSCAN plan (index-served, no COLLSCAN)', () => {
+    const clusteredIxscan = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'CLUSTERED_IXSCAN' },
+    } });
+    expect(suggestESRIndex(clusteredIxscan)).toBeNull();
+  });
+
+  it('returns null when winningPlan has neither COLLSCAN nor a recognized index-served stage', () => {
+    const eof = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'EOF' },
+    } });
+    expect(suggestESRIndex(eof)).toBeNull();
+  });
+
+  it('still suggests an index for a plain COLLSCAN plan', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'COLLSCAN' },
+    } });
+    expect(suggestESRIndex(collscan)?.keys).toEqual({ status: 1 });
+  });
+
+  it('skips unknown/non-indexable operators (e.g. $geoWithin) instead of treating them as equality', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { loc: { $geoWithin: { $box: [[0, 0], [1, 1]] } }, status: { $eq: 'x' } },
+      winningPlan: { stage: 'COLLSCAN' },
+    } });
+    const s = suggestESRIndex(collscan)!;
+    expect(s.keys).toEqual({ status: 1 });
+  });
+
+  it('returns null when the only predicate uses an unknown/non-indexable operator', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { loc: { $geoWithin: { $box: [[0, 0], [1, 1]] } } },
+      winningPlan: { stage: 'COLLSCAN' },
+    } });
+    expect(suggestESRIndex(collscan)).toBeNull();
+  });
 });

--- a/src/lib/__tests__/indexSuggestions.test.ts
+++ b/src/lib/__tests__/indexSuggestions.test.ts
@@ -21,4 +21,22 @@ describe('suggestESRIndex (ESR rule)', () => {
     const agg = JSON.stringify({ stages: [{ $cursor: { queryPlanner: { namespace: 'db.c', parsedQuery: { x: { $eq: 1 } }, winningPlan: { stage: 'COLLSCAN' } } } }] });
     expect(suggestESRIndex(agg)?.keys).toEqual({ x: 1 });
   });
+  it('suggests ESR keys from a real-server normalized $and parsedQuery', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { $and: [ { status: { $eq: 'open' } }, { total: { $gt: 100 } } ] },
+      winningPlan: { stage: 'SORT', sortPattern: { createdAt: 1 }, inputStage: { stage: 'COLLSCAN' } },
+    } });
+    const s = suggestESRIndex(collscan)!;
+    expect(Object.keys(s.keys)).toEqual(['status', 'createdAt', 'total']);
+  });
+  it('excludes $not and $regex predicates from the equality lead, keeping other fields', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { name: { $regex: 'x' }, status: { $eq: 'open' } },
+      winningPlan: { stage: 'COLLSCAN' },
+    } });
+    const s = suggestESRIndex(collscan)!;
+    expect(s.keys).toEqual({ status: 1 });
+  });
 });

--- a/src/lib/__tests__/indexSuggestions.test.ts
+++ b/src/lib/__tests__/indexSuggestions.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { suggestESRIndex } from '../indexSuggestions';
+
+describe('suggestESRIndex (ESR rule)', () => {
+  it('returns null when the plan already uses an index (IXSCAN)', () => {
+    const ix = JSON.stringify({ queryPlanner: { namespace: 'db.c', winningPlan: { stage: 'FETCH', inputStage: { stage: 'IXSCAN', indexName: 'a_1' } } } });
+    expect(suggestESRIndex(ix)).toBeNull();
+  });
+  it('suggests an ESR-ordered key for a COLLSCAN with equality + sort + range', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { status: { $eq: 'open' }, total: { $gt: 100 } },
+      winningPlan: { stage: 'SORT', sortPattern: { createdAt: 1 }, inputStage: { stage: 'COLLSCAN' } },
+    } });
+    const s = suggestESRIndex(collscan)!;
+    expect(Object.keys(s.keys)).toEqual(['status', 'createdAt', 'total']);
+    expect(s.keys.createdAt).toBe(1);
+    expect(s.namespace).toBe('shop.orders');
+  });
+  it('handles aggregate explain ($cursor COLLSCAN)', () => {
+    const agg = JSON.stringify({ stages: [{ $cursor: { queryPlanner: { namespace: 'db.c', parsedQuery: { x: { $eq: 1 } }, winningPlan: { stage: 'COLLSCAN' } } } }] });
+    expect(suggestESRIndex(agg)?.keys).toEqual({ x: 1 });
+  });
+});

--- a/src/lib/indexSuggestions.ts
+++ b/src/lib/indexSuggestions.ts
@@ -1,0 +1,66 @@
+export interface IndexSuggestion {
+  namespace: string;
+  keys: Record<string, 1 | -1>;
+  suggestedName: string;
+  reason: string;
+}
+
+const RANGE_OPS = new Set(['$gt', '$gte', '$lt', '$lte', '$ne', '$in', '$nin']);
+
+const extractPlan = (json: any): { wp: any; parsed: any; ns: string } | null => {
+  if (Array.isArray(json?.stages)) {
+    const cursor = json.stages.find((s: any) => s && s.$cursor)?.$cursor?.queryPlanner;
+    if (!cursor) return null;
+    return { wp: cursor.winningPlan, parsed: cursor.parsedQuery ?? {}, ns: cursor.namespace ?? '' };
+  }
+  const qp = json?.queryPlanner;
+  if (!qp) return null;
+  return { wp: qp.winningPlan, parsed: qp.parsedQuery ?? {}, ns: qp.namespace ?? '' };
+};
+
+const walk = (stage: any, acc: { hasIxscan: boolean; sort?: Record<string, number> }) => {
+  if (!stage || typeof stage !== 'object') return;
+  if (stage.stage === 'IXSCAN') acc.hasIxscan = true;
+  if (stage.stage === 'SORT' && stage.sortPattern) acc.sort = stage.sortPattern;
+  if (stage.inputStage) walk(stage.inputStage, acc);
+  if (Array.isArray(stage.inputStages)) stage.inputStages.forEach((s: any) => walk(s, acc));
+};
+
+const classify = (parsed: any): { eq: string[]; range: string[] } => {
+  const eq: string[] = []; const range: string[] = [];
+  Object.entries(parsed || {}).forEach(([field, cond]) => {
+    if (field.startsWith('$')) return;
+    if (cond && typeof cond === 'object' && !Array.isArray(cond)) {
+      const ops = Object.keys(cond);
+      if (ops.includes('$eq')) eq.push(field);
+      else if (ops.some((o) => RANGE_OPS.has(o))) range.push(field);
+      else eq.push(field);
+    } else { eq.push(field); }
+  });
+  return { eq, range };
+};
+
+export const suggestESRIndex = (explainStr: string): IndexSuggestion | null => {
+  let json: any;
+  try { json = JSON.parse(explainStr); } catch { return null; }
+  const plan = extractPlan(json);
+  if (!plan?.wp) return null;
+  const acc = { hasIxscan: false as boolean, sort: undefined as Record<string, number> | undefined };
+  walk(plan.wp, acc);
+  if (acc.hasIxscan) return null;
+  const { eq, range } = classify(plan.parsed);
+  const sortFields = acc.sort ? Object.keys(acc.sort) : [];
+  const ordered: string[] = [];
+  const keys: Record<string, 1 | -1> = {};
+  const push = (f: string, dir: 1 | -1) => { if (!ordered.includes(f)) { ordered.push(f); keys[f] = dir; } };
+  eq.forEach((f) => push(f, 1));
+  sortFields.forEach((f) => push(f, acc.sort![f] === -1 ? -1 : 1));
+  range.forEach((f) => push(f, 1));
+  if (ordered.length === 0) return null;
+  return {
+    namespace: plan.ns,
+    keys,
+    suggestedName: ordered.map((f) => `${f}_${keys[f]}`).join('_'),
+    reason: 'This query performs a full collection scan (COLLSCAN). A compound index ordered by the ESR rule (Equality, Sort, Range) can serve it from an index scan.',
+  };
+};

--- a/src/lib/indexSuggestions.ts
+++ b/src/lib/indexSuggestions.ts
@@ -26,12 +26,29 @@ const walk = (stage: any, acc: { hasIxscan: boolean; sort?: Record<string, numbe
   if (Array.isArray(stage.inputStages)) stage.inputStages.forEach((s: any) => walk(s, acc));
 };
 
+const flattenTopLevelAnd = (parsed: any): [string, any][] => {
+  const entries: [string, any][] = [];
+  Object.entries(parsed || {}).forEach(([field, cond]) => {
+    if (field === '$and' && Array.isArray(cond)) {
+      cond.forEach((clause) => {
+        if (clause && typeof clause === 'object' && !Array.isArray(clause)) {
+          entries.push(...Object.entries(clause));
+        }
+      });
+      return;
+    }
+    entries.push([field, cond]);
+  });
+  return entries;
+};
+
 const classify = (parsed: any): { eq: string[]; range: string[] } => {
   const eq: string[] = []; const range: string[] = [];
-  Object.entries(parsed || {}).forEach(([field, cond]) => {
+  flattenTopLevelAnd(parsed).forEach(([field, cond]) => {
     if (field.startsWith('$')) return;
     if (cond && typeof cond === 'object' && !Array.isArray(cond)) {
       const ops = Object.keys(cond);
+      if (ops.includes('$not') || ops.includes('$regex')) return;
       if (ops.includes('$eq')) eq.push(field);
       else if (ops.some((o) => RANGE_OPS.has(o))) range.push(field);
       else eq.push(field);

--- a/src/lib/indexSuggestions.ts
+++ b/src/lib/indexSuggestions.ts
@@ -18,9 +18,12 @@ const extractPlan = (json: any): { wp: any; parsed: any; ns: string } | null => 
   return { wp: qp.winningPlan, parsed: qp.parsedQuery ?? {}, ns: qp.namespace ?? '' };
 };
 
-const walk = (stage: any, acc: { hasIxscan: boolean; sort?: Record<string, number> }) => {
+const INDEX_SERVED_STAGES = new Set(['IXSCAN', 'IDHACK', 'COUNT_SCAN', 'DISTINCT_SCAN', 'CLUSTERED_IXSCAN']);
+
+const walk = (stage: any, acc: { served: boolean; hasCollscan: boolean; sort?: Record<string, number> }) => {
   if (!stage || typeof stage !== 'object') return;
-  if (stage.stage === 'IXSCAN') acc.hasIxscan = true;
+  if (INDEX_SERVED_STAGES.has(stage.stage)) acc.served = true;
+  if (stage.stage === 'COLLSCAN') acc.hasCollscan = true;
   if (stage.stage === 'SORT' && stage.sortPattern) acc.sort = stage.sortPattern;
   if (stage.inputStage) walk(stage.inputStage, acc);
   if (Array.isArray(stage.inputStages)) stage.inputStages.forEach((s: any) => walk(s, acc));
@@ -48,10 +51,9 @@ const classify = (parsed: any): { eq: string[]; range: string[] } => {
     if (field.startsWith('$')) return;
     if (cond && typeof cond === 'object' && !Array.isArray(cond)) {
       const ops = Object.keys(cond);
-      if (ops.includes('$not') || ops.includes('$regex')) return;
       if (ops.includes('$eq')) eq.push(field);
-      else if (ops.some((o) => RANGE_OPS.has(o))) range.push(field);
-      else eq.push(field);
+      else if (ops.every((o) => RANGE_OPS.has(o))) range.push(field);
+      else return;
     } else { eq.push(field); }
   });
   return { eq, range };
@@ -62,9 +64,9 @@ export const suggestESRIndex = (explainStr: string): IndexSuggestion | null => {
   try { json = JSON.parse(explainStr); } catch { return null; }
   const plan = extractPlan(json);
   if (!plan?.wp) return null;
-  const acc = { hasIxscan: false as boolean, sort: undefined as Record<string, number> | undefined };
+  const acc = { served: false as boolean, hasCollscan: false as boolean, sort: undefined as Record<string, number> | undefined };
   walk(plan.wp, acc);
-  if (acc.hasIxscan) return null;
+  if (acc.served || !acc.hasCollscan) return null;
   const { eq, range } = classify(plan.parsed);
   const sortFields = acc.sort ? Object.keys(acc.sort) : [];
   const ordered: string[] = [];


### PR DESCRIPTION
Closes #90 (the suggestion half; the stats half shipped in #178).

- **IndexViewer**: per-index Size and Usage cards from the existing `index_stats` command, with an "unused" badge (ops = 0). A stats failure never blocks the definition view.
- **ESR suggestions**: a pure `suggestESRIndex` module detects COLLSCAN winning plans (find and aggregate $cursor explains) and derives an Equality → Sort → Range compound key from the parsed query — including real-server `$and`-normalized shapes. `$not`/`$regex` predicates never land in the equality lead. Any IXSCAN anywhere suppresses the suggestion (fail-safe: no spurious banners).
- **One-click create**: the explain panel's suggestion banner pre-fills the existing IndexModal (create mode) scoped to the active tab's collection.
- **Demo mode**: `sales_db.transactions` explains as a COLLSCAN in the mock, so the banner is visible without a live server.

Verification: cargo 246/246, vitest 719/719 (with coverage), tsc clean.