### PR TITLE
feat: collection validation rules editor (#93)

### DIFF
--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -8,6 +8,14 @@ pub struct DatabaseRenameResult {
     pub documents: u64,
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionValidation {
+    pub validator: String,
+    pub validation_level: String,
+    pub validation_action: String,
+}
+
 pub async fn create_collection_impl(
     state: &AppState,
     id: &str,
@@ -117,6 +125,56 @@ pub async fn rename_collection_impl(
         .await
         .map(|_| ())
         .map_err(|e| format!("Failed to rename collection: {}", e))
+}
+
+pub async fn get_collection_options_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+) -> Result<CollectionValidation, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(CollectionValidation {
+            validator: "{}".into(),
+            validation_level: String::new(),
+            validation_action: String::new(),
+        });
+    }
+    let client = require_real_client(state, id)?;
+    let db = client.database(database);
+    let mut cursor = db
+        .list_collections()
+        .filter(mongodb::bson::doc! { "name": collection })
+        .await
+        .map_err(|e| format!("Failed to read collection options: {}", e))?;
+    use futures::stream::StreamExt;
+    let spec = match cursor.next().await {
+        Some(r) => r.map_err(|e| format!("Collection read error: {}", e))?,
+        None => return Err(format!("Collection \"{}\" not found", collection)),
+    };
+    let validator = match &spec.options.validator {
+        Some(doc) => serde_json::to_string_pretty(doc)
+            .map_err(|e| format!("Failed to serialize validator: {}", e))?,
+        None => "{}".to_string(),
+    };
+    let validation_level = match &spec.options.validation_level {
+        Some(mongodb::options::ValidationLevel::Off) => "off",
+        Some(mongodb::options::ValidationLevel::Moderate) => "moderate",
+        Some(mongodb::options::ValidationLevel::Strict) => "strict",
+        _ => "",
+    }
+    .to_string();
+    let validation_action = match &spec.options.validation_action {
+        Some(mongodb::options::ValidationAction::Error) => "error",
+        Some(mongodb::options::ValidationAction::Warn) => "warn",
+        _ => "",
+    }
+    .to_string();
+    Ok(CollectionValidation {
+        validator,
+        validation_level,
+        validation_action,
+    })
 }
 
 pub async fn drop_database_impl(state: &AppState, id: &str, database: &str) -> Result<(), String> {
@@ -374,5 +432,21 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.contains("validationLevel"));
+    }
+
+    #[tokio::test]
+    async fn test_get_collection_options_mock() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let opts = get_collection_options_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .expect("get collection options");
+
+        assert_eq!(opts.validator, "{}");
+        assert_eq!(opts.validation_level, "");
+        assert_eq!(opts.validation_action, "");
     }
 }

--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -302,3 +302,77 @@ pub async fn rename_database_impl(
         }
     }
 }
+
+// Helper functions for validation rules (Tasks 1-3)
+fn validation_level_value(level: Option<&str>) -> Result<Option<&str>, String> {
+    match level {
+        None | Some("") => Ok(None),
+        Some(v @ ("off" | "moderate" | "strict")) => Ok(Some(v)),
+        Some(other) => Err(format!("Invalid validationLevel: {}", other)),
+    }
+}
+
+fn validation_action_value(action: Option<&str>) -> Result<Option<&str>, String> {
+    match action {
+        None | Some("") => Ok(None),
+        Some(v @ ("error" | "warn")) => Ok(Some(v)),
+        Some(other) => Err(format!("Invalid validationAction: {}", other)),
+    }
+}
+
+fn build_collmod_command(
+    collection: &str,
+    validator: mongodb::bson::Document,
+    level: Option<&str>,
+    action: Option<&str>,
+) -> Result<mongodb::bson::Document, String> {
+    let mut cmd = mongodb::bson::doc! { "collMod": collection, "validator": validator };
+    if let Some(lvl) = validation_level_value(level)? {
+        cmd.insert("validationLevel", lvl);
+    }
+    if let Some(act) = validation_action_value(action)? {
+        cmd.insert("validationAction", act);
+    }
+    Ok(cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_collmod_full() {
+        let validator = mongodb::bson::doc! { "$jsonSchema": { "type": "object" } };
+        let result = build_collmod_command("test_coll", validator.clone(), Some("moderate"), Some("error"));
+
+        assert!(result.is_ok());
+        let cmd = result.unwrap();
+        assert_eq!(cmd.get_str("collMod").unwrap(), "test_coll");
+        assert!(cmd.contains_key("validator"));
+        assert_eq!(cmd.get_str("validationLevel").unwrap(), "moderate");
+        assert_eq!(cmd.get_str("validationAction").unwrap(), "error");
+    }
+
+    #[test]
+    fn test_build_collmod_empty_opts() {
+        let validator = mongodb::bson::doc! { "$jsonSchema": { "type": "object" } };
+        let result = build_collmod_command("test_coll", validator.clone(), Some(""), Some(""));
+
+        assert!(result.is_ok());
+        let cmd = result.unwrap();
+        assert_eq!(cmd.get_str("collMod").unwrap(), "test_coll");
+        assert!(cmd.contains_key("validator"));
+        assert!(!cmd.contains_key("validationLevel"));
+        assert!(!cmd.contains_key("validationAction"));
+    }
+
+    #[test]
+    fn test_build_collmod_invalid_level() {
+        let validator = mongodb::bson::doc! { "$jsonSchema": { "type": "object" } };
+        let result = build_collmod_command("test_coll", validator, Some("invalid"), Some("error"));
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("validationLevel"));
+    }
+}

