### PR TITLE
release: v0.12 (#184)

### DIFF
--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -8,6 +8,14 @@ pub struct DatabaseRenameResult {
     pub documents: u64,
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionValidation {
+    pub validator: String,
+    pub validation_level: String,
+    pub validation_action: String,
+}
+
 pub async fn create_collection_impl(
     state: &AppState,
     id: &str,
@@ -117,6 +125,102 @@ pub async fn rename_collection_impl(
         .await
         .map(|_| ())
         .map_err(|e| format!("Failed to rename collection: {}", e))
+}
+
+pub async fn get_collection_options_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+) -> Result<CollectionValidation, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(CollectionValidation {
+            validator: "{}".into(),
+            validation_level: String::new(),
+            validation_action: String::new(),
+        });
+    }
+    let client = require_real_client(state, id)?;
+    let db = client.database(database);
+    let mut cursor = db
+        .list_collections()
+        .filter(mongodb::bson::doc! { "name": collection })
+        .await
+        .map_err(|e| format!("Failed to read collection options: {}", e))?;
+    use futures::stream::StreamExt;
+    let spec = match cursor.next().await {
+        Some(r) => r.map_err(|e| format!("Collection read error: {}", e))?,
+        None => return Err(format!("Collection \"{}\" not found", collection)),
+    };
+    let validator = match &spec.options.validator {
+        Some(doc) => serde_json::to_string_pretty(doc)
+            .map_err(|e| format!("Failed to serialize validator: {}", e))?,
+        None => "{}".to_string(),
+    };
+    let validation_level = match &spec.options.validation_level {
+        Some(mongodb::options::ValidationLevel::Off) => "off",
+        Some(mongodb::options::ValidationLevel::Moderate) => "moderate",
+        Some(mongodb::options::ValidationLevel::Strict) => "strict",
+        _ => "",
+    }
+    .to_string();
+    let validation_action = match &spec.options.validation_action {
+        Some(mongodb::options::ValidationAction::Error) => "error",
+        Some(mongodb::options::ValidationAction::Warn) => "warn",
+        _ => "",
+    }
+    .to_string();
+    Ok(CollectionValidation {
+        validator,
+        validation_level,
+        validation_action,
+    })
+}
+
+pub async fn set_validator_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    validator: &str,
+    validation_level: &str,
+    validation_action: &str,
+) -> Result<(), String> {
+    if collection.trim().is_empty() {
+        return Err("Collection name is required".into());
+    }
+    let validator_val: serde_json::Value = if validator.trim().is_empty() {
+        serde_json::Value::Object(serde_json::Map::new())
+    } else {
+        serde_json::from_str(validator)
+            .map_err(|e| format!("Invalid validator JSON: {}", e))?
+    };
+    if !validator_val.is_object() {
+        return Err("Validator must be a JSON object".into());
+    }
+    let validator_doc = mongodb::bson::to_document(&validator_val)
+        .map_err(|e| format!("Failed to convert validator to BSON: {}", e))?;
+    let level = if validation_level.is_empty() {
+        None
+    } else {
+        Some(validation_level)
+    };
+    let action = if validation_action.is_empty() {
+        None
+    } else {
+        Some(validation_action)
+    };
+    let command = build_collmod_command(collection, validator_doc, level, action)?;
+    if connection_is_mock(state, id)? {
+        return Ok(());
+    }
+    let client = require_real_client(state, id)?;
+    client
+        .database(database)
+        .run_command(command)
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("Failed to apply validation rules: {}", e))
 }
 
 pub async fn drop_database_impl(state: &AppState, id: &str, database: &str) -> Result<(), String> {
@@ -300,5 +404,187 @@ pub async fn rename_database_impl(
             let _ = target_db.drop().await;
             Err(err)
         }
+    }
+}
+
+// Helper functions for validation rules (Tasks 1-3)
+fn validation_level_value(level: Option<&str>) -> Result<Option<&str>, String> {
+    match level {
+        None | Some("") => Ok(None),
+        Some(v @ ("off" | "moderate" | "strict")) => Ok(Some(v)),
+        Some(other) => Err(format!("Invalid validationLevel: {}", other)),
+    }
+}
+
+fn validation_action_value(action: Option<&str>) -> Result<Option<&str>, String> {
+    match action {
+        None | Some("") => Ok(None),
+        Some(v @ ("error" | "warn")) => Ok(Some(v)),
+        Some(other) => Err(format!("Invalid validationAction: {}", other)),
+    }
+}
+
+fn build_collmod_command(
+    collection: &str,
+    validator: mongodb::bson::Document,
+    level: Option<&str>,
+    action: Option<&str>,
+) -> Result<mongodb::bson::Document, String> {
+    let mut cmd = mongodb::bson::doc! { "collMod": collection, "validator": validator };
+    if let Some(lvl) = validation_level_value(level)? {
+        cmd.insert("validationLevel", lvl);
+    }
+    if let Some(act) = validation_action_value(action)? {
+        cmd.insert("validationAction", act);
+    }
+    Ok(cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_collmod_full() {
+        let validator = mongodb::bson::doc! { "$jsonSchema": { "type": "object" } };
+        let result = build_collmod_command("test_coll", validator.clone(), Some("moderate"), Some("error"));
+
+        assert!(result.is_ok());
+        let cmd = result.unwrap();
+        assert_eq!(cmd.get_str("collMod").unwrap(), "test_coll");
+        assert!(cmd.contains_key("validator"));
+        assert_eq!(cmd.get_str("validationLevel").unwrap(), "moderate");
+        assert_eq!(cmd.get_str("validationAction").unwrap(), "error");
+    }
+
+    #[test]
+    fn test_build_collmod_empty_opts() {
+        let validator = mongodb::bson::doc! { "$jsonSchema": { "type": "object" } };
+        let result = build_collmod_command("test_coll", validator.clone(), Some(""), Some(""));
+
+        assert!(result.is_ok());
+        let cmd = result.unwrap();
+        assert_eq!(cmd.get_str("collMod").unwrap(), "test_coll");
+        assert!(cmd.contains_key("validator"));
+        assert!(!cmd.contains_key("validationLevel"));
+        assert!(!cmd.contains_key("validationAction"));
+    }
+
+    #[test]
+    fn test_build_collmod_invalid_level() {
+        let validator = mongodb::bson::doc! { "$jsonSchema": { "type": "object" } };
+        let result = build_collmod_command("test_coll", validator, Some("invalid"), Some("error"));
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("validationLevel"));
+    }
+
+    #[tokio::test]
+    async fn test_get_collection_options_mock() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let opts = get_collection_options_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .expect("get collection options");
+
+        assert_eq!(opts.validator, "{}");
+        assert_eq!(opts.validation_level, "");
+        assert_eq!(opts.validation_action, "");
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_malformed_json() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "db",
+            "coll",
+            "{invalid json",
+            "moderate",
+            "error",
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid validator JSON"));
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_non_object_rejected() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(&state, &conn_id, "db", "coll", "[1,2,3]", "", "")
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be a JSON object"));
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_invalid_level_rejected() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "db",
+            "coll",
+            "{}",
+            "invalid_level",
+            "error",
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("validationLevel"));
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_empty_clears() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(&state, &conn_id, "db", "coll", "", "", "")
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_valid() {
+        let state = crate::AppState::new();
+        let conn_id = crate::connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "db",
+            "coll",
+            r#"{"$jsonSchema": {"type": "object"}}"#,
+            "moderate",
+            "error",
+        )
+        .await;
+
+        assert!(result.is_ok());
     }
 }

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -11,6 +11,7 @@ pub mod metadata;
 pub mod mongotools;
 pub mod query;
 pub mod schema;
+pub mod stats;
 pub mod tasks;
 pub mod users;
 pub mod version;

