### PR TITLE
feat: side-by-side document diff (#92)

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -463,10 +463,11 @@ export const DataGrid: React.FC<DataGridProps> = ({
 
   // A new result set invalidates any armed compare source: the armed doc may
   // no longer exist (or may differ) in the fresh documents array, and matching
-  // is by reference — silently diffing a stale doc would mislead.
+  // is by reference — silently diffing a stale doc would mislead. An OPEN diff
+  // modal is deliberately left alone: it deep-copied its two docs and stays
+  // valid regardless of what the grid refreshes to underneath it.
   useEffect(() => {
     setPendingCompare(null);
-    setDiffPair(null);
   }, [documents]);
 
   const writeClipboard = (text: string) => {

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -461,6 +461,14 @@ export const DataGrid: React.FC<DataGridProps> = ({
   const [pendingCompare, setPendingCompare] = useState<Record<string, any> | null>(null);
   const [diffPair, setDiffPair] = useState<{ a: Record<string, any>; b: Record<string, any> } | null>(null);
 
+  // A new result set invalidates any armed compare source: the armed doc may
+  // no longer exist (or may differ) in the fresh documents array, and matching
+  // is by reference — silently diffing a stale doc would mislead.
+  useEffect(() => {
+    setPendingCompare(null);
+    setDiffPair(null);
+  }, [documents]);
+
   const writeClipboard = (text: string) => {
     try { navigator.clipboard?.writeText(text); } catch { /* clipboard unavailable */ }
   };

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useMemo, useEffect, useContext } from 'react';
 import { DocumentViewerContext } from './DocumentViewer';
 import { List } from 'react-window';
-import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3 } from 'lucide-react';
+import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3, GitCompareArrows } from 'lucide-react';
 import { ChartView } from './ChartView';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
+import { DocumentDiffModal } from './DocumentDiffModal';
 import Editor from '@monaco-editor/react';
 import { generateQueryCode, CODE_LANGUAGES, CODE_LANGUAGE_MONACO_IDS, type CodeLanguage, type QueryCodeSpec } from '../lib/queryCodeGen';
 import { useMonacoTheme } from '../lib/useMonacoTheme';
@@ -455,6 +456,11 @@ export const DataGrid: React.FC<DataGridProps> = ({
     { x: number; y: number; doc: Record<string, any>; field?: string; value?: any } | null
   >(null);
 
+  // Two-step "Compare with…" flow: the first pick is held here as the armed
+  // source; the second pick (a different document) opens the diff modal.
+  const [pendingCompare, setPendingCompare] = useState<Record<string, any> | null>(null);
+  const [diffPair, setDiffPair] = useState<{ a: Record<string, any>; b: Record<string, any> } | null>(null);
+
   const writeClipboard = (text: string) => {
     try { navigator.clipboard?.writeText(text); } catch { /* clipboard unavailable */ }
   };
@@ -481,6 +487,36 @@ export const DataGrid: React.FC<DataGridProps> = ({
     if (onEditDocument) items.push({ label: 'Edit document', icon: <Edit size={13} />, onClick: () => onEditDocument(m.doc) });
     if (onDuplicateDocument) items.push({ label: 'Duplicate document', icon: <Plus size={13} />, onClick: () => onDuplicateDocument(m.doc) });
     items.push({ label: 'Copy document (JSON)', icon: <Copy size={13} />, onClick: () => writeClipboard(JSON.stringify(m.doc, null, 2)) });
+    if (!pendingCompare) {
+      items.push({
+        label: 'Compare with…',
+        icon: <GitCompareArrows size={13} />,
+        separatorBefore: true,
+        onClick: () => setPendingCompare(m.doc),
+      });
+    } else if (pendingCompare === m.doc) {
+      items.push({
+        label: 'Cancel compare selection',
+        icon: <GitCompareArrows size={13} />,
+        separatorBefore: true,
+        onClick: () => setPendingCompare(null),
+      });
+    } else {
+      items.push({
+        label: 'Compare with selected',
+        icon: <GitCompareArrows size={13} />,
+        separatorBefore: true,
+        onClick: () => {
+          setDiffPair({ a: pendingCompare, b: m.doc });
+          setPendingCompare(null);
+        },
+      });
+      items.push({
+        label: 'Compare with… (replace selection)',
+        icon: <GitCompareArrows size={13} />,
+        onClick: () => setPendingCompare(m.doc),
+      });
+    }
     if (m.field) {
       items.push({ label: 'Copy value', icon: <Copy size={13} />, separatorBefore: true, onClick: () => writeClipboard(valueToText(m.value)) });
       items.push({ label: 'Copy field name', icon: <Copy size={13} />, onClick: () => writeClipboard(m.field!) });
@@ -1585,6 +1621,14 @@ export const DataGrid: React.FC<DataGridProps> = ({
           </div>
         );
       })()}
+      {diffPair && (
+        <DocumentDiffModal
+          isOpen
+          left={diffPair.a}
+          right={diffPair.b}
+          onClose={() => setDiffPair(null)}
+        />
+      )}
       {ctxMenu && (
         <ContextMenu
           x={ctxMenu.x}

--- a/src/components/DocumentDiffModal.tsx
+++ b/src/components/DocumentDiffModal.tsx
@@ -37,12 +37,24 @@ function renderScalar(val: unknown): React.ReactNode {
   if (typeof val === 'string') return <span className="text-syntax-string">{printableString(val)}</span>;
   if (val instanceof ObjectId) return <><span className="text-syntax-boolean">ObjectId</span>(<span className="text-syntax-string">{printableString(val.toString())}</span>)</>;
   if (val instanceof Date) return <><span className="text-syntax-boolean">ISODate</span>(<span className="text-syntax-string">{printableString(val.toISOString())}</span>)</>;
+  // Timestamp extends Long in bson, so this check MUST precede the Long
+  // check below, otherwise every Timestamp would render as NumberLong(...).
+  if (val instanceof Timestamp) return <><span className="text-syntax-boolean">Timestamp</span>(<span className="text-syntax-number">{val.t}</span>, <span className="text-syntax-number">{val.i}</span>)</>;
   if (val instanceof Long) return <><span className="text-syntax-boolean">NumberLong</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
   if (val instanceof Decimal128) return <><span className="text-syntax-boolean">NumberDecimal</span>(<span className="text-syntax-string">{printableString(val.toString())}</span>)</>;
   if (val instanceof Int32) return <><span className="text-syntax-boolean">NumberInt</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
   if (val instanceof Double) return <><span className="text-syntax-boolean">Double</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
   if (val instanceof Binary) return <><span className="text-syntax-boolean">BinData</span>(<span className="text-syntax-number">{val.sub_type}</span>, <span className="text-syntax-string">{printableString(val.toString('base64'))}</span>)</>;
-  if (val instanceof Timestamp) return <><span className="text-syntax-boolean">Timestamp</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
+  if (Array.isArray(val) || (typeof val === 'object' && val !== null)) {
+    let preview: string;
+    try {
+      preview = EJSON.stringify(val, { relaxed: true });
+    } catch {
+      preview = String(val);
+    }
+    if (preview.length > 120) preview = `${preview.slice(0, 120)}…`;
+    return <span className="text-muted-foreground">{preview}</span>;
+  }
   return <span>{String(val)}</span>;
 }
 
@@ -109,8 +121,14 @@ const DiffColumn: React.FC<{ lines: DiffLine[]; testid: string }> = ({ lines, te
   </div>
 );
 
+// No virtualization in v1 — past this many lines the DOM cost of rendering
+// every row outweighs the value of the raw diff view, so we show an honest
+// guard instead of a laggy/broken column.
+const MAX_DIFF_LINES = 4000;
+
 export const DocumentDiffModal: React.FC<DocumentDiffModalProps> = ({ isOpen, left, right, onClose }) => {
   const diff = useMemo(() => diffDocuments(toBson(left), toBson(right)), [left, right]);
+  const tooLarge = diff.left.length > MAX_DIFF_LINES;
 
   useEscapeClose(isOpen, onClose);
 
@@ -154,20 +172,29 @@ export const DocumentDiffModal: React.FC<DocumentDiffModalProps> = ({ isOpen, le
             </Button>
           </DialogHeader>
 
-          <div className="mql-diff-grid grid min-h-0 flex-1 grid-cols-2 gap-3 p-4">
-            <div className="flex min-h-0 flex-col gap-1">
-              <div className="mql-diff-colhead text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
-                Document A
-              </div>
-              <DiffColumn lines={diff.left} testid="diff-left" />
+          {tooLarge ? (
+            <div
+              className="flex flex-1 items-center justify-center p-4 text-sm text-muted-foreground"
+              data-testid="diff-too-large"
+            >
+              This diff is too large to display ({diff.left.length} lines)
             </div>
-            <div className="flex min-h-0 flex-col gap-1">
-              <div className="mql-diff-colhead text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
-                Document B
+          ) : (
+            <div className="mql-diff-grid grid min-h-0 flex-1 grid-cols-2 gap-3 p-4">
+              <div className="flex min-h-0 flex-col gap-1">
+                <div className="mql-diff-colhead text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                  Document A
+                </div>
+                <DiffColumn lines={diff.left} testid="diff-left" />
               </div>
-              <DiffColumn lines={diff.right} testid="diff-right" />
+              <div className="flex min-h-0 flex-col gap-1">
+                <div className="mql-diff-colhead text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                  Document B
+                </div>
+                <DiffColumn lines={diff.right} testid="diff-right" />
+              </div>
             </div>
-          </div>
+          )}
         </DraggableDialogContent>
       )}
     </Dialog>

--- a/src/components/DocumentDiffModal.tsx
+++ b/src/components/DocumentDiffModal.tsx
@@ -1,0 +1,175 @@
+import React, { useMemo } from 'react';
+import { X, GitCompareArrows } from 'lucide-react';
+import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
+import { Dialog, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { DraggableDialogContent } from '@/components/ui/draggable-dialog-content';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { diffDocuments, type DiffLine, type DiffStatus } from '../lib/docDiff';
+import { useEscapeClose } from '../lib/useEscapeClose';
+
+interface DocumentDiffModalProps {
+  isOpen: boolean;
+  left: Record<string, unknown>;
+  right: Record<string, unknown>;
+  onClose: () => void;
+}
+
+// Parse raw (possibly Extended-JSON) docs into rich BSON instances, mirroring
+// DataGrid's parsedDocs, so the diff engine compares real ObjectId/Date/Long.
+function toBson(doc: Record<string, unknown>): Record<string, unknown> {
+  try {
+    return EJSON.parse(JSON.stringify(doc)) as Record<string, unknown>;
+  } catch {
+    return doc;
+  }
+}
+
+const printableString = (value: string): string => JSON.stringify(value);
+
+// Syntax-colored rendering of one scalar value (same palette as DataGrid's
+// renderBsonValueNode).
+function renderScalar(val: unknown): React.ReactNode {
+  if (val === null || val === undefined) return <span className="text-syntax-null">null</span>;
+  if (typeof val === 'boolean') return <span className="text-syntax-boolean font-bold">{val ? 'true' : 'false'}</span>;
+  if (typeof val === 'number') return <span className="text-syntax-number">{String(val)}</span>;
+  if (typeof val === 'string') return <span className="text-syntax-string">{printableString(val)}</span>;
+  if (val instanceof ObjectId) return <><span className="text-syntax-boolean">ObjectId</span>(<span className="text-syntax-string">{printableString(val.toString())}</span>)</>;
+  if (val instanceof Date) return <><span className="text-syntax-boolean">ISODate</span>(<span className="text-syntax-string">{printableString(val.toISOString())}</span>)</>;
+  if (val instanceof Long) return <><span className="text-syntax-boolean">NumberLong</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
+  if (val instanceof Decimal128) return <><span className="text-syntax-boolean">NumberDecimal</span>(<span className="text-syntax-string">{printableString(val.toString())}</span>)</>;
+  if (val instanceof Int32) return <><span className="text-syntax-boolean">NumberInt</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
+  if (val instanceof Double) return <><span className="text-syntax-boolean">Double</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
+  if (val instanceof Binary) return <><span className="text-syntax-boolean">BinData</span>(<span className="text-syntax-number">{val.sub_type}</span>, <span className="text-syntax-string">{printableString(val.toString('base64'))}</span>)</>;
+  if (val instanceof Timestamp) return <><span className="text-syntax-boolean">Timestamp</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
+  return <span>{String(val)}</span>;
+}
+
+function renderLineContent(line: DiffLine): React.ReactNode {
+  if (line.status === 'gap' || line.kind === 'gap') return null;
+  const key = line.keyLabel ? (
+    <>
+      <span className="text-syntax-key">"{line.keyLabel}"</span>
+      <span className="text-muted-foreground"> : </span>
+    </>
+  ) : null;
+  if (line.kind === 'object' || line.kind === 'array') {
+    return (
+      <>
+        {key}
+        <span className="text-muted-foreground">{line.bracket}</span>
+        {(line.bracket === '{' || line.bracket === '[') && line.childCount !== undefined ? (
+          <span className="text-muted-foreground"> {line.childCount}</span>
+        ) : null}
+      </>
+    );
+  }
+  return (
+    <>
+      {key}
+      {renderScalar(line.value)}
+    </>
+  );
+}
+
+// Map a diff status to the repo's success/warning/destructive tint convention
+// (see ConnectionCard.tsx / DocumentEditModal.tsx usage).
+const lineTintClass = (status: DiffStatus): string => {
+  switch (status) {
+    case 'changed':
+      return 'bg-warning/10';
+    case 'added':
+      return 'bg-success/10';
+    case 'removed':
+      return 'bg-destructive/10';
+    case 'gap':
+      return 'bg-muted/30';
+    default:
+      return '';
+  }
+};
+
+const DiffColumn: React.FC<{ lines: DiffLine[]; testid: string }> = ({ lines, testid }) => (
+  <div className="mql-diff-col overflow-auto rounded-md border border-border bg-background" data-testid={testid}>
+    {lines.map((line, i) => (
+      <div
+        key={i}
+        className={cn('mql-diff-line flex items-start whitespace-pre font-mono text-xs leading-6', `is-${line.status}`, lineTintClass(line.status))}
+        data-status={line.status}
+      >
+        <span className="mql-diff-num w-9 shrink-0 select-none pr-2 text-right text-muted-foreground/70">
+          {line.status === 'gap' ? '' : i + 1}
+        </span>
+        <span className="mql-diff-content min-w-0 flex-1" style={{ paddingLeft: line.depth * 16 }}>
+          {renderLineContent(line)}
+        </span>
+      </div>
+    ))}
+  </div>
+);
+
+export const DocumentDiffModal: React.FC<DocumentDiffModalProps> = ({ isOpen, left, right, onClose }) => {
+  const diff = useMemo(() => diffDocuments(toBson(left), toBson(right)), [left, right]);
+
+  useEscapeClose(isOpen, onClose);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      {isOpen && (
+        <DraggableDialogContent
+          resetKey={isOpen}
+          defaultWidth={1000}
+          defaultHeight={640}
+          minWidth={640}
+          minHeight={360}
+          hideClose
+          className="flex min-h-0 flex-col gap-0 p-0"
+          data-testid="document-diff-modal"
+        >
+          <DialogHeader
+            data-dialog-drag-handle
+            className="flex cursor-grab flex-row items-center justify-between border-b border-border px-4 py-3 active:cursor-grabbing"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <DialogTitle className="flex items-center gap-2 text-sm">
+                <GitCompareArrows size={14} className="text-primary" />
+                Compare Documents
+              </DialogTitle>
+              <span className="flex items-center gap-1.5" data-testid="diff-summary">
+                <Badge variant="warning">{diff.changedCount} changed</Badge>
+                <Badge variant="success">{diff.addedCount} added</Badge>
+                <Badge variant="destructive">{diff.removedCount} removed</Badge>
+              </span>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onClose}
+              aria-label="Close modal"
+            >
+              <X size={13} />
+            </Button>
+          </DialogHeader>
+
+          <div className="mql-diff-grid grid min-h-0 flex-1 grid-cols-2 gap-3 p-4">
+            <div className="flex min-h-0 flex-col gap-1">
+              <div className="mql-diff-colhead text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                Document A
+              </div>
+              <DiffColumn lines={diff.left} testid="diff-left" />
+            </div>
+            <div className="flex min-h-0 flex-col gap-1">
+              <div className="mql-diff-colhead text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                Document B
+              </div>
+              <DiffColumn lines={diff.right} testid="diff-right" />
+            </div>
+          </div>
+        </DraggableDialogContent>
+      )}
+    </Dialog>
+  );
+};

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -322,6 +322,7 @@ describe('DataGrid Component', () => {
     fireEvent.contextMenu(screen.getByText(/"Alice Smith"/));
     expect(screen.getByTestId('context-menu')).toBeInTheDocument();
     expect(screen.getByText('Edit document')).toBeInTheDocument();
+    expect(screen.getByText('Compare with…')).toBeInTheDocument();
   });
 
   it('copies a document as pretty-printed JSON via the copy button and shows a confirmation', () => {
@@ -417,6 +418,26 @@ describe('DataGrid — Compare documents', () => {
     expect(within(modal).getByTestId('diff-left')).toHaveTextContent(/"Bob"/);
     expect(within(modal).getByTestId('diff-right')).toHaveTextContent(/"Carol"/);
     expect(within(modal).queryByText(/"Alice"/)).not.toBeInTheDocument();
+  });
+
+  it('clears an armed compare source when the documents array is replaced (query re-run)', () => {
+    const { rerender } = render(<DataGrid documents={docs} onEditDocument={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    // Arm Alice as the compare source.
+    openMenuForRow('Alice');
+    fireEvent.click(screen.getByText('Compare with…'));
+
+    // Query re-run / paging / sorting replaces the documents array (same
+    // instance, but a fresh reference — content can even be identical).
+    const freshDocs = docs.map((d) => ({ ...d }));
+    rerender(<DataGrid documents={freshDocs} onEditDocument={() => {}} />);
+
+    // Bob's menu should offer only the plain arm action, not "Compare with
+    // selected" — the old armed source must not survive the new result set.
+    openMenuForRow('Bob');
+    expect(screen.getByText('Compare with…')).toBeInTheDocument();
+    expect(screen.queryByText('Compare with selected')).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 
 // Monaco renders the Query Code panel; mock it as a plain textarea (same shape
 // as the other component tests) so assertions can read the generated code.
@@ -338,6 +338,85 @@ describe('DataGrid Component', () => {
     expect(writeText).toHaveBeenCalledWith(JSON.stringify(mockDocuments[0], null, 2));
     // The control flips to a "Copied" confirmation state.
     expect(screen.getAllByLabelText('Copied').length).toBeGreaterThan(0);
+  });
+});
+
+describe('DataGrid — Compare documents', () => {
+  const docs = [
+    { _id: { $oid: '603d779f4f102e3a185c3220' }, name: 'Alice', city: 'NYC' },
+    { _id: { $oid: '603d779f4f102e3a185c3221' }, name: 'Bob', country: 'UK' },
+    { _id: { $oid: '603d779f4f102e3a185c3222' }, name: 'Carol', country: 'FR' },
+  ];
+
+  // The JSON view is virtualized and (in JSDOM, with no real layout height)
+  // only renders the first document's lines, so the two-step flow — which
+  // needs to right-click several distinct rows — exercises Table view
+  // instead, where react-window renders every row of this small fixture.
+  const openMenuForRow = (name: string) => {
+    fireEvent.contextMenu(screen.getByText(name));
+  };
+
+  const renderInTableView = () => {
+    render(<DataGrid documents={docs} onEditDocument={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+  };
+
+  it('two-step compare: first pick arms, second pick opens the diff modal', () => {
+    renderInTableView();
+
+    // First doc: open menu, choose "Compare with…".
+    openMenuForRow('Alice');
+    fireEvent.click(screen.getByText('Compare with…'));
+    // No modal yet — we are armed, waiting for the second pick.
+    expect(screen.queryByTestId('document-diff-modal')).not.toBeInTheDocument();
+
+    // Second doc: the menu now offers "Compare with selected".
+    openMenuForRow('Bob');
+    fireEvent.click(screen.getByText('Compare with selected'));
+
+    const modal = screen.getByTestId('document-diff-modal');
+    expect(modal).toBeInTheDocument();
+    expect(within(modal).getByTestId('diff-left')).toHaveTextContent(/"Alice"/);
+    expect(within(modal).getByTestId('diff-right')).toHaveTextContent(/"Bob"/);
+  });
+
+  it('armed source can be canceled from its own context menu', () => {
+    renderInTableView();
+
+    openMenuForRow('Alice');
+    fireEvent.click(screen.getByText('Compare with…'));
+
+    // Re-opening Alice's own menu offers a cancel action, not "compare with selected".
+    openMenuForRow('Alice');
+    expect(screen.queryByText('Compare with selected')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Cancel compare selection'));
+
+    // Armed state cleared: Alice's menu offers "Compare with…" again, and no
+    // modal ever opened.
+    openMenuForRow('Alice');
+    expect(screen.getByText('Compare with…')).toBeInTheDocument();
+    expect(screen.queryByTestId('document-diff-modal')).not.toBeInTheDocument();
+  });
+
+  it('re-arming with a different document replaces the pending compare source', () => {
+    renderInTableView();
+
+    openMenuForRow('Alice');
+    fireEvent.click(screen.getByText('Compare with…'));
+
+    // Arm Bob instead of finishing the compare with Alice — this should
+    // replace Alice as the pending source.
+    openMenuForRow('Bob');
+    fireEvent.click(screen.getByText('Compare with… (replace selection)'));
+
+    // Finishing the compare now pairs Bob with Carol, not Alice.
+    openMenuForRow('Carol');
+    fireEvent.click(screen.getByText('Compare with selected'));
+
+    const modal = screen.getByTestId('document-diff-modal');
+    expect(within(modal).getByTestId('diff-left')).toHaveTextContent(/"Bob"/);
+    expect(within(modal).getByTestId('diff-right')).toHaveTextContent(/"Carol"/);
+    expect(within(modal).queryByText(/"Alice"/)).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/__tests__/DocumentDiffModal.test.tsx
+++ b/src/components/__tests__/DocumentDiffModal.test.tsx
@@ -5,6 +5,10 @@ import { DocumentDiffModal } from '../DocumentDiffModal';
 const left = { _id: 1, name: 'Ada', city: 'London' };
 const right = { _id: 1, name: 'Grace', country: 'USA' };
 
+// diffPair.a/b arrive as raw (possibly Extended-JSON) docs, same as DataGrid
+// passes them — see DocumentDiffModal's toBson().
+const ejsonTimestamp = (t: number, i: number) => ({ $timestamp: { t, i } });
+
 describe('DocumentDiffModal', () => {
   it('does not render when closed', () => {
     render(<DocumentDiffModal isOpen={false} left={left} right={right} onClose={() => {}} />);
@@ -47,5 +51,41 @@ describe('DocumentDiffModal', () => {
     render(<DocumentDiffModal isOpen left={left} right={right} onClose={onClose} />);
     fireEvent.click(screen.getByLabelText('Close modal'));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders a Timestamp field as Timestamp(...), not NumberLong(...)', () => {
+    // Timestamp extends Long in bson — renderScalar must check Timestamp
+    // before Long or every Timestamp renders as NumberLong(...).
+    const tsLeft = { _id: 1, ts: ejsonTimestamp(1700000000, 1) };
+    const tsRight = { _id: 1, ts: ejsonTimestamp(1700000000, 2) };
+    render(<DocumentDiffModal isOpen left={tsLeft} right={tsRight} onClose={() => {}} />);
+    expect(screen.getByTestId('diff-left')).toHaveTextContent('Timestamp(1700000000, 1)');
+    expect(screen.getByTestId('diff-right')).toHaveTextContent('Timestamp(1700000000, 2)');
+    expect(screen.getByTestId('diff-left')).not.toHaveTextContent('NumberLong');
+    expect(screen.getByTestId('diff-right')).not.toHaveTextContent('NumberLong');
+  });
+
+  it('renders a nested-object preview instead of "[object Object]" on a scalar<->container change', () => {
+    const scalarLeft = { x: 1 };
+    const containerRight = { x: { y: 2 } };
+    render(<DocumentDiffModal isOpen left={scalarLeft} right={containerRight} onClose={() => {}} />);
+    const rightCol = screen.getByTestId('diff-right');
+    expect(rightCol).not.toHaveTextContent('[object Object]');
+    expect(rightCol.textContent).toMatch(/"y"\s*:\s*2/);
+  });
+
+  it('shows a "too large" notice instead of columns when the diff exceeds the line cap', () => {
+    // Build a doc with enough top-level keys to blow past the 4000-line cap
+    // (each changed scalar key produces exactly one line per side).
+    const bigLeft: Record<string, number> = {};
+    const bigRight: Record<string, number> = {};
+    for (let i = 0; i < 4500; i++) {
+      bigLeft[`k${i}`] = i;
+      bigRight[`k${i}`] = i + 1;
+    }
+    render(<DocumentDiffModal isOpen left={bigLeft} right={bigRight} onClose={() => {}} />);
+    expect(screen.getByTestId('diff-too-large')).toHaveTextContent(/too large to display \(\d+ lines\)/);
+    expect(screen.queryByTestId('diff-left')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('diff-right')).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/DocumentDiffModal.test.tsx
+++ b/src/components/__tests__/DocumentDiffModal.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DocumentDiffModal } from '../DocumentDiffModal';
+
+const left = { _id: 1, name: 'Ada', city: 'London' };
+const right = { _id: 1, name: 'Grace', country: 'USA' };
+
+describe('DocumentDiffModal', () => {
+  it('does not render when closed', () => {
+    render(<DocumentDiffModal isOpen={false} left={left} right={right} onClose={() => {}} />);
+    expect(screen.queryByTestId('document-diff-modal')).not.toBeInTheDocument();
+  });
+
+  it('renders both documents side by side and a change summary', () => {
+    render(<DocumentDiffModal isOpen left={left} right={right} onClose={() => {}} />);
+    expect(screen.getByTestId('document-diff-modal')).toBeInTheDocument();
+
+    // Both column values are present.
+    expect(screen.getByTestId('diff-left')).toHaveTextContent(/"Ada"/);
+    expect(screen.getByTestId('diff-right')).toHaveTextContent(/"Grace"/);
+
+    // Summary counts (1 changed: name, 1 added: country, 1 removed: city).
+    const summary = screen.getByTestId('diff-summary');
+    expect(summary).toHaveTextContent('1 changed');
+    expect(summary).toHaveTextContent('1 added');
+    expect(summary).toHaveTextContent('1 removed');
+  });
+
+  it('tags changed/added/removed lines with distinct status markers', () => {
+    render(<DocumentDiffModal isOpen left={left} right={right} onClose={() => {}} />);
+    expect(document.querySelectorAll('.mql-diff-line.is-changed').length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('.mql-diff-line.is-added').length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('.mql-diff-line.is-removed').length).toBeGreaterThan(0);
+    // Gap lines fill the opposite column so both stay aligned.
+    expect(document.querySelectorAll('.mql-diff-line.is-gap').length).toBeGreaterThan(0);
+  });
+
+  it('keeps the two columns row-aligned', () => {
+    render(<DocumentDiffModal isOpen left={left} right={right} onClose={() => {}} />);
+    const leftRows = screen.getByTestId('diff-left').querySelectorAll('.mql-diff-line');
+    const rightRows = screen.getByTestId('diff-right').querySelectorAll('.mql-diff-line');
+    expect(leftRows.length).toBe(rightRows.length);
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<DocumentDiffModal isOpen left={left} right={right} onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText('Close modal'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/docDiff.test.ts
+++ b/src/lib/__tests__/docDiff.test.ts
@@ -69,3 +69,54 @@ describe('diffDocuments — flat objects', () => {
     expect(d.left[i].status).toBe('gap'); // empty filler on the side that lacks the key
   });
 });
+
+describe('diffDocuments — nested objects and arrays', () => {
+  it('recurses into nested objects and marks only the changed leaf', () => {
+    const left = { addr: { city: 'London', zip: 'N1' } };
+    const right = { addr: { city: 'Paris', zip: 'N1' } };
+    const d = diffDocuments(left, right);
+
+    // Columns are aligned and contain a container "open" line for `addr`.
+    expect(d.left.length).toBe(d.right.length);
+    const open = d.left.find((l) => l.path === 'addr')!;
+    expect(open.kind).toBe('object');
+    expect(open.bracket).toBe('{');
+
+    const city = d.left.find((l) => l.path === 'addr.city')!;
+    expect(city.depth).toBe(1);
+    expect(city.status).toBe('changed');
+    expect(d.left.find((l) => l.path === 'addr.zip')!.status).toBe('unchanged');
+    expect(d.changedCount).toBe(1);
+  });
+
+  it('treats a scalar->object change as a single changed entry, not a recurse', () => {
+    const d = diffDocuments({ x: 1 }, { x: { y: 2 } });
+    const lx = d.left.find((l) => l.path === 'x')!;
+    const rx = d.right.find((l) => l.path === 'x')!;
+    expect(lx.status).toBe('changed');
+    expect(rx.status).toBe('changed');
+    // No recursion into x.y because the kinds differ.
+    expect(d.left.some((l) => l.path === 'x.y')).toBe(false);
+    expect(d.changedCount).toBe(1);
+  });
+
+  it('diffs arrays positionally, marking added/removed/changed elements', () => {
+    const d = diffDocuments({ tags: ['a', 'b', 'c'] }, { tags: ['a', 'B', 'c', 'd'] });
+    expect(d.left.find((l) => l.path === 'tags[0]')!.status).toBe('unchanged');
+    expect(d.left.find((l) => l.path === 'tags[1]')!.status).toBe('changed');
+    const added = d.right.find((l) => l.path === 'tags[3]')!;
+    expect(added.status).toBe('added');
+    // The left column has a gap opposite the right-only element.
+    const i = d.right.findIndex((l) => l.path === 'tags[3]');
+    expect(d.left[i].status).toBe('gap');
+    expect(d.addedCount).toBe(1);
+    expect(d.changedCount).toBe(1);
+  });
+
+  it('recurses into nested objects inside array elements', () => {
+    const left = { items: [{ q: 1 }] };
+    const right = { items: [{ q: 2 }] };
+    const d = diffDocuments(left, right);
+    expect(d.left.find((l) => l.path === 'items[0].q')!.status).toBe('changed');
+  });
+});

--- a/src/lib/__tests__/docDiff.test.ts
+++ b/src/lib/__tests__/docDiff.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { ObjectId, Int32, Double, Long, Decimal128 } from 'bson';
+import { bsonEqual, valueKind } from '../docDiff';
+
+describe('valueKind', () => {
+  it('classifies containers vs scalars', () => {
+    expect(valueKind({ a: 1 })).toBe('object');
+    expect(valueKind([1, 2])).toBe('array');
+    expect(valueKind('s')).toBe('scalar');
+    expect(valueKind(3)).toBe('scalar');
+    expect(valueKind(null)).toBe('scalar');
+    // BSON wrappers are leaf scalars, not objects to recurse into.
+    expect(valueKind(new ObjectId('507f1f77bcf86cd799439011'))).toBe('scalar');
+    expect(valueKind(new Date('2025-01-01'))).toBe('scalar');
+  });
+});
+
+describe('bsonEqual', () => {
+  it('treats equal primitives as equal', () => {
+    expect(bsonEqual(1, 1)).toBe(true);
+    expect(bsonEqual('a', 'a')).toBe(true);
+    expect(bsonEqual(null, null)).toBe(true);
+    expect(bsonEqual(1, 2)).toBe(false);
+    expect(bsonEqual('a', 'b')).toBe(false);
+  });
+  it('compares BSON wrappers by value', () => {
+    expect(bsonEqual(new ObjectId('507f1f77bcf86cd799439011'), new ObjectId('507f1f77bcf86cd799439011'))).toBe(true);
+    expect(bsonEqual(new ObjectId('507f1f77bcf86cd799439011'), new ObjectId('507f1f77bcf86cd799439012'))).toBe(false);
+    expect(bsonEqual(new Date('2025-01-01'), new Date('2025-01-01'))).toBe(true);
+    expect(bsonEqual(new Int32(7), new Int32(7))).toBe(true);
+    expect(bsonEqual(new Double(2.5), new Double(2.5))).toBe(true);
+    expect(bsonEqual(new Long(42), new Long(42))).toBe(true);
+    expect(bsonEqual(Decimal128.fromString('3.14'), Decimal128.fromString('3.14'))).toBe(true);
+  });
+  it('numeric BSON wrappers equal their plain-number counterpart', () => {
+    expect(bsonEqual(new Int32(7), 7)).toBe(true);
+    expect(bsonEqual(new Double(2.5), 2.5)).toBe(true);
+  });
+  it('different kinds are not equal', () => {
+    expect(bsonEqual(1, '1')).toBe(false);
+    expect(bsonEqual(new ObjectId('507f1f77bcf86cd799439011'), '507f1f77bcf86cd799439011')).toBe(false);
+  });
+});

--- a/src/lib/__tests__/docDiff.test.ts
+++ b/src/lib/__tests__/docDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ObjectId, Int32, Double, Long, Decimal128, EJSON } from 'bson';
+import { ObjectId, Int32, Double, Long, Decimal128, Timestamp, EJSON } from 'bson';
 import { bsonEqual, valueKind, diffDocuments } from '../docDiff';
 
 describe('valueKind', () => {
@@ -39,6 +39,45 @@ describe('bsonEqual', () => {
   it('different kinds are not equal', () => {
     expect(bsonEqual(1, '1')).toBe(false);
     expect(bsonEqual(new ObjectId('507f1f77bcf86cd799439011'), '507f1f77bcf86cd799439011')).toBe(false);
+  });
+
+  // Timestamp extends Long in bson, and the numeric fallback (asNumber) uses
+  // lossy toNumber()/Number(toString()) conversions. Exact wrapper-vs-wrapper
+  // comparisons must happen before that lossy path is ever reached.
+  it('distinguishes distinct Timestamps with the same seconds but different increments', () => {
+    const a = Timestamp.fromBits(1, 1700000000);
+    const b = Timestamp.fromBits(2, 1700000000);
+    expect(bsonEqual(a, b)).toBe(false);
+  });
+
+  it('treats equal Timestamps as equal', () => {
+    const a = Timestamp.fromBits(1, 1700000000);
+    const b = Timestamp.fromBits(1, 1700000000);
+    expect(bsonEqual(a, b)).toBe(true);
+  });
+
+  it('distinguishes distinct Longs above 2^53 that toNumber() would collapse', () => {
+    const a = Long.fromString('9007199254740993');
+    const b = Long.fromString('9007199254740992');
+    expect(bsonEqual(a, b)).toBe(false);
+  });
+
+  it('treats equal large Longs as equal', () => {
+    const a = Long.fromString('9007199254740993');
+    const b = Long.fromString('9007199254740993');
+    expect(bsonEqual(a, b)).toBe(true);
+  });
+
+  it('distinguishes distinct Decimal128s that collapse to the same double', () => {
+    const a = Decimal128.fromString('1.00000000000000000001');
+    const b = Decimal128.fromString('1.00000000000000000002');
+    expect(bsonEqual(a, b)).toBe(false);
+  });
+
+  it('treats equal Decimal128s as equal', () => {
+    const a = Decimal128.fromString('1.00000000000000000001');
+    const b = Decimal128.fromString('1.00000000000000000001');
+    expect(bsonEqual(a, b)).toBe(true);
   });
 });
 

--- a/src/lib/__tests__/docDiff.test.ts
+++ b/src/lib/__tests__/docDiff.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ObjectId, Int32, Double, Long, Decimal128 } from 'bson';
-import { bsonEqual, valueKind } from '../docDiff';
+import { bsonEqual, valueKind, diffDocuments } from '../docDiff';
 
 describe('valueKind', () => {
   it('classifies containers vs scalars', () => {
@@ -39,5 +39,33 @@ describe('bsonEqual', () => {
   it('different kinds are not equal', () => {
     expect(bsonEqual(1, '1')).toBe(false);
     expect(bsonEqual(new ObjectId('507f1f77bcf86cd799439011'), '507f1f77bcf86cd799439011')).toBe(false);
+  });
+});
+
+describe('diffDocuments — flat objects', () => {
+  it('marks unchanged, changed, added, removed at the top level', () => {
+    const left = { _id: 1, name: 'Ada', age: 36, city: 'London' };
+    const right = { _id: 1, name: 'Grace', age: 36, country: 'USA' };
+    const d = diffDocuments(left, right);
+
+    // Left + right line arrays are aligned (same length, same index = same row).
+    expect(d.left.length).toBe(d.right.length);
+    expect(d.changedCount).toBe(1);   // name
+    expect(d.addedCount).toBe(1);     // country (right only)
+    expect(d.removedCount).toBe(1);   // city (left only)
+
+    const byPath = (arr: typeof d.left, p: string) => arr.find((l) => l.path === p)!;
+    expect(byPath(d.left, 'name').status).toBe('changed');
+    expect(byPath(d.right, 'name').status).toBe('changed');
+    expect(byPath(d.left, 'age').status).toBe('unchanged');
+    expect(byPath(d.left, 'city').status).toBe('removed');
+    expect(byPath(d.right, 'country').status).toBe('added');
+  });
+
+  it('renders a placeholder (gap) opposite an added/removed key so columns align', () => {
+    const d = diffDocuments({ a: 1 }, { a: 1, b: 2 });
+    const i = d.right.findIndex((l) => l.path === 'b');
+    expect(d.right[i].status).toBe('added');
+    expect(d.left[i].status).toBe('gap'); // empty filler on the side that lacks the key
   });
 });

--- a/src/lib/__tests__/docDiff.test.ts
+++ b/src/lib/__tests__/docDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ObjectId, Int32, Double, Long, Decimal128 } from 'bson';
+import { ObjectId, Int32, Double, Long, Decimal128, EJSON } from 'bson';
 import { bsonEqual, valueKind, diffDocuments } from '../docDiff';
 
 describe('valueKind', () => {
@@ -118,5 +118,29 @@ describe('diffDocuments — nested objects and arrays', () => {
     const right = { items: [{ q: 2 }] };
     const d = diffDocuments(left, right);
     expect(d.left.find((l) => l.path === 'items[0].q')!.status).toBe('changed');
+  });
+});
+
+describe('diffDocuments — BSON-typed values', () => {
+  // Parse like DataGrid does (EJSON.parse of JSON.stringify) so the engine sees
+  // real ObjectId/Date/Long instances.
+  const parse = (o: unknown) => EJSON.parse(JSON.stringify(o));
+
+  it('treats equal ObjectIds/Dates as unchanged and differing ones as changed', () => {
+    const left = parse({
+      _id: { $oid: '603d779f4f102e3a185c3220' },
+      at: { $date: '2025-01-01T00:00:00Z' },
+      n: { $numberLong: '42' },
+    });
+    const right = parse({
+      _id: { $oid: '603d779f4f102e3a185c3220' },
+      at: { $date: '2025-02-01T00:00:00Z' },
+      n: { $numberLong: '42' },
+    });
+    const d = diffDocuments(left, right);
+    expect(d.left.find((l) => l.path === '_id')!.status).toBe('unchanged');
+    expect(d.left.find((l) => l.path === 'n')!.status).toBe('unchanged');
+    expect(d.left.find((l) => l.path === 'at')!.status).toBe('changed');
+    expect(d.changedCount).toBe(1);
   });
 });

--- a/src/lib/docDiff.ts
+++ b/src/lib/docDiff.ts
@@ -54,3 +54,103 @@ export function bsonEqual(a: unknown, b: unknown): boolean {
   // Anything else (mismatched kinds, distinct primitives) is unequal.
   return false;
 }
+
+export type DiffStatus = 'unchanged' | 'changed' | 'added' | 'removed' | 'gap';
+
+// One rendered line in a column. `gap` lines carry no value — they are blank
+// filler that keeps the left/right columns vertically aligned.
+export interface DiffLine {
+  path: string;          // dotted/bracketed path, e.g. "address.city" or "tags[0]"
+  keyLabel: string;      // the key or index shown at this depth (e.g. "city" or "0")
+  depth: number;         // indentation level
+  status: DiffStatus;
+  kind: ValueKind | 'gap';
+  value?: unknown;       // scalar value (when kind === 'scalar')
+  bracket?: string;      // '{' '[' '}' ']' for container open/close lines
+  childCount?: number;   // for container open lines
+}
+
+export interface DocDiff {
+  left: DiffLine[];
+  right: DiffLine[];
+  addedCount: number;
+  removedCount: number;
+  changedCount: number;
+}
+
+const gap = (depth: number): DiffLine => ({ path: '', keyLabel: '', depth, status: 'gap', kind: 'gap' });
+
+function joinPath(parent: string, key: string, isIndex: boolean): string {
+  if (!parent) return isIndex ? `[${key}]` : key;
+  return isIndex ? `${parent}[${key}]` : `${parent}.${key}`;
+}
+
+interface Counts { added: number; removed: number; changed: number; }
+
+// Walk both objects in parallel for a single (object) level, emitting aligned
+// left/right scalar lines. Nested containers are handled in Task 3.
+export function diffDocuments(leftDoc: unknown, rightDoc: unknown): DocDiff {
+  const left: DiffLine[] = [];
+  const right: DiffLine[] = [];
+  const counts = { added: 0, removed: 0, changed: 0 };
+
+  walkLevel(leftDoc, rightDoc, '', 0, left, right, counts);
+
+  return {
+    left,
+    right,
+    addedCount: counts.added,
+    removedCount: counts.removed,
+    changedCount: counts.changed,
+  };
+}
+
+function walkLevel(
+  lv: unknown,
+  rv: unknown,
+  parentPath: string,
+  depth: number,
+  left: DiffLine[],
+  right: DiffLine[],
+  counts: Counts,
+): void {
+  const lKind = valueKind(lv);
+  const rKind = valueKind(rv);
+
+  // For Task 2 both sides are plain objects; the union of keys preserves left
+  // order first, then right-only keys, so columns read naturally.
+  const lObj = (lKind === 'object' ? (lv as Record<string, unknown>) : {});
+  const rObj = (rKind === 'object' ? (rv as Record<string, unknown>) : {});
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  for (const k of Object.keys(lObj)) { keys.push(k); seen.add(k); }
+  for (const k of Object.keys(rObj)) { if (!seen.has(k)) keys.push(k); }
+
+  for (const key of keys) {
+    const inL = Object.prototype.hasOwnProperty.call(lObj, key);
+    const inR = Object.prototype.hasOwnProperty.call(rObj, key);
+    const path = joinPath(parentPath, key, false);
+    const a = lObj[key];
+    const b = rObj[key];
+
+    if (inL && !inR) {
+      counts.removed++;
+      left.push({ path, keyLabel: key, depth, status: 'removed', kind: 'scalar', value: a });
+      right.push(gap(depth));
+      continue;
+    }
+    if (!inL && inR) {
+      counts.added++;
+      left.push(gap(depth));
+      right.push({ path, keyLabel: key, depth, status: 'added', kind: 'scalar', value: b });
+      continue;
+    }
+
+    // Present on both sides (Task 2: scalars only).
+    const equal = bsonEqual(a, b);
+    if (!equal) counts.changed++;
+    const status: DiffStatus = equal ? 'unchanged' : 'changed';
+    left.push({ path, keyLabel: key, depth, status, kind: 'scalar', value: a });
+    right.push({ path, keyLabel: key, depth, status, kind: 'scalar', value: b });
+  }
+}

--- a/src/lib/docDiff.ts
+++ b/src/lib/docDiff.ts
@@ -38,18 +38,34 @@ function asNumber(val: unknown): number {
 export function bsonEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
 
-  // Numeric equivalence across plain numbers and BSON numeric wrappers.
+  // Exact comparisons for 64-bit / high-precision wrappers MUST precede the
+  // lossy `asNumber` fallback below. Timestamp extends Long in bson, so the
+  // Timestamp check must come first, otherwise it would be caught by the
+  // Long check (or by asNumber's toNumber()) and lose precision.
+  if (a instanceof Timestamp && b instanceof Timestamp) {
+    return a.equals(b);
+  }
+  if (
+    a instanceof Long && b instanceof Long &&
+    !(a instanceof Timestamp) && !(b instanceof Timestamp)
+  ) {
+    return a.equals(b);
+  }
+  if (a instanceof Decimal128 && b instanceof Decimal128) {
+    return a.toString() === b.toString();
+  }
+
+  // Numeric equivalence across plain numbers and mixed BSON numeric wrapper
+  // types. Same-wrapper 64-bit/high-precision values are handled exactly above.
   const an = asNumber(a);
   const bn = asNumber(b);
   if (!Number.isNaN(an) && !Number.isNaN(bn)) return an === bn;
 
   if (a instanceof ObjectId && b instanceof ObjectId) return a.equals(b);
   if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
-  if (a instanceof Decimal128 && b instanceof Decimal128) return a.toString() === b.toString();
   if (a instanceof Binary && b instanceof Binary) {
     return a.sub_type === b.sub_type && a.toString('base64') === b.toString('base64');
   }
-  if (a instanceof Timestamp && b instanceof Timestamp) return a.toString() === b.toString();
 
   // Anything else (mismatched kinds, distinct primitives) is unequal.
   return false;

--- a/src/lib/docDiff.ts
+++ b/src/lib/docDiff.ts
@@ -181,9 +181,6 @@ function walkLevel(
         counts.changed !== beforeChanged ||
         counts.added !== beforeAdded ||
         counts.removed !== beforeRemoved;
-      if (touched) {
-        const openIdxL = left.length - 1; // not used; container header status update below
-      }
       // Re-tag the open lines as 'changed' when descendants differ.
       if (touched) {
         // open lines are the pair pushed just before recursion.

--- a/src/lib/docDiff.ts
+++ b/src/lib/docDiff.ts
@@ -166,6 +166,8 @@ function walkLevel(
       const closeBracket = aKind === 'array' ? ']' : '}';
       const aChildren = aKind === 'array' ? (a as unknown[]).length : Object.keys(a as object).length;
       const bChildren = bKind === 'array' ? (b as unknown[]).length : Object.keys(b as object).length;
+      const openL = left.length;
+      const openR = right.length;
       left.push({ path, keyLabel: key, depth, status: 'unchanged', kind: aKind, bracket, childCount: aChildren });
       right.push({ path, keyLabel: key, depth, status: 'unchanged', kind: bKind, bracket, childCount: bChildren });
 
@@ -181,13 +183,11 @@ function walkLevel(
         counts.changed !== beforeChanged ||
         counts.added !== beforeAdded ||
         counts.removed !== beforeRemoved;
-      // Re-tag the open lines as 'changed' when descendants differ.
+      // Re-tag the open lines (captured by index before the push) as
+      // 'changed' when descendants differ — O(1) instead of re-scanning.
       if (touched) {
-        // open lines are the pair pushed just before recursion.
-        const openL = left.findIndex((l) => l.path === path && l.bracket === bracket);
-        const openR = right.findIndex((l) => l.path === path && l.bracket === bracket);
-        if (openL >= 0) left[openL] = { ...left[openL], status: 'changed' };
-        if (openR >= 0) right[openR] = { ...right[openR], status: 'changed' };
+        left[openL] = { ...left[openL], status: 'changed' };
+        right[openR] = { ...right[openR], status: 'changed' };
       }
       continue;
     }

--- a/src/lib/docDiff.ts
+++ b/src/lib/docDiff.ts
@@ -114,43 +114,155 @@ function walkLevel(
   right: DiffLine[],
   counts: Counts,
 ): void {
-  const lKind = valueKind(lv);
-  const rKind = valueKind(rv);
+  const lArr = Array.isArray(lv);
+  const rArr = Array.isArray(rv);
+  const isIndex = lArr || rArr;
 
-  // For Task 2 both sides are plain objects; the union of keys preserves left
-  // order first, then right-only keys, so columns read naturally.
-  const lObj = (lKind === 'object' ? (lv as Record<string, unknown>) : {});
-  const rObj = (rKind === 'object' ? (rv as Record<string, unknown>) : {});
-  const keys: string[] = [];
-  const seen = new Set<string>();
-  for (const k of Object.keys(lObj)) { keys.push(k); seen.add(k); }
-  for (const k of Object.keys(rObj)) { if (!seen.has(k)) keys.push(k); }
+  // Build the aligned key list for this level.
+  let keys: string[];
+  if (isIndex) {
+    const len = Math.max(lArr ? (lv as unknown[]).length : 0, rArr ? (rv as unknown[]).length : 0);
+    keys = Array.from({ length: len }, (_, i) => String(i));
+  } else {
+    const lObj = (valueKind(lv) === 'object' ? (lv as Record<string, unknown>) : {});
+    const rObj = (valueKind(rv) === 'object' ? (rv as Record<string, unknown>) : {});
+    keys = [];
+    const seen = new Set<string>();
+    for (const k of Object.keys(lObj)) { keys.push(k); seen.add(k); }
+    for (const k of Object.keys(rObj)) { if (!seen.has(k)) keys.push(k); }
+  }
+
+  const getL = (key: string) => (valueKind(lv) === 'object' || lArr ? (lv as any)[key] : undefined);
+  const getR = (key: string) => (valueKind(rv) === 'object' || rArr ? (rv as any)[key] : undefined);
+  const hasL = (key: string) =>
+    lArr ? Number(key) < (lv as unknown[]).length
+         : valueKind(lv) === 'object' && Object.prototype.hasOwnProperty.call(lv, key);
+  const hasR = (key: string) =>
+    rArr ? Number(key) < (rv as unknown[]).length
+         : valueKind(rv) === 'object' && Object.prototype.hasOwnProperty.call(rv, key);
 
   for (const key of keys) {
-    const inL = Object.prototype.hasOwnProperty.call(lObj, key);
-    const inR = Object.prototype.hasOwnProperty.call(rObj, key);
-    const path = joinPath(parentPath, key, false);
-    const a = lObj[key];
-    const b = rObj[key];
+    const inL = hasL(key);
+    const inR = hasR(key);
+    const path = joinPath(parentPath, key, isIndex);
+    const a = getL(key);
+    const b = getR(key);
 
     if (inL && !inR) {
-      counts.removed++;
-      left.push({ path, keyLabel: key, depth, status: 'removed', kind: 'scalar', value: a });
-      right.push(gap(depth));
+      emitRemoved(path, key, depth, a, left, right, counts);
       continue;
     }
     if (!inL && inR) {
-      counts.added++;
-      left.push(gap(depth));
-      right.push({ path, keyLabel: key, depth, status: 'added', kind: 'scalar', value: b });
+      emitAdded(path, key, depth, b, left, right, counts);
       continue;
     }
 
-    // Present on both sides (Task 2: scalars only).
-    const equal = bsonEqual(a, b);
+    const aKind = valueKind(a);
+    const bKind = valueKind(b);
+
+    // Both are the same container kind -> emit an open line on both sides and recurse.
+    if (aKind === bKind && (aKind === 'object' || aKind === 'array')) {
+      const bracket = aKind === 'array' ? '[' : '{';
+      const closeBracket = aKind === 'array' ? ']' : '}';
+      const aChildren = aKind === 'array' ? (a as unknown[]).length : Object.keys(a as object).length;
+      const bChildren = bKind === 'array' ? (b as unknown[]).length : Object.keys(b as object).length;
+      left.push({ path, keyLabel: key, depth, status: 'unchanged', kind: aKind, bracket, childCount: aChildren });
+      right.push({ path, keyLabel: key, depth, status: 'unchanged', kind: bKind, bracket, childCount: bChildren });
+
+      const beforeChanged = counts.changed, beforeAdded = counts.added, beforeRemoved = counts.removed;
+      walkLevel(a, b, path, depth + 1, left, right, counts);
+
+      // Close lines.
+      left.push({ path, keyLabel: '', depth, status: 'unchanged', kind: aKind, bracket: closeBracket });
+      right.push({ path, keyLabel: '', depth, status: 'unchanged', kind: bKind, bracket: closeBracket });
+
+      // Mark the container "changed" (visually) if any descendant changed.
+      const touched =
+        counts.changed !== beforeChanged ||
+        counts.added !== beforeAdded ||
+        counts.removed !== beforeRemoved;
+      if (touched) {
+        const openIdxL = left.length - 1; // not used; container header status update below
+      }
+      // Re-tag the open lines as 'changed' when descendants differ.
+      if (touched) {
+        // open lines are the pair pushed just before recursion.
+        const openL = left.findIndex((l) => l.path === path && l.bracket === bracket);
+        const openR = right.findIndex((l) => l.path === path && l.bracket === bracket);
+        if (openL >= 0) left[openL] = { ...left[openL], status: 'changed' };
+        if (openR >= 0) right[openR] = { ...right[openR], status: 'changed' };
+      }
+      continue;
+    }
+
+    // Scalar-vs-scalar, or kind mismatch (scalar<->container): single line, no recurse.
+    const equal = aKind === 'scalar' && bKind === 'scalar' && bsonEqual(a, b);
     if (!equal) counts.changed++;
     const status: DiffStatus = equal ? 'unchanged' : 'changed';
     left.push({ path, keyLabel: key, depth, status, kind: 'scalar', value: a });
     right.push({ path, keyLabel: key, depth, status, kind: 'scalar', value: b });
+  }
+}
+
+function emitRemoved(
+  path: string, key: string, depth: number, a: unknown,
+  left: DiffLine[], right: DiffLine[], counts: Counts,
+): void {
+  counts.removed++;
+  const kind = valueKind(a);
+  if (kind === 'object' || kind === 'array') {
+    // Flatten the removed container as scalar-ish lines on the left only.
+    left.push({ path, keyLabel: key, depth, status: 'removed', kind, bracket: kind === 'array' ? '[' : '{', childCount: kind === 'array' ? (a as unknown[]).length : Object.keys(a as object).length });
+    right.push(gap(depth));
+    flattenOneSide(a, path, depth + 1, 'removed', left, right);
+    left.push({ path, keyLabel: '', depth, status: 'removed', kind, bracket: kind === 'array' ? ']' : '}' });
+    right.push(gap(depth));
+    return;
+  }
+  left.push({ path, keyLabel: key, depth, status: 'removed', kind: 'scalar', value: a });
+  right.push(gap(depth));
+}
+
+function emitAdded(
+  path: string, key: string, depth: number, b: unknown,
+  left: DiffLine[], right: DiffLine[], counts: Counts,
+): void {
+  counts.added++;
+  const kind = valueKind(b);
+  if (kind === 'object' || kind === 'array') {
+    right.push({ path, keyLabel: key, depth, status: 'added', kind, bracket: kind === 'array' ? '[' : '{', childCount: kind === 'array' ? (b as unknown[]).length : Object.keys(b as object).length });
+    left.push(gap(depth));
+    flattenOneSide(b, path, depth + 1, 'added', right, left);
+    right.push({ path, keyLabel: '', depth, status: 'added', kind, bracket: kind === 'array' ? ']' : '}' });
+    left.push(gap(depth));
+    return;
+  }
+  right.push({ path, keyLabel: key, depth, status: 'added', kind: 'scalar', value: b });
+  left.push(gap(depth));
+}
+
+// Emit every leaf of a one-sided (added or removed) container into `side`, with a
+// matching gap pushed into `other` so the two columns stay aligned.
+function flattenOneSide(
+  val: unknown, parentPath: string, depth: number, status: DiffStatus,
+  side: DiffLine[], other: DiffLine[],
+): void {
+  const isArr = Array.isArray(val);
+  const entries: [string, unknown][] = isArr
+    ? (val as unknown[]).map((v, i) => [String(i), v])
+    : Object.entries(val as Record<string, unknown>);
+  for (const [key, v] of entries) {
+    const path = joinPath(parentPath, key, isArr);
+    const kind = valueKind(v);
+    if (kind === 'object' || kind === 'array') {
+      side.push({ path, keyLabel: key, depth, status, kind, bracket: kind === 'array' ? '[' : '{', childCount: kind === 'array' ? (v as unknown[]).length : Object.keys(v as object).length });
+      other.push(gap(depth));
+      flattenOneSide(v, path, depth + 1, status, side, other);
+      side.push({ path, keyLabel: '', depth, status, kind, bracket: kind === 'array' ? ']' : '}' });
+      other.push(gap(depth));
+    } else {
+      side.push({ path, keyLabel: key, depth, status, kind: 'scalar', value: v });
+      other.push(gap(depth));
+    }
   }
 }

--- a/src/lib/docDiff.ts
+++ b/src/lib/docDiff.ts
@@ -1,0 +1,56 @@
+import { ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
+
+// A value is a "container" (recurse into it) only when it is a plain object or
+// array. BSON wrappers (ObjectId, Date, Long, …) are leaf scalars: we diff them
+// by value, never by walking their internal fields.
+export type ValueKind = 'object' | 'array' | 'scalar';
+
+export function isBsonScalar(val: unknown): boolean {
+  return (
+    val instanceof ObjectId ||
+    val instanceof Date ||
+    val instanceof Long ||
+    val instanceof Decimal128 ||
+    val instanceof Int32 ||
+    val instanceof Double ||
+    val instanceof Binary ||
+    val instanceof Timestamp
+  );
+}
+
+export function valueKind(val: unknown): ValueKind {
+  if (Array.isArray(val)) return 'array';
+  if (val !== null && typeof val === 'object' && !isBsonScalar(val)) return 'object';
+  return 'scalar';
+}
+
+// Unwrap a BSON numeric wrapper (or plain number) to a JS number, else NaN.
+function asNumber(val: unknown): number {
+  if (typeof val === 'number') return val;
+  if (val instanceof Int32 || val instanceof Double) return val.valueOf();
+  if (val instanceof Long) return val.toNumber();
+  if (val instanceof Decimal128) return Number(val.toString());
+  return NaN;
+}
+
+// Deep value equality for scalars and BSON wrappers. Containers are compared
+// recursively by the caller (diffDocuments), so this only needs to handle leaves.
+export function bsonEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+
+  // Numeric equivalence across plain numbers and BSON numeric wrappers.
+  const an = asNumber(a);
+  const bn = asNumber(b);
+  if (!Number.isNaN(an) && !Number.isNaN(bn)) return an === bn;
+
+  if (a instanceof ObjectId && b instanceof ObjectId) return a.equals(b);
+  if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+  if (a instanceof Decimal128 && b instanceof Decimal128) return a.toString() === b.toString();
+  if (a instanceof Binary && b instanceof Binary) {
+    return a.sub_type === b.sub_type && a.toString('base64') === b.toString('base64');
+  }
+  if (a instanceof Timestamp && b instanceof Timestamp) return a.toString() === b.toString();
+
+  // Anything else (mismatched kinds, distinct primitives) is unequal.
+  return false;
+}


### PR DESCRIPTION
Closes #92.

- **Compare with…** on any document's context menu (JSON, Table, and Tree views): arm a source document, then pick a second — a read-only side-by-side diff opens.
- **BSON-aware diff engine**: ObjectId/Date/Decimal128/Binary compared by value; nested objects and arrays diffed recursively with aligned left/right lines; stable key ordering; positional array alignment (LCS/move detection deliberately out of scope for v1).
- **Highlighting**: added / removed / changed tints with summary badges; gap rows where a key exists on one side only.
- Armed compare selection clears when the result set changes (no stale-document comparisons); an already-open diff survives background refreshes (it holds deep copies).
- Built on the standard Dialog primitives; read-only in v1 per the issue.

Verification: vitest 730/730 (with coverage), tsc clean; backend untouched.