--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -177,6 +177,52 @@ pub async fn get_collection_options_impl(
     })
 }
 
+pub async fn set_validator_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    validator: &str,
+    validation_level: &str,
+    validation_action: &str,
+) -> Result<(), String> {
+    if collection.trim().is_empty() {
+        return Err("Collection name is required".into());
+    }
+    let validator_val: serde_json::Value = if validator.trim().is_empty() {
+        serde_json::Value::Object(serde_json::Map::new())
+    } else {
+        serde_json::from_str(validator)
+            .map_err(|e| format!("Invalid validator JSON: {}", e))?
+    };
+    if !validator_val.is_object() {
+        return Err("Validator must be a JSON object".into());
+    }
+    let validator_doc = mongodb::bson::to_document(&validator_val)
+        .map_err(|e| format!("Failed to convert validator to BSON: {}", e))?;
+    let level = if validation_level.is_empty() {
+        None
+    } else {
+        Some(validation_level)
+    };
+    let action = if validation_action.is_empty() {
+        None
+    } else {
+        Some(validation_action)
+    };
+    let command = build_collmod_command(collection, validator_doc, level, action)?;
+    if connection_is_mock(state, id)? {
+        return Ok(());
+    }
+    let client = require_real_client(state, id)?;
+    client
+        .database(database)
+        .run_command(command)
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("Failed to apply validation rules: {}", e))
+}
+
 pub async fn drop_database_impl(state: &AppState, id: &str, database: &str) -> Result<(), String> {
     if database.trim().is_empty() {
         return Err("Database name is required".to_string());
@@ -448,5 +494,97 @@ mod tests {
         assert_eq!(opts.validator, "{}");
         assert_eq!(opts.validation_level, "");
         assert_eq!(opts.validation_action, "");
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_malformed_json() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "db",
+            "coll",
+            "{invalid json",
+            "moderate",
+            "error",
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid validator JSON"));
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_non_object_rejected() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(&state, &conn_id, "db", "coll", "[1,2,3]", "", "")
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be a JSON object"));
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_invalid_level_rejected() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "db",
+            "coll",
+            "{}",
+            "invalid_level",
+            "error",
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("validationLevel"));
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_empty_clears() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(&state, &conn_id, "db", "coll", "", "", "")
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_valid() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "db",
+            "coll",
+            r#"{"$jsonSchema": {"type": "object"}}"#,
+            "moderate",
+            "error",
+        )
+        .await;
+
+        assert!(result.is_ok());
     }
 }

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -19,6 +19,7 @@ mod integration {
         list_gridfs_files_impl, list_indexes_impl, preflight_copy_impl, rename_collection_impl,
         rename_database_impl, start_collection_copy_impl, start_collection_export_impl,
         start_database_copy_impl, update_document_impl, update_many_impl, upload_gridfs_file_impl,
+        get_collection_options_impl, set_validator_impl,
         AppState, CopyTargetRef,
     };
     use mongodb::bson::{doc, Document};
@@ -849,5 +850,48 @@ mod integration {
         assert!(ok_phases.contains(&TestPhase::Resolve));
         assert!(ok_phases.contains(&TestPhase::Connect));
         assert!(ok_phases.contains(&TestPhase::Ping));
+    }
+
+    #[tokio::test]
+    async fn it_set_and_get_validator() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+
+        let coll = "test_validator_coll";
+        create_collection_impl(&state, &id, &db, coll)
+            .await
+            .expect("create collection");
+
+        let validator_json = r#"{"$jsonSchema": {"type": "object", "properties": {"name": {"type": "string"}}}}"#;
+        set_validator_impl(
+            &state,
+            &id,
+            &db,
+            coll,
+            validator_json,
+            "moderate",
+            "error",
+        )
+        .await
+        .expect("set validator");
+
+        let opts = get_collection_options_impl(&state, &id, &db, coll)
+            .await
+            .expect("get collection options");
+
+        assert!(!opts.validator.is_empty(), "validator should not be empty");
+        assert_eq!(opts.validation_level, "moderate");
+        assert_eq!(opts.validation_action, "error");
+
+        // Verify the returned validator contains the $jsonSchema we set
+        let validator_val: serde_json::Value = serde_json::from_str(&opts.validator)
+            .expect("validator should be valid JSON");
+        assert!(
+            validator_val.get("$jsonSchema").is_some(),
+            "validator should contain $jsonSchema"
+        );
+
+        cleanup(&state, &id, &db).await;
     }
 }

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -894,4 +894,64 @@ mod integration {
 
         cleanup(&state, &id, &db).await;
     }