--- a/src-tauri/src/db/stats.rs
+++ b/src-tauri/src/db/stats.rs
@@ -1,0 +1,294 @@
+//! Database / collection / index statistics for the sidebar stats popovers
+//! (#178). Same shape as monitoring.rs: pure curation functions (unit-tested)
+//! + async `*_impl` wrappers with mock branches for demo mode.
+
+use crate::{connection_is_mock, require_real_client, AppState};
+use mongodb::bson::{doc, Bson, Document};
+use serde::Serialize;
+
+fn num(d: &Document, key: &str) -> i64 {
+    match d.get(key) {
+        Some(Bson::Int32(v)) => *v as i64,
+        Some(Bson::Int64(v)) => *v,
+        Some(Bson::Double(v)) => *v as i64,
+        _ => 0,
+    }
+}
+fn fnum(d: &Document, key: &str) -> f64 {
+    match d.get(key) {
+        Some(Bson::Int32(v)) => *v as f64,
+        Some(Bson::Int64(v)) => *v as f64,
+        Some(Bson::Double(v)) => *v,
+        _ => 0.0,
+    }
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DbStatsUi {
+    pub collections: i64,
+    pub views: i64,
+    pub objects: i64,
+    pub avg_obj_size: f64,
+    pub data_size: i64,
+    pub storage_size: i64,
+    pub indexes: i64,
+    pub total_index_size: i64,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CollStatsUi {
+    pub count: i64,
+    pub avg_obj_size: f64,
+    pub size: i64,
+    pub storage_size: i64,
+    pub nindexes: i64,
+    pub total_index_size: i64,
+    pub capped: bool,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexStatUi {
+    pub name: String,
+    pub size_bytes: i64,
+    /// Accesses since the counter started ($indexStats); 0 when unavailable.
+    pub ops: i64,
+    pub since_ms: i64,
+}
+
+/// Curate a raw `dbStats` command reply.
+pub fn curate_db_stats(raw: &Document) -> DbStatsUi {
+    DbStatsUi {
+        collections: num(raw, "collections"),
+        views: num(raw, "views"),
+        objects: num(raw, "objects"),
+        avg_obj_size: fnum(raw, "avgObjSize"),
+        data_size: num(raw, "dataSize"),
+        storage_size: num(raw, "storageSize"),
+        indexes: num(raw, "indexes"),
+        total_index_size: num(raw, "totalIndexSize"),
+    }
+}
+
+/// Curate the `storageStats` subdocument of a `$collStats` aggregation result.
+pub fn curate_coll_stats(storage: &Document) -> CollStatsUi {
+    CollStatsUi {
+        count: num(storage, "count"),
+        avg_obj_size: fnum(storage, "avgObjSize"),
+        size: num(storage, "size"),
+        storage_size: num(storage, "storageSize"),
+        nindexes: num(storage, "nindexes"),
+        total_index_size: num(storage, "totalIndexSize"),
+        capped: storage.get_bool("capped").unwrap_or(false),
+    }
+}
+
+/// Join `$collStats.storageStats.indexSizes` (authoritative index list) with
+/// `$indexStats` usage docs; indexes missing from `$indexStats` report zero
+/// usage. Sorted by on-disk size, largest first.
+pub fn curate_index_stats(index_sizes: &Document, stats_docs: &[Document]) -> Vec<IndexStatUi> {
+    let usage = |name: &str| -> (i64, i64) {
+        stats_docs
+            .iter()
+            .find(|d| d.get_str("name").ok() == Some(name))
+            .and_then(|d| d.get_document("accesses").ok())
+            .map(|a| {
+                let since = match a.get("since") {
+                    Some(Bson::DateTime(dt)) => dt.timestamp_millis(),
+                    _ => 0,
+                };
+                (num(a, "ops"), since)
+            })
+            .unwrap_or((0, 0))
+    };
+    let mut out: Vec<IndexStatUi> = index_sizes
+        .iter()
+        .map(|(name, size)| {
+            let (ops, since_ms) = usage(name);
+            IndexStatUi {
+                name: name.clone(),
+                size_bytes: match size {
+                    Bson::Int32(v) => *v as i64,
+                    Bson::Int64(v) => *v,
+                    Bson::Double(v) => *v as i64,
+                    _ => 0,
+                },
+                ops,
+                since_ms,
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes));
+    out
+}
+
+// ── Mock data (demo connections) ─────────────────────────────────────────────
+
+fn mock_db_stats(db: &str) -> DbStatsUi {
+    match db {
+        "sales_db" => DbStatsUi { collections: 4, views: 0, objects: 12, avg_obj_size: 512.0, data_size: 6_144, storage_size: 24_576, indexes: 10, total_index_size: 40_960 },
+        "user_analytics" => DbStatsUi { collections: 2, views: 0, objects: 6, avg_obj_size: 384.0, data_size: 2_304, storage_size: 12_288, indexes: 5, total_index_size: 20_480 },
+        _ => DbStatsUi { collections: 2, views: 0, objects: 2, avg_obj_size: 128.0, data_size: 256, storage_size: 8_192, indexes: 2, total_index_size: 8_192 },
+    }
+}
+
+fn mock_coll_stats() -> CollStatsUi {
+    CollStatsUi { count: 3, avg_obj_size: 512.0, size: 1_536, storage_size: 8_192, nindexes: 3, total_index_size: 12_288, capped: false }
+}
+
+fn mock_index_stats(db: &str, coll: &str) -> Vec<IndexStatUi> {
+    crate::mock_db::get_mock_indexes(db, coll)
+        .into_iter()
+        .enumerate()
+        .map(|(i, info)| IndexStatUi {
+            name: info.name.clone(),
+            size_bytes: 36_864 - (i as i64) * 8_192,
+            ops: if info.name == "_id_" { 10_500 } else { 42 * (i as i64 + 1) },
+            since_ms: 1_749_427_200_000,
+        })
+        .collect()
+}
+
+// ── Async command impls ──────────────────────────────────────────────────────
+
+pub async fn db_stats_impl(state: &AppState, id: &str, db: &str) -> Result<DbStatsUi, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(mock_db_stats(db));
+    }
+    let client = require_real_client(state, id)?;
+    let raw = client
+        .database(db)
+        .run_command(doc! { "dbStats": 1 })
+        .await
+        .map_err(|e| format!("dbStats failed: {}", e))?;
+    Ok(curate_db_stats(&raw))
+}
+
+/// Run `$collStats {storageStats}` and return the first result's storageStats.
+async fn coll_storage_stats(
+    client: &mongodb::Client,
+    db: &str,
+    coll: &str,
+) -> Result<Document, String> {
+    use futures::stream::StreamExt;
+    let mut cursor = client
+        .database(db)
+        .collection::<Document>(coll)
+        .aggregate(vec![doc! { "$collStats": { "storageStats": {} } }])
+        .await
+        .map_err(|e| format!("collStats failed: {}", e))?;
+    match cursor.next().await {
+        Some(Ok(d)) => Ok(d.get_document("storageStats").cloned().unwrap_or_default()),
+        Some(Err(e)) => Err(format!("collStats cursor error: {}", e)),
+        None => Ok(Document::new()),
+    }
+}
+
+pub async fn coll_stats_impl(state: &AppState, id: &str, db: &str, coll: &str) -> Result<CollStatsUi, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(mock_coll_stats());
+    }
+    let client = require_real_client(state, id)?;
+    let storage = coll_storage_stats(&client, db, coll).await?;
+    Ok(curate_coll_stats(&storage))
+}
+
+pub async fn index_stats_impl(state: &AppState, id: &str, db: &str, coll: &str) -> Result<Vec<IndexStatUi>, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(mock_index_stats(db, coll));
+    }
+    let client = require_real_client(state, id)?;
+    let storage = coll_storage_stats(&client, db, coll).await?;
+    let index_sizes = storage.get_document("indexSizes").cloned().unwrap_or_default();
+    use futures::stream::StreamExt;
+    let mut stats_docs: Vec<Document> = Vec::new();
+    // $indexStats can fail on views / old servers — degrade to zero usage.
+    if let Ok(mut cursor) = client
+        .database(db)
+        .collection::<Document>(coll)
+        .aggregate(vec![doc! { "$indexStats": {} }])
+        .await
+    {
+        while let Some(Ok(d)) = cursor.next().await {
+            stats_docs.push(d);
+        }
+    }
+    Ok(curate_index_stats(&index_sizes, &stats_docs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mongodb::bson::{doc, DateTime};
+
+    #[test]
+    fn curates_db_stats_subset() {
+        let raw = doc! {
+            "db": "sales_db", "collections": 4i32, "views": 1i32, "objects": 12_345i64,
+            "avgObjSize": 512.5, "dataSize": 6_324_712i64, "storageSize": 2_502_656i64,
+            "indexes": 9i32, "totalIndexSize": 1_105_920i64, "ok": 1.0,
+        };
+        let s = curate_db_stats(&raw);
+        assert_eq!(s.collections, 4);
+        assert_eq!(s.views, 1);
+        assert_eq!(s.objects, 12_345);
+        assert_eq!(s.avg_obj_size, 512.5);
+        assert_eq!(s.data_size, 6_324_712);
+        assert_eq!(s.storage_size, 2_502_656);
+        assert_eq!(s.indexes, 9);
+        assert_eq!(s.total_index_size, 1_105_920);
+    }
+
+    #[test]
+    fn db_stats_resilient_to_missing_fields() {
+        let s = curate_db_stats(&doc! { "db": "x" });
+        assert_eq!(s, DbStatsUi::default());
+    }
+
+    #[test]
+    fn curates_coll_stats_from_storage_stats() {
+        let storage = doc! {
+            "count": 5_000i64, "avgObjSize": 256i32, "size": 1_280_000i64,
+            "storageSize": 540_672i64, "nindexes": 3i32, "totalIndexSize": 122_880i64,
+            "capped": false,
+        };
+        let s = curate_coll_stats(&storage);
+        assert_eq!(s.count, 5_000);
+        assert_eq!(s.avg_obj_size, 256.0);
+        assert_eq!(s.size, 1_280_000);
+        assert_eq!(s.storage_size, 540_672);
+        assert_eq!(s.nindexes, 3);
+        assert_eq!(s.total_index_size, 122_880);
+        assert!(!s.capped);
+    }
+
+    #[test]
+    fn curates_index_stats_joining_sizes_and_usage() {
+        let sizes = doc! { "_id_": 36_864i64, "email_1": 20_480i64, "unused_1": 8_192i64 };
+        let stats = vec![
+            doc! { "name": "_id_", "accesses": { "ops": 10_500i64, "since": DateTime::from_millis(1_700_000_000_000) } },
+            doc! { "name": "email_1", "accesses": { "ops": 42i64, "since": DateTime::from_millis(1_700_000_000_000) } },
+            // "unused_1" intentionally absent from $indexStats output.
+        ];
+        let out = curate_index_stats(&sizes, &stats);
+        assert_eq!(out.len(), 3);
+        let id = out.iter().find(|i| i.name == "_id_").unwrap();
+        assert_eq!(id.size_bytes, 36_864);
+        assert_eq!(id.ops, 10_500);
+        assert_eq!(id.since_ms, 1_700_000_000_000);
+        let unused = out.iter().find(|i| i.name == "unused_1").unwrap();
+        assert_eq!(unused.size_bytes, 8_192);
+        assert_eq!(unused.ops, 0, "index absent from $indexStats reports zero usage");
+        assert_eq!(unused.since_ms, 0);
+    }
+
+    #[test]
+    fn index_stats_sorted_by_size_desc() {
+        let sizes = doc! { "small_1": 100i64, "big_1": 900i64 };
+        let out = curate_index_stats(&sizes, &[]);
+        assert_eq!(out[0].name, "big_1");
+        assert_eq!(out[1].name, "small_1");
+    }
+}

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -19,6 +19,7 @@ mod integration {
         list_gridfs_files_impl, list_indexes_impl, preflight_copy_impl, rename_collection_impl,
         rename_database_impl, start_collection_copy_impl, start_collection_export_impl,
         start_database_copy_impl, update_document_impl, update_many_impl, upload_gridfs_file_impl,
+        get_collection_options_impl, set_validator_impl,
         AppState, CopyTargetRef,
     };
     use mongodb::bson::{doc, Document};
@@ -849,5 +850,108 @@ mod integration {
         assert!(ok_phases.contains(&TestPhase::Resolve));
         assert!(ok_phases.contains(&TestPhase::Connect));
         assert!(ok_phases.contains(&TestPhase::Ping));
+    }
+
+    #[tokio::test]
+    async fn it_set_and_get_validator() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+
+        let coll = "test_validator_coll";
+        create_collection_impl(&state, &id, &db, coll)
+            .await
+            .expect("create collection");
+
+        let validator_json = r#"{"$jsonSchema": {"type": "object", "properties": {"name": {"type": "string"}}}}"#;
+        set_validator_impl(
+            &state,
+            &id,
+            &db,
+            coll,
+            validator_json,
+            "moderate",
+            "error",
+        )
+        .await
+        .expect("set validator");
+
+        let opts = get_collection_options_impl(&state, &id, &db, coll)
+            .await
+            .expect("get collection options");
+
+        assert!(!opts.validator.is_empty(), "validator should not be empty");
+        assert_eq!(opts.validation_level, "moderate");
+        assert_eq!(opts.validation_action, "error");
+
+        // Verify the returned validator contains the $jsonSchema we set
+        let validator_val: serde_json::Value = serde_json::from_str(&opts.validator)
+            .expect("validator should be valid JSON");
+        assert!(
+            validator_val.get("$jsonSchema").is_some(),
+            "validator should contain $jsonSchema"
+        );
+
+        cleanup(&state, &id, &db).await;
+    }
+
+    /// Regression guard for the `bson::to_document` human-readable extended-JSON
+    /// invariant: `set_validator_impl` converts the validator JSON via
+    /// `mongodb::bson::to_document`, a plain serde bridge — not the extended-JSON-aware
+    /// `Bson::try_from` used elsewhere in this crate — so wrapper keys like `$date` are
+    /// stored (and later re-serialized by `get_collection_options_impl`) as ordinary
+    /// nested documents rather than being parsed into real BSON types. This test proves
+    /// that behavior is stable across a get -> re-apply-unchanged -> get cycle: the
+    /// `$date` literal must survive untouched every time, not just on the first read.
+    #[tokio::test]
+    async fn it_validator_bson_types_round_trip() {
+        let Some((state, id, db)) = connect().await else {
+            return;
+        };
+
+        let coll = "test_validator_bson_types_coll";
+        create_collection_impl(&state, &id, &db, coll)
+            .await
+            .expect("create collection");
+
+        let validator_json =
+            r#"{"created": {"$gte": {"$date": "2026-01-01T00:00:00Z"}}}"#;
+        set_validator_impl(&state, &id, &db, coll, validator_json, "moderate", "error")
+            .await
+            .expect("set validator with extended-JSON $date literal");
+
+        let opts1 = get_collection_options_impl(&state, &id, &db, coll)
+            .await
+            .expect("get collection options after initial set");
+        assert!(
+            opts1.validator.contains("$date"),
+            "extended JSON $date wrapper should survive the round trip, got: {}",
+            opts1.validator
+        );
+
+        // Re-apply the exact string we got back, unchanged.
+        set_validator_impl(
+            &state,
+            &id,
+            &db,
+            coll,
+            &opts1.validator,
+            &opts1.validation_level,
+            &opts1.validation_action,
+        )
+        .await
+        .expect("re-applying the returned validator unchanged should succeed");
+
+        let opts2 = get_collection_options_impl(&state, &id, &db, coll)
+            .await
+            .expect("get collection options after re-apply");
+        assert!(
+            opts2.validator.contains("$date"),
+            "extended JSON $date wrapper should still be present after a lossless \
+             get -> apply-unchanged -> get cycle, got: {}",
+            opts2.validator
+        );
+
+        cleanup(&state, &id, &db).await;
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,8 @@ pub mod biometric;
 pub use db::aggregate::{execute_aggregate_impl, explain_aggregate_query_impl};
 pub use db::ddl::{
     create_collection_impl, create_view_impl, drop_collection_impl, drop_database_impl,
-    rename_collection_impl, rename_database_impl, DatabaseRenameResult,
+    rename_collection_impl, rename_database_impl, DatabaseRenameResult, CollectionValidation,
+    get_collection_options_impl, set_validator_impl,
 };
 pub use db::documents::{
     delete_document_impl, delete_many_impl, import_documents_impl, insert_document_impl,
@@ -51,6 +52,7 @@ pub use db::metadata::{
     create_index_impl, delete_index_impl, list_collections_impl, list_databases_impl,
     list_indexes_impl,
 };
+pub use db::stats::{db_stats_impl, coll_stats_impl, index_stats_impl};
 pub use db::query::{count_documents_impl, execute_mql_query_impl, explain_mql_query_impl};
 pub use db::schema::{analyze_schema_impl, infer_schema, FieldStat, SchemaReport, TypeCount};
 pub use db::users::{
@@ -931,6 +933,35 @@ async fn list_indexes(
     list_indexes_impl(&state, &id, &db, &collection).await
 }
 
+#[tauri::command]
+async fn db_stats(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    db: String,
+) -> Result<db::stats::DbStatsUi, String> {
+    db::stats::db_stats_impl(&state, &id, &db).await
+}
+
+#[tauri::command]
+async fn coll_stats(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    db: String,
+    collection: String,
+) -> Result<db::stats::CollStatsUi, String> {
+    db::stats::coll_stats_impl(&state, &id, &db, &collection).await
+}
+
+#[tauri::command]
+async fn index_stats(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    db: String,
+    collection: String,
+) -> Result<Vec<db::stats::IndexStatUi>, String> {
+    db::stats::index_stats_impl(&state, &id, &db, &collection).await
+}
+
 // ── Cluster monitoring ────────────────────────────────────────────────────────
 
 #[tauri::command]
@@ -947,6 +978,14 @@ async fn current_ops(
     id: String,
 ) -> Result<Vec<monitoring::CurrentOp>, String> {
     monitoring::current_ops_impl(&state, &id).await
+}
+
+#[tauri::command]
+async fn repl_set_status(
+    state: tauri::State<'_, AppState>,
+    id: String,
+) -> Result<monitoring::ReplSetStatus, String> {
+    monitoring::repl_set_status_impl(&state, &id).await
 }
 
 #[tauri::command]
@@ -1312,6 +1351,38 @@ async fn rename_collection(
     to: String,
 ) -> Result<(), String> {
     rename_collection_impl(&state, &id, &database, &from, &to).await
+}
+
+#[tauri::command]
+async fn get_collection_options(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+    collection: String,
+) -> Result<CollectionValidation, String> {
+    get_collection_options_impl(&state, &id, &database, &collection).await
+}
+
+#[tauri::command]
+async fn set_validator(
+    state: tauri::State<'_, AppState>,
+    id: String,
+    database: String,
+    collection: String,
+    validator: String,
+    validation_level: String,
+    validation_action: String,
+) -> Result<(), String> {
+    set_validator_impl(
+        &state,
+        &id,
+        &database,
+        &collection,
+        &validator,
+        &validation_level,
+        &validation_action,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -1815,6 +1886,9 @@ pub fn run() {
             list_databases,
             list_collections,
             list_indexes,
+            db_stats,
+            coll_stats,
+            index_stats,
             create_index,
             delete_index,
             delete_document,
@@ -1846,6 +1920,8 @@ pub fn run() {
             create_view,
             drop_collection,
             rename_collection,
+            get_collection_options,
+            set_validator,
             drop_database,
             rename_database,
             explain_mql_query,
@@ -1876,6 +1952,7 @@ pub fn run() {
             queries::list_all_saved_queries,
             server_status,
             current_ops,
+            repl_set_status,
             kill_op,
             list_users,
             create_user,

--- a/src-tauri/src/mock_db.rs
+++ b/src-tauri/src/mock_db.rs
@@ -145,19 +145,38 @@ pub fn execute_mock_query(
 }
 
 pub fn get_mock_explain(database: &str, collection: &str, filter: &str) -> String {
+    // Only sales_db.transactions returns a COLLSCAN plan, so the index-suggestion
+    // banner has somewhere to demo without a real server. Every other namespace
+    // keeps the pre-existing IXSCAN shape.
+    let winning_plan = if database == "sales_db" && collection == "transactions" {
+        serde_json::json!({
+            "stage": "SORT",
+            "sortPattern": { "timestamp": -1 },
+            "inputStage": { "stage": "COLLSCAN" }
+        })
+    } else {
+        serde_json::json!({
+            "stage": "IXSCAN",
+            "keyPattern": { "category": 1 },
+            "indexName": "category_1",
+            "isMultiKey": false,
+            "direction": "forward"
+        })
+    };
+
+    let parsed_query = if database == "sales_db" && collection == "transactions" {
+        serde_json::json!({ "$and": [ { "customer_name": { "$eq": "Alice Smith" } } ] })
+    } else {
+        serde_json::from_str::<serde_json::Value>(filter).unwrap_or_default()
+    };
+
     let plan = serde_json::json!({
         "explainVersion": "1",
         "queryPlanner": {
             "namespace": format!("{}.{}", database, collection),
             "indexFilterSet": false,
-            "parsedQuery": serde_json::from_str::<serde_json::Value>(filter).unwrap_or_default(),
-            "winningPlan": {
-                "stage": "IXSCAN",
-                "keyPattern": { "category": 1 },
-                "indexName": "category_1",
-                "isMultiKey": false,
-                "direction": "forward"
-            }
+            "parsedQuery": parsed_query,
+            "winningPlan": winning_plan
         },
         "executionStats": {
             "executionSuccess": true,

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -227,6 +227,107 @@ pub fn curate_profile_entry(d: &Document) -> ProfileEntry {
     }
 }
 
+// ── Replica-set health (issue #114) ──────────────────────────────────────────
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplSetMember {
+    pub name: String,
+    pub state_str: String,
+    pub health: i64,
+    #[serde(rename = "self")]
+    pub self_member: bool,
+    pub uptime_secs: i64,
+    pub optime_date_ms: i64,
+    pub ping_ms: Option<i64>,
+    pub sync_source: String,
+    /// Seconds behind the primary; None for the primary itself and whenever
+    /// the set has no primary (election in progress).
+    pub lag_secs: Option<f64>,
+}
+
+#[derive(Serialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplSetStatus {
+    /// false = standalone server (replSetGetStatus said NoReplicationEnabled).
+    pub is_replica_set: bool,
+    /// "replicaSet" | "sharded" | "standalone"
+    pub cluster_type: String,
+    pub set: String,
+    pub my_state_str: String,
+    pub mongo_version: String,
+    pub members: Vec<ReplSetMember>,
+}
+
+/// Classify a `hello` response: mongos advertises msg "isdbgrid", replica-set
+/// members carry setName, anything else is a standalone server.
+pub fn classify_topology(hello: &Document) -> &'static str {
+    if hello.get_str("msg").ok() == Some("isdbgrid") {
+        return "sharded";
+    }
+    if hello.get_str("setName").is_ok() {
+        return "replicaSet";
+    }
+    "standalone"
+}
+
+/// Curate a raw `replSetGetStatus` document. Lag per non-primary member is
+/// primary optimeDate − member optimeDate (clamped at 0); without a primary
+/// there is no reference point, so lag stays None.
+pub fn curate_repl_set_status(raw: &Document, mongo_version: &str) -> ReplSetStatus {
+    let raw_members: Vec<&Document> = raw
+        .get_array("members")
+        .map(|a| a.iter().filter_map(|b| b.as_document()).collect())
+        .unwrap_or_default();
+    let optime_ms = |m: &Document| match m.get("optimeDate") {
+        Some(Bson::DateTime(dt)) => dt.timestamp_millis(),
+        _ => 0,
+    };
+    let primary_optime_ms = raw_members
+        .iter()
+        .find(|m| m.get_str("stateStr").ok() == Some("PRIMARY"))
+        .map(|m| optime_ms(m));
+
+    let members: Vec<ReplSetMember> = raw_members
+        .iter()
+        .map(|m| {
+            let state_str = m.get_str("stateStr").unwrap_or_default().to_string();
+            let optime_date_ms = optime_ms(m);
+            let health = num(m, "health");
+            let lag_secs = if state_str == "PRIMARY" || health != 1 || optime_date_ms == 0 {
+                None
+            } else {
+                primary_optime_ms.map(|p| ((p - optime_date_ms).max(0)) as f64 / 1000.0)
+            };
+            ReplSetMember {
+                name: m.get_str("name").unwrap_or_default().to_string(),
+                health,
+                self_member: m.get_bool("self").unwrap_or(false),
+                uptime_secs: num(m, "uptime"),
+                optime_date_ms,
+                ping_ms: m.get("pingMs").map(|_| num(m, "pingMs")),
+                sync_source: m.get_str("syncSourceHost").unwrap_or_default().to_string(),
+                state_str,
+                lag_secs,
+            }
+        })
+        .collect();
+    let my_state_str = members
+        .iter()
+        .find(|m| m.self_member)
+        .map(|m| m.state_str.clone())
+        .unwrap_or_default();
+
+    ReplSetStatus {
+        is_replica_set: true,
+        cluster_type: "replicaSet".to_string(),
+        set: raw.get_str("set").unwrap_or_default().to_string(),
+        my_state_str,
+        mongo_version: mongo_version.to_string(),
+        members,
+    }
+}
+
 // ── Mock data (demo connections) ──────────────────────────────────────────────
 
 fn mock_server_status() -> ServerStatus {
@@ -240,6 +341,33 @@ fn mock_server_status() -> ServerStatus {
         network: Network { bytes_in: 8_400_000, bytes_out: 19_200_000, num_requests: 64_000 },
         cache: Some(CacheStats { bytes_in_cache: 268_435_456, max_bytes: 536_870_912, dirty_bytes: 12_582_912 }),
         repl_set: None,
+    }
+}
+
+fn mock_repl_set_status() -> ReplSetStatus {
+    let now = 1_749_427_200_000i64;
+    let member = |name: &str, state: &str, self_m: bool, uptime: i64, optime: i64, ping: Option<i64>, sync: &str, lag: Option<f64>| ReplSetMember {
+        name: name.into(),
+        state_str: state.into(),
+        health: 1,
+        self_member: self_m,
+        uptime_secs: uptime,
+        optime_date_ms: optime,
+        ping_ms: ping,
+        sync_source: sync.into(),
+        lag_secs: lag,
+    };
+    ReplSetStatus {
+        is_replica_set: true,
+        cluster_type: "replicaSet".into(),
+        set: "rs0".into(),
+        my_state_str: "PRIMARY".into(),
+        mongo_version: "7.0.0".into(),
+        members: vec![
+            member("mqlens-demo:27017", "PRIMARY", true, 86_400, now, None, "", None),
+            member("mqlens-demo-2:27017", "SECONDARY", false, 86_300, now - 800, Some(1), "mqlens-demo:27017", Some(0.8)),
+            member("mqlens-demo-3:27017", "SECONDARY", false, 4_200, now - 42_000, Some(3), "mqlens-demo:27017", Some(42.0)),
+        ],
     }
 }
 
@@ -372,6 +500,53 @@ pub async fn read_profile_impl(
     Ok(out)
 }
 
+pub async fn repl_set_status_impl(state: &AppState, id: &str) -> Result<ReplSetStatus, String> {
+    if connection_is_mock(state, id)? {
+        return Ok(mock_repl_set_status());
+    }
+    let client = require_real_client(state, id)?;
+    let admin = client.database("admin");
+    let hello = admin
+        .run_command(doc! { "hello": 1 })
+        .await
+        .map_err(|e| format!("hello failed: {}", e))?;
+    // Server version applies to every topology; buildInfo needs no privileges.
+    let version = match admin.run_command(doc! { "buildInfo": 1 }).await {
+        Ok(b) => b.get_str("version").unwrap_or_default().to_string(),
+        Err(_) => String::new(),
+    };
+    let cluster_type = classify_topology(&hello);
+    if cluster_type != "replicaSet" {
+        return Ok(ReplSetStatus {
+            cluster_type: cluster_type.to_string(),
+            mongo_version: version,
+            ..Default::default()
+        });
+    }
+    let raw = match admin.run_command(doc! { "replSetGetStatus": 1 }).await {
+        Ok(raw) => raw,
+        Err(e) => {
+            // Standalone servers answer NoReplicationEnabled (code 76): a
+            // valid "not a replica set" state, not an error. Kept as a safety
+            // net even though hello now classifies standalones up front.
+            if let mongodb::error::ErrorKind::Command(ref ce) = *e.kind {
+                if ce.code == 76 {
+                    return Ok(ReplSetStatus {
+                        is_replica_set: false,
+                        cluster_type: "standalone".to_string(),
+                        ..Default::default()
+                    });
+                }
+                if ce.code == 13 {
+                    return Err("Not authorized to run replSetGetStatus — the connection's user needs the clusterMonitor role.".to_string());
+                }
+            }
+            return Err(format!("replSetGetStatus failed: {}", e));
+        }
+    };
+    Ok(curate_repl_set_status(&raw, &version))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -459,5 +634,107 @@ mod tests {
         assert_eq!(p.millis, 142);
         assert_eq!(p.ts_ms, 1_700_000_000_000);
         assert_eq!(p.plan_summary, "COLLSCAN");
+    }
+
+    fn repl_status_doc() -> Document {
+        doc! {
+            "set": "rs0",
+            "myState": 1i32,
+            "members": [
+                { "name": "db1:27017", "stateStr": "PRIMARY", "health": 1.0, "self": true,
+                  "uptime": 1_209_600i64, "optimeDate": DateTime::from_millis(1_700_000_042_000) },
+                { "name": "db2:27017", "stateStr": "SECONDARY", "health": 1.0,
+                  "uptime": 86_400i64, "optimeDate": DateTime::from_millis(1_700_000_041_200),
+                  "pingMs": 1i64, "syncSourceHost": "db1:27017" },
+                { "name": "db3:27017", "stateStr": "(not reachable/healthy)", "health": 0.0,
+                  "uptime": 0i64, "optimeDate": DateTime::from_millis(1_700_000_000_000),
+                  "pingMs": 3i64, "syncSourceHost": "" },
+            ],
+        }
+    }
+
+    #[test]
+    fn classifies_topology_from_hello() {
+        assert_eq!(classify_topology(&doc! { "msg": "isdbgrid", "ok": 1.0 }), "sharded");
+        assert_eq!(classify_topology(&doc! { "setName": "rs0", "ok": 1.0 }), "replicaSet");
+        assert_eq!(classify_topology(&doc! { "ok": 1.0 }), "standalone");
+    }
+
+    #[test]
+    fn curates_repl_set_status_with_lag() {
+        let s = curate_repl_set_status(&repl_status_doc(), "7.0.5");
+        assert!(s.is_replica_set);
+        assert_eq!(s.set, "rs0");
+        assert_eq!(s.my_state_str, "PRIMARY", "role comes from the self member");
+        assert_eq!(s.mongo_version, "7.0.5");
+        assert_eq!(s.cluster_type, "replicaSet");
+        assert_eq!(s.members.len(), 3);
+
+        let primary = &s.members[0];
+        assert!(primary.self_member);
+        assert_eq!(primary.lag_secs, None, "primary carries no lag");
+        assert_eq!(primary.ping_ms, None, "self member has no pingMs");
+
+        let healthy = &s.members[1];
+        assert_eq!(healthy.lag_secs, Some(0.8));
+        assert_eq!(healthy.ping_ms, Some(1));
+        assert_eq!(healthy.sync_source, "db1:27017");
+
+        let down = &s.members[2];
+        assert_eq!(down.health, 0);
+        assert_eq!(down.state_str, "(not reachable/healthy)");
+        assert_eq!(down.lag_secs, None, "unhealthy members report no lag, even with a real optimeDate");
+    }
+
+    #[test]
+    fn repl_set_lag_is_none_without_primary() {
+        let d = doc! {
+            "set": "rs0",
+            "members": [
+                { "name": "db2:27017", "stateStr": "SECONDARY", "health": 1.0, "self": true,
+                  "uptime": 5i64, "optimeDate": DateTime::from_millis(1_700_000_000_000) },
+                { "name": "db3:27017", "stateStr": "SECONDARY", "health": 1.0,
+                  "uptime": 5i64, "optimeDate": DateTime::from_millis(1_699_999_000_000) },
+            ],
+        };
+        let s = curate_repl_set_status(&d, "7.0.5");
+        assert!(s.members.iter().all(|m| m.lag_secs.is_none()), "no primary -> no lag numbers");
+        assert_eq!(s.my_state_str, "SECONDARY");
+    }
+
+    #[test]
+    fn repl_set_lag_clamps_ahead_of_primary_to_zero() {
+        let d = doc! {
+            "set": "rs0",
+            "members": [
+                { "name": "p:1", "stateStr": "PRIMARY", "health": 1.0, "optimeDate": DateTime::from_millis(1_000) },
+                { "name": "s:1", "stateStr": "SECONDARY", "health": 1.0, "optimeDate": DateTime::from_millis(2_000) },
+            ],
+        };
+        let s = curate_repl_set_status(&d, "x");
+        assert_eq!(s.members[1].lag_secs, Some(0.0));
+    }
+
+    #[test]
+    fn repl_set_status_is_resilient_to_empty_doc() {
+        let s = curate_repl_set_status(&doc! {}, "");
+        assert!(s.is_replica_set);
+        assert!(s.members.is_empty());
+        assert_eq!(s.my_state_str, "");
+    }
+
+    #[test]
+    fn repl_set_down_member_gets_no_lag_not_a_bogus_epoch_delta() {
+        let d = doc! {
+            "set": "rs0",
+            "members": [
+                { "name": "p:1", "stateStr": "PRIMARY", "health": 1.0, "optimeDate": DateTime::from_millis(1_700_000_000_000) },
+                { "name": "down:1", "stateStr": "(not reachable/healthy)", "health": 0.0, "optimeDate": DateTime::from_millis(0) },
+                { "name": "gone:1", "stateStr": "(not reachable/healthy)", "health": 0.0 },
+            ],
+        };
+        let s = curate_repl_set_status(&d, "x");
+        assert_eq!(s.members[1].lag_secs, None, "epoch-0 optime must not become a multi-year lag");
+        assert_eq!(s.members[2].lag_secs, None, "missing optime must not become a lag");
     }
 }

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -13,7 +13,7 @@ mod tests {
         list_indexes_impl, parse_json_array_docs,
         preview_export_impl, rename_collection_impl, rename_database_impl, sample_export_fields_impl,
         start_collection_export_impl, start_filtered_export_impl, update_document_impl,
-        upload_gridfs_file_impl,
+        upload_gridfs_file_impl, get_collection_options_impl, set_validator_impl,
     };
     use crate::{
         create_user_impl, drop_user_impl, list_roles_impl, list_users_impl, update_user_impl,
@@ -212,6 +212,114 @@ mod tests {
             .find(|c| c.name == "customers")
             .expect("customers still listed");
         assert_eq!(customers.collection_type, "collection");
+    }
+
+    #[tokio::test]
+    async fn test_get_collection_options_mock_path() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let opts = get_collection_options_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .expect("get collection options");
+
+        assert_eq!(opts.validator, "{}");
+        assert_eq!(opts.validation_level, "");
+        assert_eq!(opts.validation_action, "");
+    }
+
+    #[tokio::test]
+    async fn test_set_validator_mock_path() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            r#"{"$jsonSchema": {"type": "object"}}"#,
+            "moderate",
+            "error",
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validator_get_set_roundtrip() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+
+        let opts = get_collection_options_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .expect("get collection options");
+
+        let result = set_validator_impl(
+            &state,
+            &conn_id,
+            "sales_db",
+            "customers",
+            &opts.validator,
+            &opts.validation_level,
+            &opts.validation_action,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    // Issue #114: demo mode returns a synthetic replica set so the Cluster
+    // tab is populated without a live cluster — including a lagging
+    // secondary so the warning styling is visible.
+    #[tokio::test]
+    async fn test_mock_repl_set_status_returns_synthetic_set() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+        let s = crate::monitoring::repl_set_status_impl(&state, &conn_id).await.unwrap();
+        assert!(s.is_replica_set);
+        assert_eq!(s.set, "rs0");
+        assert_eq!(s.cluster_type, "replicaSet");
+        assert_eq!(s.members.len(), 3);
+        assert_eq!(s.members.iter().filter(|m| m.state_str == "PRIMARY").count(), 1);
+        assert!(
+            s.members.iter().any(|m| m.lag_secs.map(|l| l >= 10.0).unwrap_or(false)),
+            "demo set includes a lagging secondary"
+        );
+    }
+
+    // Issue #178: demo mode returns believable stats so all three popovers
+    // render without a live server.
+    #[tokio::test]
+    async fn test_mock_stats_impls_return_demo_numbers() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+
+        let db = crate::db::stats::db_stats_impl(&state, &conn_id, "sales_db").await.unwrap();
+        assert!(db.collections >= 4);
+        assert!(db.objects > 0);
+        assert!(db.data_size > 0);
+
+        let coll = crate::db::stats::coll_stats_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .unwrap();
+        assert!(coll.count > 0);
+        assert!(coll.size > 0);
+        assert!(coll.nindexes >= 1);
+
+        let idx = crate::db::stats::index_stats_impl(&state, &conn_id, "sales_db", "customers")
+            .await
+            .unwrap();
+        assert!(!idx.is_empty());
+        assert!(idx.iter().any(|i| i.name == "_id_"));
+        assert!(idx.iter().all(|i| i.size_bytes > 0));
     }
 
     #[tokio::test]
@@ -2946,6 +3054,23 @@ mod tests {
         // Explain renders a plan namespaced to the requested collection.
         let explain = get_mock_explain("user_analytics", "events", "{}");
         assert!(explain.contains("user_analytics.events"));
+        assert!(explain.contains("IXSCAN"));
+
+        // sales_db.transactions is the one namespace that demos a COLLSCAN plan,
+        // so the index-suggestion banner is reachable without a real server.
+        let tx_explain = get_mock_explain("sales_db", "transactions", "{}");
+        assert!(tx_explain.contains("COLLSCAN"));
+        assert!(!tx_explain.contains("IXSCAN"));
+        let tx_plan: serde_json::Value = serde_json::from_str(&tx_explain).unwrap();
+        assert_eq!(
+            tx_plan["queryPlanner"]["parsedQuery"]["$and"][0]["customer_name"]["$eq"],
+            "Alice Smith"
+        );
+
+        // Every other namespace (e.g. sales_db.products) keeps the original IXSCAN shape.
+        let products_explain = get_mock_explain("sales_db", "products", "{}");
+        assert!(products_explain.contains("IXSCAN"));
+        assert!(!products_explain.contains("COLLSCAN"));
 
         // Index sets for each collection, including the admin and unknown fallbacks.
         let idx = |db, coll| -> Vec<String> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import {
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
 import { CreateViewView } from './components/CreateViewView';
+import { ValidationRulesView } from './components/ValidationRulesView';
 import { GridFsView } from './components/GridFsView';
 import { MonitoringView } from './components/MonitoringView';
 import { UserManagementView } from './components/UserManagementView';
@@ -48,6 +49,7 @@ import { UpdatePrompt } from './components/UpdatePrompt';
 import { DialogProvider, useDialogs } from './components/dialogs/DialogProvider';
 import { formatBytes } from './lib/format';
 import type { QueryCodeSpec } from './lib/queryCodeGen';
+import type { IndexSuggestion } from './lib/indexSuggestions';
 import { docToShell } from './lib/shellDoc';
 import { recordHistory, loadCollectionQueries, type SavedQueryBody } from './lib/queryStore';
 import { clearNamespaceIndex, loadNamespaceIndex, matchesNamespaceScope } from './lib/paletteIndex';
@@ -57,12 +59,12 @@ import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
-import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap } from 'lucide-react';
+import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 interface QueryTab {
   id: string;
-  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users' | 'dump' | 'restore';
+  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users' | 'dump' | 'restore' | 'validation';
   connectionId: string;
   db: string;
   collection: string;
@@ -212,6 +214,8 @@ const tabIconFor = (tab: QueryTab, isActive: boolean): React.ReactNode => {
       return <DatabaseBackup size={size} className={className} />;
     case 'restore':
       return <DatabaseZap size={size} className={className} />;
+    case 'validation':
+      return <ShieldCheck size={size} className={className} />;
     default:
       return <FolderCode size={size} className={className} />;
   }
@@ -250,6 +254,8 @@ const tabLabelFor = (
       return `Dump: ${tab.db || connectionName(tab.connectionId)}`;
     case 'restore':
       return `Restore: ${connectionName(tab.connectionId)}`;
+    case 'validation':
+      return `Validation: ${tab.collection}`;
     default:
       return tab.collection;
   }
@@ -320,6 +326,10 @@ function Workspace() {
       keys: Record<string, number>;
       unique: boolean;
       sparse: boolean;
+    } | null;
+    prefill?: {
+      name: string;
+      keys: Record<string, number>;
     } | null;
   } | null>(null);
   const [indexMutationTrigger, setIndexMutationTrigger] = useState(0);
@@ -1002,6 +1012,25 @@ function Workspace() {
     setActiveTabId(tabId);
   };
 
+  // #93: open a Validation Rules tab for a collection.
+  const handleOpenValidationTab = (connectionId: string, db: string, collection: string) => {
+    const tabId = `validation.${connectionId}.${db}.${collection}`;
+    if (!tabs.some(t => t.id === tabId)) {
+      setTabs(prev => [...prev, {
+        id: tabId,
+        type: 'validation',
+        connectionId,
+        db,
+        collection,
+        results: [],
+        loading: false,
+        error: null,
+        explainResult: null,
+      }]);
+    }
+    setActiveTabId(tabId);
+  };
+
   // M7: open a GridFS browser tab for a bucket (bucket stored in `collection`).
   const handleOpenGridfsTab = (connectionId: string, db: string, bucket: string) => {
     const tabId = `gridfs.${connectionId}.${db}.${bucket}`;
@@ -1171,6 +1200,24 @@ function Workspace() {
       db: dbName,
       collection: collName,
       initialData: null,
+    });
+    setIsIndexModalOpen(true);
+  };
+
+  // Fired by the DataGrid COLLSCAN suggestion banner: opens the create-index
+  // flow pre-filled with the ESR-ordered keys, scoped to the active tab's own
+  // connection/db/collection (preferred over parsing the explain namespace).
+  const handleCreateSuggestedIndex = (suggestion: IndexSuggestion) => {
+    if (!activeTab || activeTab.type !== 'collection') return;
+    setIndexModalTarget({
+      connectionId: activeTab.connectionId,
+      db: activeTab.db,
+      collection: activeTab.collection,
+      initialData: null,
+      prefill: {
+        name: suggestion.suggestedName,
+        keys: suggestion.keys,
+      },
     });
     setIsIndexModalOpen(true);
   };
@@ -1955,6 +2002,7 @@ function Workspace() {
           onOpenMonitoring={handleOpenMonitoringTab}
           onOpenUsers={handleOpenUsersTab}
           onAnalyzeSchema={handleOpenSchemaTab}
+          onEditValidation={handleOpenValidationTab}
           onCreateView={handleOpenCreateViewTab}
           onOpenGridfs={handleOpenGridfsTab}
           onOpenDump={handleOpenDumpTab}
@@ -2058,6 +2106,7 @@ function Workspace() {
             collectionName={indexModalTarget?.collection}
             availableFields={availableFields}
             initialData={indexModalTarget?.initialData}
+            prefill={indexModalTarget?.prefill}
           />
 
           <DocumentEditModal
@@ -2236,6 +2285,7 @@ function Workspace() {
                           countLoading={activeTab.countLoading}
                           skip={activeTab.lastQuery?.skip ?? 0}
                           limit={activeTab.lastQuery?.limit ?? 50}
+                          onCreateSuggestedIndex={handleCreateSuggestedIndex}
                           {...(!activeTab.lastAggregate ? {
                             onPageChange: handlePageChange,
                             onPageSizeChange: handlePageSizeChange,
@@ -2261,6 +2311,14 @@ function Workspace() {
                     setCollectionMutationTrigger(prev => prev + 1);
                     handleSelectCollection(activeTab.connectionId, activeTab.db, viewName);
                   }}
+                />
+              )}
+              {activeTab && activeTab.type === 'validation' && (
+                <ValidationRulesView
+                  connectionId={activeTab.connectionId}
+                  databaseName={activeTab.db}
+                  collectionName={activeTab.collection}
+                  onApplied={() => setCollectionMutationTrigger(prev => prev + 1)}
                 />
               )}
               {activeTab && activeTab.type === 'gridfs' && (

--- a/src/components/ClusterHealthCard.tsx
+++ b/src/components/ClusterHealthCard.tsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useState } from 'react';
+import { replSetStatus, type ReplSetStatus } from '@/lib/monitoringApi';
+import { lagText, lagClass, memberDotClass, memberUnhealthy, uriUser, uriReadPreference } from '@/lib/clusterHealth';
+import { cn } from '@/lib/utils';
+
+interface ClusterHealthCardProps {
+  connectionId: string;
+  connectionName?: string;
+  connectionUri?: string;
+  onOpenMonitoring?: (connectionId: string) => void;
+}
+
+const capitalize = (s: string): string => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+/** Compact replica-set health summary. Fetches once on mount — i.e. once per
+ *  popover open — so there is no background polling cost. Refresh re-runs
+ *  the fetch in place via the `nonce` bump below. */
+export const ClusterHealthCard: React.FC<ClusterHealthCardProps> = ({
+  connectionId,
+  connectionName,
+  connectionUri,
+  onOpenMonitoring,
+}) => {
+  const [data, setData] = useState<ReplSetStatus | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    let alive = true;
+    replSetStatus(connectionId)
+      .then((s) => {
+        if (alive) setData(s);
+      })
+      .catch((e: unknown) => {
+        if (alive) setErr(String((e as Error)?.message || e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [connectionId, nonce]);
+
+  const user = connectionUri ? uriUser(connectionUri) : null;
+  const readPref = connectionUri ? uriReadPreference(connectionUri) : null;
+
+  return (
+    <div className="flex w-max min-w-72 max-w-[28rem] flex-col gap-1.5 text-xs" data-testid="cluster-health-card">
+      {err && <div className="text-destructive">{err}</div>}
+      {!err && !data && <div className="text-muted-foreground">Loading cluster health…</div>}
+      {(data || err) && connectionName && (
+        <div data-testid="cluster-card-connection">
+          Connection: <span className="font-semibold text-foreground">{connectionName}</span>
+          {data?.isReplicaSet && (
+            <>
+              {' '}
+              [replica set: <span className="font-semibold text-foreground">{data.set}</span>]
+            </>
+          )}
+        </div>
+      )}
+      {(data || err) && user && <div data-testid="cluster-card-user">User: {user}</div>}
+      {!err && data && !data.isReplicaSet && data.clusterType === 'sharded' && (
+        <div className="text-muted-foreground" data-testid="cluster-card-sharded">
+          Sharded cluster (mongos).
+        </div>
+      )}
+      {!err && data && !data.isReplicaSet && data.clusterType !== 'sharded' && (
+        <div className="text-muted-foreground" data-testid="cluster-card-standalone">
+          Standalone server — no replica set.
+        </div>
+      )}
+      {!err && data && data.isReplicaSet && (
+        <>
+          <div className="text-muted-foreground">Server(s):</div>
+          <div className="flex flex-col gap-1">
+            {data.members.map((m) => {
+              const unhealthy = memberUnhealthy(m);
+              const isPrimary = m.stateStr === 'PRIMARY';
+              return (
+                <div
+                  key={m.name}
+                  className={cn('flex flex-wrap items-center gap-x-1.5 gap-y-0.5', unhealthy && 'text-destructive')}
+                  data-testid={`cluster-card-member-${m.name}`}
+                >
+                  <span className={cn('h-2 w-2 shrink-0 rounded-full', memberDotClass(m))} />
+                  <span className="whitespace-nowrap font-mono">{m.name}</span>
+                  <span className="whitespace-nowrap text-muted-foreground">
+                    {unhealthy ? (
+                      '— Offline [(not reachable/healthy)]'
+                    ) : isPrimary ? (
+                      '— Online [PRIMARY]'
+                    ) : (
+                      <>
+                        — Online [{m.stateStr}] · <span className={lagClass(m.lagSecs)}>lag {lagText(m.lagSecs)}</span>
+                      </>
+                    )}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          {readPref && (
+            <div data-testid="cluster-card-read-pref">Read preference mode: {capitalize(readPref)}</div>
+          )}
+        </>
+      )}
+      {!err && data && data.mongoVersion && (
+        <div data-testid="cluster-card-version">Server version: {data.mongoVersion}</div>
+      )}
+      {!err && data && data.isReplicaSet && (
+        <div className="mt-0.5 flex items-center gap-2">
+          <button
+            type="button"
+            className="self-start text-primary underline-offset-2 hover:underline"
+            onClick={() => {
+              setErr(null);
+              setData(null);
+              setNonce((n) => n + 1);
+            }}
+            data-testid="cluster-card-refresh"
+          >
+            Refresh
+          </button>
+          {onOpenMonitoring && (
+            <button
+              type="button"
+              className="self-start text-primary underline-offset-2 hover:underline"
+              onClick={() => onOpenMonitoring(connectionId)}
+              data-testid="cluster-card-open-monitoring"
+            >
+              Open Monitoring →
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1945,7 +1945,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                       <span>Import URI</span>
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start">
+                  <DropdownMenuContent align="start" className={NESTED_SELECT_Z}>
                     <DropdownMenuItem onClick={handleImportFromClipboard} data-testid="import-from-clipboard">
                       From clipboard
                     </DropdownMenuItem>

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useMemo, useEffect, useContext } from 'react';
 import { DocumentViewerContext } from './DocumentViewer';
 import { List } from 'react-window';
-import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3 } from 'lucide-react';
+import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3, Lightbulb, GitCompareArrows } from 'lucide-react';
 import { ChartView } from './ChartView';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
+import { DocumentDiffModal } from './DocumentDiffModal';
 import Editor from '@monaco-editor/react';
 import { generateQueryCode, CODE_LANGUAGES, CODE_LANGUAGE_MONACO_IDS, type CodeLanguage, type QueryCodeSpec } from '../lib/queryCodeGen';
+import { suggestESRIndex, type IndexSuggestion } from '../lib/indexSuggestions';
 import { useMonacoTheme } from '../lib/useMonacoTheme';
 import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
 import { Button } from '@/components/ui/button';
@@ -36,6 +38,8 @@ interface DataGridProps {
   limit?: number;
   onPageChange?: (newSkip: number) => void;
   onPageSizeChange?: (newLimit: number) => void;
+  // Fired when the user accepts the COLLSCAN suggestion banner's "Create Index" CTA.
+  onCreateSuggestedIndex?: (suggestion: IndexSuggestion) => void;
 }
 
 type ViewMode = 'table' | 'tree' | 'json' | 'chart';
@@ -445,15 +449,36 @@ export const DataGrid: React.FC<DataGridProps> = ({
   limit,
   onPageChange,
   onPageSizeChange,
+  onCreateSuggestedIndex,
 }) => {
   const themeCtx = useThemeOptional();
   const density: SpacingDensity =
     densityProp ?? themeCtx?.config.spacingDensity ?? 'cozy';
 
+  // ESR-rule suggestion derived from the current explain plan (null unless it's a COLLSCAN).
+  const indexSuggestion = useMemo(
+    () => (explainResult ? suggestESRIndex(explainResult) : null),
+    [explainResult]
+  );
+
   // Right-click context menu shared by all result views (Table / Tree / JSON).
   const [ctxMenu, setCtxMenu] = useState<
     { x: number; y: number; doc: Record<string, any>; field?: string; value?: any } | null
   >(null);
+
+  // Two-step "Compare with…" flow: the first pick is held here as the armed
+  // source; the second pick (a different document) opens the diff modal.
+  const [pendingCompare, setPendingCompare] = useState<Record<string, any> | null>(null);
+  const [diffPair, setDiffPair] = useState<{ a: Record<string, any>; b: Record<string, any> } | null>(null);
+
+  // A new result set invalidates any armed compare source: the armed doc may
+  // no longer exist (or may differ) in the fresh documents array, and matching
+  // is by reference — silently diffing a stale doc would mislead. An OPEN diff
+  // modal is deliberately left alone: it deep-copied its two docs and stays
+  // valid regardless of what the grid refreshes to underneath it.
+  useEffect(() => {
+    setPendingCompare(null);
+  }, [documents]);
 
   const writeClipboard = (text: string) => {
     try { navigator.clipboard?.writeText(text); } catch { /* clipboard unavailable */ }
@@ -481,6 +506,36 @@ export const DataGrid: React.FC<DataGridProps> = ({
     if (onEditDocument) items.push({ label: 'Edit document', icon: <Edit size={13} />, onClick: () => onEditDocument(m.doc) });
     if (onDuplicateDocument) items.push({ label: 'Duplicate document', icon: <Plus size={13} />, onClick: () => onDuplicateDocument(m.doc) });
     items.push({ label: 'Copy document (JSON)', icon: <Copy size={13} />, onClick: () => writeClipboard(JSON.stringify(m.doc, null, 2)) });
+    if (!pendingCompare) {
+      items.push({
+        label: 'Compare with…',
+        icon: <GitCompareArrows size={13} />,
+        separatorBefore: true,
+        onClick: () => setPendingCompare(m.doc),
+      });
+    } else if (pendingCompare === m.doc) {
+      items.push({
+        label: 'Cancel compare selection',
+        icon: <GitCompareArrows size={13} />,
+        separatorBefore: true,
+        onClick: () => setPendingCompare(null),
+      });
+    } else {
+      items.push({
+        label: 'Compare with selected',
+        icon: <GitCompareArrows size={13} />,
+        separatorBefore: true,
+        onClick: () => {
+          setDiffPair({ a: pendingCompare, b: m.doc });
+          setPendingCompare(null);
+        },
+      });
+      items.push({
+        label: 'Compare with… (replace selection)',
+        icon: <GitCompareArrows size={13} />,
+        onClick: () => setPendingCompare(m.doc),
+      });
+    }
     if (m.field) {
       items.push({ label: 'Copy value', icon: <Copy size={13} />, separatorBefore: true, onClick: () => writeClipboard(valueToText(m.value)) });
       items.push({ label: 'Copy field name', icon: <Copy size={13} />, onClick: () => writeClipboard(m.field!) });
@@ -1480,6 +1535,29 @@ export const DataGrid: React.FC<DataGridProps> = ({
                 </div>
               </div>
 
+              {indexSuggestion && (
+                <div
+                  className="mx-3 mt-3 flex shrink-0 items-start gap-2.5 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2.5"
+                  data-testid="index-suggestion-banner"
+                >
+                  <Lightbulb size={16} className="mt-0.5 shrink-0 text-warning" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                    <p className="text-xs leading-relaxed text-foreground">{indexSuggestion.reason}</p>
+                    <code className="w-fit rounded bg-background/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+                      {JSON.stringify(indexSuggestion.keys)}
+                    </code>
+                  </div>
+                  <Button
+                    size="sm"
+                    className="h-7 shrink-0 gap-1.5 text-[11px] font-semibold"
+                    onClick={() => onCreateSuggestedIndex?.(indexSuggestion)}
+                    data-testid="create-suggested-index-btn"
+                  >
+                    Create Index
+                  </Button>
+                </div>
+              )}
+
               {explainView === 'visual' ? (
                 <div
                   className="flex flex-1 flex-col items-center gap-5 overflow-auto bg-background px-8 py-6"
@@ -1585,6 +1663,14 @@ export const DataGrid: React.FC<DataGridProps> = ({
           </div>
         );
       })()}
+      {diffPair && (
+        <DocumentDiffModal
+          isOpen
+          left={diffPair.a}
+          right={diffPair.b}
+          onClose={() => setDiffPair(null)}
+        />
+      )}
       {ctxMenu && (
         <ContextMenu
           x={ctxMenu.x}

--- a/src/components/DocumentDiffModal.tsx
+++ b/src/components/DocumentDiffModal.tsx
@@ -1,0 +1,202 @@
+import React, { useMemo } from 'react';
+import { X, GitCompareArrows } from 'lucide-react';
+import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
+import { Dialog, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { DraggableDialogContent } from '@/components/ui/draggable-dialog-content';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { diffDocuments, type DiffLine, type DiffStatus } from '../lib/docDiff';
+import { useEscapeClose } from '../lib/useEscapeClose';
+
+interface DocumentDiffModalProps {
+  isOpen: boolean;
+  left: Record<string, unknown>;
+  right: Record<string, unknown>;
+  onClose: () => void;
+}
+
+// Parse raw (possibly Extended-JSON) docs into rich BSON instances, mirroring
+// DataGrid's parsedDocs, so the diff engine compares real ObjectId/Date/Long.
+function toBson(doc: Record<string, unknown>): Record<string, unknown> {
+  try {
+    return EJSON.parse(JSON.stringify(doc)) as Record<string, unknown>;
+  } catch {
+    return doc;
+  }
+}
+
+const printableString = (value: string): string => JSON.stringify(value);
+
+// Syntax-colored rendering of one scalar value (same palette as DataGrid's
+// renderBsonValueNode).
+function renderScalar(val: unknown): React.ReactNode {
+  if (val === null || val === undefined) return <span className="text-syntax-null">null</span>;
+  if (typeof val === 'boolean') return <span className="text-syntax-boolean font-bold">{val ? 'true' : 'false'}</span>;
+  if (typeof val === 'number') return <span className="text-syntax-number">{String(val)}</span>;
+  if (typeof val === 'string') return <span className="text-syntax-string">{printableString(val)}</span>;
+  if (val instanceof ObjectId) return <><span className="text-syntax-boolean">ObjectId</span>(<span className="text-syntax-string">{printableString(val.toString())}</span>)</>;
+  if (val instanceof Date) return <><span className="text-syntax-boolean">ISODate</span>(<span className="text-syntax-string">{printableString(val.toISOString())}</span>)</>;
+  // Timestamp extends Long in bson, so this check MUST precede the Long
+  // check below, otherwise every Timestamp would render as NumberLong(...).
+  if (val instanceof Timestamp) return <><span className="text-syntax-boolean">Timestamp</span>(<span className="text-syntax-number">{val.t}</span>, <span className="text-syntax-number">{val.i}</span>)</>;
+  if (val instanceof Long) return <><span className="text-syntax-boolean">NumberLong</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
+  if (val instanceof Decimal128) return <><span className="text-syntax-boolean">NumberDecimal</span>(<span className="text-syntax-string">{printableString(val.toString())}</span>)</>;
+  if (val instanceof Int32) return <><span className="text-syntax-boolean">NumberInt</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
+  if (val instanceof Double) return <><span className="text-syntax-boolean">Double</span>(<span className="text-syntax-number">{val.toString()}</span>)</>;
+  if (val instanceof Binary) return <><span className="text-syntax-boolean">BinData</span>(<span className="text-syntax-number">{val.sub_type}</span>, <span className="text-syntax-string">{printableString(val.toString('base64'))}</span>)</>;
+  if (Array.isArray(val) || (typeof val === 'object' && val !== null)) {
+    let preview: string;
+    try {
+      preview = EJSON.stringify(val, { relaxed: true });
+    } catch {
+      preview = String(val);
+    }
+    if (preview.length > 120) preview = `${preview.slice(0, 120)}…`;
+    return <span className="text-muted-foreground">{preview}</span>;
+  }
+  return <span>{String(val)}</span>;
+}
+
+function renderLineContent(line: DiffLine): React.ReactNode {
+  if (line.status === 'gap' || line.kind === 'gap') return null;
+  const key = line.keyLabel ? (
+    <>
+      <span className="text-syntax-key">"{line.keyLabel}"</span>
+      <span className="text-muted-foreground"> : </span>
+    </>
+  ) : null;
+  if (line.kind === 'object' || line.kind === 'array') {
+    return (
+      <>
+        {key}
+        <span className="text-muted-foreground">{line.bracket}</span>
+        {(line.bracket === '{' || line.bracket === '[') && line.childCount !== undefined ? (
+          <span className="text-muted-foreground"> {line.childCount}</span>
+        ) : null}
+      </>
+    );
+  }
+  return (
+    <>
+      {key}
+      {renderScalar(line.value)}
+    </>
+  );
+}
+
+// Map a diff status to the repo's success/warning/destructive tint convention
+// (see ConnectionCard.tsx / DocumentEditModal.tsx usage).
+const lineTintClass = (status: DiffStatus): string => {
+  switch (status) {
+    case 'changed':
+      return 'bg-warning/10';
+    case 'added':
+      return 'bg-success/10';
+    case 'removed':
+      return 'bg-destructive/10';
+    case 'gap':
+      return 'bg-muted/30';
+    default:
+      return '';
+  }
+};
+
+const DiffColumn: React.FC<{ lines: DiffLine[]; testid: string }> = ({ lines, testid }) => (
+  <div className="mql-diff-col overflow-auto rounded-md border border-border bg-background" data-testid={testid}>
+    {lines.map((line, i) => (
+      <div
+        key={i}
+        className={cn('mql-diff-line flex items-start whitespace-pre font-mono text-xs leading-6', `is-${line.status}`, lineTintClass(line.status))}
+        data-status={line.status}
+      >
+        <span className="mql-diff-num w-9 shrink-0 select-none pr-2 text-right text-muted-foreground/70">
+          {line.status === 'gap' ? '' : i + 1}
+        </span>
+        <span className="mql-diff-content min-w-0 flex-1" style={{ paddingLeft: line.depth * 16 }}>
+          {renderLineContent(line)}
+        </span>
+      </div>
+    ))}
+  </div>
+);
+
+// No virtualization in v1 — past this many lines the DOM cost of rendering
+// every row outweighs the value of the raw diff view, so we show an honest
+// guard instead of a laggy/broken column.
+const MAX_DIFF_LINES = 4000;
+
+export const DocumentDiffModal: React.FC<DocumentDiffModalProps> = ({ isOpen, left, right, onClose }) => {
+  const diff = useMemo(() => diffDocuments(toBson(left), toBson(right)), [left, right]);
+  const tooLarge = diff.left.length > MAX_DIFF_LINES;
+
+  useEscapeClose(isOpen, onClose);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      {isOpen && (
+        <DraggableDialogContent
+          resetKey={isOpen}
+          defaultWidth={1000}
+          defaultHeight={640}
+          minWidth={640}
+          minHeight={360}
+          hideClose
+          className="flex min-h-0 flex-col gap-0 p-0"
+          data-testid="document-diff-modal"
+        >
+          <DialogHeader
+            data-dialog-drag-handle
+            className="flex cursor-grab flex-row items-center justify-between border-b border-border px-4 py-3 active:cursor-grabbing"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <DialogTitle className="flex items-center gap-2 text-sm">
+                <GitCompareArrows size={14} className="text-primary" />
+                Compare Documents
+              </DialogTitle>
+              <span className="flex items-center gap-1.5" data-testid="diff-summary">
+                <Badge variant="warning">{diff.changedCount} changed</Badge>
+                <Badge variant="success">{diff.addedCount} added</Badge>
+                <Badge variant="destructive">{diff.removedCount} removed</Badge>
+              </span>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onClose}
+              aria-label="Close modal"
+            >
+              <X size={13} />
+            </Button>
+          </DialogHeader>
+
+          {tooLarge ? (
+            <div
+              className="flex flex-1 items-center justify-center p-4 text-sm text-muted-foreground"
+              data-testid="diff-too-large"
+            >
+              This diff is too large to display ({diff.left.length} lines)
+            </div>
+          ) : (
+            <div className="mql-diff-grid grid min-h-0 flex-1 grid-cols-2 gap-3 p-4">
+              <div className="flex min-h-0 flex-col gap-1">
+                <div className="mql-diff-colhead text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                  Document A
+                </div>
+                <DiffColumn lines={diff.left} testid="diff-left" />
+              </div>
+              <div className="flex min-h-0 flex-col gap-1">
+                <div className="mql-diff-colhead text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                  Document B
+                </div>
+                <DiffColumn lines={diff.right} testid="diff-right" />
+              </div>
+            </div>
+          )}
+        </DraggableDialogContent>
+      )}
+    </Dialog>
+  );
+};

--- a/src/components/IndexModal.tsx
+++ b/src/components/IndexModal.tsx
@@ -48,6 +48,12 @@ interface IndexModalProps {
     unique: boolean;
     sparse: boolean;
   } | null;
+  // Pre-fills the create-mode form (e.g. from a COLLSCAN index suggestion).
+  // Ignored when initialData is set (edit mode) — unique/sparse always start false.
+  prefill?: {
+    name: string;
+    keys: Record<string, number>;
+  } | null;
 }
 
 const defaultIndexName = (json: string): string => {
@@ -77,6 +83,7 @@ export const IndexModal: React.FC<IndexModalProps> = ({
   databaseName,
   collectionName,
   initialData,
+  prefill,
 }) => {
   const [indexName, setIndexName] = useState('');
   const [nameTouched, setNameTouched] = useState(false);
@@ -120,6 +127,15 @@ export const IndexModal: React.FC<IndexModalProps> = ({
         );
         setKeysList(list.length > 0 ? list : [newKeyRule()]);
         setRawKeysJson(JSON.stringify(initialData.keys, null, 2));
+      } else if (prefill && Object.keys(prefill.keys).length > 0) {
+        setIndexName(prefill.name);
+        setUnique(false);
+        setSparse(false);
+        const list: IndexKeyRule[] = Object.entries(prefill.keys).map(([field, dir]) =>
+          newKeyRule(field, dir === -1 ? -1 : 1)
+        );
+        setKeysList(list);
+        setRawKeysJson(JSON.stringify(prefill.keys, null, 2));
       } else {
         setIndexName('');
         setUnique(false);
@@ -131,12 +147,12 @@ export const IndexModal: React.FC<IndexModalProps> = ({
       setIsRawMode(false);
       setNameTouched(false);
     }
-  }, [isOpen, initialData]);
+  }, [isOpen, initialData, prefill]);
 
   useEffect(() => {
-    if (!isOpen || initialData || nameTouched) return;
+    if (!isOpen || initialData || prefill || nameTouched) return;
     setIndexName(defaultIndexName(rawKeysJson));
-  }, [isOpen, initialData, nameTouched, rawKeysJson]);
+  }, [isOpen, initialData, prefill, nameTouched, rawKeysJson]);
 
   useEffect(() => {
     if (!isRawMode) {

--- a/src/components/IndexViewer.tsx
+++ b/src/components/IndexViewer.tsx
@@ -13,13 +13,17 @@ import {
   Edit,
   Trash2,
   Loader2,
+  HardDrive,
+  Activity,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
+import { formatBytes } from '@/lib/format';
 import type { IndexInfo } from './Sidebar';
+import type { IndexStatUi } from './StatsCards';
 import { useDialogs } from './dialogs/DialogProvider';
 
 interface IndexViewerProps {
@@ -44,12 +48,14 @@ export const IndexViewer: React.FC<IndexViewerProps> = ({
   const [info, setInfo] = useState<IndexInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<IndexStatUi[] | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
     setInfo(null);
+    setStats(null);
 
     (async () => {
       try {
@@ -72,10 +78,27 @@ export const IndexViewer: React.FC<IndexViewerProps> = ({
       }
     })();
 
+    // Fetched independently, in its own try/catch: a stats failure must
+    // never block rendering the index definition above.
+    (async () => {
+      try {
+        const s = await invoke<IndexStatUi[]>('index_stats', {
+          id: connectionId,
+          db: databaseName,
+          collection: collectionName,
+        });
+        if (!cancelled) setStats(s);
+      } catch {
+        // Usage/size stats are a nice-to-have; ignore failures silently.
+      }
+    })();
+
     return () => {
       cancelled = true;
     };
   }, [connectionId, databaseName, collectionName, indexName]);
+
+  const statEntry = useMemo(() => stats?.find((s) => s.name === indexName) ?? null, [stats, indexName]);
 
   const indexSpecs = useMemo(() => {
     let keyPattern: Record<string, number | string> = {};
@@ -308,6 +331,43 @@ export const IndexViewer: React.FC<IndexViewerProps> = ({
               </p>
             </CardContent>
           </Card>
+
+          {statEntry && (
+            <Card className="relative overflow-hidden" data-testid="index-size-card">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <HardDrive size={12} className="text-primary" />
+                  Size
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-lg font-semibold text-foreground">{formatBytes(statEntry.sizeBytes)}</div>
+                <p className="mt-1 text-[11px] text-muted-foreground">On-disk index size</p>
+              </CardContent>
+            </Card>
+          )}
+
+          {statEntry && (
+            <Card className="relative overflow-hidden" data-testid="index-usage-card">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <Activity size={12} className="text-success" />
+                  Usage
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-2">
+                  <div className="text-lg font-semibold text-foreground">{statEntry.ops.toLocaleString('en-US')} ops</div>
+                  {statEntry.ops === 0 && (
+                    <Badge variant="outline" data-testid="index-unused-badge">
+                      Unused
+                    </Badge>
+                  )}
+                </div>
+                <p className="mt-1 text-[11px] text-muted-foreground">Index accesses since last restart</p>
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         <div className="grid gap-4 lg:grid-cols-2">

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -41,11 +41,14 @@ import {
   getProfilingStatus,
   setProfilingLevel,
   readProfile,
+  replSetStatus,
   type ServerStatus,
   type CurrentOp,
   type ProfilingStatus,
   type ProfileEntry,
+  type ReplSetStatus,
 } from '../lib/monitoringApi';
+import { lagText, lagClass, memberUnhealthy, memberDotClass, fmtMemberUptime } from '@/lib/clusterHealth';
 
 interface MonitoringViewProps {
   connectionId: string;
@@ -62,7 +65,7 @@ const DEFAULT_POLL_MS = 10000;
 const MAX_SAMPLES = 30;
 const TABLE_CMD_CHARS = 120;
 
-type Section = 'ops' | 'profiler';
+type Section = 'ops' | 'profiler' | 'cluster';
 
 /** Lean time-series point — avoids retaining full ServerStatus per sample. */
 interface MetricSample {
@@ -559,12 +562,26 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
   const [profileLoading, setProfileLoading] = useState(false);
   const profilerLoadedRef = useRef(false);
 
+  const [cluster, setCluster] = useState<ReplSetStatus | null>(null);
+  const [clusterErr, setClusterErr] = useState<string | null>(null);
+
   const [pollMs, setPollMs] = useState(DEFAULT_POLL_MS);
   const aliveRef = useRef(true);
 
+  // Read by pollOnce so its identity stays stable across tab switches (the
+  // interval effect resets the samples history whenever pollOnce changes).
+  const sectionRef = useRef(section);
+  useEffect(() => {
+    sectionRef.current = section;
+  }, [section]);
+
   const pollOnce = useCallback(async () => {
     if (typeof document !== 'undefined' && document.hidden) return;
-    const [sRes, oRes] = await Promise.allSettled([serverStatus(connectionId), currentOps(connectionId)]);
+    const [sRes, oRes, cRes] = await Promise.allSettled([
+      serverStatus(connectionId),
+      currentOps(connectionId),
+      sectionRef.current === 'cluster' ? replSetStatus(connectionId) : Promise.resolve(null),
+    ]);
     if (!aliveRef.current) return;
     if (sRes.status === 'fulfilled') {
       const s = sRes.value;
@@ -579,6 +596,14 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
       setOpsErr(null);
     } else {
       setOpsErr(String((oRes.reason as Error)?.message || oRes.reason));
+    }
+    if (cRes.status === 'fulfilled') {
+      if (cRes.value) {
+        setCluster(cRes.value);
+        setClusterErr(null);
+      }
+    } else {
+      setClusterErr(String((cRes.reason as Error)?.message || cRes.reason));
     }
   }, [connectionId]);
 
@@ -597,6 +622,12 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
       clearInterval(iv);
     };
   }, [pollOnce, pollMs, connectionId]);
+
+  // Entering the Cluster tab fetches right away; pollOnce reads the section
+  // from a ref, so this does not disturb the interval or the sample history.
+  useEffect(() => {
+    if (section === 'cluster') void pollOnce();
+  }, [section, pollOnce]);
 
   const refreshProfiler = useCallback(async () => {
     if (!profilerDb) return;
@@ -742,6 +773,14 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
               onClick={() => setSection('profiler')}
             >
               Profiler
+            </TabsTrigger>
+            <TabsTrigger
+              value="cluster"
+              className="h-7 px-3 text-xs"
+              data-testid="mon-tab-cluster"
+              onClick={() => setSection('cluster')}
+            >
+              Cluster
             </TabsTrigger>
           </TabsList>
         </Tabs>
@@ -973,6 +1012,88 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
             )}
           </div>
         )}
+
+      {section === 'cluster' && (
+        <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-auto p-3" data-testid="mon-panel-cluster">
+          {clusterErr && <div className="text-xs text-red-500">{clusterErr}</div>}
+          {!clusterErr && cluster && !cluster.isReplicaSet && cluster.clusterType === 'sharded' && (
+            <div
+              className="rounded-lg border border-border bg-muted/30 p-4 text-xs text-muted-foreground"
+              data-testid="cluster-sharded"
+            >
+              Sharded cluster — member-level health isn&apos;t available through mongos. Connect directly to a
+              shard&apos;s replica set to inspect its members.
+            </div>
+          )}
+          {!clusterErr && cluster && !cluster.isReplicaSet && cluster.clusterType !== 'sharded' && (
+            <div
+              className="rounded-lg border border-border bg-muted/30 p-4 text-xs text-muted-foreground"
+              data-testid="cluster-not-replset"
+            >
+              This connection is a standalone MongoDB server — replica-set health does not apply here.
+            </div>
+          )}
+          {!clusterErr && cluster && cluster.isReplicaSet && (
+            <>
+              <div className="text-xs text-muted-foreground" data-testid="cluster-summary">
+                Replica set <span className="font-semibold text-foreground">{cluster.set}</span>
+                {' · '}
+                {cluster.members.length} members
+                {cluster.mongoVersion && <> · MongoDB {cluster.mongoVersion}</>}
+                {cluster.myStateStr && <> · you: {cluster.myStateStr}</>}
+              </div>
+              <div className="overflow-x-auto rounded-lg border border-border">
+                <table className="w-full text-xs" data-testid="cluster-members-table">
+                  <thead className="bg-muted/50 text-left text-muted-foreground">
+                    <tr>
+                      <th className="px-3 py-1.5 font-medium">Member</th>
+                      <th className="px-3 py-1.5 font-medium">State</th>
+                      <th className="px-3 py-1.5 font-medium">Uptime</th>
+                      <th className="px-3 py-1.5 font-medium">Ping</th>
+                      <th className="px-3 py-1.5 font-medium">Sync source</th>
+                      <th className="px-3 py-1.5 font-medium">Lag</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cluster.members.map((m) => (
+                      <tr
+                        key={m.name}
+                        data-testid={`cluster-member-${m.name}`}
+                        title={m.optimeDateMs > 0 ? `optime: ${new Date(m.optimeDateMs).toISOString()}` : undefined}
+                        className={cn(
+                          'border-t border-border/50',
+                          memberUnhealthy(m) && 'bg-destructive/10 text-destructive',
+                        )}
+                      >
+                        <td className="px-3 py-1.5">
+                          <span className="flex items-center gap-1.5">
+                            <span className={cn('h-2 w-2 shrink-0 rounded-full', memberDotClass(m))} />
+                            <span className="font-mono">{m.name}</span>
+                            {m.self && <span className="text-ui-2xs text-muted-foreground">(you)</span>}
+                          </span>
+                        </td>
+                        <td className="px-3 py-1.5">{m.stateStr}</td>
+                        <td className="px-3 py-1.5">{fmtMemberUptime(m.uptimeSecs)}</td>
+                        <td className="px-3 py-1.5">{m.pingMs == null ? '—' : `${m.pingMs}ms`}</td>
+                        <td className="px-3 py-1.5 font-mono">{m.syncSource || '—'}</td>
+                        <td
+                          className={cn('px-3 py-1.5', m.stateStr === 'PRIMARY' ? 'text-muted-foreground' : lagClass(m.lagSecs))}
+                          data-testid={`cluster-lag-${m.name}`}
+                        >
+                          {m.stateStr === 'PRIMARY' ? '—' : lagText(m.lagSecs)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+          {!clusterErr && !cluster && (
+            <div className="text-xs text-muted-foreground">Loading replica-set status…</div>
+          )}
+        </div>
+      )}
 
       {detail && <MonitoringDetail detail={detail} onClose={() => setDetail(null)} />}
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -56,6 +56,9 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+import { ClusterHealthCard } from '@/components/ClusterHealthCard';
+import { DbStatsCard, CollStatsCard, IndexStatsCard } from '@/components/StatsCards';
 import { ThemePicker } from '@/components/theme/ThemePicker';
 import {
   Database,
@@ -92,6 +95,7 @@ import {
   Copy,
   DatabaseBackup,
   DatabaseZap,
+  ShieldCheck,
 } from 'lucide-react';
 
 const REPO_URL = 'https://github.com/mqlens/mqlens-mongodb';
@@ -116,6 +120,27 @@ export interface IndexInfo {
   unique: boolean;
   sparse: boolean;
 }
+
+// Discriminated target for the row-hover stats popover (issue #178):
+// connection → cluster health, database/collection/index → their stats cards.
+type StatsPopoverTarget =
+  | { kind: 'connection'; connId: string }
+  | { kind: 'database'; connId: string; db: string }
+  | { kind: 'collection'; connId: string; db: string; coll: string }
+  | { kind: 'index'; connId: string; db: string; coll: string; index: string };
+
+const targetKey = (t: StatsPopoverTarget): string => {
+  switch (t.kind) {
+    case 'connection':
+      return `connection:${t.connId}`;
+    case 'database':
+      return `database:${t.connId}/${t.db}`;
+    case 'collection':
+      return `collection:${t.connId}/${t.db}/${t.coll}`;
+    case 'index':
+      return `index:${t.connId}/${t.db}/${t.coll}/${t.index}`;
+  }
+};
 
 const compareCollectionNames = (a: string, b: string) =>
   a.localeCompare(b, undefined, { sensitivity: 'base', numeric: true });
@@ -158,6 +183,7 @@ interface SidebarProps {
   onOpenMonitoring?: (connectionId: string) => void;
   onOpenUsers?: (connectionId: string, db?: string) => void;
   onAnalyzeSchema?: (connectionId: string, dbName: string, collName: string) => void;
+  onEditValidation?: (connectionId: string, dbName: string, collName: string) => void;
   onCreateView?: (connectionId: string, dbName: string) => void;
   onOpenGridfs?: (connectionId: string, dbName: string, bucket: string) => void;
   /** Open a Dump tab scoped to the whole connection, a database, or a single collection. */
@@ -189,6 +215,8 @@ interface SidebarProps {
   refreshTarget?: { connectionId: string; db?: string; expand: boolean } | null;
   /** Bumped by the parent to fire a refresh of `refreshTarget`. */
   refreshTargetNonce?: number;
+  /** Hover delay before the connection cluster-health popover opens (ms). */
+  clusterHoverDelayMs?: number;
 }
 
 const treeRowClass = (active?: boolean) =>
@@ -277,6 +305,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onOpenMonitoring,
   onOpenUsers,
   onAnalyzeSchema,
+  onEditValidation,
   onCreateView,
   onOpenGridfs,
   onOpenDump,
@@ -297,10 +326,63 @@ export const Sidebar: React.FC<SidebarProps> = ({
   canPaste,
   refreshTarget,
   refreshTargetNonce,
+  clusterHoverDelayMs = 400,
 }) => {
   const { toast, confirm, prompt } = useDialogs();
   const [filterQuery, setFilterQuery] = useState('');
   const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Stats hover popover: which row's card is open (connection → cluster
+  // health, database/collection/index → their stats cards), plus open-delay
+  // and grace-close timers so the pointer can travel into the card.
+  const [statsPopover, setStatsPopover] = useState<StatsPopoverTarget | null>(null);
+  const statsOpenTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const statsCloseTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The popover opens at the mouse cursor, not beside the row: a virtual
+  // anchor reports a zero-size rect at the last pointer position (updated
+  // until the popover opens, then frozen so the card doesn't chase the mouse).
+  const statsAnchorPoint = React.useRef({ x: 0, y: 0 });
+  const statsVirtualAnchor = React.useRef({
+    getBoundingClientRect: () => {
+      const { x, y } = statsAnchorPoint.current;
+      return { width: 0, height: 0, x, y, top: y, bottom: y, left: x, right: x, toJSON: () => ({}) } as DOMRect;
+    },
+  });
+  const cancelStatsTimers = () => {
+    if (statsOpenTimer.current) clearTimeout(statsOpenTimer.current);
+    if (statsCloseTimer.current) clearTimeout(statsCloseTimer.current);
+    statsOpenTimer.current = null;
+    statsCloseTimer.current = null;
+  };
+  const scheduleStatsOpen = (target: StatsPopoverTarget) => {
+    cancelStatsTimers();
+    // Moving to a different row: close the previous popover immediately
+    // instead of letting it linger for the open delay.
+    setStatsPopover((cur) => (cur !== null && targetKey(cur) !== targetKey(target) ? null : cur));
+    statsOpenTimer.current = setTimeout(() => setStatsPopover(target), clusterHoverDelayMs);
+  };
+  const scheduleStatsClose = () => {
+    if (statsOpenTimer.current) clearTimeout(statsOpenTimer.current);
+    statsCloseTimer.current = setTimeout(() => setStatsPopover(null), 150);
+  };
+  useEffect(() => cancelStatsTimers, []);
+
+  // Hover props for a stats-popover row: capture the cursor position on
+  // enter and schedule the open; keep tracking the pointer until this row's
+  // popover actually opens; grace-close on leave so the pointer can travel
+  // into the card without it disappearing.
+  const statsHoverHandlers = (target: StatsPopoverTarget) => ({
+    onMouseEnter: (e: React.MouseEvent) => {
+      statsAnchorPoint.current = { x: e.clientX, y: e.clientY };
+      scheduleStatsOpen(target);
+    },
+    onMouseMove: (e: React.MouseEvent) => {
+      if (statsPopover === null || targetKey(statsPopover) !== targetKey(target)) {
+        statsAnchorPoint.current = { x: e.clientX, y: e.clientY };
+      }
+    },
+    onMouseLeave: scheduleStatsClose,
+  });
 
   // Mock connections (the bundled sample data, or ids/URIs marked as such) never
   // reach a real mongodump/mongorestore binary — the backend rejects them outright
@@ -1143,6 +1225,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 }
               }}
               className={cn(treeRowClass(isActive), isSelected && 'bg-accent')}
+              {...statsHoverHandlers({ kind: 'collection', connId, db: dbName, coll: collName })}
             >
               <ChevronRight
                 size={10}
@@ -1150,7 +1233,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               />
               {collType === 'timeseries' ? (
                 <span
-                  title="Time-series collection"
+                  aria-label="Time-series collection"
                   data-testid="coll-icon-timeseries"
                   className="flex shrink-0 items-center"
                 >
@@ -1159,7 +1242,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               ) : (
                 <Layers size={11} className={cn('shrink-0', isActive ? 'text-primary' : 'text-emerald-500')} />
               )}
-              <span className="min-w-0 truncate" title={collName}>
+              <span className="min-w-0 truncate">
                 {collName}
               </span>
             </div>
@@ -1244,6 +1327,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
               <Table2 />
               <span>Analyze Schema</span>
             </ContextMenuItem>
+            {collType !== 'view' && collType !== 'timeseries' && !collName.startsWith('system.') && !/\.(files|chunks)$/.test(collName) && (
+              <ContextMenuItem className={ctxItemClass} onClick={() => onEditValidation?.(connId, dbName, collName)}>
+                <ShieldCheck />
+                <span>Validation Rules</span>
+              </ContextMenuItem>
+            )}
             {!isMockConnection(connId) && (
               <ContextMenuItem
                 className={ctxItemClass}
@@ -1346,6 +1435,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                             onSelectIndex(connId, dbName, collName, indexName);
                           }}
                           className={treeRowClass(isIndexActive)}
+                          {...statsHoverHandlers({ kind: 'index', connId, db: dbName, coll: collName, index: indexName })}
                         >
                           <KeyRound
                             size={10}
@@ -1429,6 +1519,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     aria-expanded={isConnExpanded}
                     aria-label={`Connection ${conn.name}`}
                     onClick={() => setExpandedConnections((prev) => ({ ...prev, [conn.id]: !prev[conn.id] }))}
+                    {...statsHoverHandlers({ kind: 'connection', connId: conn.id })}
                   >
                     <div className="flex min-w-0 flex-1 items-center gap-1">
                       <ChevronRight
@@ -1439,14 +1530,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         <span
                           className="h-2 w-2 shrink-0 rounded-full"
                           style={{ backgroundColor: conn.color_tag }}
-                          title="Connection color"
+                          aria-label="Connection color"
                         />
                       )}
                       <Server size={12} className="shrink-0 text-primary" />
                       <span className="min-w-0 truncate font-medium">{conn.name}</span>
                       <span
                         className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
-                        title="Connected"
+                        aria-label="Connected"
                       />
                     </div>
                     <Button
@@ -1457,7 +1548,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         e.stopPropagation();
                         loadDatabases(conn.id);
                       }}
-                      title="Refresh Databases"
                       aria-label="Refresh databases"
                     >
                       <RefreshCw className="size-3" />
@@ -1470,7 +1560,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         e.stopPropagation();
                         onDisconnect(conn.id);
                       }}
-                      title="Disconnect Connection"
                       aria-label="Disconnect"
                     >
                       <LogOut className="size-3" />
@@ -1621,6 +1710,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                               aria-expanded={isDbExpanded}
                               aria-label={`Database ${dbName}`}
                               onClick={() => toggleDb(conn.id, dbName)}
+                              {...statsHoverHandlers({ kind: 'database', connId: conn.id, db: dbName })}
                             >
                               <ChevronRight
                                 size={11}
@@ -1764,7 +1854,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                       size="icon"
                                       className="ml-auto h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
                                       data-testid={`collections-new-${conn.id}-${dbName}`}
-                                      title="New collection"
+                                      aria-label="New collection"
                                       onClick={(e) => {
                                         e.stopPropagation();
                                         void handleAddCollection(conn.id, dbName);
@@ -1850,7 +1940,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                       size="icon"
                                       className="ml-auto h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
                                       data-testid={`gridfs-new-bucket-${conn.id}-${dbName}`}
-                                      title="New bucket"
+                                      aria-label="New bucket"
                                       onClick={(e) => {
                                         e.stopPropagation();
                                         void handleOpenGridfsBucket(conn.id, dbName);
@@ -1868,7 +1958,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                           onClick={() => onOpenGridfs?.(conn.id, dbName, bucket)}
                                         >
                                           <Archive size={11} className="ml-3.5 shrink-0 text-emerald-500" />
-                                          <span className="min-w-0 truncate" title={bucket}>
+                                          <span className="min-w-0 truncate">
                                             {bucket}
                                           </span>
                                         </div>
@@ -1961,7 +2051,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           <span className="text-ui-xs font-semibold tracking-wide">MQLens Workspace</span>
         </div>
         <div className="flex items-center gap-0.5">
-          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onOpenSettings} title="Settings" aria-label="Open Settings">
+          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onOpenSettings} aria-label="Open Settings">
             <Settings className="size-3.5" />
           </Button>
           <DropdownMenu>
@@ -1970,7 +2060,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 variant="ghost"
                 size="icon"
                 className="h-7 w-7"
-                title="Help & feedback"
                 aria-label="Help and feedback"
                 data-testid="help-menu-btn"
               >
@@ -1991,7 +2080,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
             size="icon"
             className="h-7 w-7"
             onClick={onOpenConnectionManager}
-            title="Manage Connections"
             aria-label="Manage Connections"
           >
             <Plus className="size-3.5" />
@@ -2082,7 +2170,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                     : 'text-emerald-500',
                               )}
                             />
-                            <span className="min-w-0 truncate" title={label}>
+                            <span className="min-w-0 truncate">
                               {label}
                             </span>
                             <span className="ml-auto truncate text-[10px] text-muted-foreground">
@@ -2146,7 +2234,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                           <div
                             className={treeRowClass()}
                             onClick={() => void navigateToFavorite(fav)}
-                            title={`${fav.connectionName}${fav.db ? ` · ${fav.db}` : ''}${fav.collection ? `.${fav.collection}` : ''}`}
                           >
                             <FavIcon
                               size={10}
@@ -2241,7 +2328,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                   key={profile.id}
                                   className={treeRowClass()}
                                   onClick={() => onConnectProfile?.(profile)}
-                                  title={profile.name}
                                 >
                                   <Server
                                     size={11}
@@ -2254,7 +2340,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                   {isConnected && (
                                     <span
                                       className="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
-                                      title="Connected"
+                                      aria-label="Connected"
                                     />
                                   )}
                                 </div>
@@ -2274,7 +2360,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                           key={profile.id}
                           className={treeRowClass()}
                           onClick={() => onConnectProfile?.(profile)}
-                          title={profile.name}
                         >
                           <Server
                             size={11}
@@ -2308,6 +2393,56 @@ export const Sidebar: React.FC<SidebarProps> = ({
         <ThemePicker />
         <span className="text-[10px] text-muted-foreground">Theme</span>
       </footer>
+
+      {/* Single root-level stats popover shared by connection/database/collection/index
+          rows (issue #178) — the virtual anchor positions it at the cursor regardless
+          of which row triggered it, so it doesn't need to live inside the tree map. */}
+      <Popover
+        open={statsPopover !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            cancelStatsTimers();
+            setStatsPopover(null);
+          }
+        }}
+      >
+        <PopoverAnchor virtualRef={statsVirtualAnchor} />
+        <PopoverContent
+          side="bottom"
+          align="start"
+          sideOffset={8}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onMouseEnter={cancelStatsTimers}
+          onMouseLeave={scheduleStatsClose}
+        >
+          {statsPopover?.kind === 'connection' &&
+            (() => {
+              const conn = activeConnections.find((c) => c.id === statsPopover.connId);
+              return (
+                <ClusterHealthCard
+                  connectionId={statsPopover.connId}
+                  connectionName={conn?.name}
+                  connectionUri={conn?.uri}
+                  onOpenMonitoring={onOpenMonitoring}
+                />
+              );
+            })()}
+          {statsPopover?.kind === 'database' && (
+            <DbStatsCard connectionId={statsPopover.connId} db={statsPopover.db} />
+          )}
+          {statsPopover?.kind === 'collection' && (
+            <CollStatsCard connectionId={statsPopover.connId} db={statsPopover.db} collection={statsPopover.coll} />
+          )}
+          {statsPopover?.kind === 'index' && (
+            <IndexStatsCard
+              connectionId={statsPopover.connId}
+              db={statsPopover.db}
+              collection={statsPopover.coll}
+              indexName={statsPopover.index}
+            />
+          )}
+        </PopoverContent>
+      </Popover>
     </aside>
     </EmptySpaceContextMenu>
   );

--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -1,0 +1,238 @@
+import React, { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { formatBytes } from '@/lib/format';
+
+interface DbStatsUi {
+  collections: number;
+  views: number;
+  objects: number;
+  avgObjSize: number;
+  dataSize: number;
+  storageSize: number;
+  indexes: number;
+  totalIndexSize: number;
+}
+
+interface CollStatsUi {
+  count: number;
+  avgObjSize: number;
+  size: number;
+  storageSize: number;
+  nindexes: number;
+  totalIndexSize: number;
+  capped: boolean;
+}
+
+export interface IndexStatUi {
+  name: string;
+  sizeBytes: number;
+  ops: number;
+  sinceMs: number;
+}
+
+const CARD_CLASS = 'flex w-max min-w-72 max-w-[28rem] flex-col gap-1.5 text-xs';
+
+const Row: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+  <div>
+    <span className="text-muted-foreground">{label}:</span> {value}
+  </div>
+);
+
+const RefreshLink: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+  <button
+    type="button"
+    className="mt-0.5 self-start text-primary underline-offset-2 hover:underline"
+    onClick={onClick}
+    data-testid="stats-refresh"
+  >
+    Refresh
+  </button>
+);
+
+interface DbStatsCardProps {
+  connectionId: string;
+  db: string;
+}
+
+/** Compact database-level stats summary (issue #178). Fetches once on mount
+ *  — i.e. once per popover open — so there is no background polling cost.
+ *  Refresh re-runs the fetch in place via the `nonce` bump below. */
+export const DbStatsCard: React.FC<DbStatsCardProps> = ({ connectionId, db }) => {
+  const [data, setData] = useState<DbStatsUi | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    let alive = true;
+    invoke<DbStatsUi>('db_stats', { id: connectionId, db })
+      .then((s) => {
+        if (alive) setData(s);
+      })
+      .catch((e: unknown) => {
+        if (alive) setErr(String((e as Error)?.message || e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [connectionId, db, nonce]);
+
+  const refresh = () => {
+    setErr(null);
+    setData(null);
+    setNonce((n) => n + 1);
+  };
+
+  return (
+    <div className={CARD_CLASS} data-testid="db-stats-card">
+      {err && <div className="text-destructive">{err}</div>}
+      {!err && !data && <div className="text-muted-foreground">Loading database stats…</div>}
+      {!err && data && (
+        <>
+          <div>
+            Database: <span className="font-semibold text-foreground">{db}</span>
+          </div>
+          <Row label="Collections" value={data.collections.toLocaleString()} />
+          <Row label="Views" value={data.views.toLocaleString()} />
+          <Row label="Objects" value={data.objects.toLocaleString()} />
+          <Row label="Avg. object size" value={formatBytes(data.avgObjSize)} />
+          <Row label="Data size" value={formatBytes(data.dataSize)} />
+          <Row label="Storage size" value={formatBytes(data.storageSize)} />
+          <Row label="Indexes" value={data.indexes.toLocaleString()} />
+          <Row label="Total index size" value={formatBytes(data.totalIndexSize)} />
+        </>
+      )}
+      {(data || err) && <RefreshLink onClick={refresh} />}
+    </div>
+  );
+};
+
+interface CollStatsCardProps {
+  connectionId: string;
+  db: string;
+  collection: string;
+}
+
+/** Compact collection-level stats summary (issue #178). Same fetch-once +
+ *  nonce-refresh pattern as DbStatsCard. */
+export const CollStatsCard: React.FC<CollStatsCardProps> = ({ connectionId, db, collection }) => {
+  const [data, setData] = useState<CollStatsUi | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    let alive = true;
+    invoke<CollStatsUi>('coll_stats', { id: connectionId, db, collection })
+      .then((s) => {
+        if (alive) setData(s);
+      })
+      .catch((e: unknown) => {
+        if (alive) setErr(String((e as Error)?.message || e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [connectionId, db, collection, nonce]);
+
+  const refresh = () => {
+    setErr(null);
+    setData(null);
+    setNonce((n) => n + 1);
+  };
+
+  return (
+    <div className={CARD_CLASS} data-testid="coll-stats-card">
+      {err && <div className="text-destructive">{err}</div>}
+      {!err && !data && <div className="text-muted-foreground">Loading collection stats…</div>}
+      {!err && data && (
+        <>
+          <div>
+            Collection:{' '}
+            <span className="font-semibold text-foreground">
+              {db}.{collection}
+            </span>
+          </div>
+          <Row label="Documents" value={data.count.toLocaleString()} />
+          <Row label="Avg. object size" value={formatBytes(data.avgObjSize)} />
+          <Row label="Data size" value={formatBytes(data.size)} />
+          <Row label="Storage size" value={formatBytes(data.storageSize)} />
+          <Row label="Indexes" value={data.nindexes.toLocaleString()} />
+          <Row label="Total index size" value={formatBytes(data.totalIndexSize)} />
+          {data.capped && <Row label="Capped" value="yes" />}
+        </>
+      )}
+      {(data || err) && <RefreshLink onClick={refresh} />}
+    </div>
+  );
+};
+
+interface IndexStatsCardProps {
+  connectionId: string;
+  db: string;
+  collection: string;
+  indexName: string;
+}
+
+/** Compact single-index stats summary (issue #178). `index_stats` returns
+ *  every index on the collection; this card picks the one matching
+ *  `indexName` out of that array. */
+export const IndexStatsCard: React.FC<IndexStatsCardProps> = ({ connectionId, db, collection, indexName }) => {
+  const [data, setData] = useState<IndexStatUi[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    let alive = true;
+    invoke<IndexStatUi[]>('index_stats', { id: connectionId, db, collection })
+      .then((s) => {
+        if (alive) setData(s);
+      })
+      .catch((e: unknown) => {
+        if (alive) setErr(String((e as Error)?.message || e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [connectionId, db, collection, nonce]);
+
+  const refresh = () => {
+    setErr(null);
+    setData(null);
+    setNonce((n) => n + 1);
+  };
+
+  const entry = data?.find((i) => i.name === indexName) ?? null;
+
+  return (
+    <div className={CARD_CLASS} data-testid="index-stats-card">
+      {err && <div className="text-destructive">{err}</div>}
+      {!err && !data && <div className="text-muted-foreground">Loading index stats…</div>}
+      {!err && data && (
+        <>
+          <div>
+            Index:{' '}
+            <span className="font-semibold text-foreground">
+              {indexName} on {db}.{collection}
+            </span>
+          </div>
+          {!entry && <div className="text-muted-foreground">No stats for this index.</div>}
+          {entry && (
+            <>
+              <Row label="Size" value={formatBytes(entry.sizeBytes)} />
+              {entry.sinceMs > 0 ? (
+                <>
+                  <Row label="Usage" value={`${entry.ops.toLocaleString()} ops`} />
+                  <Row label="Since" value={new Date(entry.sinceMs).toLocaleDateString()} />
+                </>
+              ) : entry.ops === 0 ? (
+                <Row label="Usage" value="n/a (no data since restart)" />
+              ) : (
+                <Row label="Usage" value={`${entry.ops.toLocaleString()} ops`} />
+              )}
+            </>
+          )}
+        </>
+      )}
+      {(data || err) && <RefreshLink onClick={refresh} />}
+    </div>
+  );
+};

--- a/src/components/ValidationRulesView.tsx
+++ b/src/components/ValidationRulesView.tsx
@@ -1,0 +1,217 @@
+import React, { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { ShieldCheck, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { QueryEditor } from './QueryEditor';
+
+interface ValidationRulesViewProps {
+  connectionId: string;
+  databaseName: string;
+  collectionName: string;
+  /** Called after a successful `set_validator` apply. */
+  onApplied: () => void;
+}
+
+interface CollectionValidationUi {
+  validator: string;
+  validationLevel: string;
+  validationAction: string;
+}
+
+const NONE_VALUE = '__none__';
+
+export const ValidationRulesView: React.FC<ValidationRulesViewProps> = ({
+  connectionId,
+  databaseName,
+  collectionName,
+  onApplied,
+}) => {
+  const [validator, setValidator] = useState('{}');
+  const [validationLevel, setValidationLevel] = useState('');
+  const [validationAction, setValidationAction] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [applying, setApplying] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+    (async () => {
+      try {
+        const result = await invoke<CollectionValidationUi>('get_collection_options', {
+          id: connectionId,
+          database: databaseName,
+          collection: collectionName,
+        });
+        if (cancelled) return;
+        setValidator(result.validator ?? '{}');
+        setValidationLevel(result.validationLevel ?? '');
+        setValidationAction(result.validationAction ?? '');
+      } catch (err: any) {
+        if (!cancelled) setError(String(err?.message || err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [connectionId, databaseName, collectionName]);
+
+  const handleApply = async () => {
+    setError(null);
+    setSuccess(false);
+    const trimmed = validator.trim();
+    if (trimmed) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch (e: any) {
+        setError(`Invalid validator JSON: ${e?.message || 'syntax error'}`);
+        return;
+      }
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        setError('Validator must be a JSON object.');
+        return;
+      }
+    }
+
+    setApplying(true);
+    try {
+      await invoke('set_validator', {
+        id: connectionId,
+        database: databaseName,
+        collection: collectionName,
+        validator,
+        validationLevel,
+        validationAction,
+      });
+      setSuccess(true);
+      onApplied();
+    } catch (err: any) {
+      setError(String(err?.message || err));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-auto" data-testid="validation-rules-view">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold text-foreground">
+        <ShieldCheck size={14} className="text-success" />
+        <span>Validation Rules — {collectionName}</span>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
+          <Loader2 size={13} className="animate-spin" /> Loading validation rules…
+        </div>
+      ) : (
+        <div className="flex max-w-[640px] flex-col gap-4 p-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="validation-editor">Validator (JSON Schema)</Label>
+            <QueryEditor
+              surface="filter"
+              value={validator}
+              onChange={(v) => {
+                setValidator(v);
+                setSuccess(false);
+              }}
+              fields={['_id']}
+              height={220}
+              data-testid="validation-editor"
+            />
+            <p className="text-xs text-muted-foreground">
+              Leave empty and apply to clear validation for this collection.
+            </p>
+          </div>
+
+          <div className="flex gap-4">
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label>Validation Level</Label>
+              <Select
+                value={validationLevel || NONE_VALUE}
+                onValueChange={(v) => {
+                  setValidationLevel(v === NONE_VALUE ? '' : v);
+                  setSuccess(false);
+                }}
+              >
+                <SelectTrigger data-testid="validation-level-select">
+                  <SelectValue placeholder="(default)" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NONE_VALUE}>(default)</SelectItem>
+                  <SelectItem value="off">off</SelectItem>
+                  <SelectItem value="moderate">moderate</SelectItem>
+                  <SelectItem value="strict">strict</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label>Validation Action</Label>
+              <Select
+                value={validationAction || NONE_VALUE}
+                onValueChange={(v) => {
+                  setValidationAction(v === NONE_VALUE ? '' : v);
+                  setSuccess(false);
+                }}
+              >
+                <SelectTrigger data-testid="validation-action-select">
+                  <SelectValue placeholder="(default)" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NONE_VALUE}>(default)</SelectItem>
+                  <SelectItem value="error">error</SelectItem>
+                  <SelectItem value="warn">warn</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {error && (
+            <div
+              className="flex items-center gap-2 font-mono text-xs text-destructive"
+              data-testid="validation-error"
+            >
+              <AlertCircle size={13} className="flex-shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {success && !error && (
+            <div
+              className="flex items-center gap-2 font-mono text-xs text-success"
+              data-testid="validation-success"
+            >
+              <CheckCircle2 size={13} className="flex-shrink-0" />
+              <span>Validation rules applied.</span>
+            </div>
+          )}
+
+          <div>
+            <Button
+              type="button"
+              data-testid="validation-apply-btn"
+              onClick={handleApply}
+              disabled={applying}
+            >
+              {applying ? 'Applying…' : 'Apply'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 
 // Mock Sidebar component
 vi.mock('../Sidebar', () => ({
-  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings, onOpenDump, onOpenRestore }: any) => (
+  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings, onOpenDump, onOpenRestore, onEditValidation }: any) => (
     <div data-testid="mock-sidebar">
       <button data-testid="select-collection-btn" onClick={() => onSelectCollection('conn-1', 'sales_db', 'customers')}>
         Select Collection
@@ -84,6 +84,12 @@ vi.mock('../Sidebar', () => ({
       </button>
       <button data-testid="open-restore-btn" onClick={() => onOpenRestore && onOpenRestore('conn-1')}>
         Restore
+      </button>
+      <button
+        data-testid="open-validation-btn"
+        onClick={() => onEditValidation && onEditValidation('conn-1', 'sales_db', 'customers')}
+      >
+        Validation Rules
       </button>
     </div>
   ),
@@ -867,6 +873,31 @@ describe('App Component', () => {
 
     expect(await screen.findByTestId('restore-view')).toBeInTheDocument();
     expect(screen.getByText('Restore: conn-1')).toBeInTheDocument();
+  });
+
+  it('opens the Validation Rules tab from the collection context menu', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({ validator: '{}', validationLevel: '', validationAction: '' });
+      }
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    fireEvent.click(screen.getByTestId('open-validation-btn'));
+
+    expect(await screen.findByTestId('validation-rules-view')).toBeInTheDocument();
+    expect(screen.getByText('Validation: customers')).toBeInTheDocument();
+    await waitFor(() => {
+      const opts = calls.find((c) => c.cmd === 'get_collection_options');
+      expect(opts).toBeTruthy();
+      expect(opts.args).toMatchObject({ id: 'conn-1', database: 'sales_db', collection: 'customers' });
+    });
   });
 
   const managedStatusesFixture = [

--- a/src/components/__tests__/ClusterHealthCard.test.tsx
+++ b/src/components/__tests__/ClusterHealthCard.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => mockInvoke(...a) }));
+
+import { ClusterHealthCard } from '../ClusterHealthCard';
+
+const CLUSTER = {
+  isReplicaSet: true,
+  clusterType: 'replicaSet',
+  set: 'rs0',
+  myStateStr: 'PRIMARY',
+  mongoVersion: '7.0.0',
+  members: [
+    { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 86400, optimeDateMs: 1749427200000, pingMs: null, syncSource: '', lagSecs: null },
+    { name: 'db2:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 86300, optimeDateMs: 1749427199200, pingMs: 1, syncSource: 'db1:27017', lagSecs: 0.8 },
+    { name: 'db3:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 4200, optimeDateMs: 1749427158000, pingMs: 3, syncSource: 'db1:27017', lagSecs: 42 },
+    { name: 'db4:27017', stateStr: '(not reachable/healthy)', health: 0, self: false, uptimeSecs: 0, optimeDateMs: 0, pingMs: null, syncSource: '', lagSecs: null },
+  ],
+};
+
+beforeEach(() => mockInvoke.mockReset());
+
+describe('ClusterHealthCard', () => {
+  it('renders the connection header, member rows, read-pref and version', async () => {
+    mockInvoke.mockResolvedValue(CLUSTER);
+    render(
+      <ClusterHealthCard
+        connectionId="conn-1"
+        connectionName="Mock DB"
+        connectionUri="mongodb://root:pw@h1:27017,h2:27017/?readPreference=primary"
+      />
+    );
+    const card = await screen.findByTestId('cluster-health-card');
+    expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
+
+    expect(screen.getByTestId('cluster-card-connection')).toHaveTextContent('Mock DB');
+    expect(screen.getByTestId('cluster-card-connection')).toHaveTextContent('replica set: rs0');
+    expect(screen.getByTestId('cluster-card-user')).toHaveTextContent('root');
+    expect(screen.getByTestId('cluster-card-read-pref')).toHaveTextContent('Primary');
+    expect(screen.getByTestId('cluster-card-version')).toHaveTextContent('7.0.0');
+
+    expect(screen.getByTestId('cluster-card-member-db1:27017')).toHaveTextContent('PRIMARY');
+    expect(screen.getByTestId('cluster-card-member-db2:27017')).toHaveTextContent('Online [SECONDARY]');
+    expect(screen.getByTestId('cluster-card-member-db2:27017')).toHaveTextContent('lag 0.8s');
+    // 42s >= 10s threshold: amber class somewhere inside the row.
+    expect(screen.getByTestId('cluster-card-member-db3:27017').innerHTML).toMatch(/amber/);
+    // Unhealthy member: destructive styling + Offline instead of lag.
+    const down = screen.getByTestId('cluster-card-member-db4:27017');
+    expect(down.className).toMatch(/destructive/);
+    expect(down).toHaveTextContent('Offline');
+    expect(down).toHaveTextContent('(not reachable/healthy)');
+    expect(card).toBeInTheDocument();
+  });
+
+  it('refetches when Refresh is clicked', async () => {
+    mockInvoke.mockResolvedValue(CLUSTER);
+    render(<ClusterHealthCard connectionId="conn-1" />);
+    await screen.findByTestId('cluster-health-card');
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+
+    screen.getByTestId('cluster-card-refresh').click();
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledTimes(2));
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'repl_set_status', { id: 'conn-1' });
+  });
+
+  it('shows the standalone one-liner for non-replica-set servers, without header lines when props are omitted', async () => {
+    mockInvoke.mockResolvedValue({ isReplicaSet: false, clusterType: 'standalone', set: '', myStateStr: '', mongoVersion: '', members: [] });
+    render(<ClusterHealthCard connectionId="conn-1" />);
+    expect(await screen.findByTestId('cluster-card-standalone')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-card-connection')).toBeNull();
+    expect(screen.queryByTestId('cluster-card-user')).toBeNull();
+    expect(screen.queryByTestId('cluster-card-read-pref')).toBeNull();
+  });
+
+  it('shows the sharded one-liner for mongos connections', async () => {
+    mockInvoke.mockResolvedValue({ isReplicaSet: false, clusterType: 'sharded', set: '', myStateStr: '', mongoVersion: '', members: [] });
+    render(<ClusterHealthCard connectionId="conn-1" />);
+    expect(await screen.findByTestId('cluster-card-sharded')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-card-standalone')).toBeNull();
+  });
+
+  it('renders errors quietly and fires onOpenMonitoring from the footer link', async () => {
+    mockInvoke.mockRejectedValueOnce('Not authorized to run replSetGetStatus');
+    const { unmount } = render(<ClusterHealthCard connectionId="conn-1" />);
+    expect(await screen.findByText(/not authorized/i)).toBeInTheDocument();
+    unmount();
+
+    mockInvoke.mockResolvedValue(CLUSTER);
+    const onOpen = vi.fn();
+    render(<ClusterHealthCard connectionId="conn-2" onOpenMonitoring={onOpen} />);
+    (await screen.findByTestId('cluster-card-open-monitoring')).click();
+    expect(onOpen).toHaveBeenCalledWith('conn-2');
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 
 // Monaco renders the Query Code panel; mock it as a plain textarea (same shape
 // as the other component tests) so assertions can read the generated code.
@@ -224,6 +224,44 @@ describe('DataGrid Component', () => {
     expect(screen.getByText(/"David Miller"/)).toBeInTheDocument();
   });
 
+  it('shows a COLLSCAN suggestion banner in the explain panel and fires onCreateSuggestedIndex', () => {
+    const collscanExplain = JSON.stringify({
+      queryPlanner: {
+        namespace: 'shop.orders',
+        parsedQuery: { status: { $eq: 'open' } },
+        winningPlan: { stage: 'COLLSCAN' },
+      },
+    });
+    const onCreateSuggestedIndex = vi.fn();
+    render(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={collscanExplain}
+        onCreateSuggestedIndex={onCreateSuggestedIndex}
+      />
+    );
+
+    const btn = screen.getByTestId('create-suggested-index-btn');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+
+    expect(onCreateSuggestedIndex).toHaveBeenCalledTimes(1);
+    const suggestion = onCreateSuggestedIndex.mock.calls[0][0];
+    expect(suggestion.namespace).toBe('shop.orders');
+    expect(suggestion.keys).toEqual({ status: 1 });
+  });
+
+  it('does not show a suggestion banner when the plan already uses an index', () => {
+    const ixscanExplain = JSON.stringify({
+      queryPlanner: {
+        namespace: 'shop.orders',
+        winningPlan: { stage: 'FETCH', inputStage: { stage: 'IXSCAN', indexName: 'status_1' } },
+      },
+    });
+    render(<DataGrid documents={mockDocuments} explainResult={ixscanExplain} />);
+    expect(screen.queryByTestId('create-suggested-index-btn')).not.toBeInTheDocument();
+  });
+
   it('shows a Query Code tab rendering the query spec in the selected language', () => {
     const spec = {
       db: 'shop',
@@ -322,6 +360,7 @@ describe('DataGrid Component', () => {
     fireEvent.contextMenu(screen.getByText(/"Alice Smith"/));
     expect(screen.getByTestId('context-menu')).toBeInTheDocument();
     expect(screen.getByText('Edit document')).toBeInTheDocument();
+    expect(screen.getByText('Compare with…')).toBeInTheDocument();
   });
 
   it('copies a document as pretty-printed JSON via the copy button and shows a confirmation', () => {
@@ -338,6 +377,105 @@ describe('DataGrid Component', () => {
     expect(writeText).toHaveBeenCalledWith(JSON.stringify(mockDocuments[0], null, 2));
     // The control flips to a "Copied" confirmation state.
     expect(screen.getAllByLabelText('Copied').length).toBeGreaterThan(0);
+  });
+});
+
+describe('DataGrid — Compare documents', () => {
+  const docs = [
+    { _id: { $oid: '603d779f4f102e3a185c3220' }, name: 'Alice', city: 'NYC' },
+    { _id: { $oid: '603d779f4f102e3a185c3221' }, name: 'Bob', country: 'UK' },
+    { _id: { $oid: '603d779f4f102e3a185c3222' }, name: 'Carol', country: 'FR' },
+  ];
+
+  // The JSON view is virtualized and (in JSDOM, with no real layout height)
+  // only renders the first document's lines, so the two-step flow — which
+  // needs to right-click several distinct rows — exercises Table view
+  // instead, where react-window renders every row of this small fixture.
+  const openMenuForRow = (name: string) => {
+    fireEvent.contextMenu(screen.getByText(name));
+  };
+
+  const renderInTableView = () => {
+    render(<DataGrid documents={docs} onEditDocument={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+  };
+
+  it('two-step compare: first pick arms, second pick opens the diff modal', () => {
+    renderInTableView();
+
+    // First doc: open menu, choose "Compare with…".
+    openMenuForRow('Alice');
+    fireEvent.click(screen.getByText('Compare with…'));
+    // No modal yet — we are armed, waiting for the second pick.
+    expect(screen.queryByTestId('document-diff-modal')).not.toBeInTheDocument();
+
+    // Second doc: the menu now offers "Compare with selected".
+    openMenuForRow('Bob');
+    fireEvent.click(screen.getByText('Compare with selected'));
+
+    const modal = screen.getByTestId('document-diff-modal');
+    expect(modal).toBeInTheDocument();
+    expect(within(modal).getByTestId('diff-left')).toHaveTextContent(/"Alice"/);
+    expect(within(modal).getByTestId('diff-right')).toHaveTextContent(/"Bob"/);
+  });
+
+  it('armed source can be canceled from its own context menu', () => {
+    renderInTableView();
+
+    openMenuForRow('Alice');
+    fireEvent.click(screen.getByText('Compare with…'));
+
+    // Re-opening Alice's own menu offers a cancel action, not "compare with selected".
+    openMenuForRow('Alice');
+    expect(screen.queryByText('Compare with selected')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Cancel compare selection'));
+
+    // Armed state cleared: Alice's menu offers "Compare with…" again, and no
+    // modal ever opened.
+    openMenuForRow('Alice');
+    expect(screen.getByText('Compare with…')).toBeInTheDocument();
+    expect(screen.queryByTestId('document-diff-modal')).not.toBeInTheDocument();
+  });
+
+  it('re-arming with a different document replaces the pending compare source', () => {
+    renderInTableView();
+
+    openMenuForRow('Alice');
+    fireEvent.click(screen.getByText('Compare with…'));
+
+    // Arm Bob instead of finishing the compare with Alice — this should
+    // replace Alice as the pending source.
+    openMenuForRow('Bob');
+    fireEvent.click(screen.getByText('Compare with… (replace selection)'));
+
+    // Finishing the compare now pairs Bob with Carol, not Alice.
+    openMenuForRow('Carol');
+    fireEvent.click(screen.getByText('Compare with selected'));
+
+    const modal = screen.getByTestId('document-diff-modal');
+    expect(within(modal).getByTestId('diff-left')).toHaveTextContent(/"Bob"/);
+    expect(within(modal).getByTestId('diff-right')).toHaveTextContent(/"Carol"/);
+    expect(within(modal).queryByText(/"Alice"/)).not.toBeInTheDocument();
+  });
+
+  it('clears an armed compare source when the documents array is replaced (query re-run)', () => {
+    const { rerender } = render(<DataGrid documents={docs} onEditDocument={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    // Arm Alice as the compare source.
+    openMenuForRow('Alice');
+    fireEvent.click(screen.getByText('Compare with…'));
+
+    // Query re-run / paging / sorting replaces the documents array (same
+    // instance, but a fresh reference — content can even be identical).
+    const freshDocs = docs.map((d) => ({ ...d }));
+    rerender(<DataGrid documents={freshDocs} onEditDocument={() => {}} />);
+
+    // Bob's menu should offer only the plain arm action, not "Compare with
+    // selected" — the old armed source must not survive the new result set.
+    openMenuForRow('Bob');
+    expect(screen.getByText('Compare with…')).toBeInTheDocument();
+    expect(screen.queryByText('Compare with selected')).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/__tests__/DocumentDiffModal.test.tsx
+++ b/src/components/__tests__/DocumentDiffModal.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DocumentDiffModal } from '../DocumentDiffModal';
+
+const left = { _id: 1, name: 'Ada', city: 'London' };
+const right = { _id: 1, name: 'Grace', country: 'USA' };
+
+// diffPair.a/b arrive as raw (possibly Extended-JSON) docs, same as DataGrid
+// passes them — see DocumentDiffModal's toBson().
+const ejsonTimestamp = (t: number, i: number) => ({ $timestamp: { t, i } });
+
+describe('DocumentDiffModal', () => {
+  it('does not render when closed', () => {
+    render(<DocumentDiffModal isOpen={false} left={left} right={right} onClose={() => {}} />);
+    expect(screen.queryByTestId('document-diff-modal')).not.toBeInTheDocument();
+  });
+
+  it('renders both documents side by side and a change summary', () => {
+    render(<DocumentDiffModal isOpen left={left} right={right} onClose={() => {}} />);
+    expect(screen.getByTestId('document-diff-modal')).toBeInTheDocument();
+
+    // Both column values are present.
+    expect(screen.getByTestId('diff-left')).toHaveTextContent(/"Ada"/);
+    expect(screen.getByTestId('diff-right')).toHaveTextContent(/"Grace"/);
+
+    // Summary counts (1 changed: name, 1 added: country, 1 removed: city).
+    const summary = screen.getByTestId('diff-summary');
+    expect(summary).toHaveTextContent('1 changed');
+    expect(summary).toHaveTextContent('1 added');
+    expect(summary).toHaveTextContent('1 removed');
+  });
+
+  it('tags changed/added/removed lines with distinct status markers', () => {
+    render(<DocumentDiffModal isOpen left={left} right={right} onClose={() => {}} />);
+    expect(document.querySelectorAll('.mql-diff-line.is-changed').length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('.mql-diff-line.is-added').length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('.mql-diff-line.is-removed').length).toBeGreaterThan(0);
+    // Gap lines fill the opposite column so both stay aligned.
+    expect(document.querySelectorAll('.mql-diff-line.is-gap').length).toBeGreaterThan(0);
+  });
+
+  it('keeps the two columns row-aligned', () => {
+    render(<DocumentDiffModal isOpen left={left} right={right} onClose={() => {}} />);
+    const leftRows = screen.getByTestId('diff-left').querySelectorAll('.mql-diff-line');
+    const rightRows = screen.getByTestId('diff-right').querySelectorAll('.mql-diff-line');
+    expect(leftRows.length).toBe(rightRows.length);
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<DocumentDiffModal isOpen left={left} right={right} onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText('Close modal'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders a Timestamp field as Timestamp(...), not NumberLong(...)', () => {
+    // Timestamp extends Long in bson — renderScalar must check Timestamp
+    // before Long or every Timestamp renders as NumberLong(...).
+    const tsLeft = { _id: 1, ts: ejsonTimestamp(1700000000, 1) };
+    const tsRight = { _id: 1, ts: ejsonTimestamp(1700000000, 2) };
+    render(<DocumentDiffModal isOpen left={tsLeft} right={tsRight} onClose={() => {}} />);
+    expect(screen.getByTestId('diff-left')).toHaveTextContent('Timestamp(1700000000, 1)');
+    expect(screen.getByTestId('diff-right')).toHaveTextContent('Timestamp(1700000000, 2)');
+    expect(screen.getByTestId('diff-left')).not.toHaveTextContent('NumberLong');
+    expect(screen.getByTestId('diff-right')).not.toHaveTextContent('NumberLong');
+  });
+
+  it('renders a nested-object preview instead of "[object Object]" on a scalar<->container change', () => {
+    const scalarLeft = { x: 1 };
+    const containerRight = { x: { y: 2 } };
+    render(<DocumentDiffModal isOpen left={scalarLeft} right={containerRight} onClose={() => {}} />);
+    const rightCol = screen.getByTestId('diff-right');
+    expect(rightCol).not.toHaveTextContent('[object Object]');
+    expect(rightCol.textContent).toMatch(/"y"\s*:\s*2/);
+  });
+
+  it('shows a "too large" notice instead of columns when the diff exceeds the line cap', () => {
+    // Build a doc with enough top-level keys to blow past the 4000-line cap
+    // (each changed scalar key produces exactly one line per side).
+    const bigLeft: Record<string, number> = {};
+    const bigRight: Record<string, number> = {};
+    for (let i = 0; i < 4500; i++) {
+      bigLeft[`k${i}`] = i;
+      bigRight[`k${i}`] = i + 1;
+    }
+    render(<DocumentDiffModal isOpen left={bigLeft} right={bigRight} onClose={() => {}} />);
+    expect(screen.getByTestId('diff-too-large')).toHaveTextContent(/too large to display \(\d+ lines\)/);
+    expect(screen.queryByTestId('diff-left')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('diff-right')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/IndexViewer.test.tsx
+++ b/src/components/__tests__/IndexViewer.test.tsx
@@ -22,10 +22,22 @@ describe('IndexViewer (T2)', () => {
     indexName: 'city_1',
   };
 
+  const CITY_INDEX = { name: 'city_1', keys: '{"city":1}', unique: true, sparse: false };
+
+  // Routes invoke calls by command name so list_indexes and index_stats can
+  // each return their own shape (a single mockResolvedValue would make
+  // index_stats resolve with the list_indexes payload and vice versa).
+  const mockInvokeByCommand = (handlers: Record<string, any>) => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      const handler = handlers[cmd];
+      if (handler === undefined) return Promise.resolve([]);
+      if (handler instanceof Error || handler === 'reject') return Promise.reject(handler);
+      return Promise.resolve(handler);
+    });
+  };
+
   it('renders the REAL index spec from list_indexes (C3/H4)', async () => {
-    mockInvoke.mockResolvedValue([
-      { name: 'city_1', keys: '{"city":1}', unique: true, sparse: false },
-    ]);
+    mockInvokeByCommand({ list_indexes: [CITY_INDEX], index_stats: [] });
     render(<IndexViewer {...baseProps} />);
 
     // Real key field + unique/sparse flags (not guessed from the name).
@@ -46,9 +58,7 @@ describe('IndexViewer (T2)', () => {
   });
 
   it('deletes the index after the in-app confirm', async () => {
-    mockInvoke.mockResolvedValue([
-      { name: 'city_1', keys: '{"city":1}', unique: false, sparse: false },
-    ]);
+    mockInvokeByCommand({ list_indexes: [{ ...CITY_INDEX, unique: false }], index_stats: [] });
     const onDeleteIndex = vi.fn();
     render(<IndexViewer {...baseProps} onDeleteIndex={onDeleteIndex} />);
 
@@ -56,5 +66,50 @@ describe('IndexViewer (T2)', () => {
     fireEvent.click(await screen.findByTestId('dialog-confirm'));
 
     await waitFor(() => expect(onDeleteIndex).toHaveBeenCalledWith('city_1'));
+  });
+
+  it('fetches index_stats and renders Size + Usage cards for the matching index', async () => {
+    mockInvokeByCommand({
+      list_indexes: [CITY_INDEX],
+      index_stats: [
+        { name: 'city_1', sizeBytes: 16_384, ops: 4_200, sinceMs: 1_749_427_200_000 },
+        { name: 'other_1', sizeBytes: 999, ops: 1, sinceMs: 1_749_427_200_000 },
+      ],
+    });
+    render(<IndexViewer {...baseProps} />);
+
+    expect(mockInvoke).toHaveBeenCalledWith('index_stats', {
+      id: 'c1',
+      db: 'shop',
+      collection: 'products',
+    });
+
+    const sizeCard = await screen.findByTestId('index-size-card');
+    expect(sizeCard).toHaveTextContent('16 KB');
+
+    const usageCard = await screen.findByTestId('index-usage-card');
+    expect(usageCard).toHaveTextContent('4,200');
+    expect(usageCard).not.toHaveTextContent(/unused/i);
+  });
+
+  it('shows an "unused" badge when the matching index has zero ops', async () => {
+    mockInvokeByCommand({
+      list_indexes: [CITY_INDEX],
+      index_stats: [{ name: 'city_1', sizeBytes: 8_192, ops: 0, sinceMs: 0 }],
+    });
+    render(<IndexViewer {...baseProps} />);
+
+    const usageCard = await screen.findByTestId('index-usage-card');
+    expect(usageCard).toHaveTextContent('0');
+    expect(usageCard).toHaveTextContent(/unused/i);
+  });
+
+  it('still renders the definition when index_stats fails', async () => {
+    mockInvokeByCommand({ list_indexes: [CITY_INDEX], index_stats: new Error('stats down') });
+    render(<IndexViewer {...baseProps} />);
+
+    expect(await screen.findByText('city')).toBeInTheDocument();
+    expect(screen.queryByTestId('index-size-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('index-usage-card')).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -15,6 +15,20 @@ const STATUS = {
   cache: { bytesInCache: 1024, maxBytes: 4096, dirtyBytes: 0 },
 };
 
+const CLUSTER = {
+  isReplicaSet: true,
+  clusterType: 'replicaSet',
+  set: 'rs0',
+  myStateStr: 'PRIMARY',
+  mongoVersion: '7.0.0',
+  members: [
+    { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 86400, optimeDateMs: 1749427200000, pingMs: null, syncSource: '', lagSecs: null },
+    { name: 'db2:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 86300, optimeDateMs: 1749427199200, pingMs: 1, syncSource: 'db1:27017', lagSecs: 0.8 },
+    { name: 'db3:27017', stateStr: 'SECONDARY', health: 1, self: false, uptimeSecs: 4200, optimeDateMs: 1749427158000, pingMs: 3, syncSource: 'db1:27017', lagSecs: 42 },
+    { name: 'db4:27017', stateStr: '(not reachable/healthy)', health: 0, self: false, uptimeSecs: 0, optimeDateMs: 0, pingMs: null, syncSource: '', lagSecs: null },
+  ],
+};
+
 beforeEach(() => {
   mockInvoke.mockReset();
   mockInvoke.mockImplementation((cmd: string) => {
@@ -26,6 +40,7 @@ beforeEach(() => {
       case 'list_databases': return Promise.resolve(['admin', 'sales_db']);
       case 'get_profiling_status': return Promise.resolve({ level: 0, slowMs: 100 });
       case 'read_profile': return Promise.resolve([]);
+      case 'repl_set_status': return Promise.resolve(CLUSTER);
       case 'kill_op': return Promise.resolve();
       default: return Promise.resolve(null);
     }
@@ -130,5 +145,69 @@ describe('MonitoringView', () => {
     await waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith('set_profiling_level', expect.objectContaining({ id: 'conn-1', level: 1 }));
     });
+  });
+
+  it('does not fetch replica-set status until the Cluster tab is active', async () => {
+    render(<MonitoringView connectionId="conn-1" />);
+    expect(await screen.findByTestId('current-ops-table')).toBeInTheDocument();
+    expect(mockInvoke).not.toHaveBeenCalledWith('repl_set_status', expect.anything());
+    fireEvent.click(screen.getByTestId('mon-tab-cluster'));
+    expect(await screen.findByTestId('mon-panel-cluster')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
+    });
+  });
+
+  it('renders replica-set members with roles and lag warning styling', async () => {
+    render(<MonitoringView connectionId="conn-1" />);
+    fireEvent.click(await screen.findByTestId('mon-tab-cluster'));
+
+    const summary = await screen.findByTestId('cluster-summary');
+    expect(summary).toHaveTextContent('rs0');
+    expect(summary).toHaveTextContent('4 members');
+    expect(summary).toHaveTextContent('7.0.0');
+    expect(summary).toHaveTextContent('PRIMARY');
+
+    expect(screen.getByTestId('cluster-member-db1:27017')).toHaveTextContent('PRIMARY');
+    // Healthy secondary: sub-threshold lag, no warning class.
+    const okLag = screen.getByTestId('cluster-lag-db2:27017');
+    expect(okLag).toHaveTextContent('0.8s');
+    expect(okLag.className).not.toMatch(/amber|red/);
+    // Lagging secondary (42s >= 10s): amber warning.
+    const warnLag = screen.getByTestId('cluster-lag-db3:27017');
+    expect(warnLag).toHaveTextContent('42');
+    expect(warnLag.className).toMatch(/amber/);
+    // Down/unreachable member: unhealthy styling and no bogus lag.
+    expect(screen.getByTestId('cluster-member-db4:27017').className).toMatch(/destructive/);
+    expect(screen.getByTestId('cluster-lag-db4:27017')).toHaveTextContent('n/a');
+  });
+
+  it('shows a friendly empty state for standalone (non-replica-set) servers', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'server_status') return Promise.resolve(STATUS);
+      if (cmd === 'current_ops') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({ isReplicaSet: false, clusterType: 'standalone', set: '', myStateStr: '', mongoVersion: '', members: [] });
+      return Promise.resolve(null);
+    });
+    render(<MonitoringView connectionId="conn-1" />);
+    fireEvent.click(await screen.findByTestId('mon-tab-cluster'));
+    expect(await screen.findByTestId('cluster-not-replset')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-members-table')).toBeNull();
+  });
+
+  it('shows a sharded-cluster notice for mongos connections', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'server_status') return Promise.resolve(STATUS);
+      if (cmd === 'current_ops') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({ isReplicaSet: false, clusterType: 'sharded', set: '', myStateStr: '', mongoVersion: '', members: [] });
+      return Promise.resolve(null);
+    });
+    render(<MonitoringView connectionId="conn-1" />);
+    fireEvent.click(await screen.findByTestId('mon-tab-cluster'));
+    expect(await screen.findByTestId('cluster-sharded')).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-not-replset')).toBeNull();
+    expect(screen.queryByTestId('cluster-members-table')).toBeNull();
   });
 });

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -290,8 +290,280 @@ describe('Sidebar Component', () => {
     // generic Layers icon.
     const tsIcons = screen.getAllByTestId('coll-icon-timeseries');
     expect(tsIcons).toHaveLength(1);
-    expect(tsIcons[0]).toHaveAttribute('title', 'Time-series collection');
+    expect(tsIcons[0]).toHaveAttribute('aria-label', 'Time-series collection');
     expect(tsIcons[0].closest('div')).toHaveTextContent('sensor_readings');
+  });
+
+  it('shows a cluster-health popover when hovering a connection (#114)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({
+          isReplicaSet: true, clusterType: 'replicaSet', set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          members: [
+            { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
+          ],
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+    const row = await screen.findByLabelText('Connection Mock DB');
+    expect(mockInvoke).not.toHaveBeenCalledWith('repl_set_status', expect.anything());
+    fireEvent.mouseEnter(row);
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
+    expect(await screen.findByText('rs0')).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith('repl_set_status', { id: 'conn-1' });
+    // #114 follow-up: connection name is passed through; the fixture's
+    // auth-less uri ('mongodb://mock') means no user line.
+    expect(screen.getByTestId('cluster-card-connection')).toHaveTextContent('Mock DB');
+    expect(screen.queryByTestId('cluster-card-user')).toBeNull();
+  });
+
+  it('closes the cluster-health popover on Escape (#114)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({
+          isReplicaSet: true, clusterType: 'replicaSet', set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          members: [
+            { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
+          ],
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+    const row = await screen.findByLabelText('Connection Mock DB');
+    fireEvent.mouseEnter(row);
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByTestId('cluster-health-card')).toBeNull());
+  });
+
+  it('refetches cluster health once per open when closed then reopened (#114)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({
+          isReplicaSet: true, clusterType: 'replicaSet', set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          members: [
+            { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
+          ],
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+    const row = await screen.findByLabelText('Connection Mock DB');
+
+    fireEvent.mouseEnter(row);
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(row);
+    // Grace close is 150ms of real time before the popover actually closes.
+    await waitFor(() => expect(screen.queryByTestId('cluster-health-card')).toBeNull());
+
+    fireEvent.mouseEnter(row);
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
+
+    const replSetStatusCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === 'repl_set_status');
+    expect(replSetStatusCalls).toHaveLength(2);
+  });
+
+  it('shows a database stats popover when hovering a database row (#178)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'db_stats')
+        return Promise.resolve({
+          collections: 3, views: 0, objects: 100, avgObjSize: 128,
+          dataSize: 12800, storageSize: 20000, indexes: 4, totalIndexSize: 4096,
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+
+    const dbRow = await screen.findByLabelText('Database sales_db');
+    fireEvent.mouseEnter(dbRow);
+    expect(await screen.findByTestId('db-stats-card')).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith('db_stats', { id: 'conn-1', db: 'sales_db' });
+  });
+
+  it('shows a collection stats popover when hovering a collection row (#178)', async () => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections' && args.db === 'sales_db') {
+        return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      }
+      if (cmd === 'coll_stats')
+        return Promise.resolve({
+          count: 500, avgObjSize: 256, size: 128000, storageSize: 150000,
+          nindexes: 2, totalIndexSize: 8192, capped: false,
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+
+    const dbNode = await screen.findByText('sales_db');
+    fireEvent.click(dbNode);
+    const collectionsFolder = await screen.findByText('Collections');
+    fireEvent.click(collectionsFolder);
+    const collText = await screen.findByText('customers');
+    const collRow = collText.closest('div')!;
+    fireEvent.mouseEnter(collRow);
+    expect(await screen.findByTestId('coll-stats-card')).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith('coll_stats', { id: 'conn-1', db: 'sales_db', collection: 'customers' });
+  });
+
+  it('shows an index stats popover when hovering an index row (#178)', async () => {
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections' && args.db === 'sales_db') {
+        return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      }
+      if (cmd === 'list_indexes') {
+        return Promise.resolve([
+          { name: '_id_', keys: '{"_id":1}', unique: true, sparse: false },
+          { name: 'email_1', keys: '{"email":1}', unique: false, sparse: false },
+        ]);
+      }
+      if (cmd === 'index_stats')
+        return Promise.resolve([
+          { name: '_id_', sizeBytes: 4096, ops: 10, sinceMs: 0 },
+          { name: 'email_1', sizeBytes: 2048, ops: 5, sinceMs: 0 },
+        ]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+
+    const dbNode = await screen.findByText('sales_db');
+    fireEvent.click(dbNode);
+    const collectionsFolder = await screen.findByText('Collections');
+    fireEvent.click(collectionsFolder);
+    const collNode = await screen.findByText('customers');
+    fireEvent.click(collNode);
+    const indexesFolder = await screen.findByText('indexes');
+    fireEvent.click(indexesFolder);
+    const indexText = await screen.findByText('email_1');
+    const indexRow = indexText.closest('div')!;
+    fireEvent.mouseEnter(indexRow);
+    expect(await screen.findByTestId('index-stats-card')).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith('index_stats', { id: 'conn-1', db: 'sales_db', collection: 'customers' });
+  });
+
+  it('closes the db popover and opens the health popover moving from a database row to the connection row (#178)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') return Promise.resolve([]);
+      if (cmd === 'db_stats')
+        return Promise.resolve({
+          collections: 1, views: 0, objects: 1, avgObjSize: 1,
+          dataSize: 1, storageSize: 1, indexes: 1, totalIndexSize: 1,
+        });
+      if (cmd === 'repl_set_status')
+        return Promise.resolve({
+          isReplicaSet: true, clusterType: 'replicaSet', set: 'rs0', myStateStr: 'PRIMARY', mongoVersion: '7.0.0',
+          members: [
+            { name: 'db1:27017', stateStr: 'PRIMARY', health: 1, self: true, uptimeSecs: 1, optimeDateMs: 1, pingMs: null, syncSource: '', lagSecs: null },
+          ],
+        });
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Mock DB', uri: 'mongodb://mock' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        clusterHoverDelayMs={0}
+      />
+    );
+
+    const connRow = await screen.findByLabelText('Connection Mock DB');
+    const dbRow = await screen.findByLabelText('Database sales_db');
+
+    fireEvent.mouseEnter(dbRow);
+    expect(await screen.findByTestId('db-stats-card')).toBeInTheDocument();
+
+    fireEvent.mouseEnter(connRow);
+    await waitFor(() => expect(screen.queryByTestId('db-stats-card')).toBeNull());
+    expect(await screen.findByTestId('cluster-health-card')).toBeInTheDocument();
   });
 
   it('sorts collections by name before rendering', async () => {
@@ -710,6 +982,129 @@ describe('Sidebar Component', () => {
     expect(handleOpenDump).toHaveBeenCalledWith('conn-1', 'sales_db', 'customers');
   });
 
+  it('opens Validation Rules from the collection context menu', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases' && args.id === 'conn-1') {
+        return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections' && args.id === 'conn-1' && args.db === 'sales_db') {
+        return Promise.resolve([{ name: 'customers', type: 'collection' }]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    const handleEditValidation = vi.fn();
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Prod DB Server', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onEditValidation={handleEditValidation}
+      />
+    );
+
+    const dbNode = await screen.findByText('sales_db');
+    fireEvent.click(dbNode);
+    const collectionsFolder = await screen.findByText('Collections');
+    fireEvent.click(collectionsFolder);
+    const collectionNode = await screen.findByText('customers');
+    fireEvent.contextMenu(collectionNode);
+    fireEvent.click(screen.getByText('Validation Rules'));
+    expect(handleEditValidation).toHaveBeenCalledWith('conn-1', 'sales_db', 'customers');
+  });
+
+  it('hides Validation Rules for views but shows it for regular collections (#93)', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases' && args.id === 'conn-1') {
+        return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections' && args.id === 'conn-1' && args.db === 'sales_db') {
+        return Promise.resolve([
+          { name: 'customers', type: 'collection' },
+          { name: 'active_users', type: 'view' },
+        ]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Prod DB Server', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onEditValidation={vi.fn()}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('sales_db'));
+
+    // Views live in their own folder — expand it and right-click the view row.
+    fireEvent.click(await screen.findByText('Views'));
+    const viewNode = await screen.findByText('active_users');
+    fireEvent.contextMenu(viewNode);
+    expect(screen.queryByText('Validation Rules')).not.toBeInTheDocument();
+    expect(screen.getByText('Analyze Schema')).toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    // Regular collection still offers it.
+    fireEvent.click(await screen.findByText('Collections'));
+    const collectionNode = await screen.findByText('customers');
+    fireEvent.contextMenu(collectionNode);
+    expect(screen.getByText('Validation Rules')).toBeInTheDocument();
+  });
+
+  it('hides Validation Rules for time-series collections but shows it for regular collections (#93)', async () => {
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd === 'list_databases' && args.id === 'conn-1') {
+        return Promise.resolve(['sales_db']);
+      }
+      if (cmd === 'list_collections' && args.id === 'conn-1' && args.db === 'sales_db') {
+        return Promise.resolve([
+          { name: 'customers', type: 'collection' },
+          { name: 'sensor_readings', type: 'timeseries' },
+        ]);
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Prod DB Server', uri: 'mongodb://localhost:27017' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+        onEditValidation={vi.fn()}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('sales_db'));
+    fireEvent.click(await screen.findByText('Collections'));
+
+    // Time-series collection: MongoDB rejects collMod validators on these.
+    const tsNode = await screen.findByText('sensor_readings');
+    fireEvent.contextMenu(tsNode);
+    expect(screen.queryByText('Validation Rules')).not.toBeInTheDocument();
+    expect(screen.getByText('Analyze Schema')).toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    // Regular collection still offers it.
+    const collectionNode = screen.getByText('customers');
+    fireEvent.contextMenu(collectionNode);
+    expect(screen.getByText('Validation Rules')).toBeInTheDocument();
+  });
+
   it('hides Dump/Restore context-menu items for mock connections', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases' && args.id === 'conn-1') {
@@ -1015,7 +1410,7 @@ describe('Sidebar Component', () => {
       />
     );
 
-    expect(await screen.findByTitle('Connection color')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Connection color')).toBeInTheDocument();
     expect(screen.getByText('Staging')).toBeInTheDocument();
   });
 

--- a/src/components/__tests__/StatsCards.test.tsx
+++ b/src/components/__tests__/StatsCards.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => mockInvoke(...a) }));
+
+import { DbStatsCard, CollStatsCard, IndexStatsCard } from '../StatsCards';
+
+const DB_STATS = {
+  collections: 4,
+  views: 1,
+  objects: 12345,
+  avgObjSize: 512.5,
+  dataSize: 6324712,
+  storageSize: 2502656,
+  indexes: 9,
+  totalIndexSize: 1105920,
+};
+
+const COLL_STATS = {
+  count: 42123,
+  avgObjSize: 256,
+  size: 10_768_000,
+  storageSize: 4_194_304,
+  nindexes: 3,
+  totalIndexSize: 98_304,
+  capped: false,
+};
+
+const CAPPED_COLL_STATS = { ...COLL_STATS, capped: true };
+
+const INDEX_STATS = [
+  { name: '_id_', sizeBytes: 36_864, ops: 10_500, sinceMs: 1_749_427_200_000 },
+  { name: 'email_1', sizeBytes: 20_480, ops: 42, sinceMs: 1_749_427_200_000 },
+  { name: 'unused_1', sizeBytes: 8_192, ops: 0, sinceMs: 0 },
+];
+
+beforeEach(() => mockInvoke.mockReset());
+
+describe('DbStatsCard', () => {
+  it('renders labeled values with human sizes', async () => {
+    mockInvoke.mockResolvedValue(DB_STATS);
+    render(<DbStatsCard connectionId="conn-1" db="sales_db" />);
+    const card = await screen.findByTestId('db-stats-card');
+    expect(mockInvoke).toHaveBeenCalledWith('db_stats', { id: 'conn-1', db: 'sales_db' });
+
+    expect(card).toHaveTextContent('Database:');
+    expect(card).toHaveTextContent('sales_db');
+    expect(card).toHaveTextContent('12,345');
+    expect(card).toHaveTextContent('6 MB'); // dataSize
+    expect(card).toHaveTextContent('9'); // indexes
+  });
+
+  it('refetches when Refresh is clicked', async () => {
+    mockInvoke.mockResolvedValue(DB_STATS);
+    render(<DbStatsCard connectionId="conn-1" db="sales_db" />);
+    await screen.findByTestId('db-stats-card');
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+
+    screen.getByTestId('stats-refresh').click();
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledTimes(2));
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'db_stats', { id: 'conn-1', db: 'sales_db' });
+  });
+
+  it('renders the error text quietly', async () => {
+    mockInvoke.mockRejectedValueOnce('dbStats failed: not authorized');
+    render(<DbStatsCard connectionId="conn-1" db="sales_db" />);
+    expect(await screen.findByText(/not authorized/i)).toBeInTheDocument();
+  });
+});
+
+describe('CollStatsCard', () => {
+  it('renders the document count with locale formatting and hides Capped when false', async () => {
+    mockInvoke.mockResolvedValue(COLL_STATS);
+    render(<CollStatsCard connectionId="conn-1" db="sales_db" collection="orders" />);
+    const card = await screen.findByTestId('coll-stats-card');
+    expect(mockInvoke).toHaveBeenCalledWith('coll_stats', { id: 'conn-1', db: 'sales_db', collection: 'orders' });
+
+    expect(card).toHaveTextContent('Collection:');
+    expect(card).toHaveTextContent('sales_db.orders');
+    expect(card).toHaveTextContent('42,123');
+    expect(card.textContent).not.toMatch(/Capped/);
+  });
+
+  it('shows Capped: yes when the collection is capped', async () => {
+    mockInvoke.mockResolvedValue(CAPPED_COLL_STATS);
+    render(<CollStatsCard connectionId="conn-1" db="sales_db" collection="logs" />);
+    const card = await screen.findByTestId('coll-stats-card');
+    expect(card).toHaveTextContent('Capped: yes');
+  });
+});
+
+describe('IndexStatsCard', () => {
+  it('picks the matching index from the array and renders usage + since', async () => {
+    mockInvoke.mockResolvedValue(INDEX_STATS);
+    render(<IndexStatsCard connectionId="conn-1" db="sales_db" collection="orders" indexName="email_1" />);
+    const card = await screen.findByTestId('index-stats-card');
+    expect(mockInvoke).toHaveBeenCalledWith('index_stats', { id: 'conn-1', db: 'sales_db', collection: 'orders' });
+
+    expect(card).toHaveTextContent('Index:');
+    expect(card).toHaveTextContent('email_1 on sales_db.orders');
+    expect(card).toHaveTextContent('20 KB');
+    expect(card).toHaveTextContent('42 ops');
+    expect(card).toHaveTextContent(new Date(1_749_427_200_000).toLocaleDateString());
+  });
+
+  it('shows the no-data-since-restart line when ops and sinceMs are both zero', async () => {
+    mockInvoke.mockResolvedValue(INDEX_STATS);
+    render(<IndexStatsCard connectionId="conn-1" db="sales_db" collection="orders" indexName="unused_1" />);
+    const card = await screen.findByTestId('index-stats-card');
+    expect(card).toHaveTextContent('Usage: n/a (no data since restart)');
+    expect(card.textContent).not.toMatch(/Since:/);
+  });
+
+  it('shows a fallback message when the index is missing from the response', async () => {
+    mockInvoke.mockResolvedValue(INDEX_STATS);
+    render(<IndexStatsCard connectionId="conn-1" db="sales_db" collection="orders" indexName="ghost_1" />);
+    const card = await screen.findByTestId('index-stats-card');
+    expect(card).toHaveTextContent('No stats for this index.');
+  });
+});

--- a/src/components/__tests__/ValidationRulesView.test.tsx
+++ b/src/components/__tests__/ValidationRulesView.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-with-providers';
+import { ValidationRulesView } from '../ValidationRulesView';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: any[]) => mockInvoke(...args),
+}));
+
+vi.mock('../QueryEditor', () => ({
+  QueryEditor: ({
+    value,
+    onChange,
+    'data-testid': testId,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    'data-testid'?: string;
+  }) => (
+    <textarea
+      data-testid={testId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+describe('ValidationRulesView', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('loads existing rules on mount', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({
+          validator: '{"$jsonSchema":{"bsonType":"object"}}',
+          validationLevel: 'moderate',
+          validationAction: 'warn',
+        });
+      }
+      return Promise.reject(new Error(`unhandled ${cmd}`));
+    });
+
+    renderWithProviders(
+      <ValidationRulesView
+        connectionId="c1"
+        databaseName="shop"
+        collectionName="customers"
+        onApplied={() => {}}
+      />
+    );
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('get_collection_options', {
+        id: 'c1',
+        database: 'shop',
+        collection: 'customers',
+      })
+    );
+
+    const editor = await screen.findByTestId('validation-editor');
+    expect(editor).toHaveValue('{"$jsonSchema":{"bsonType":"object"}}');
+    expect(screen.getByTestId('validation-level-select')).toHaveTextContent('moderate');
+    expect(screen.getByTestId('validation-action-select')).toHaveTextContent('warn');
+  });
+
+  it('rejects invalid validator JSON before calling set_validator', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({ validator: '{}', validationLevel: '', validationAction: '' });
+      }
+      return Promise.resolve();
+    });
+
+    renderWithProviders(
+      <ValidationRulesView
+        connectionId="c1"
+        databaseName="shop"
+        collectionName="customers"
+        onApplied={() => {}}
+      />
+    );
+
+    const editor = await screen.findByTestId('validation-editor');
+    fireEvent.change(editor, { target: { value: '{ not json' } });
+    fireEvent.click(screen.getByTestId('validation-apply-btn'));
+
+    expect(await screen.findByTestId('validation-error')).toBeInTheDocument();
+    expect(mockInvoke).not.toHaveBeenCalledWith('set_validator', expect.anything());
+  });
+
+  it('applies rules via set_validator with the exact payload and calls onApplied', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({ validator: '{}', validationLevel: '', validationAction: '' });
+      }
+      if (cmd === 'set_validator') return Promise.resolve();
+      return Promise.reject(new Error(`unhandled ${cmd}`));
+    });
+
+    const onApplied = vi.fn();
+    renderWithProviders(
+      <ValidationRulesView
+        connectionId="c1"
+        databaseName="shop"
+        collectionName="customers"
+        onApplied={onApplied}
+      />
+    );
+
+    const editor = await screen.findByTestId('validation-editor');
+    fireEvent.change(editor, {
+      target: { value: '{"$jsonSchema":{"bsonType":"object"}}' },
+    });
+
+    fireEvent.click(screen.getByTestId('validation-level-select'));
+    fireEvent.click(screen.getByRole('option', { name: 'strict' }));
+    fireEvent.click(screen.getByTestId('validation-action-select'));
+    fireEvent.click(screen.getByRole('option', { name: 'error' }));
+
+    fireEvent.click(screen.getByTestId('validation-apply-btn'));
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('set_validator', {
+        id: 'c1',
+        database: 'shop',
+        collection: 'customers',
+        validator: '{"$jsonSchema":{"bsonType":"object"}}',
+        validationLevel: 'strict',
+        validationAction: 'error',
+      })
+    );
+    await waitFor(() => expect(onApplied).toHaveBeenCalled());
+
+    expect(await screen.findByTestId('validation-success')).toBeInTheDocument();
+
+    fireEvent.change(editor, {
+      target: { value: '{"$jsonSchema":{"bsonType":"object","required":["email"]}}' },
+    });
+
+    expect(screen.queryByTestId('validation-success')).not.toBeInTheDocument();
+  });
+
+  it('applies an empty validator to clear validation rules', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_collection_options') {
+        return Promise.resolve({
+          validator: '{"$jsonSchema":{"bsonType":"object"}}',
+          validationLevel: 'strict',
+          validationAction: 'error',
+        });
+      }
+      if (cmd === 'set_validator') return Promise.resolve();
+      return Promise.reject(new Error(`unhandled ${cmd}`));
+    });
+
+    const onApplied = vi.fn();
+    renderWithProviders(
+      <ValidationRulesView
+        connectionId="c1"
+        databaseName="shop"
+        collectionName="customers"
+        onApplied={onApplied}
+      />
+    );
+
+    const editor = await screen.findByTestId('validation-editor');
+    fireEvent.change(editor, { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('validation-apply-btn'));
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('set_validator', {
+        id: 'c1',
+        database: 'shop',
+        collection: 'customers',
+        validator: '',
+        validationLevel: 'strict',
+        validationAction: 'error',
+      })
+    );
+    await waitFor(() => expect(onApplied).toHaveBeenCalled());
+  });
+});

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { cn } from '@/lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 rounded-md border border-border bg-popover p-3 text-popover-foreground shadow-md outline-none',
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };

--- a/src/lib/__tests__/clusterHealth.test.ts
+++ b/src/lib/__tests__/clusterHealth.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { uriUser, uriReadPreference } from '../clusterHealth';
+
+describe('uriUser', () => {
+  it('extracts the user from a user+pass URI', () => {
+    expect(uriUser('mongodb://root:pw@h1:27017,h2:27017/db')).toBe('root');
+  });
+
+  it('extracts the user from a user-only URI', () => {
+    expect(uriUser('mongodb://root@h1:27017/db')).toBe('root');
+  });
+
+  it('returns null for an auth-less URI', () => {
+    expect(uriUser('mongodb://h1:27017,h2:27017/db')).toBeNull();
+  });
+
+  it('decodes a percent-encoded user in a mongodb+srv URI', () => {
+    expect(uriUser('mongodb+srv://user%40corp:pw@cluster0.example.mongodb.net/db')).toBe('user@corp');
+  });
+});
+
+describe('uriReadPreference', () => {
+  it('defaults to primary when absent', () => {
+    expect(uriReadPreference('mongodb://h1:27017/db')).toBe('primary');
+  });
+
+  it('reads readPreference from the query string', () => {
+    expect(uriReadPreference('mongodb://h1:27017/db?readPreference=secondaryPreferred')).toBe('secondaryPreferred');
+  });
+
+  it('reads readPreference when other params are present', () => {
+    expect(
+      uriReadPreference('mongodb://h1:27017/db?retryWrites=true&readPreference=secondaryPreferred&w=majority')
+    ).toBe('secondaryPreferred');
+  });
+});

--- a/src/lib/__tests__/docDiff.test.ts
+++ b/src/lib/__tests__/docDiff.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { ObjectId, Int32, Double, Long, Decimal128, Timestamp, EJSON } from 'bson';
+import { bsonEqual, valueKind, diffDocuments } from '../docDiff';
+
+describe('valueKind', () => {
+  it('classifies containers vs scalars', () => {
+    expect(valueKind({ a: 1 })).toBe('object');
+    expect(valueKind([1, 2])).toBe('array');
+    expect(valueKind('s')).toBe('scalar');
+    expect(valueKind(3)).toBe('scalar');
+    expect(valueKind(null)).toBe('scalar');
+    // BSON wrappers are leaf scalars, not objects to recurse into.
+    expect(valueKind(new ObjectId('507f1f77bcf86cd799439011'))).toBe('scalar');
+    expect(valueKind(new Date('2025-01-01'))).toBe('scalar');
+  });
+});
+
+describe('bsonEqual', () => {
+  it('treats equal primitives as equal', () => {
+    expect(bsonEqual(1, 1)).toBe(true);
+    expect(bsonEqual('a', 'a')).toBe(true);
+    expect(bsonEqual(null, null)).toBe(true);
+    expect(bsonEqual(1, 2)).toBe(false);
+    expect(bsonEqual('a', 'b')).toBe(false);
+  });
+  it('compares BSON wrappers by value', () => {
+    expect(bsonEqual(new ObjectId('507f1f77bcf86cd799439011'), new ObjectId('507f1f77bcf86cd799439011'))).toBe(true);
+    expect(bsonEqual(new ObjectId('507f1f77bcf86cd799439011'), new ObjectId('507f1f77bcf86cd799439012'))).toBe(false);
+    expect(bsonEqual(new Date('2025-01-01'), new Date('2025-01-01'))).toBe(true);
+    expect(bsonEqual(new Int32(7), new Int32(7))).toBe(true);
+    expect(bsonEqual(new Double(2.5), new Double(2.5))).toBe(true);
+    expect(bsonEqual(new Long(42), new Long(42))).toBe(true);
+    expect(bsonEqual(Decimal128.fromString('3.14'), Decimal128.fromString('3.14'))).toBe(true);
+  });
+  it('numeric BSON wrappers equal their plain-number counterpart', () => {
+    expect(bsonEqual(new Int32(7), 7)).toBe(true);
+    expect(bsonEqual(new Double(2.5), 2.5)).toBe(true);
+  });
+  it('different kinds are not equal', () => {
+    expect(bsonEqual(1, '1')).toBe(false);
+    expect(bsonEqual(new ObjectId('507f1f77bcf86cd799439011'), '507f1f77bcf86cd799439011')).toBe(false);
+  });
+
+  // Timestamp extends Long in bson, and the numeric fallback (asNumber) uses
+  // lossy toNumber()/Number(toString()) conversions. Exact wrapper-vs-wrapper
+  // comparisons must happen before that lossy path is ever reached.
+  it('distinguishes distinct Timestamps with the same seconds but different increments', () => {
+    const a = Timestamp.fromBits(1, 1700000000);
+    const b = Timestamp.fromBits(2, 1700000000);
+    expect(bsonEqual(a, b)).toBe(false);
+  });
+
+  it('treats equal Timestamps as equal', () => {
+    const a = Timestamp.fromBits(1, 1700000000);
+    const b = Timestamp.fromBits(1, 1700000000);
+    expect(bsonEqual(a, b)).toBe(true);
+  });
+
+  it('distinguishes distinct Longs above 2^53 that toNumber() would collapse', () => {
+    const a = Long.fromString('9007199254740993');
+    const b = Long.fromString('9007199254740992');
+    expect(bsonEqual(a, b)).toBe(false);
+  });
+
+  it('treats equal large Longs as equal', () => {
+    const a = Long.fromString('9007199254740993');
+    const b = Long.fromString('9007199254740993');
+    expect(bsonEqual(a, b)).toBe(true);
+  });
+
+  it('distinguishes distinct Decimal128s that collapse to the same double', () => {
+    const a = Decimal128.fromString('1.00000000000000000001');
+    const b = Decimal128.fromString('1.00000000000000000002');
+    expect(bsonEqual(a, b)).toBe(false);
+  });
+
+  it('treats equal Decimal128s as equal', () => {
+    const a = Decimal128.fromString('1.00000000000000000001');
+    const b = Decimal128.fromString('1.00000000000000000001');
+    expect(bsonEqual(a, b)).toBe(true);
+  });
+});
+
+describe('diffDocuments — flat objects', () => {
+  it('marks unchanged, changed, added, removed at the top level', () => {
+    const left = { _id: 1, name: 'Ada', age: 36, city: 'London' };
+    const right = { _id: 1, name: 'Grace', age: 36, country: 'USA' };
+    const d = diffDocuments(left, right);
+
+    // Left + right line arrays are aligned (same length, same index = same row).
+    expect(d.left.length).toBe(d.right.length);
+    expect(d.changedCount).toBe(1);   // name
+    expect(d.addedCount).toBe(1);     // country (right only)
+    expect(d.removedCount).toBe(1);   // city (left only)
+
+    const byPath = (arr: typeof d.left, p: string) => arr.find((l) => l.path === p)!;
+    expect(byPath(d.left, 'name').status).toBe('changed');
+    expect(byPath(d.right, 'name').status).toBe('changed');
+    expect(byPath(d.left, 'age').status).toBe('unchanged');
+    expect(byPath(d.left, 'city').status).toBe('removed');
+    expect(byPath(d.right, 'country').status).toBe('added');
+  });
+
+  it('renders a placeholder (gap) opposite an added/removed key so columns align', () => {
+    const d = diffDocuments({ a: 1 }, { a: 1, b: 2 });
+    const i = d.right.findIndex((l) => l.path === 'b');
+    expect(d.right[i].status).toBe('added');
+    expect(d.left[i].status).toBe('gap'); // empty filler on the side that lacks the key
+  });
+});
+
+describe('diffDocuments — nested objects and arrays', () => {
+  it('recurses into nested objects and marks only the changed leaf', () => {
+    const left = { addr: { city: 'London', zip: 'N1' } };
+    const right = { addr: { city: 'Paris', zip: 'N1' } };
+    const d = diffDocuments(left, right);
+
+    // Columns are aligned and contain a container "open" line for `addr`.
+    expect(d.left.length).toBe(d.right.length);
+    const open = d.left.find((l) => l.path === 'addr')!;
+    expect(open.kind).toBe('object');
+    expect(open.bracket).toBe('{');
+
+    const city = d.left.find((l) => l.path === 'addr.city')!;
+    expect(city.depth).toBe(1);
+    expect(city.status).toBe('changed');
+    expect(d.left.find((l) => l.path === 'addr.zip')!.status).toBe('unchanged');
+    expect(d.changedCount).toBe(1);
+  });
+
+  it('treats a scalar->object change as a single changed entry, not a recurse', () => {
+    const d = diffDocuments({ x: 1 }, { x: { y: 2 } });
+    const lx = d.left.find((l) => l.path === 'x')!;
+    const rx = d.right.find((l) => l.path === 'x')!;
+    expect(lx.status).toBe('changed');
+    expect(rx.status).toBe('changed');
+    // No recursion into x.y because the kinds differ.
+    expect(d.left.some((l) => l.path === 'x.y')).toBe(false);
+    expect(d.changedCount).toBe(1);
+  });
+
+  it('diffs arrays positionally, marking added/removed/changed elements', () => {
+    const d = diffDocuments({ tags: ['a', 'b', 'c'] }, { tags: ['a', 'B', 'c', 'd'] });
+    expect(d.left.find((l) => l.path === 'tags[0]')!.status).toBe('unchanged');
+    expect(d.left.find((l) => l.path === 'tags[1]')!.status).toBe('changed');
+    const added = d.right.find((l) => l.path === 'tags[3]')!;
+    expect(added.status).toBe('added');
+    // The left column has a gap opposite the right-only element.
+    const i = d.right.findIndex((l) => l.path === 'tags[3]');
+    expect(d.left[i].status).toBe('gap');
+    expect(d.addedCount).toBe(1);
+    expect(d.changedCount).toBe(1);
+  });
+
+  it('recurses into nested objects inside array elements', () => {
+    const left = { items: [{ q: 1 }] };
+    const right = { items: [{ q: 2 }] };
+    const d = diffDocuments(left, right);
+    expect(d.left.find((l) => l.path === 'items[0].q')!.status).toBe('changed');
+  });
+});
+
+describe('diffDocuments — BSON-typed values', () => {
+  // Parse like DataGrid does (EJSON.parse of JSON.stringify) so the engine sees
+  // real ObjectId/Date/Long instances.
+  const parse = (o: unknown) => EJSON.parse(JSON.stringify(o));
+
+  it('treats equal ObjectIds/Dates as unchanged and differing ones as changed', () => {
+    const left = parse({
+      _id: { $oid: '603d779f4f102e3a185c3220' },
+      at: { $date: '2025-01-01T00:00:00Z' },
+      n: { $numberLong: '42' },
+    });
+    const right = parse({
+      _id: { $oid: '603d779f4f102e3a185c3220' },
+      at: { $date: '2025-02-01T00:00:00Z' },
+      n: { $numberLong: '42' },
+    });
+    const d = diffDocuments(left, right);
+    expect(d.left.find((l) => l.path === '_id')!.status).toBe('unchanged');
+    expect(d.left.find((l) => l.path === 'n')!.status).toBe('unchanged');
+    expect(d.left.find((l) => l.path === 'at')!.status).toBe('changed');
+    expect(d.changedCount).toBe(1);
+  });
+});

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -15,4 +15,8 @@ describe('formatBytes', () => {
     expect(formatBytes(150 * 1024 * 1024)).toBe('150 MB');
     expect(formatBytes(2 * 1024 * 1024 * 1024)).toBe('2 GB');
   });
+
+  it('scales past TB into PB', () => {
+    expect(formatBytes(2 * 1024 ** 5)).toBe('2 PB');
+  });
 });

--- a/src/lib/__tests__/indexSuggestions.test.ts
+++ b/src/lib/__tests__/indexSuggestions.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { suggestESRIndex } from '../indexSuggestions';
+
+describe('suggestESRIndex (ESR rule)', () => {
+  it('returns null when the plan already uses an index (IXSCAN)', () => {
+    const ix = JSON.stringify({ queryPlanner: { namespace: 'db.c', winningPlan: { stage: 'FETCH', inputStage: { stage: 'IXSCAN', indexName: 'a_1' } } } });
+    expect(suggestESRIndex(ix)).toBeNull();
+  });
+  it('suggests an ESR-ordered key for a COLLSCAN with equality + sort + range', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { status: { $eq: 'open' }, total: { $gt: 100 } },
+      winningPlan: { stage: 'SORT', sortPattern: { createdAt: 1 }, inputStage: { stage: 'COLLSCAN' } },
+    } });
+    const s = suggestESRIndex(collscan)!;
+    expect(Object.keys(s.keys)).toEqual(['status', 'createdAt', 'total']);
+    expect(s.keys.createdAt).toBe(1);
+    expect(s.namespace).toBe('shop.orders');
+  });
+  it('handles aggregate explain ($cursor COLLSCAN)', () => {
+    const agg = JSON.stringify({ stages: [{ $cursor: { queryPlanner: { namespace: 'db.c', parsedQuery: { x: { $eq: 1 } }, winningPlan: { stage: 'COLLSCAN' } } } }] });
+    expect(suggestESRIndex(agg)?.keys).toEqual({ x: 1 });
+  });
+  it('suggests ESR keys from a real-server normalized $and parsedQuery', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { $and: [ { status: { $eq: 'open' } }, { total: { $gt: 100 } } ] },
+      winningPlan: { stage: 'SORT', sortPattern: { createdAt: 1 }, inputStage: { stage: 'COLLSCAN' } },
+    } });
+    const s = suggestESRIndex(collscan)!;
+    expect(Object.keys(s.keys)).toEqual(['status', 'createdAt', 'total']);
+  });
+  it('excludes $not and $regex predicates from the equality lead, keeping other fields', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { name: { $regex: 'x' }, status: { $eq: 'open' } },
+      winningPlan: { stage: 'COLLSCAN' },
+    } });
+    const s = suggestESRIndex(collscan)!;
+    expect(s.keys).toEqual({ status: 1 });
+  });
+
+  it('returns null for an IDHACK plan (index-served find-by-_id, no COLLSCAN)', () => {
+    const idhack = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { _id: { $eq: 1 } },
+      winningPlan: { stage: 'IDHACK' },
+    } });
+    expect(suggestESRIndex(idhack)).toBeNull();
+  });
+
+  it('returns null for a COUNT_SCAN plan (index-served, no COLLSCAN)', () => {
+    const countScan = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'COUNT_SCAN' },
+    } });
+    expect(suggestESRIndex(countScan)).toBeNull();
+  });
+
+  it('returns null for a DISTINCT_SCAN plan (index-served, no COLLSCAN)', () => {
+    const distinctScan = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'DISTINCT_SCAN' },
+    } });
+    expect(suggestESRIndex(distinctScan)).toBeNull();
+  });
+
+  it('returns null for a CLUSTERED_IXSCAN plan (index-served, no COLLSCAN)', () => {
+    const clusteredIxscan = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'CLUSTERED_IXSCAN' },
+    } });
+    expect(suggestESRIndex(clusteredIxscan)).toBeNull();
+  });
+
+  it('returns null when winningPlan has neither COLLSCAN nor a recognized index-served stage', () => {
+    const eof = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'EOF' },
+    } });
+    expect(suggestESRIndex(eof)).toBeNull();
+  });
+
+  it('still suggests an index for a plain COLLSCAN plan', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'db.c',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'COLLSCAN' },
+    } });
+    expect(suggestESRIndex(collscan)?.keys).toEqual({ status: 1 });
+  });
+
+  it('skips unknown/non-indexable operators (e.g. $geoWithin) instead of treating them as equality', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { loc: { $geoWithin: { $box: [[0, 0], [1, 1]] } }, status: { $eq: 'x' } },
+      winningPlan: { stage: 'COLLSCAN' },
+    } });
+    const s = suggestESRIndex(collscan)!;
+    expect(s.keys).toEqual({ status: 1 });
+  });
+
+  it('returns null when the only predicate uses an unknown/non-indexable operator', () => {
+    const collscan = JSON.stringify({ queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { loc: { $geoWithin: { $box: [[0, 0], [1, 1]] } } },
+      winningPlan: { stage: 'COLLSCAN' },
+    } });
+    expect(suggestESRIndex(collscan)).toBeNull();
+  });
+});

--- a/src/lib/clusterHealth.ts
+++ b/src/lib/clusterHealth.ts
@@ -1,0 +1,40 @@
+export const lagText = (lagSecs: number | null | undefined): string =>
+  lagSecs == null ? 'n/a' : `${lagSecs < 10 ? lagSecs.toFixed(1) : Math.round(lagSecs)}s`;
+
+export const lagClass = (lagSecs: number | null | undefined): string => {
+  if (lagSecs == null) return 'text-muted-foreground';
+  if (lagSecs >= 60) return 'font-semibold text-red-500';
+  if (lagSecs >= 10) return 'font-semibold text-amber-500';
+  return 'text-muted-foreground';
+};
+
+export const memberUnhealthy = (m: { health: number; stateStr: string }): boolean =>
+  m.health !== 1 || /not reachable|DOWN|UNKNOWN/i.test(m.stateStr);
+
+export const memberDotClass = (m: { health: number; stateStr: string }): string => {
+  if (memberUnhealthy(m)) return 'bg-red-500';
+  if (m.stateStr === 'PRIMARY') return 'bg-emerald-500';
+  if (m.stateStr === 'SECONDARY') return 'bg-sky-500';
+  return 'bg-amber-500';
+};
+
+export const fmtMemberUptime = (secs: number): string => {
+  const d = Math.floor(secs / 86_400);
+  const h = Math.floor((secs % 86_400) / 3_600);
+  return d > 0 ? `${d}d ${h}h` : `${h}h ${Math.floor((secs % 3_600) / 60)}m`;
+};
+
+/** Username from a mongodb:// or mongodb+srv:// URI, or null when auth-less.
+ *  Multi-host URIs (mongodb://u:p@h1:27017,h2:27017/db) break `new URL`, so
+ *  this is regex-based rather than parsed via the URL API. */
+export const uriUser = (uri: string): string | null => {
+  const m = /^mongodb(?:\+srv)?:\/\/([^:@/]+)(?::[^@/]*)?@/.exec(uri);
+  return m ? decodeURIComponent(m[1]) : null;
+};
+
+/** readPreference from the URI query string; MongoDB's default is "primary". */
+export const uriReadPreference = (uri: string): string => {
+  const m = /[?&]readPreference=([^&]+)/i.exec(uri);
+  return m ? decodeURIComponent(m[1]) : 'primary';
+};
+

--- a/src/lib/docDiff.ts
+++ b/src/lib/docDiff.ts
@@ -1,0 +1,281 @@
+import { ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
+
+// A value is a "container" (recurse into it) only when it is a plain object or
+// array. BSON wrappers (ObjectId, Date, Long, …) are leaf scalars: we diff them
+// by value, never by walking their internal fields.
+export type ValueKind = 'object' | 'array' | 'scalar';
+
+export function isBsonScalar(val: unknown): boolean {
+  return (
+    val instanceof ObjectId ||
+    val instanceof Date ||
+    val instanceof Long ||
+    val instanceof Decimal128 ||
+    val instanceof Int32 ||
+    val instanceof Double ||
+    val instanceof Binary ||
+    val instanceof Timestamp
+  );
+}
+
+export function valueKind(val: unknown): ValueKind {
+  if (Array.isArray(val)) return 'array';
+  if (val !== null && typeof val === 'object' && !isBsonScalar(val)) return 'object';
+  return 'scalar';
+}
+
+// Unwrap a BSON numeric wrapper (or plain number) to a JS number, else NaN.
+function asNumber(val: unknown): number {
+  if (typeof val === 'number') return val;
+  if (val instanceof Int32 || val instanceof Double) return val.valueOf();
+  if (val instanceof Long) return val.toNumber();
+  if (val instanceof Decimal128) return Number(val.toString());
+  return NaN;
+}
+
+// Deep value equality for scalars and BSON wrappers. Containers are compared
+// recursively by the caller (diffDocuments), so this only needs to handle leaves.
+export function bsonEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+
+  // Exact comparisons for 64-bit / high-precision wrappers MUST precede the
+  // lossy `asNumber` fallback below. Timestamp extends Long in bson, so the
+  // Timestamp check must come first, otherwise it would be caught by the
+  // Long check (or by asNumber's toNumber()) and lose precision.
+  if (a instanceof Timestamp && b instanceof Timestamp) {
+    return a.equals(b);
+  }
+  if (
+    a instanceof Long && b instanceof Long &&
+    !(a instanceof Timestamp) && !(b instanceof Timestamp)
+  ) {
+    return a.equals(b);
+  }
+  if (a instanceof Decimal128 && b instanceof Decimal128) {
+    return a.toString() === b.toString();
+  }
+
+  // Numeric equivalence across plain numbers and mixed BSON numeric wrapper
+  // types. Same-wrapper 64-bit/high-precision values are handled exactly above.
+  const an = asNumber(a);
+  const bn = asNumber(b);
+  if (!Number.isNaN(an) && !Number.isNaN(bn)) return an === bn;
+
+  if (a instanceof ObjectId && b instanceof ObjectId) return a.equals(b);
+  if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+  if (a instanceof Binary && b instanceof Binary) {
+    return a.sub_type === b.sub_type && a.toString('base64') === b.toString('base64');
+  }
+
+  // Anything else (mismatched kinds, distinct primitives) is unequal.
+  return false;
+}
+
+export type DiffStatus = 'unchanged' | 'changed' | 'added' | 'removed' | 'gap';
+
+// One rendered line in a column. `gap` lines carry no value — they are blank
+// filler that keeps the left/right columns vertically aligned.
+export interface DiffLine {
+  path: string;          // dotted/bracketed path, e.g. "address.city" or "tags[0]"
+  keyLabel: string;      // the key or index shown at this depth (e.g. "city" or "0")
+  depth: number;         // indentation level
+  status: DiffStatus;
+  kind: ValueKind | 'gap';
+  value?: unknown;       // scalar value (when kind === 'scalar')
+  bracket?: string;      // '{' '[' '}' ']' for container open/close lines
+  childCount?: number;   // for container open lines
+}
+
+export interface DocDiff {
+  left: DiffLine[];
+  right: DiffLine[];
+  addedCount: number;
+  removedCount: number;
+  changedCount: number;
+}
+
+const gap = (depth: number): DiffLine => ({ path: '', keyLabel: '', depth, status: 'gap', kind: 'gap' });
+
+function joinPath(parent: string, key: string, isIndex: boolean): string {
+  if (!parent) return isIndex ? `[${key}]` : key;
+  return isIndex ? `${parent}[${key}]` : `${parent}.${key}`;
+}
+
+interface Counts { added: number; removed: number; changed: number; }
+
+// Walk both objects in parallel for a single (object) level, emitting aligned
+// left/right scalar lines. Nested containers are handled in Task 3.
+export function diffDocuments(leftDoc: unknown, rightDoc: unknown): DocDiff {
+  const left: DiffLine[] = [];
+  const right: DiffLine[] = [];
+  const counts = { added: 0, removed: 0, changed: 0 };
+
+  walkLevel(leftDoc, rightDoc, '', 0, left, right, counts);
+
+  return {
+    left,
+    right,
+    addedCount: counts.added,
+    removedCount: counts.removed,
+    changedCount: counts.changed,
+  };
+}
+
+function walkLevel(
+  lv: unknown,
+  rv: unknown,
+  parentPath: string,
+  depth: number,
+  left: DiffLine[],
+  right: DiffLine[],
+  counts: Counts,
+): void {
+  const lArr = Array.isArray(lv);
+  const rArr = Array.isArray(rv);
+  const isIndex = lArr || rArr;
+
+  // Build the aligned key list for this level.
+  let keys: string[];
+  if (isIndex) {
+    const len = Math.max(lArr ? (lv as unknown[]).length : 0, rArr ? (rv as unknown[]).length : 0);
+    keys = Array.from({ length: len }, (_, i) => String(i));
+  } else {
+    const lObj = (valueKind(lv) === 'object' ? (lv as Record<string, unknown>) : {});
+    const rObj = (valueKind(rv) === 'object' ? (rv as Record<string, unknown>) : {});
+    keys = [];
+    const seen = new Set<string>();
+    for (const k of Object.keys(lObj)) { keys.push(k); seen.add(k); }
+    for (const k of Object.keys(rObj)) { if (!seen.has(k)) keys.push(k); }
+  }
+
+  const getL = (key: string) => (valueKind(lv) === 'object' || lArr ? (lv as any)[key] : undefined);
+  const getR = (key: string) => (valueKind(rv) === 'object' || rArr ? (rv as any)[key] : undefined);
+  const hasL = (key: string) =>
+    lArr ? Number(key) < (lv as unknown[]).length
+         : valueKind(lv) === 'object' && Object.prototype.hasOwnProperty.call(lv, key);
+  const hasR = (key: string) =>
+    rArr ? Number(key) < (rv as unknown[]).length
+         : valueKind(rv) === 'object' && Object.prototype.hasOwnProperty.call(rv, key);
+
+  for (const key of keys) {
+    const inL = hasL(key);
+    const inR = hasR(key);
+    const path = joinPath(parentPath, key, isIndex);
+    const a = getL(key);
+    const b = getR(key);
+
+    if (inL && !inR) {
+      emitRemoved(path, key, depth, a, left, right, counts);
+      continue;
+    }
+    if (!inL && inR) {
+      emitAdded(path, key, depth, b, left, right, counts);
+      continue;
+    }
+
+    const aKind = valueKind(a);
+    const bKind = valueKind(b);
+
+    // Both are the same container kind -> emit an open line on both sides and recurse.
+    if (aKind === bKind && (aKind === 'object' || aKind === 'array')) {
+      const bracket = aKind === 'array' ? '[' : '{';
+      const closeBracket = aKind === 'array' ? ']' : '}';
+      const aChildren = aKind === 'array' ? (a as unknown[]).length : Object.keys(a as object).length;
+      const bChildren = bKind === 'array' ? (b as unknown[]).length : Object.keys(b as object).length;
+      const openL = left.length;
+      const openR = right.length;
+      left.push({ path, keyLabel: key, depth, status: 'unchanged', kind: aKind, bracket, childCount: aChildren });
+      right.push({ path, keyLabel: key, depth, status: 'unchanged', kind: bKind, bracket, childCount: bChildren });
+
+      const beforeChanged = counts.changed, beforeAdded = counts.added, beforeRemoved = counts.removed;
+      walkLevel(a, b, path, depth + 1, left, right, counts);
+
+      // Close lines.
+      left.push({ path, keyLabel: '', depth, status: 'unchanged', kind: aKind, bracket: closeBracket });
+      right.push({ path, keyLabel: '', depth, status: 'unchanged', kind: bKind, bracket: closeBracket });
+
+      // Mark the container "changed" (visually) if any descendant changed.
+      const touched =
+        counts.changed !== beforeChanged ||
+        counts.added !== beforeAdded ||
+        counts.removed !== beforeRemoved;
+      // Re-tag the open lines (captured by index before the push) as
+      // 'changed' when descendants differ — O(1) instead of re-scanning.
+      if (touched) {
+        left[openL] = { ...left[openL], status: 'changed' };
+        right[openR] = { ...right[openR], status: 'changed' };
+      }
+      continue;
+    }
+
+    // Scalar-vs-scalar, or kind mismatch (scalar<->container): single line, no recurse.
+    const equal = aKind === 'scalar' && bKind === 'scalar' && bsonEqual(a, b);
+    if (!equal) counts.changed++;
+    const status: DiffStatus = equal ? 'unchanged' : 'changed';
+    left.push({ path, keyLabel: key, depth, status, kind: 'scalar', value: a });
+    right.push({ path, keyLabel: key, depth, status, kind: 'scalar', value: b });
+  }
+}
+
+function emitRemoved(
+  path: string, key: string, depth: number, a: unknown,
+  left: DiffLine[], right: DiffLine[], counts: Counts,
+): void {
+  counts.removed++;
+  const kind = valueKind(a);
+  if (kind === 'object' || kind === 'array') {
+    // Flatten the removed container as scalar-ish lines on the left only.
+    left.push({ path, keyLabel: key, depth, status: 'removed', kind, bracket: kind === 'array' ? '[' : '{', childCount: kind === 'array' ? (a as unknown[]).length : Object.keys(a as object).length });
+    right.push(gap(depth));
+    flattenOneSide(a, path, depth + 1, 'removed', left, right);
+    left.push({ path, keyLabel: '', depth, status: 'removed', kind, bracket: kind === 'array' ? ']' : '}' });
+    right.push(gap(depth));
+    return;
+  }
+  left.push({ path, keyLabel: key, depth, status: 'removed', kind: 'scalar', value: a });
+  right.push(gap(depth));
+}
+
+function emitAdded(
+  path: string, key: string, depth: number, b: unknown,
+  left: DiffLine[], right: DiffLine[], counts: Counts,
+): void {
+  counts.added++;
+  const kind = valueKind(b);
+  if (kind === 'object' || kind === 'array') {
+    right.push({ path, keyLabel: key, depth, status: 'added', kind, bracket: kind === 'array' ? '[' : '{', childCount: kind === 'array' ? (b as unknown[]).length : Object.keys(b as object).length });
+    left.push(gap(depth));
+    flattenOneSide(b, path, depth + 1, 'added', right, left);
+    right.push({ path, keyLabel: '', depth, status: 'added', kind, bracket: kind === 'array' ? ']' : '}' });
+    left.push(gap(depth));
+    return;
+  }
+  right.push({ path, keyLabel: key, depth, status: 'added', kind: 'scalar', value: b });
+  left.push(gap(depth));
+}
+
+// Emit every leaf of a one-sided (added or removed) container into `side`, with a
+// matching gap pushed into `other` so the two columns stay aligned.
+function flattenOneSide(
+  val: unknown, parentPath: string, depth: number, status: DiffStatus,
+  side: DiffLine[], other: DiffLine[],
+): void {
+  const isArr = Array.isArray(val);
+  const entries: [string, unknown][] = isArr
+    ? (val as unknown[]).map((v, i) => [String(i), v])
+    : Object.entries(val as Record<string, unknown>);
+  for (const [key, v] of entries) {
+    const path = joinPath(parentPath, key, isArr);
+    const kind = valueKind(v);
+    if (kind === 'object' || kind === 'array') {
+      side.push({ path, keyLabel: key, depth, status, kind, bracket: kind === 'array' ? '[' : '{', childCount: kind === 'array' ? (v as unknown[]).length : Object.keys(v as object).length });
+      other.push(gap(depth));
+      flattenOneSide(v, path, depth + 1, status, side, other);
+      side.push({ path, keyLabel: '', depth, status, kind, bracket: kind === 'array' ? ']' : '}' });
+      other.push(gap(depth));
+    } else {
+      side.push({ path, keyLabel: key, depth, status, kind: 'scalar', value: v });
+      other.push(gap(depth));
+    }
+  }
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,7 +1,7 @@
 // Format a byte count into a compact human-readable string (e.g. 145 MB).
 export function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
-  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
   const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
   const value = bytes / Math.pow(1024, i);
   // No decimals for bytes; one decimal otherwise, trimmed.

--- a/src/lib/indexSuggestions.ts
+++ b/src/lib/indexSuggestions.ts
@@ -1,0 +1,85 @@
+export interface IndexSuggestion {
+  namespace: string;
+  keys: Record<string, 1 | -1>;
+  suggestedName: string;
+  reason: string;
+}
+
+const RANGE_OPS = new Set(['$gt', '$gte', '$lt', '$lte', '$ne', '$in', '$nin']);
+
+const extractPlan = (json: any): { wp: any; parsed: any; ns: string } | null => {
+  if (Array.isArray(json?.stages)) {
+    const cursor = json.stages.find((s: any) => s && s.$cursor)?.$cursor?.queryPlanner;
+    if (!cursor) return null;
+    return { wp: cursor.winningPlan, parsed: cursor.parsedQuery ?? {}, ns: cursor.namespace ?? '' };
+  }
+  const qp = json?.queryPlanner;
+  if (!qp) return null;
+  return { wp: qp.winningPlan, parsed: qp.parsedQuery ?? {}, ns: qp.namespace ?? '' };
+};
+
+const INDEX_SERVED_STAGES = new Set(['IXSCAN', 'IDHACK', 'COUNT_SCAN', 'DISTINCT_SCAN', 'CLUSTERED_IXSCAN']);
+
+const walk = (stage: any, acc: { served: boolean; hasCollscan: boolean; sort?: Record<string, number> }) => {
+  if (!stage || typeof stage !== 'object') return;
+  if (INDEX_SERVED_STAGES.has(stage.stage)) acc.served = true;
+  if (stage.stage === 'COLLSCAN') acc.hasCollscan = true;
+  if (stage.stage === 'SORT' && stage.sortPattern) acc.sort = stage.sortPattern;
+  if (stage.inputStage) walk(stage.inputStage, acc);
+  if (Array.isArray(stage.inputStages)) stage.inputStages.forEach((s: any) => walk(s, acc));
+};
+
+const flattenTopLevelAnd = (parsed: any): [string, any][] => {
+  const entries: [string, any][] = [];
+  Object.entries(parsed || {}).forEach(([field, cond]) => {
+    if (field === '$and' && Array.isArray(cond)) {
+      cond.forEach((clause) => {
+        if (clause && typeof clause === 'object' && !Array.isArray(clause)) {
+          entries.push(...Object.entries(clause));
+        }
+      });
+      return;
+    }
+    entries.push([field, cond]);
+  });
+  return entries;
+};
+
+const classify = (parsed: any): { eq: string[]; range: string[] } => {
+  const eq: string[] = []; const range: string[] = [];
+  flattenTopLevelAnd(parsed).forEach(([field, cond]) => {
+    if (field.startsWith('$')) return;
+    if (cond && typeof cond === 'object' && !Array.isArray(cond)) {
+      const ops = Object.keys(cond);
+      if (ops.includes('$eq')) eq.push(field);
+      else if (ops.every((o) => RANGE_OPS.has(o))) range.push(field);
+      else return;
+    } else { eq.push(field); }
+  });
+  return { eq, range };
+};
+
+export const suggestESRIndex = (explainStr: string): IndexSuggestion | null => {
+  let json: any;
+  try { json = JSON.parse(explainStr); } catch { return null; }
+  const plan = extractPlan(json);
+  if (!plan?.wp) return null;
+  const acc = { served: false as boolean, hasCollscan: false as boolean, sort: undefined as Record<string, number> | undefined };
+  walk(plan.wp, acc);
+  if (acc.served || !acc.hasCollscan) return null;
+  const { eq, range } = classify(plan.parsed);
+  const sortFields = acc.sort ? Object.keys(acc.sort) : [];
+  const ordered: string[] = [];
+  const keys: Record<string, 1 | -1> = {};
+  const push = (f: string, dir: 1 | -1) => { if (!ordered.includes(f)) { ordered.push(f); keys[f] = dir; } };
+  eq.forEach((f) => push(f, 1));
+  sortFields.forEach((f) => push(f, acc.sort![f] === -1 ? -1 : 1));
+  range.forEach((f) => push(f, 1));
+  if (ordered.length === 0) return null;
+  return {
+    namespace: plan.ns,
+    keys,
+    suggestedName: ordered.map((f) => `${f}_${keys[f]}`).join('_'),
+    reason: 'This query performs a full collection scan (COLLSCAN). A compound index ordered by the ESR rule (Equality, Sort, Range) can serve it from an index scan.',
+  };
+};

--- a/src/lib/monitoringApi.ts
+++ b/src/lib/monitoringApi.ts
@@ -45,3 +45,26 @@ export const setProfilingLevel = (id: string, database: string, level: number, s
   invoke<ProfilingStatus>('set_profiling_level', { id, database, level, slowMs });
 export const readProfile = (id: string, database: string, limit: number) =>
   invoke<ProfileEntry[]>('read_profile', { id, database, limit });
+
+export interface ReplSetMember {
+  name: string;
+  stateStr: string;
+  health: number;
+  self: boolean;
+  uptimeSecs: number;
+  optimeDateMs: number;
+  pingMs?: number | null;
+  syncSource: string;
+  lagSecs?: number | null;
+}
+
+export interface ReplSetStatus {
+  isReplicaSet: boolean;
+  clusterType: string;
+  set: string;
+  myStateStr: string;
+  mongoVersion: string;
+  members: ReplSetMember[];
+}
+
+export const replSetStatus = (id: string) => invoke<ReplSetStatus>('repl_set_status', { id });


### PR DESCRIPTION
* feat: Cluster Health monitor — replica-set status and replication lag (#114) (#177)

* feat: replica-set status backend for the Cluster Health tab

* feat: Cluster Health tab with replica-set members and replication lag

* fix: down replica-set members show n/a lag instead of an epoch-sized number

* feat: cluster-health popover when hovering a connection in the sidebar

* fix: sidebar health popover closes on Escape, outside click, and row change

* chore: retrigger CI after GitHub Actions outage

* fix: cluster-health popover opens at the cursor position

* feat: cluster type (replica set, sharded, standalone) shown in cluster health

* feat: richer cluster popover — connection, user, read preference, server version, refresh

* fix: cluster popover sizes to content so member hosts are never truncated

* fix: cluster popover shows the member's real state label and polishes the set-name styling

* fix: widen the cluster popover card

* feat: stats popovers for databases, collections, and indexes (#178) (#179)

* feat: database, collection, and index statistics backend

* feat: database, collection, and index stat cards

* feat: stats popovers on database, collection, and index rows

* fix: reuse the existing formatBytes helper and extend it past TB

* fix: remove native title tooltips from sidebar and fix Import URI dropdown z-index

Native HTML title attributes rendered as black rectangles on Linux/WebKitGTK (Tauri webview). Replace with aria-label for accessibility without broken tooltips.

The Import URI DropdownMenuContent in the editor dialog was at z-50 while the dialog itself is at z-[100], making options unreachable. Apply NESTED_SELECT_Z (z-[110]) consistent with other Select components in the same dialog.



* feat: index usage stats and ESR index suggestions (#90) (#180)

* feat: ESR index suggestion from COLLSCAN explain plans

* feat: index size and usage cards in the index viewer

* feat: one-click index creation from a COLLSCAN explain suggestion

* fix: ESR suggestions work on real-server $and explains; demoable COLLSCAN in mock

* fix: index suggestions require a real COLLSCAN and skip non-indexable operators

* feat: collection validation rules editor (#93) (#182)

* feat: add collMod command builder for validation rules

Implements build_collmod_command and validation helpers to construct MongoDB collMod commands with validator, validationLevel, and validationAction fields. Includes unit tests for full validator, empty options, and invalid input rejection.

* feat: validation rules editor view

* feat: add validation rules entry to collection context menu

* feat: read collection validator and validation level/action

Adds CollectionValidation struct and get_collection_options_impl to read a collection's $jsonSchema validator, validationLevel, and validationAction via list_collections. Mock connections return empty defaults. Includes unit tests for mock-path and helper functions.

* feat: apply collection validator via collMod

Implements set_validator_impl to update a collection's $jsonSchema validator, validationLevel, and validationAction via collMod command. Validates inputs (JSON syntax, object type, valid level/action) before calling database. Mock connections no-op. Includes comprehensive tests.

* feat: open validation rules tab from sidebar

* feat: register get_collection_options and set_validator commands

Adds Tauri command wrappers for get_collection_options_impl and set_validator_impl, exposing them to the frontend. Includes mock-path round-trip test to verify correct public surface. Commands are auto-camelCased by Tauri (validationLevel/validationAction).

* test: real-server round-trip for validator get/set

Adds integration test that creates a collection, sets a \$jsonSchema validator with moderate/error, then calls get_collection_options_impl to verify the validator was persisted. Test is server-gated and skipped when MQLENS_TEST_MONGO_URI is not set.

* fix: validation rules menu only on real collections; success banner clears on edit

* fix: validation rules hidden on time-series collections; BSON round-trip regression test

* feat: side-by-side document diff (#92) (#181)

* feat: add value equality and kind helpers for document diff

* feat: diff flat documents into aligned left/right lines

* feat: recurse into nested objects and arrays in document diff

* test: lock in BSON-typed scalar diff behavior

* chore: remove unused variable from document diff

* feat: side-by-side document diff modal

* feat: compare two documents side by side from the context menu

* fix: re-running a query clears the armed compare selection

* fix: O(1) container re-tag in the diff engine; open diff survives background refresh

* fix: document diff compares Timestamp, Long, and Decimal128 exactly instead of via lossy doubles

---------

<!-- Thanks for contributing to MQLens! PRs target the `dev` branch. -->

## Summary

<!-- What does this change and why? -->

## Related issue

<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` (Vitest) passes
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` passes (if backend touched)
- [ ] Manually verified in the running app (`npm run tauri dev`)

## Screenshots

<!-- For UI changes, before/after screenshots help. -->

## Checklist

- [ ] This PR targets `dev` (not `main`)
- [ ] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [ ] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
