### PR TITLE
fix: remove native title tooltips from sidebar and fix Import URI dro…

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1945,7 +1945,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                       <span>Import URI</span>
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start">
+                  <DropdownMenuContent align="start" className={NESTED_SELECT_Z}>
                     <DropdownMenuItem onClick={handleImportFromClipboard} data-testid="import-from-clipboard">
                       From clipboard
                     </DropdownMenuItem>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1230,7 +1230,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               />
               {collType === 'timeseries' ? (
                 <span
-                  title="Time-series collection"
+                  aria-label="Time-series collection"
                   data-testid="coll-icon-timeseries"
                   className="flex shrink-0 items-center"
                 >
@@ -1239,7 +1239,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               ) : (
                 <Layers size={11} className={cn('shrink-0', isActive ? 'text-primary' : 'text-emerald-500')} />
               )}
-              <span className="min-w-0 truncate" title={collName}>
+              <span className="min-w-0 truncate">
                 {collName}
               </span>
             </div>
@@ -1521,14 +1521,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         <span
                           className="h-2 w-2 shrink-0 rounded-full"
                           style={{ backgroundColor: conn.color_tag }}
-                          title="Connection color"
+                          aria-label="Connection color"
                         />
                       )}
                       <Server size={12} className="shrink-0 text-primary" />
                       <span className="min-w-0 truncate font-medium">{conn.name}</span>
                       <span
                         className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
-                        title="Connected"
+                        aria-label="Connected"
                       />
                     </div>
                     <Button
@@ -1539,7 +1539,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         e.stopPropagation();
                         loadDatabases(conn.id);
                       }}
-                      title="Refresh Databases"
                       aria-label="Refresh databases"
                     >
                       <RefreshCw className="size-3" />
@@ -1552,7 +1551,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         e.stopPropagation();
                         onDisconnect(conn.id);
                       }}
-                      title="Disconnect Connection"
                       aria-label="Disconnect"
                     >
                       <LogOut className="size-3" />
@@ -1847,7 +1845,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                       size="icon"
                                       className="ml-auto h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
                                       data-testid={`collections-new-${conn.id}-${dbName}`}
-                                      title="New collection"
+                                      aria-label="New collection"
                                       onClick={(e) => {
                                         e.stopPropagation();
                                         void handleAddCollection(conn.id, dbName);
@@ -1933,7 +1931,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                       size="icon"
                                       className="ml-auto h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
                                       data-testid={`gridfs-new-bucket-${conn.id}-${dbName}`}
-                                      title="New bucket"
+                                      aria-label="New bucket"
                                       onClick={(e) => {
                                         e.stopPropagation();
                                         void handleOpenGridfsBucket(conn.id, dbName);
@@ -1951,7 +1949,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                           onClick={() => onOpenGridfs?.(conn.id, dbName, bucket)}
                                         >
                                           <Archive size={11} className="ml-3.5 shrink-0 text-emerald-500" />
-                                          <span className="min-w-0 truncate" title={bucket}>
+                                          <span className="min-w-0 truncate">
                                             {bucket}
                                           </span>
                                         </div>
@@ -2044,7 +2042,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           <span className="text-ui-xs font-semibold tracking-wide">MQLens Workspace</span>
         </div>
         <div className="flex items-center gap-0.5">
-          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onOpenSettings} title="Settings" aria-label="Open Settings">
+          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onOpenSettings} aria-label="Open Settings">
             <Settings className="size-3.5" />
           </Button>
           <DropdownMenu>
@@ -2053,7 +2051,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 variant="ghost"
                 size="icon"
                 className="h-7 w-7"
-                title="Help & feedback"
                 aria-label="Help and feedback"
                 data-testid="help-menu-btn"
               >
@@ -2074,7 +2071,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
             size="icon"
             className="h-7 w-7"
             onClick={onOpenConnectionManager}
-            title="Manage Connections"
             aria-label="Manage Connections"
           >
             <Plus className="size-3.5" />
@@ -2165,7 +2161,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                     : 'text-emerald-500',
                               )}
                             />
-                            <span className="min-w-0 truncate" title={label}>
+                            <span className="min-w-0 truncate">
                               {label}
                             </span>
                             <span className="ml-auto truncate text-[10px] text-muted-foreground">
@@ -2229,7 +2225,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                           <div
                             className={treeRowClass()}
                             onClick={() => void navigateToFavorite(fav)}
-                            title={`${fav.connectionName}${fav.db ? ` · ${fav.db}` : ''}${fav.collection ? `.${fav.collection}` : ''}`}
                           >
                             <FavIcon
                               size={10}
@@ -2324,7 +2319,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                   key={profile.id}
                                   className={treeRowClass()}
                                   onClick={() => onConnectProfile?.(profile)}
-                                  title={profile.name}
                                 >
                                   <Server
                                     size={11}
@@ -2337,7 +2331,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                   {isConnected && (
                                     <span
                                       className="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
-                                      title="Connected"
+                                      aria-label="Connected"
                                     />
                                   )}
                                 </div>
@@ -2357,7 +2351,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                           key={profile.id}
                           className={treeRowClass()}
                           onClick={() => onConnectProfile?.(profile)}
-                          title={profile.name}
                         >
                           <Server
                             size={11}

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -290,7 +290,7 @@ describe('Sidebar Component', () => {
     // generic Layers icon.
     const tsIcons = screen.getAllByTestId('coll-icon-timeseries');
     expect(tsIcons).toHaveLength(1);
-    expect(tsIcons[0]).toHaveAttribute('title', 'Time-series collection');
+    expect(tsIcons[0]).toHaveAttribute('aria-label', 'Time-series collection');
     expect(tsIcons[0].closest('div')).toHaveTextContent('sensor_readings');
   });
 
@@ -1287,7 +1287,7 @@ describe('Sidebar Component', () => {
       />
     );
 
-    expect(await screen.findByTitle('Connection color')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Connection color')).toBeInTheDocument();
     expect(screen.getByText('Staging')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Native HTML title attributes rendered as black rectangles on Linux/WebKitGTK (Tauri webview). Replace with aria-label for accessibility without broken tooltips.

The Import URI DropdownMenuContent in the editor dialog was at z-50 while the dialog itself is at z-[100], making options unreachable. Apply NESTED_SELECT_Z (z-[110]) consistent with other Select components in the same dialog.

<!-- Thanks for contributing to MQLens! PRs target the `dev` branch. -->

## Summary

<!-- What does this change and why? -->

## Related issue

<!-- e.g. Closes #123 -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` (Vitest) passes
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` passes (if backend touched)
- [ ] Manually verified in the running app (`npm run tauri dev`)

## Screenshots

<!-- For UI changes, before/after screenshots help. -->

## Checklist

- [ ] This PR targets `dev` (not `main`)
- [ ] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [ ] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