+
+    /// Regression guard for the `bson::to_document` human-readable extended-JSON
+    /// invariant: `set_validator_impl` converts the validator JSON via
+    /// `mongodb::bson::to_document`, a plain serde bridge — not the extended-JSON-aware
+    /// `Bson::try_from` used elsewhere in this crate — so wrapper keys like `$date` are
+    /// stored (and later re-serialized by `get_collection_options_impl`) as ordinary
+    /// nested documents rather than being parsed into real BSON types. This test proves
+    /// that behavior is stable across a get -> re-apply-unchanged -> get cycle: the
+    /// `$date` literal must survive untouched every time, not just on the first read.
+    #[tokio::test]
+    async fn it_validator_bson_types_round_trip() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+
+        let coll = "test_validator_bson_types_coll";
+        create_collection_impl(&state, &id, &db, coll)
+            .await
+            .expect("create collection");
+
+        let validator_json =
+            r#"{"created": {"$gte": {"$date": "2026-01-01T00:00:00Z"}}}"#;
+        set_validator_impl(&state, &id, &db, coll, validator_json, "moderate", "error")
+            .await
+            .expect("set validator with extended-JSON $date literal");
+
+        let opts1 = get_collection_options_impl(&state, &id, &db, coll)
+            .await
+            .expect("get collection options after initial set");
+        assert!(
+            opts1.validator.contains("$date"),
+            "extended JSON $date wrapper should survive the round trip, got: {}",
+            opts1.validator
+        );
+
+        // Re-apply the exact string we got back, unchanged.
+        set_validator_impl(
+            &state,
+            &id,
+            &db,
+            coll,
+            &opts1.validator,
+            &opts1.validation_level,
+            &opts1.validation_action,
+        )
+        .await
+        .expect("re-applying the returned validator unchanged should succeed");
+
+        let opts2 = get_collection_options_impl(&state, &id, &db, coll)
+            .await
+            .expect("get collection options after re-apply");
+        assert!(
+            opts2.validator.contains("$date"),
+            "extended JSON $date wrapper should still be present after a lossless \
+             get -> apply-unchanged -> get cycle, got: {}",
+            opts2.validator
+        );
+
+        cleanup(&state, &id, &db).await;
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ pub use db::aggregate::{execute_aggregate_impl, explain_aggregate_query_impl};
 pub use db::ddl::{
     create_collection_impl, create_view_impl, drop_collection_impl, drop_database_impl,
     rename_collection_impl, rename_database_impl, DatabaseRenameResult, CollectionValidation,
-    get_collection_options_impl,
+    get_collection_options_impl, set_validator_impl,
 };
 pub use db::documents::{
     delete_document_impl, delete_many_impl, import_documents_impl, insert_document_impl,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,8 @@ pub mod biometric;
 pub use db::aggregate::{execute_aggregate_impl, explain_aggregate_query_impl};
 pub use db::ddl::{
     create_collection_impl, create_view_impl, drop_collection_impl, drop_database_impl,
-    rename_collection_impl, rename_database_impl, DatabaseRenameResult,
+    rename_collection_impl, rename_database_impl, DatabaseRenameResult, CollectionValidation,
+    get_collection_options_impl,
 };
 pub use db::documents::{
     delete_document_impl, delete_many_impl, import_documents_impl, insert_document_impl,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1354,6 +1354,38 @@ async fn rename_collection(
 }
 
 #[tauri::command]
+async fn get_collection_options(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+    collection: String,
+) -> Result<CollectionValidation, String> {
+    get_collection_options_impl(&state, &id, &database, &collection).await
+}
+
+#[tauri::command]
+async fn set_validator(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+    collection: String,
+    validator: String,
+    validation_level: String,
+    validation_action: String,
+) -> Result<(), String> {
+    set_validator_impl(
+        &state,
+        &id,
+        &database,
+        &collection,
+        &validator,
+        &validation_level,
+        &validation_action,
+    )
+    .await
+}
+
+#[tauri::command]
 async fn drop_database(
     state: tauri::State<'_, AppState>,
     id: String,
@@ -1888,6 +1920,8 @@ pub fn run() {
             create_view,
             drop_collection,
             rename_collection,
+            get_collection_options,
+            set_validator,
             drop_database,
             rename_database,
             explain_mql_query,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -13,7 +13,7 @@ mod tests {
         list_indexes_impl, parse_json_array_docs,
         preview_export_impl, rename_collection_impl, rename_database_impl, sample_export_fields_impl,
         start_collection_export_impl, start_filtered_export_impl, update_document_impl,
-        upload_gridfs_file_impl,
+        upload_gridfs_file_impl, get_collection_options_impl,
     };
     use crate::{
         create_user_impl, drop_user_impl, list_roles_impl, list_users_impl, update_user_impl,
@@ -212,6 +212,22 @@ mod tests {
             .find(|c| c.name == "customers")
             .expect("customers still listed");
         assert_eq!(customers.collection_type, "collection");
+    }
+
+    #[tokio::test]
+    async fn test_get_collection_options_mock_path() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let opts = get_collection_options_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .expect("get collection options");
+
+        assert_eq!(opts.validator, "{}");
+        assert_eq!(opts.validation_level, "");
+        assert_eq!(opts.validation_action, "");
     }
 
     // Issue #114: demo mode returns a synthetic replica set so the Cluster

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -13,7 +13,7 @@ mod tests {
         list_indexes_impl, parse_json_array_docs,
         preview_export_impl, rename_collection_impl, rename_database_impl, sample_export_fields_impl,
         start_collection_export_impl, start_filtered_export_impl, update_document_impl,
-        upload_gridfs_file_impl, get_collection_options_impl,
+        upload_gridfs_file_impl, get_collection_options_impl, set_validator_impl,
     };
     use crate::{
         create_user_impl, drop_user_impl, list_roles_impl, list_users_impl, update_user_impl,
@@ -228,6 +228,27 @@ mod tests {
         assert_eq!(opts.validator, "{}");
         assert_eq!(opts.validation_level, "");
         assert_eq!(opts.validation_action, "");
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_mock_path() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            r#"{"$jsonSchema": {"type": "object"}}"#,
+            "moderate",
+            "error",
+        )
+        .await;
+
+        assert!(result.is_ok());
     }
 
     // Issue #114: demo mode returns a synthetic replica set so the Cluster

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -251,6 +251,31 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[tokio::test]
+    async fn test_validator_get_set_roundtrip() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let opts = get_collection_options_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .expect("get collection options");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            &opts.validator,
+            &opts.validation_level,
+            &opts.validation_action,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
     // Issue #114: demo mode returns a synthetic replica set so the Cluster
     // tab is populated without a live cluster — including a lagging
     // secondary so the warning styling is visible.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import {
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
 import { CreateViewView } from './components/CreateViewView';
+import { ValidationRulesView } from './components/ValidationRulesView';
 import { GridFsView } from './components/GridFsView';
 import { MonitoringView } from './components/MonitoringView';
 import { UserManagementView } from './components/UserManagementView';
@@ -57,12 +58,12 @@ import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
-import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap } from 'lucide-react';
+import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 interface QueryTab {
   id: string;
-  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users' | 'dump' | 'restore';
+  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users' | 'dump' | 'restore' | 'validation';
   connectionId: string;
   db: string;
   collection: string;
@@ -212,6 +213,8 @@ const tabIconFor = (tab: QueryTab, isActive: boolean): React.ReactNode => {
       return <DatabaseBackup size={size} className={className} />;
     case 'restore':
       return <DatabaseZap size={size} className={className} />;
+    case 'validation':
+      return <ShieldCheck size={size} className={className} />;
     default:
       return <FolderCode size={size} className={className} />;
   }
@@ -250,6 +253,8 @@ const tabLabelFor = (
       return `Dump: ${tab.db || connectionName(tab.connectionId)}`;
     case 'restore':
       return `Restore: ${connectionName(tab.connectionId)}`;
+    case 'validation':
+      return `Validation: ${tab.collection}`;
     default:
       return tab.collection;
   }
@@ -993,6 +998,25 @@ function Workspace() {
         connectionId,
         db,
         collection: '',
+        results: [],
+        loading: false,
+        error: null,
+        explainResult: null,
+      }]);
+    }
+    setActiveTabId(tabId);
+  };
+
+  // #93: open a Validation Rules tab for a collection.
+  const handleOpenValidationTab = (connectionId: string, db: string, collection: string) => {
+    const tabId = `validation.${connectionId}.${db}.${collection}`;
+    if (!tabs.some(t => t.id === tabId)) {
+      setTabs(prev => [...prev, {
+        id: tabId,
+        type: 'validation',
+        connectionId,
+        db,
+        collection,
         results: [],
         loading: false,
         error: null,
@@ -1955,6 +1979,7 @@ function Workspace() {
           onOpenMonitoring={handleOpenMonitoringTab}
           onOpenUsers={handleOpenUsersTab}
           onAnalyzeSchema={handleOpenSchemaTab}
+          onEditValidation={handleOpenValidationTab}
           onCreateView={handleOpenCreateViewTab}
           onOpenGridfs={handleOpenGridfsTab}
           onOpenDump={handleOpenDumpTab}
@@ -2261,6 +2286,14 @@ function Workspace() {
                     setCollectionMutationTrigger(prev => prev + 1);
                     handleSelectCollection(activeTab.connectionId, activeTab.db, viewName);
                   }}
+                />
+              )}
+              {activeTab && activeTab.type === 'validation' && (
+                <ValidationRulesView
+                  connectionId={activeTab.connectionId}
+                  databaseName={activeTab.db}
+                  collectionName={activeTab.collection}
+                  onApplied={() => setCollectionMutationTrigger(prev => prev + 1)}
                 />
               )}
               {activeTab && activeTab.type === 'gridfs' && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1327,7 +1327,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               <Table2 />
               <span>Analyze Schema</span>
             </ContextMenuItem>
-            {collType !== 'view' && !collName.startsWith('system.') && !/\.(files|chunks)$/.test(collName) && (
+            {collType !== 'view' && collType !== 'timeseries' && !collName.startsWith('system.') && !/\.(files|chunks)$/.test(collName) && (
               <ContextMenuItem className={ctxItemClass} onClick={() => onEditValidation?.(connId, dbName, collName)}>
                 <ShieldCheck />
                 <span>Validation Rules</span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -95,6 +95,7 @@ import {
   Copy,
   DatabaseBackup,
   DatabaseZap,
+  ShieldCheck,
 } from 'lucide-react';
 
 const REPO_URL = 'https://github.com/mqlens/mqlens-mongodb';
@@ -182,6 +183,7 @@ interface SidebarProps {
   onOpenMonitoring?: (connectionId: string) => void;
   onOpenUsers?: (connectionId: string, db?: string) => void;
   onAnalyzeSchema?: (connectionId: string, dbName: string, collName: string) => void;
+  onEditValidation?: (connectionId: string, dbName: string, collName: string) => void;
   onCreateView?: (connectionId: string, dbName: string) => void;
   onOpenGridfs?: (connectionId: string, dbName: string, bucket: string) => void;
   /** Open a Dump tab scoped to the whole connection, a database, or a single collection. */
@@ -303,6 +305,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onOpenMonitoring,
   onOpenUsers,
   onAnalyzeSchema,
+  onEditValidation,
   onCreateView,
   onOpenGridfs,
   onOpenDump,
@@ -1323,6 +1326,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
             <ContextMenuItem className={ctxItemClass} onClick={() => onAnalyzeSchema?.(connId, dbName, collName)}>
               <Table2 />
               <span>Analyze Schema</span>
+            </ContextMenuItem>
+            <ContextMenuItem className={ctxItemClass} onClick={() => onEditValidation?.(connId, dbName, collName)}>
+              <ShieldCheck />
+              <span>Validation Rules</span>
             </ContextMenuItem>
             {!isMockConnection(connId) && (
               <ContextMenuItem

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1327,10 +1327,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
               <Table2 />
               <span>Analyze Schema</span>
             </ContextMenuItem>
-            <ContextMenuItem className={ctxItemClass} onClick={() => onEditValidation?.(connId, dbName, collName)}>
-              <ShieldCheck />
-              <span>Validation Rules</span>
-            </ContextMenuItem>
+            {collType !== 'view' && !collName.startsWith('system.') && !/\.(files|chunks)$/.test(collName) && (
+              <ContextMenuItem className={ctxItemClass} onClick={() => onEditValidation?.(connId, dbName, collName)}>
+                <ShieldCheck />
+                <span>Validation Rules</span>
+              </ContextMenuItem>
+            )}
             {!isMockConnection(connId) && (
               <ContextMenuItem
                 className={ctxItemClass}

--- a/src/components/ValidationRulesView.tsx
+++ b/src/components/ValidationRulesView.tsx
@@ -124,7 +124,10 @@ export const ValidationRulesView: React.FC<ValidationRulesViewProps> = ({
             <QueryEditor
               surface="filter"
               value={validator}
-              onChange={setValidator}
+              onChange={(v) => {
+                setValidator(v);
+                setSuccess(false);
+              }}
               fields={['_id']}
               height={220}
               data-testid="validation-editor"
@@ -139,7 +142,10 @@ export const ValidationRulesView: React.FC<ValidationRulesViewProps> = ({
               <Label>Validation Level</Label>
               <Select
                 value={validationLevel || NONE_VALUE}
-                onValueChange={(v) => setValidationLevel(v === NONE_VALUE ? '' : v)}
+                onValueChange={(v) => {
+                  setValidationLevel(v === NONE_VALUE ? '' : v);
+                  setSuccess(false);
+                }}
               >
                 <SelectTrigger data-testid="validation-level-select">
                   <SelectValue placeholder="(default)" />
@@ -157,7 +163,10 @@ export const ValidationRulesView: React.FC<ValidationRulesViewProps> = ({
               <Label>Validation Action</Label>
               <Select
                 value={validationAction || NONE_VALUE}
-                onValueChange={(v) => setValidationAction(v === NONE_VALUE ? '' : v)}
+                onValueChange={(v) => {
+                  setValidationAction(v === NONE_VALUE ? '' : v);
+                  setSuccess(false);
+                }}
               >
                 <SelectTrigger data-testid="validation-action-select">
                   <SelectValue placeholder="(default)" />

--- a/src/components/ValidationRulesView.tsx
+++ b/src/components/ValidationRulesView.tsx
@@ -1,0 +1,208 @@
+import React, { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { ShieldCheck, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { QueryEditor } from './QueryEditor';
+
+interface ValidationRulesViewProps {
+  connectionId: string;
+  databaseName: string;
+  collectionName: string;
+  /** Called after a successful `set_validator` apply. */
+  onApplied: () => void;
+}
+
+interface CollectionValidationUi {
+  validator: string;
+  validationLevel: string;
+  validationAction: string;
+}
+
+const NONE_VALUE = '__none__';
+
+export const ValidationRulesView: React.FC<ValidationRulesViewProps> = ({
+  connectionId,
+  databaseName,
+  collectionName,
+  onApplied,
+}) => {
+  const [validator, setValidator] = useState('{}');
+  const [validationLevel, setValidationLevel] = useState('');
+  const [validationAction, setValidationAction] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [applying, setApplying] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+    (async () => {
+      try {
+        const result = await invoke<CollectionValidationUi>('get_collection_options', {
+          id: connectionId,
+          database: databaseName,
+          collection: collectionName,
+        });
+        if (cancelled) return;
+        setValidator(result.validator ?? '{}');
+        setValidationLevel(result.validationLevel ?? '');
+        setValidationAction(result.validationAction ?? '');
+      } catch (err: any) {
+        if (!cancelled) setError(String(err?.message || err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [connectionId, databaseName, collectionName]);
+
+  const handleApply = async () => {
+    setError(null);
+    setSuccess(false);
+    const trimmed = validator.trim();
+    if (trimmed) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch (e: any) {
+        setError(`Invalid validator JSON: ${e?.message || 'syntax error'}`);
+        return;
+      }
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        setError('Validator must be a JSON object.');
+        return;
+      }
+    }
+
+    setApplying(true);
+    try {
+      await invoke('set_validator', {
+        id: connectionId,
+        database: databaseName,
+        collection: collectionName,
+        validator,
+        validationLevel,
+        validationAction,
+      });
+      setSuccess(true);
+      onApplied();
+    } catch (err: any) {
+      setError(String(err?.message || err));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-auto" data-testid="validation-rules-view">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold text-foreground">
+        <ShieldCheck size={14} className="text-success" />
+        <span>Validation Rules — {collectionName}</span>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
+          <Loader2 size={13} className="animate-spin" /> Loading validation rules…
+        </div>
+      ) : (
+        <div className="flex max-w-[640px] flex-col gap-4 p-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="validation-editor">Validator (JSON Schema)</Label>
+            <QueryEditor
+              surface="filter"
+              value={validator}
+              onChange={setValidator}
+              fields={['_id']}
+              height={220}
+              data-testid="validation-editor"
+            />
+            <p className="text-xs text-muted-foreground">
+              Leave empty and apply to clear validation for this collection.
+            </p>
+          </div>
+
+          <div className="flex gap-4">
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label>Validation Level</Label>
+              <Select
+                value={validationLevel || NONE_VALUE}
+                onValueChange={(v) => setValidationLevel(v === NONE_VALUE ? '' : v)}
+              >
+                <SelectTrigger data-testid="validation-level-select">
+                  <SelectValue placeholder="(default)" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NONE_VALUE}>(default)</SelectItem>
+                  <SelectItem value="off">off</SelectItem>
+                  <SelectItem value="moderate">moderate</SelectItem>
+                  <SelectItem value="strict">strict</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label>Validation Action</Label>
+              <Select
+                value={validationAction || NONE_VALUE}
+                onValueChange={(v) => setValidationAction(v === NONE_VALUE ? '' : v)}
+              >
+                <SelectTrigger data-testid="validation-action-select">
+                  <SelectValue placeholder="(default)" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NONE_VALUE}>(default)</SelectItem>
+                  <SelectItem value="error">error</SelectItem>
+                  <SelectItem value="warn">warn</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {error && (
+            <div
+              className="flex items-center gap-2 font-mono text-xs text-destructive"
+              data-testid="validation-error"
+            >
+              <AlertCircle size={13} className="flex-shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {success && !error && (
+            <div
+              className="flex items-center gap-2 font-mono text-xs text-success"
+              data-testid="validation-success"
+            >
+              <CheckCircle2 size={13} className="flex-shrink-0" />
+              <span>Validation rules applied.</span>
+            </div>
+          )}
+
+          <div>
+            <Button
+              type="button"
+              data-testid="validation-apply-btn"
+              onClick={handleApply}
+              disabled={applying}
+            >
+              {applying ? 'Applying…' : 'Apply'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 
 // Mock Sidebar component
 vi.mock('../Sidebar', () => ({
-  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings, onOpenDump, onOpenRestore }: any) => (
+  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings, onOpenDump, onOpenRestore, onEditValidation }: any) => (
     <div data-testid="mock-sidebar">
       <button data-testid="select-collection-btn" onClick={() => onSelectCollection('conn-1', 'sales_db', 'customers')}>
         Select Collection
@@ -84,6 +84,12 @@ vi.mock('../Sidebar', () => ({
       </button>
       <button data-testid="open-restore-btn" onClick={() => onOpenRestore && onOpenRestore('conn-1')}>
         Restore
+      </button>
+      <button
+        data-testid="open-validation-btn"
+        onClick={() => onEditValidation && onEditValidation('conn-1', 'sales_db', 'customers')}
+      >
+        Validation Rules
       </button>
     </div>
   ),
@@ -867,6 +873,31 @@ describe('App Component', () => {
 
     expect(await screen.findByTestId('restore-view')).toBeInTheDocument();
     expect(screen.getByText('Restore: conn-1')).toBeInTheDocument();
+  });
+
+  it('opens the Validation Rules tab from the collection context menu', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({ validator: '{}', validationLevel: '', validationAction: '' });
+      }
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-validation-btn'));
+
+    expect(await screen.findByTestId('validation-rules-view')).toBeInTheDocument();
+    expect(screen.getByText('Validation: customers')).toBeInTheDocument();
+    await waitFor(() => {
+      const opts = calls.find((c) => c.cmd === 'get_collection_options');
+      expect(opts).toBeTruthy();
+      expect(opts.args).toMatchObject({ id: 'conn-1', database: 'sales_db', collection: 'customers' });
+    });
   });
 
   const managedStatusesFixture = [

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -982,6 +982,42 @@ describe('Sidebar Component', () => {
     expect(handleOpenDump).toHaveBeenCalledWith('conn-1', 'sales_db', 'customers');
   });
 
+  it('opens Validation Rules from the collection context menu', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases' && args.id === 'conn-1') {
+        return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections' && args.id === 'conn-1' && args.db === 'sales_db') {
+        return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    const handleEditValidation = vi.fn();
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Prod DB Server', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onEditValidation={handleEditValidation}
+      />
+    );
+
+    const dbNode = await screen.findByText('sales_db');
+    fireEvent.click(dbNode);
+    const collectionsFolder = await screen.findByText('Collections');
+    fireEvent.click(collectionsFolder);
+    const collectionNode = await screen.findByText('customers');
+    fireEvent.contextMenu(collectionNode);
+    fireEvent.click(screen.getByText('Validation Rules'));
+    expect(handleEditValidation).toHaveBeenCalledWith('conn-1', 'sales_db', 'customers');
+  });
+
   it('hides Dump/Restore context-menu items for mock connections', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases' && args.id === 'conn-1') {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -1018,6 +1018,50 @@ describe('Sidebar Component', () => {
     expect(handleEditValidation).toHaveBeenCalledWith('conn-1', 'sales_db', 'customers');
   });
 
+  it('hides Validation Rules for views but shows it for regular collections (#93)', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases' && args.id === 'conn-1') {
+        return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections' && args.id === 'conn-1' && args.db === 'sales_db') {
+        return Promise.resolve([
+          { name: 'customers', type: 'collection' },
+          { name: 'active_users', type: 'view' },
+        ]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Prod DB Server', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onEditValidation={vi.fn()}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('sales_db'));
+
+    // Views live in their own folder — expand it and right-click the view row.
+    fireEvent.click(await screen.findByText('Views'));
+    const viewNode = await screen.findByText('active_users');
+    fireEvent.contextMenu(viewNode);
+    expect(screen.queryByText('Validation Rules')).not.toBeInTheDocument();
+    expect(screen.getByText('Analyze Schema')).toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    // Regular collection still offers it.
+    fireEvent.click(await screen.findByText('Collections'));
+    const collectionNode = await screen.findByText('customers');
+    fireEvent.contextMenu(collectionNode);
+    expect(screen.getByText('Validation Rules')).toBeInTheDocument();
+  });
+
   it('hides Dump/Restore context-menu items for mock connections', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases' && args.id === 'conn-1') {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -1062,6 +1062,49 @@ describe('Sidebar Component', () => {
     expect(screen.getByText('Validation Rules')).toBeInTheDocument();
   });
 
+  it('hides Validation Rules for time-series collections but shows it for regular collections (#93)', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases' && args.id === 'conn-1') {
+        return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections' && args.id === 'conn-1' && args.db === 'sales_db') {
+        return Promise.resolve([
+          { name: 'customers', type: 'collection' },
+          { name: 'sensor_readings', type: 'timeseries' },
+        ]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Prod DB Server', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onEditValidation={vi.fn()}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('sales_db'));
+    fireEvent.click(await screen.findByText('Collections'));
+
+    // Time-series collection: MongoDB rejects collMod validators on these.
+    const tsNode = await screen.findByText('sensor_readings');
+    fireEvent.contextMenu(tsNode);
+    expect(screen.queryByText('Validation Rules')).not.toBeInTheDocument();
+    expect(screen.getByText('Analyze Schema')).toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    // Regular collection still offers it.
+    const collectionNode = screen.getByText('customers');
+    fireEvent.contextMenu(collectionNode);
+    expect(screen.getByText('Validation Rules')).toBeInTheDocument();
+  });
+
   it('hides Dump/Restore context-menu items for mock connections', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases' && args.id === 'conn-1') {

--- a/src/components/__tests__/ValidationRulesView.test.tsx
+++ b/src/components/__tests__/ValidationRulesView.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-with-providers';
+import { ValidationRulesView } from '../ValidationRulesView';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: any[]) => mockInvoke(...args),
+}));
+
+vi.mock('../QueryEditor', () => ({
+  QueryEditor: ({
+    value,
+    onChange,
+    'data-testid': testId,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    'data-testid'?: string;
+  }) => (
+    <textarea
+      data-testid={testId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+describe('ValidationRulesView', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('loads existing rules on mount', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({
+          validator: '{"$jsonSchema":{"bsonType":"object"}}',
+          validationLevel: 'moderate',
+          validationAction: 'warn',
+        });
+      }
+      return Promise.reject(new Error(`unhandled ${cmd}`));
+    });
+
+    renderWithProviders(
+      <ValidationRulesView
+        connectionId="c1"
+        databaseName="shop"
+        collectionName="customers"
+        onApplied={() => {}}
+      />
+    );
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('get_collection_options', {
+        id: 'c1',
+        database: 'shop',
+        collection: 'customers',
+      })
+    );
+
+    const editor = await screen.findByTestId('validation-editor');
+    expect(editor).toHaveValue('{"$jsonSchema":{"bsonType":"object"}}');
+    expect(screen.getByTestId('validation-level-select')).toHaveTextContent('moderate');
+    expect(screen.getByTestId('validation-action-select')).toHaveTextContent('warn');
+  });
+
+  it('rejects invalid validator JSON before calling set_validator', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({ validator: '{}', validationLevel: '', validationAction: '' });
+      }
+      return Promise.resolve();
+    });
+
+    renderWithProviders(
+      <ValidationRulesView
+        connectionId="c1"
+        databaseName="shop"
+        collectionName="customers"
+        onApplied={() => {}}
+      />
+    );
+
+    const editor = await screen.findByTestId('validation-editor');
+    fireEvent.change(editor, { target: { value: '{ not json' } });
+    fireEvent.click(screen.getByTestId('validation-apply-btn'));
+
+    expect(await screen.findByTestId('validation-error')).toBeInTheDocument();
+    expect(mockInvoke).not.toHaveBeenCalledWith('set_validator', expect.anything());
+  });
+
+  it('applies rules via set_validator with the exact payload and calls onApplied', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({ validator: '{}', validationLevel: '', validationAction: '' });
+      }
+      if (cmd === 'set_validator') return Promise.resolve();
+      return Promise.reject(new Error(`unhandled ${cmd}`));
+    });
+
+    const onApplied = vi.fn();
+    renderWithProviders(
+      <ValidationRulesView
+        connectionId="c1"
+        databaseName="shop"
+        collectionName="customers"
+        onApplied={onApplied}
+      />
+    );
+
+    const editor = await screen.findByTestId('validation-editor');
+    fireEvent.change(editor, {
+      target: { value: '{"$jsonSchema":{"bsonType":"object"}}' },
+    });
+
+    fireEvent.click(screen.getByTestId('validation-level-select'));
+    fireEvent.click(screen.getByRole('option', { name: 'strict' }));
+    fireEvent.click(screen.getByTestId('validation-action-select'));
+    fireEvent.click(screen.getByRole('option', { name: 'error' }));
+
+    fireEvent.click(screen.getByTestId('validation-apply-btn'));
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('set_validator', {
+        id: 'c1',
+        database: 'shop',
+        collection: 'customers',
+        validator: '{"$jsonSchema":{"bsonType":"object"}}',
+        validationLevel: 'strict',
+        validationAction: 'error',
+      })
+    );
+    await waitFor(() => expect(onApplied).toHaveBeenCalled());
+  });
+
+  it('applies an empty validator to clear validation rules', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({
+          validator: '{"$jsonSchema":{"bsonType":"object"}}',
+          validationLevel: 'strict',
+          validationAction: 'error',
+        });
+      }
+      if (cmd === 'set_validator') return Promise.resolve();
+      return Promise.reject(new Error(`unhandled ${cmd}`));
+    });
+
+    const onApplied = vi.fn();
+    renderWithProviders(
+      <ValidationRulesView
+        connectionId="c1"
+        databaseName="shop"
+        collectionName="customers"
+        onApplied={onApplied}
+      />
+    );
+
+    const editor = await screen.findByTestId('validation-editor');
+    fireEvent.change(editor, { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('validation-apply-btn'));
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('set_validator', {
+        id: 'c1',
+        database: 'shop',
+        collection: 'customers',
+        validator: '',
+        validationLevel: 'strict',
+        validationAction: 'error',
+      })
+    );
+    await waitFor(() => expect(onApplied).toHaveBeenCalled());
+  });
+});

--- a/src/components/__tests__/ValidationRulesView.test.tsx
+++ b/src/components/__tests__/ValidationRulesView.test.tsx
@@ -131,6 +131,14 @@ describe('ValidationRulesView', () => {
       })
     );
     await waitFor(() => expect(onApplied).toHaveBeenCalled());
+
+    expect(await screen.findByTestId('validation-success')).toBeInTheDocument();
+
+    fireEvent.change(editor, {
+      target: { value: '{"$jsonSchema":{"bsonType":"object","required":["email"]}}' },
+    });
+
+    expect(screen.queryByTestId('validation-success')).not.toBeInTheDocument();
   });
 
   it('applies an empty validator to clear validation rules', async () => {


### PR DESCRIPTION
Closes #93.

- **Validation Rules** tab from a collection's context menu: view and edit the collection's `$jsonSchema` validator, `validationLevel` (off/moderate/strict), and `validationAction` (error/warn), applied via `collMod`.
- Monaco JSON editor for the validator; client-side JSON validation plus independent backend validation (defense in depth); an empty validator clears validation (canonical collMod behavior).
- The menu entry only appears on real collections — views, `system.*`, and GridFS `.files`/`.chunks` rows are gated (collMod would only fail there).
- Mock connections no-op; a server-gated integration test round-trips create → set → get.

Verification: cargo 259/259, vitest 716/716 (with coverage), tsc clean.