### PR TITLE
feat: split panes — multi-panel workspace phase 1 (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ queries actually do — from a single cross-platform desktop app.
 - **Encrypted credentials** — a master password gates the app; connection
   profiles and settings are encrypted at rest with AES-256-GCM (Argon2id key
   derivation).
+- **Split panes** — drag a tab to any pane edge to split the workspace; compare
+  collections side by side, keep a shell under your results.
 
 ## Install
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -277,8 +277,14 @@ function Workspace() {
   const activeTabId = focusedPane?.activeTabId ?? null;
   if (import.meta.env.DEV) {
     const known = new Set(tabs.map(t => t.id));
-    for (const id of allTabIds(layout)) {
+    const layoutIds = allTabIds(layout);
+    for (const id of layoutIds) {
       if (!known.has(id)) console.error(`workspace layout references unknown tab: ${id}`);
+    }
+    const inLayout = new Set(layoutIds);
+    const orphans = tabs.map(t => t.id).filter(id => !inLayout.has(id));
+    if (orphans.length > 0) {
+      console.error(`tabs[] contains ids missing from workspace layout: ${orphans.join(', ')}`);
     }
   }
   const tabBuilderStateCache = useRef(new Map<string, BuilderState>());
@@ -542,7 +548,6 @@ function Workspace() {
         t.collection === exportTab.collection
     ) ||
     null;
-  const exportSourceTab = activeTab && activeTab.type === 'export' ? deriveExportSourceTab(activeTab) : null;
 
   // MongoDB server version of the active connection, for the status bar.
   const activeConnId = activeTab && activeConnections.some(c => c.id === activeTab.connectionId) ? activeTab.connectionId : null;
@@ -1449,7 +1454,7 @@ function Workspace() {
       { id: 'analyze-schema', title: 'Analyze Schema', hint: `${activeTab.db}.${activeTab.collection}`, keywords: 'fields types', run: () => handleOpenSchemaTab(activeTab.connectionId, activeTab.db, activeTab.collection) },
     ] : []),
     ...(activeTabId ? [{ id: 'close-tab', title: 'Close Tab', keywords: 'tab', run: () => closeTabById(activeTabId) }] : []),
-    ...(tabs.length > 1 ? [
+    ...(focusedPane && focusedPane.tabIds.length > 1 ? [
       { id: 'next-tab', title: 'Next Tab', keywords: 'tab switch', run: () => cycleTab(1) },
       { id: 'prev-tab', title: 'Previous Tab', keywords: 'tab switch', run: () => cycleTab(-1) },
     ] : []),
@@ -1692,50 +1697,57 @@ function Workspace() {
     }
   };
 
+  // All three take the rendered export `tab` (not activeTab / focused-pane state) so
+  // that every per-pane ExportView instance acts on its own pane's collection, even
+  // when a different pane is focused (see renderTabContent's export branch).
   const handleCopyCurrentExport = async (
+    tab: QueryTab,
     format: 'json' | 'ndjson' | 'csv',
     options: ExportOptions
   ) => {
-    if (!exportSourceTab?.results?.length) return;
+    const sourceTab = deriveExportSourceTab(tab);
+    if (!sourceTab?.results?.length) return;
     try {
       const text = await invoke<string | null>('format_current_docs', {
-        docs: exportSourceTab.results,
+        docs: sourceTab.results,
         format,
         options,
         path: null,
       });
       if (text) await navigator.clipboard.writeText(text);
-      toast(`Copied ${exportSourceTab.results.length} document(s) as ${format.toUpperCase()}`, 'success');
+      toast(`Copied ${sourceTab.results.length} document(s) as ${format.toUpperCase()}`, 'success');
     } catch (err: any) {
       toast(`Copy failed: ${err?.message || err}`, 'error');
     }
   };
 
-  const handleScanExportFields = (query?: FilteredExportQuery) =>
+  const handleScanExportFields = (tab: QueryTab, query?: FilteredExportQuery) =>
     invoke<string[]>('sample_export_fields', {
-      id: activeTab?.connectionId,
-      database: activeTab?.db,
-      collection: activeTab?.collection,
+      id: tab.connectionId,
+      database: tab.db,
+      collection: tab.collection,
       filter: query?.kind === 'find' ? query.filter : '{}',
       pipeline: query?.kind === 'aggregate' ? query.pipeline : '',
     });
 
   const handlePreviewExport = async (
+    tab: QueryTab,
     format: ExportFormat,
     scope: 'current' | 'full' | 'filtered',
     options: ExportOptions,
     query?: FilteredExportQuery
   ): Promise<string> => {
     if (scope === 'current') {
-      const docs = (exportSourceTab?.results ?? []).slice(0, 5);
+      const sourceTab = deriveExportSourceTab(tab);
+      const docs = (sourceTab?.results ?? []).slice(0, 5);
       return (
         (await invoke<string | null>('format_current_docs', { docs, format, options, path: null })) ?? ''
       );
     }
     return invoke<string>('preview_export', {
-      id: activeTab?.connectionId,
-      database: activeTab?.db,
-      collection: activeTab?.collection,
+      id: tab.connectionId,
+      database: tab.db,
+      collection: tab.collection,
       format,
       filter: query?.kind === 'find' ? query.filter : '{}',
       sort: query?.kind === 'find' ? query.sort : '{}',
@@ -2152,9 +2164,9 @@ function Workspace() {
                 })
               }
               onOpenTasks={handleOpenTasksTab}
-              onScanFields={handleScanExportFields}
-              onCopyCurrent={handleCopyCurrentExport}
-              onPreview={handlePreviewExport}
+              onScanFields={(query) => handleScanExportFields(tab, query)}
+              onCopyCurrent={(format, options) => handleCopyCurrentExport(tab, format, options)}
+              onPreview={(format, scope, options, query) => handlePreviewExport(tab, format, scope, options, query)}
             />
           );
         })()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useReducer } from 'react';
 import { AppShell } from '@/components/layout/AppShell';
-import { WorkspaceTabBar } from '@/components/layout/WorkspaceTabBar';
 import { StatusBar } from '@/components/layout/StatusBar';
 import { Toaster } from '@/components/ui/sonner';
 import { useTheme } from '@/hooks/use-theme';
@@ -38,7 +37,8 @@ import {
 } from './components/RestoreView';
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
-import { workspaceReducer, createInitialLayout, findPane } from './workspace/model';
+import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, type WorkspaceAction } from './workspace/model';
+import { WorkspaceRoot } from './workspace/WorkspaceRoot';
 import { CreateViewView } from './components/CreateViewView';
 import { ValidationRulesView } from './components/ValidationRulesView';
 import { GridFsView } from './components/GridFsView';
@@ -275,6 +275,12 @@ function Workspace() {
   );
   const focusedPane = findPane(layout.root, layout.focusedPaneId);
   const activeTabId = focusedPane?.activeTabId ?? null;
+  if (import.meta.env.DEV) {
+    const known = new Set(tabs.map(t => t.id));
+    for (const id of allTabIds(layout)) {
+      if (!known.has(id)) console.error(`workspace layout references unknown tab: ${id}`);
+    }
+  }
   const tabBuilderStateCache = useRef(new Map<string, BuilderState>());
   const handleBuilderStateChange = useCallback((tabId: string, state: BuilderState) => {
     tabBuilderStateCache.current.set(tabId, state);
@@ -1208,12 +1214,12 @@ function Workspace() {
   // Fired by the DataGrid COLLSCAN suggestion banner: opens the create-index
   // flow pre-filled with the ESR-ordered keys, scoped to the active tab's own
   // connection/db/collection (preferred over parsing the explain namespace).
-  const handleCreateSuggestedIndex = (suggestion: IndexSuggestion) => {
-    if (!activeTab || activeTab.type !== 'collection') return;
+  const handleCreateSuggestedIndex = (tab: QueryTab, suggestion: IndexSuggestion) => {
+    if (tab.type !== 'collection') return;
     setIndexModalTarget({
-      connectionId: activeTab.connectionId,
-      db: activeTab.db,
-      collection: activeTab.collection,
+      connectionId: tab.connectionId,
+      db: tab.db,
+      collection: tab.collection,
       initialData: null,
       prefill: {
         name: suggestion.suggestedName,
@@ -1316,6 +1322,18 @@ function Workspace() {
     const updatedTabs = tabs.filter(t => t.id !== tabId);
     setTabs(updatedTabs);
     dispatchLayout({ type: 'close_tab', tabId });
+  };
+
+  // Passed to WorkspaceRoot/PaneView as their `dispatch`. Panes close their own
+  // tabs by dispatching `close_tab` directly (drag/drop and split ops only need
+  // the layout reducer), so we intercept that one action to also keep `tabs`
+  // state and the builder-state cache in sync — mirroring closeTabById.
+  const dispatchWorkspace = (action: WorkspaceAction) => {
+    if (action.type === 'close_tab') {
+      closeTabById(action.tabId);
+      return;
+    }
+    dispatchLayout(action);
   };
 
   const cycleTab = (dir: 1 | -1) => {
@@ -1434,6 +1452,17 @@ function Workspace() {
     ...(tabs.length > 1 ? [
       { id: 'next-tab', title: 'Next Tab', keywords: 'tab switch', run: () => cycleTab(1) },
       { id: 'prev-tab', title: 'Previous Tab', keywords: 'tab switch', run: () => cycleTab(-1) },
+    ] : []),
+    ...(activeTabId && focusedPane && focusedPane.tabIds.length > 1 ? [
+      { id: 'workspace.split-right', title: 'Split Right', keywords: 'workspace pane layout', run: () => dispatchLayout({ type: 'split_pane', paneId: focusedPane.id, dir: 'row', side: 'end', moveTabId: activeTabId }) },
+      { id: 'workspace.split-down', title: 'Split Down', keywords: 'workspace pane layout', run: () => dispatchLayout({ type: 'split_pane', paneId: focusedPane.id, dir: 'col', side: 'end', moveTabId: activeTabId }) },
+    ] : []),
+    ...(allPanes(layout.root).length > 1 ? [
+      { id: 'workspace.focus-next-pane', title: 'Focus Next Pane', keywords: 'workspace pane layout switch', run: () => {
+        const panes = allPanes(layout.root);
+        const i = panes.findIndex(p => p.id === layout.focusedPaneId);
+        dispatchLayout({ type: 'focus_pane', paneId: panes[(i + 1) % panes.length].id });
+      } },
     ] : []),
     ...activeConnections.map(c => ({
       id: `monitoring:${c.id}`,
@@ -1944,16 +1973,6 @@ function Workspace() {
     return plan;
   };
 
-  const workspaceTabs = React.useMemo(
-    () =>
-      tabs.map((tab) => ({
-        id: tab.id,
-        label: tabLabelFor(tab, connectionNameFor),
-        icon: tabIconFor(tab, tab.id === activeTabId),
-      })),
-    [tabs, activeTabId, activeConnections]
-  );
-
   // Renders the content pane for a single tab. Parameterized by `tab` (not the
   // module-level `activeTab`) so multiple panes can each render their own tab
   // simultaneously.
@@ -2057,7 +2076,7 @@ function Workspace() {
                     countLoading={tab.countLoading}
                     skip={tab.lastQuery?.skip ?? 0}
                     limit={tab.lastQuery?.limit ?? 50}
-                    onCreateSuggestedIndex={handleCreateSuggestedIndex}
+                    onCreateSuggestedIndex={s => handleCreateSuggestedIndex(tab, s)}
                     {...(!tab.lastAggregate ? {
                       onPageChange: (newSkip: number) => handlePageChange(tab, newSkip),
                       onPageSizeChange: (newLimit: number) => handlePageSizeChange(tab, newLimit),
@@ -2381,16 +2400,7 @@ function Workspace() {
       }
       sidebarWidth={sidebarWidth}
       onResizeStart={startResizing}
-      tabBar={
-        tabs.length > 0 ? (
-          <WorkspaceTabBar
-            tabs={workspaceTabs}
-            activeTabId={activeTabId}
-            onSelectTab={(id) => dispatchLayout({ type: 'set_active', paneId: layout.focusedPaneId, tabId: id })}
-            onCloseTab={closeTabById}
-          />
-        ) : null
-      }
+      tabBar={null}
       statusBar={
         <StatusBar
           cpu={resUsage ? `${resUsage.cpu_percent.toFixed(0)}%` : undefined}
@@ -2521,7 +2531,18 @@ function Workspace() {
         </>
       }
     >
-      {activeTabId ? renderTabContent(activeTabId) : renderEmptyPane()}
+      <WorkspaceRoot
+        layout={layout}
+        dispatch={dispatchWorkspace}
+        tabsFor={pane =>
+          pane.tabIds
+            .map(id => tabs.find(t => t.id === id))
+            .filter((t): t is QueryTab => !!t)
+            .map(t => ({ id: t.id, label: tabLabelFor(t, connectionNameFor), icon: tabIconFor(t, t.id === pane.activeTabId) }))
+        }
+        renderTabContent={renderTabContent}
+        renderEmptyPane={renderEmptyPane}
+      />
     </AppShell>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useReducer } from 'react';
 import { AppShell } from '@/components/layout/AppShell';
 import { WorkspaceTabBar } from '@/components/layout/WorkspaceTabBar';
 import { StatusBar } from '@/components/layout/StatusBar';
@@ -38,6 +38,7 @@ import {
 } from './components/RestoreView';
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
+import { workspaceReducer, createInitialLayout, findPane } from './workspace/model';
 import { CreateViewView } from './components/CreateViewView';
 import { ValidationRulesView } from './components/ValidationRulesView';
 import { GridFsView } from './components/GridFsView';
@@ -267,7 +268,13 @@ function Workspace() {
   const density = config.spacingDensity;
   // Open the Quick Start tab by default so the app never starts on a blank canvas.
   const [tabs, setTabs] = useState<QueryTab[]>([createQuickStartTab()]);
-  const [activeTabId, setActiveTabId] = useState<string | null>(QUICK_START_TAB_ID);
+  const [layout, dispatchLayout] = useReducer(
+    workspaceReducer,
+    undefined,
+    () => createInitialLayout([QUICK_START_TAB_ID], QUICK_START_TAB_ID),
+  );
+  const focusedPane = findPane(layout.root, layout.focusedPaneId);
+  const activeTabId = focusedPane?.activeTabId ?? null;
   const tabBuilderStateCache = useRef(new Map<string, BuilderState>());
   const handleBuilderStateChange = useCallback((tabId: string, state: BuilderState) => {
     tabBuilderStateCache.current.set(tabId, state);
@@ -553,7 +560,7 @@ function Workspace() {
   useEffect(() => {
     if (tabs.length === 0) {
       setTabs([createQuickStartTab()]);
-      setActiveTabId(QUICK_START_TAB_ID);
+      dispatchLayout({ type: 'open_tab', tabId: QUICK_START_TAB_ID });
     }
   }, [tabs.length]);
 
@@ -583,7 +590,7 @@ function Workspace() {
       } else {
         setTabs(prev => prev.map(t => t.id === tabId ? { ...t, loading: true, error: null } : t));
       }
-      setActiveTabId(tabId);
+      dispatchLayout({ type: 'open_tab', tabId });
 
       try {
         // A saved query (palette) wins; otherwise a pinned default query loads
@@ -657,7 +664,7 @@ function Workspace() {
         setTabs(prev => prev.map(t => t.id === tabId ? { ...t, error: String(err), loading: false } : t));
       }
     } else {
-      setActiveTabId(tabId);
+      dispatchLayout({ type: 'open_tab', tabId });
     }
   };
 
@@ -681,9 +688,9 @@ function Workspace() {
         explainResult: null
       };
       setTabs(prev => [...prev, newTab]);
-      setActiveTabId(tabId);
+      dispatchLayout({ type: 'open_tab', tabId });
     } else {
-      setActiveTabId(tabId);
+      dispatchLayout({ type: 'open_tab', tabId });
     }
   };
 
@@ -711,7 +718,7 @@ function Workspace() {
       setTabs(prev => prev.map(t => t.id === tabId ? { ...t, initialShellCommand: initialCommand } : t));
     }
 
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
   };
 
   const openSettingsTab = (section: SettingsTabId = 'appearance') => {
@@ -731,7 +738,7 @@ function Workspace() {
       }]);
     }
     setSettingsInitialTab(section);
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
   };
 
   const handleOpenSettingsTab = () => openSettingsTab('appearance');
@@ -744,7 +751,7 @@ function Workspace() {
     if (!tabs.some(t => t.id === TASKS_TAB_ID)) {
       setTabs(prev => [...prev, createTasksTab()]);
     }
-    setActiveTabId(TASKS_TAB_ID);
+    dispatchLayout({ type: 'open_tab', tabId: TASKS_TAB_ID });
   };
 
   const handleOpenExportTab = (sourceTab: QueryTab) => {
@@ -765,7 +772,7 @@ function Workspace() {
         explainResult: null,
       }]);
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
     loadExportTasks();
   };
 
@@ -786,7 +793,7 @@ function Workspace() {
         explainResult: null,
       }]);
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
     loadExportTasks();
   };
 
@@ -935,7 +942,7 @@ function Workspace() {
         explainResult: null,
       }]);
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
     void loadMongoTools();
     void loadDumpDbTree(connectionId);
   };
@@ -955,7 +962,7 @@ function Workspace() {
         explainResult: null,
       }]);
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
     void loadMongoTools();
   };
 
@@ -1009,7 +1016,7 @@ function Workspace() {
         explainResult: null,
       }]);
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
   };
 
   // #93: open a Validation Rules tab for a collection.
@@ -1028,7 +1035,7 @@ function Workspace() {
         explainResult: null,
       }]);
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
   };
 
   // M7: open a GridFS browser tab for a bucket (bucket stored in `collection`).
@@ -1047,7 +1054,7 @@ function Workspace() {
         explainResult: null,
       }]);
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
   };
 
   // M6: open a schema-analysis tab for a collection.
@@ -1067,7 +1074,7 @@ function Workspace() {
         explainResult: null,
       }]);
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
   };
 
   const handleOpenMonitoringTab = (connectionId: string) => {
@@ -1085,7 +1092,7 @@ function Workspace() {
         explainResult: null,
       }]);
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
   };
 
   const handleOpenUsersTab = (connectionId: string, db?: string) => {
@@ -1106,7 +1113,7 @@ function Workspace() {
       // Re-opened scoped to a database (sidebar db menu): refocus the scope.
       setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, db } : t)));
     }
-    setActiveTabId(tabId);
+    dispatchLayout({ type: 'open_tab', tabId });
   };
 
   const handleCollectionRenamed = (
@@ -1131,26 +1138,21 @@ function Workspace() {
       return { ...tab, id: `${connectionId}.${dbName}.${newName}`, collection: newName };
     };
 
+    const renamedPairs = tabs
+      .map(t => ({ oldId: t.id, newId: renameTab(t).id }))
+      .filter(p => p.oldId !== p.newId);
     setTabs(prev => prev.map(renameTab));
-    setActiveTabId(prev => {
-      const current = tabs.find(t => t.id === prev);
-      return current ? renameTab(current).id : prev;
-    });
+    renamedPairs.forEach(({ oldId, newId }) => dispatchLayout({ type: 'rename_tab', oldId, newId }));
     invalidatePaletteNamespaceIndex(connectionId);
   };
 
   const handleDatabaseDropped = (connectionId: string, dbName: string) => {
     invalidatePaletteNamespaceIndex(connectionId);
-    setTabs(prev => {
-      const updated = prev.filter(t => t.connectionId !== connectionId || t.db !== dbName);
-      const activeWasDropped = activeTabId
-        ? prev.some(t => t.id === activeTabId && t.connectionId === connectionId && t.db === dbName)
-        : false;
-      if (activeWasDropped) {
-        setActiveTabId(updated.length > 0 ? updated[updated.length - 1].id : null);
-      }
-      return updated;
-    });
+    const removed = tabs
+      .filter(t => t.connectionId === connectionId && t.db === dbName)
+      .map(t => t.id);
+    setTabs(prev => prev.filter(t => t.connectionId !== connectionId || t.db !== dbName));
+    dispatchLayout({ type: 'close_many', tabIds: removed });
   };
 
   const handleDatabaseRenamed = (connectionId: string, oldName: string, newName: string) => {
@@ -1186,11 +1188,11 @@ function Workspace() {
       };
     };
 
+    const renamedPairs = tabs
+      .map(t => ({ oldId: t.id, newId: renameTab(t).id }))
+      .filter(p => p.oldId !== p.newId);
     setTabs(prev => prev.map(renameTab));
-    setActiveTabId(prev => {
-      const current = tabs.find(t => t.id === prev);
-      return current ? renameTab(current).id : prev;
-    });
+    renamedPairs.forEach(({ oldId, newId }) => dispatchLayout({ type: 'rename_tab', oldId, newId }));
     invalidatePaletteNamespaceIndex(connectionId);
   };
 
@@ -1262,6 +1264,7 @@ function Workspace() {
         // Close/rename tab
         const oldTabId = `${connectionId}.${db}.${collection}.${initialData.name}`;
         setTabs(prev => prev.filter(t => t.id !== oldTabId));
+        dispatchLayout({ type: 'close_tab', tabId: oldTabId });
       }
 
       // Create new index
@@ -1300,15 +1303,7 @@ function Workspace() {
       // Close the deleted index tab
       const tabId = `${connectionId}.${dbName}.${collName}.${indexName}`;
       setTabs(prev => prev.filter(t => t.id !== tabId));
-      if (activeTabId === tabId) {
-        // Find if there's any remaining tabs
-        const remaining = tabs.filter(t => t.id !== tabId);
-        if (remaining.length > 0) {
-          setActiveTabId(remaining[remaining.length - 1].id);
-        } else {
-          setActiveTabId(null);
-        }
-      }
+      dispatchLayout({ type: 'close_tab', tabId });
 
       // Trigger sidebar refresh
       setIndexMutationTrigger(prev => prev + 1);
@@ -1321,25 +1316,20 @@ function Workspace() {
     tabBuilderStateCache.current.delete(tabId);
     const updatedTabs = tabs.filter(t => t.id !== tabId);
     setTabs(updatedTabs);
-
-    if (activeTabId === tabId) {
-      if (updatedTabs.length > 0) {
-        setActiveTabId(updatedTabs[updatedTabs.length - 1].id);
-      } else {
-        setActiveTabId(null);
-      }
-    }
+    dispatchLayout({ type: 'close_tab', tabId });
   };
 
   const cycleTab = (dir: 1 | -1) => {
-    if (tabs.length < 2) return;
-    const idx = tabs.findIndex(t => t.id === activeTabId);
-    setActiveTabId(tabs[(idx + dir + tabs.length) % tabs.length].id);
+    const p = focusedPane;
+    if (!p || p.tabIds.length < 2) return;
+    const i = p.tabIds.indexOf(p.activeTabId ?? '');
+    const next = p.tabIds[(i + dir + p.tabIds.length) % p.tabIds.length];
+    dispatchLayout({ type: 'set_active', paneId: p.id, tabId: next });
   };
 
   const openQuickStartTab = () => {
     setTabs(prev => prev.some(t => t.id === QUICK_START_TAB_ID) ? prev : [...prev, createQuickStartTab()]);
-    setActiveTabId(QUICK_START_TAB_ID);
+    dispatchLayout({ type: 'open_tab', tabId: QUICK_START_TAB_ID });
   };
 
   // Command palette: Cmd/Ctrl+K from anywhere in the workspace.
@@ -2024,17 +2014,9 @@ function Workspace() {
               await invoke('disconnect_db', { id: connId });
             } catch (err) {}
             setActiveConnections(prev => prev.filter(c => c.id !== connId));
-            setTabs(prev => {
-              const updated = prev.filter(t => t.connectionId !== connId);
-              if (activeTabId && prev.find(t => t.id === activeTabId)?.connectionId === connId) {
-                if (updated.length > 0) {
-                  setActiveTabId(updated[updated.length - 1].id);
-                } else {
-                  setActiveTabId(null);
-                }
-              }
-              return updated;
-            });
+            const removed = tabs.filter(t => t.connectionId === connId).map(t => t.id);
+            setTabs(prev => prev.filter(t => t.connectionId !== connId));
+            dispatchLayout({ type: 'close_many', tabIds: removed });
           }}
           onOpenSettings={handleOpenSettingsTab}
           onCopyCollections={handleCopyCollections}
@@ -2053,7 +2035,7 @@ function Workspace() {
           <WorkspaceTabBar
             tabs={workspaceTabs}
             activeTabId={activeTabId}
-            onSelectTab={setActiveTabId}
+            onSelectTab={(id) => dispatchLayout({ type: 'set_active', paneId: layout.focusedPaneId, tabId: id })}
             onCloseTab={closeTabById}
           />
         ) : null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -526,18 +526,17 @@ function Workspace() {
   // The collection tab an 'export' tab was opened from (results/query source for the
   // Current Results and Filtered cards). Falls back to a matching collection tab by
   // namespace when the originating tab has since closed.
-  const exportSourceTab =
-    activeTab && activeTab.type === 'export'
-      ? tabs.find(t => t.id === activeTab.exportSourceTabId && t.type === 'collection') ||
-        tabs.find(
-          t =>
-            t.type === 'collection' &&
-            t.connectionId === activeTab.connectionId &&
-            t.db === activeTab.db &&
-            t.collection === activeTab.collection
-        ) ||
-        null
-      : null;
+  const deriveExportSourceTab = (exportTab: QueryTab): QueryTab | null =>
+    tabs.find(t => t.id === exportTab.exportSourceTabId && t.type === 'collection') ||
+    tabs.find(
+      t =>
+        t.type === 'collection' &&
+        t.connectionId === exportTab.connectionId &&
+        t.db === exportTab.db &&
+        t.collection === exportTab.collection
+    ) ||
+    null;
+  const exportSourceTab = activeTab && activeTab.type === 'export' ? deriveExportSourceTab(activeTab) : null;
 
   // MongoDB server version of the active connection, for the status bar.
   const activeConnId = activeTab && activeConnections.some(c => c.id === activeTab.connectionId) ? activeTab.connectionId : null;
@@ -1452,17 +1451,15 @@ function Workspace() {
     ...paletteDynamicItems,
   ];
 
-  const handleExecuteQuery = async (query: { filter: string; sort: string; projection: string; limit: number; skip: number }) => {
-    if (!activeTab) return;
-
-    // Update active tab loading state
-    setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, loading: true, error: null } : t));
+  const handleExecuteQuery = async (tab: QueryTab, query: { filter: string; sort: string; projection: string; limit: number; skip: number }) => {
+    // Update the tab's loading state
+    setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, loading: true, error: null } : t));
 
     try {
       const resultStrs = await invoke<string[]>('execute_mql_query', {
-        id: activeTab.connectionId,
-        database: activeTab.db,
-        collection: activeTab.collection,
+        id: tab.connectionId,
+        database: tab.db,
+        collection: tab.collection,
         filter: query.filter,
         sort: query.sort,
         projection: query.projection,
@@ -1471,9 +1468,9 @@ function Workspace() {
       });
 
       const parsedResults = resultStrs.map(s => JSON.parse(s));
-      setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, results: parsedResults, loading: false, lastQuery: query, lastAggregate: undefined } : t));
+      setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, results: parsedResults, loading: false, lastQuery: query, lastAggregate: undefined } : t));
       // History is best-effort: never surface an error after a successful run.
-      recordHistory(connectionNameFor(activeTab.connectionId), activeTab.db, activeTab.collection, {
+      recordHistory(connectionNameFor(tab.connectionId), tab.db, tab.collection, {
         queryType: 'find',
         filter: JSON.parse(query.filter || '{}'),
         sort: JSON.parse(query.sort || '{}'),
@@ -1482,58 +1479,54 @@ function Workspace() {
         skip: query.skip,
       }).catch(() => {});
       // Pagination count: recount only when the filter changed since the last count.
-      const prevFilter = activeTab.lastQuery?.filter;
-      if (query.filter !== prevFilter || activeTab.totalCount === undefined) {
-        setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, countLoading: true } : t));
+      const prevFilter = tab.lastQuery?.filter;
+      if (query.filter !== prevFilter || tab.totalCount === undefined) {
+        setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, countLoading: true } : t));
         try {
           const total = await invoke<number>('count_documents', {
-            id: activeTab.connectionId, database: activeTab.db, collection: activeTab.collection, filter: query.filter,
+            id: tab.connectionId, database: tab.db, collection: tab.collection, filter: query.filter,
           });
-          setTabs(prev => prev.map(t => t.id === activeTab.id
+          setTabs(prev => prev.map(t => t.id === tab.id
             ? { ...t, totalCount: total, estimated: isEmptyFilter(query.filter), countLoading: false }
             : t));
         } catch {
-          setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, countLoading: false } : t));
+          setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, countLoading: false } : t));
         }
       }
     } catch (err: any) {
-      setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, error: String(err), loading: false } : t));
+      setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, error: String(err), loading: false } : t));
     }
   };
 
-  const handlePageChange = (newSkip: number) => {
-    const tab = tabs.find(t => t.id === activeTabId);
-    if (!tab || !tab.lastQuery) return;
-    handleExecuteQuery({ ...tab.lastQuery, skip: Math.max(0, newSkip) });
+  const handlePageChange = (tab: QueryTab, newSkip: number) => {
+    if (!tab.lastQuery) return;
+    handleExecuteQuery(tab, { ...tab.lastQuery, skip: Math.max(0, newSkip) });
   };
 
-  const handlePageSizeChange = (newLimit: number) => {
-    const tab = tabs.find(t => t.id === activeTabId);
-    if (!tab || !tab.lastQuery) return;
-    handleExecuteQuery({ ...tab.lastQuery, limit: newLimit, skip: 0 });
+  const handlePageSizeChange = (tab: QueryTab, newLimit: number) => {
+    if (!tab.lastQuery) return;
+    handleExecuteQuery(tab, { ...tab.lastQuery, limit: newLimit, skip: 0 });
   };
 
-  const handleExecuteAggregate = async (pipeline: Record<string, unknown>[]) => {
-    if (!activeTab) return;
-
-    setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, loading: true, error: null } : t));
+  const handleExecuteAggregate = async (tab: QueryTab, pipeline: Record<string, unknown>[]) => {
+    setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, loading: true, error: null } : t));
 
     try {
       const resultStrs = await invoke<string[]>('execute_aggregate', {
-        id: activeTab.connectionId,
-        database: activeTab.db,
-        collection: activeTab.collection,
+        id: tab.connectionId,
+        database: tab.db,
+        collection: tab.collection,
         pipeline: JSON.stringify(pipeline),
       });
 
       const parsedResults = resultStrs.map(s => JSON.parse(s));
-      setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, results: parsedResults, loading: false, lastAggregate: pipeline } : t));
-      recordHistory(connectionNameFor(activeTab.connectionId), activeTab.db, activeTab.collection, {
+      setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, results: parsedResults, loading: false, lastAggregate: pipeline } : t));
+      recordHistory(connectionNameFor(tab.connectionId), tab.db, tab.collection, {
         queryType: 'aggregate',
         pipeline,
       }).catch(() => {});
     } catch (err: any) {
-      setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, error: String(err), loading: false } : t));
+      setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, error: String(err), loading: false } : t));
     }
   };
 
@@ -1594,11 +1587,11 @@ function Workspace() {
   }, [exportTasks]);
 
   const [documentModal, setDocumentModal] = useState<
-    { mode: 'insert' | 'edit'; initialJson: string; targetDoc: Record<string, any> | null } | null
+    { mode: 'insert' | 'edit'; initialJson: string; targetDoc: Record<string, any> | null; tabId: string } | null
   >(null);
 
-  const handleInsertDocument = () => {
-    setDocumentModal({ mode: 'insert', initialJson: '{\n  \n}', targetDoc: null });
+  const handleInsertDocument = (tab: QueryTab) => {
+    setDocumentModal({ mode: 'insert', initialJson: '{\n  \n}', targetDoc: null, tabId: tab.id });
   };
 
   const handleExportForTab = async (
@@ -1753,23 +1746,22 @@ function Workspace() {
     };
   };
 
-  const handleImport = () => {
-    if (!activeTab || activeTab.type !== 'collection') return;
-    handleOpenImportTab(activeTab);
+  const handleImport = (tab: QueryTab) => {
+    if (tab.type !== 'collection') return;
+    handleOpenImportTab(tab);
   };
 
-  const handleEditDocument = (doc: Record<string, any>) => {
-    setDocumentModal({ mode: 'edit', initialJson: docToShell(doc), targetDoc: doc });
+  const handleEditDocument = (tab: QueryTab, doc: Record<string, any>) => {
+    setDocumentModal({ mode: 'edit', initialJson: docToShell(doc), targetDoc: doc, tabId: tab.id });
   };
 
   // Duplicate: open the insert modal pre-filled with the document minus its _id.
-  const handleDuplicateDocument = (doc: Record<string, any>) => {
+  const handleDuplicateDocument = (tab: QueryTab, doc: Record<string, any>) => {
     const { _id, ...rest } = doc;
-    setDocumentModal({ mode: 'insert', initialJson: docToShell(rest), targetDoc: null });
+    setDocumentModal({ mode: 'insert', initialJson: docToShell(rest), targetDoc: null, tabId: tab.id });
   };
 
-  const handleDeleteDocument = async (doc: Record<string, any>) => {
-    if (!activeTab) return;
+  const handleDeleteDocument = async (tab: QueryTab, doc: Record<string, any>) => {
     if (doc._id === undefined) {
       toast('Cannot delete: this document has no _id.', 'error');
       return;
@@ -1785,20 +1777,20 @@ function Workspace() {
       return;
     try {
       await invoke('delete_document', {
-        id: activeTab.connectionId,
-        database: activeTab.db,
-        collection: activeTab.collection,
+        id: tab.connectionId,
+        database: tab.db,
+        collection: tab.collection,
         filter: JSON.stringify({ _id: doc._id }),
       });
-      await refreshTabResults(activeTab);
-      toast(`Document deleted from ${activeTab.collection}`, 'success', { title: 'Deleted' });
+      await refreshTabResults(tab);
+      toast(`Document deleted from ${tab.collection}`, 'success', { title: 'Deleted' });
     } catch (err: any) {
       toast(`Failed to delete document: ${err}`, 'error');
     }
   };
 
-  // M7: bulk operations on the active collection's current query filter.
-  const bulkFilter = () => activeTab?.lastQuery?.filter?.trim() || '{}';
+  // M7: bulk operations on a collection tab's current query filter.
+  const bulkFilter = (tab: QueryTab) => tab.lastQuery?.filter?.trim() || '{}';
   const isEmptyFilterStr = (f: string) => {
     try { return Object.keys(JSON.parse(f)).length === 0; } catch { return false; }
   };
@@ -1809,14 +1801,14 @@ function Workspace() {
       : base;
   };
 
-  const handleDeleteMany = async () => {
-    if (!activeTab || activeTab.type !== 'collection') return;
-    const filter = bulkFilter();
+  const handleDeleteMany = async (tab: QueryTab) => {
+    if (tab.type !== 'collection') return;
+    const filter = bulkFilter(tab);
     try {
       const count = await invoke<number>('count_documents', {
-        id: activeTab.connectionId,
-        database: activeTab.db,
-        collection: activeTab.collection,
+        id: tab.connectionId,
+        database: tab.db,
+        collection: tab.collection,
         filter,
       });
       if (
@@ -1829,21 +1821,21 @@ function Workspace() {
       )
         return;
       const deleted = await invoke<number>('delete_many', {
-        id: activeTab.connectionId,
-        database: activeTab.db,
-        collection: activeTab.collection,
+        id: tab.connectionId,
+        database: tab.db,
+        collection: tab.collection,
         filter,
       });
-      await refreshTabResults(activeTab);
+      await refreshTabResults(tab);
       toast(`Deleted ${deleted} document(s)`, 'success', { title: 'Deleted' });
     } catch (err: any) {
       toast(`Delete failed: ${err?.message || err}`, 'error');
     }
   };
 
-  const handleUpdateMany = async () => {
-    if (!activeTab || activeTab.type !== 'collection') return;
-    const filter = bulkFilter();
+  const handleUpdateMany = async (tab: QueryTab) => {
+    if (tab.type !== 'collection') return;
+    const filter = bulkFilter(tab);
     const update = await prompt({
       title: 'Update many',
       message: 'Update document (operators, e.g. {"$set": {...}}):',
@@ -1867,9 +1859,9 @@ function Workspace() {
     if (!update) return; // cancelled
     try {
       const count = await invoke<number>('count_documents', {
-        id: activeTab.connectionId,
-        database: activeTab.db,
-        collection: activeTab.collection,
+        id: tab.connectionId,
+        database: tab.db,
+        collection: tab.collection,
         filter,
       });
       if (
@@ -1882,13 +1874,13 @@ function Workspace() {
       )
         return;
       const modified = await invoke<number>('update_many', {
-        id: activeTab.connectionId,
-        database: activeTab.db,
-        collection: activeTab.collection,
+        id: tab.connectionId,
+        database: tab.db,
+        collection: tab.collection,
         filter,
         update,
       });
-      await refreshTabResults(activeTab);
+      await refreshTabResults(tab);
       toast(`Modified ${modified} document(s)`, 'success', { title: 'Updated' });
     } catch (err: any) {
       toast(`Update failed: ${err?.message || err}`, 'error');
@@ -1896,17 +1888,19 @@ function Workspace() {
   };
 
   const handleSaveDocument = async (json: string) => {
-    if (!activeTab || !documentModal) return;
-    const collection = activeTab.collection;
+    if (!documentModal) return;
+    const tab = tabs.find(t => t.id === documentModal.tabId);
+    if (!tab) return;
+    const collection = tab.collection;
     if (documentModal.mode === 'insert') {
       await invoke('insert_document', {
-        id: activeTab.connectionId,
-        database: activeTab.db,
+        id: tab.connectionId,
+        database: tab.db,
         collection,
         document: json,
       });
       setDocumentModal(null);
-      await refreshTabResults(activeTab);
+      await refreshTabResults(tab);
       toast(`Document inserted into ${collection}`, 'success', { title: 'Inserted' });
       return;
     }
@@ -1916,59 +1910,39 @@ function Workspace() {
       throw new Error('Cannot update: this document has no _id.');
     }
     await invoke('update_document', {
-      id: activeTab.connectionId,
-      database: activeTab.db,
+      id: tab.connectionId,
+      database: tab.db,
       collection,
       filter: JSON.stringify({ _id: target._id }),
       replacement: json,
     });
     setDocumentModal(null);
-    await refreshTabResults(activeTab);
+    await refreshTabResults(tab);
     toast(`Document saved in ${collection}`, 'success', { title: 'Saved' });
   };
 
-  const handleExplainQuery = async (filter: string): Promise<string> => {
-    if (!activeTab) throw new Error("No active tab");
+  const handleExplainQuery = async (tab: QueryTab, filter: string): Promise<string> => {
     const plan = await invoke<string>('explain_mql_query', {
-      id: activeTab.connectionId,
-      database: activeTab.db,
-      collection: activeTab.collection,
+      id: tab.connectionId,
+      database: tab.db,
+      collection: tab.collection,
       filter
     });
-    setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, explainResult: plan } : t));
+    setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, explainResult: plan } : t));
     return plan;
   };
 
   // M1: explain the full aggregation pipeline (not just its $match stage).
-  const handleExplainAggregate = async (pipeline: string): Promise<string> => {
-    if (!activeTab) throw new Error("No active tab");
+  const handleExplainAggregate = async (tab: QueryTab, pipeline: string): Promise<string> => {
     const plan = await invoke<string>('explain_aggregate_query', {
-      id: activeTab.connectionId,
-      database: activeTab.db,
-      collection: activeTab.collection,
+      id: tab.connectionId,
+      database: tab.db,
+      collection: tab.collection,
       pipeline
     });
-    setTabs(prev => prev.map(t => t.id === activeTab.id ? { ...t, explainResult: plan } : t));
+    setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, explainResult: plan } : t));
     return plan;
   };
-
-  const availableFields = React.useMemo(() => {
-    if (!activeTab || activeTab.type !== 'collection' || !activeTab.results || activeTab.results.length === 0) {
-      return ['_id'];
-    }
-    const keys = new Set<string>();
-    activeTab.results.forEach(doc => {
-      if (doc && typeof doc === 'object') {
-        Object.keys(doc).forEach(k => keys.add(k));
-      }
-    });
-    keys.add('_id');
-    return Array.from(keys).sort((a, b) => {
-      if (a === '_id') return -1;
-      if (b === '_id') return 1;
-      return a.localeCompare(b);
-    });
-  }, [activeTab?.results, activeTab?.type]);
 
   const workspaceTabs = React.useMemo(
     () =>
@@ -1978,6 +1952,383 @@ function Workspace() {
         icon: tabIconFor(tab, tab.id === activeTabId),
       })),
     [tabs, activeTabId, activeConnections]
+  );
+
+  // Renders the content pane for a single tab. Parameterized by `tab` (not the
+  // module-level `activeTab`) so multiple panes can each render their own tab
+  // simultaneously.
+  const renderTabContent = (tabId: string): React.ReactNode => {
+    const tab = tabs.find(t => t.id === tabId);
+    if (!tab) return null;
+    return (
+      <>
+        {tab.type === 'index' && (
+          <IndexViewer
+            connectionId={tab.connectionId}
+            databaseName={tab.db}
+            collectionName={tab.collection}
+            indexName={tab.indexName || ''}
+            onEditIndex={(indexName, keys, unique, sparse) =>
+              handleOpenIndexModalForEdit(
+                tab.connectionId,
+                tab.db,
+                tab.collection,
+                indexName,
+                keys,
+                unique,
+                sparse
+              )
+            }
+            onDeleteIndex={(indexName) =>
+              handleDeleteIndex(
+                tab.connectionId,
+                tab.db,
+                tab.collection,
+                indexName
+              )
+            }
+          />
+        )}
+        {tab.type === 'collection' && (() => {
+          const activeConnection = activeConnections.find(c => c.id === tab.connectionId);
+          const connectionName = activeConnection ? activeConnection.name : 'cmi-dev';
+          const connectionUser = activeConnection ? usernameFromUri(activeConnection.uri) : '';
+          return (
+            <DocumentViewer
+              key={tab.id}
+              connectionId={tab.connectionId}
+              connectionName={connectionName}
+              connectionUser={connectionUser}
+              databaseName={tab.db}
+              collectionName={tab.collection}
+              initialBuilderState={
+                tabBuilderStateCache.current.get(tab.id)
+                ?? builderStateFromQueryTab(tab.lastQuery, tab.lastAggregate)
+              }
+              onBuilderStateChange={(state) => handleBuilderStateChange(tab.id, state)}
+              onExecute={q => handleExecuteQuery(tab, q)}
+              onExecuteAggregate={pipeline => handleExecuteAggregate(tab, pipeline)}
+              onExplain={filter => handleExplainQuery(tab, filter)}
+              onExplainAggregate={pipeline => handleExplainAggregate(tab, pipeline)}
+              onOpenShell={(command) => handleOpenShell(tab.connectionId, tab.db, tab.collection, command)}
+              onOpenExport={() => handleOpenExportTab(tab)}
+              onImport={() => handleImport(tab)}
+              loading={tab.loading}
+              availableFields={fieldsFromResults(tab.results)}
+            >
+              <div className="flex min-h-0 flex-1 flex-col min-w-0 overflow-hidden">
+                {tab.error && (
+                  <div className="p-3 bg-destructive/10 border-b border-border text-destructive font-mono text-xs select-text flex items-start gap-2">
+                    <span className="flex-grow">Error loading dataset: {tab.error}</span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="shrink-0"
+                      title="Copy error message"
+                      onClick={() => { try { navigator.clipboard?.writeText(String(tab.error)); } catch { /* clipboard unavailable */ } }}
+                    >
+                      <Copy size={11} />
+                      Copy
+                    </Button>
+                  </div>
+                )}
+                {tab.loading ? (
+                  <div className="flex-grow flex items-center justify-center text-muted-foreground bg-background">
+                    <div className="flex flex-col items-center gap-2 select-none">
+                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary"></div>
+                      <span className="text-xs">Streaming documents asynchronously...</span>
+                    </div>
+                  </div>
+                ) : (
+                  <DataGrid
+                    documents={tab.results}
+                    density={density}
+                    explainResult={tab.explainResult}
+                    querySpec={buildTabQuerySpec(tab)}
+                    onInsertDocument={() => handleInsertDocument(tab)}
+                    onEditDocument={doc => handleEditDocument(tab, doc)}
+                    onDuplicateDocument={doc => handleDuplicateDocument(tab, doc)}
+                    onDeleteDocument={doc => handleDeleteDocument(tab, doc)}
+                    onAnalyzeSchema={() => handleOpenSchemaTab(tab.connectionId, tab.db, tab.collection)}
+                    onUpdateMany={() => handleUpdateMany(tab)}
+                    onDeleteMany={() => handleDeleteMany(tab)}
+                    totalCount={tab.totalCount}
+                    estimated={tab.estimated}
+                    countLoading={tab.countLoading}
+                    skip={tab.lastQuery?.skip ?? 0}
+                    limit={tab.lastQuery?.limit ?? 50}
+                    onCreateSuggestedIndex={handleCreateSuggestedIndex}
+                    {...(!tab.lastAggregate ? {
+                      onPageChange: (newSkip: number) => handlePageChange(tab, newSkip),
+                      onPageSizeChange: (newLimit: number) => handlePageSizeChange(tab, newLimit),
+                    } : {})}
+                  />
+                )}
+              </div>
+            </DocumentViewer>
+          );
+        })()}
+        {tab.type === 'schema' && (
+          <SchemaView
+            connectionId={tab.connectionId}
+            databaseName={tab.db}
+            collectionName={tab.collection}
+          />
+        )}
+        {tab.type === 'create-view' && (
+          <CreateViewView
+            connectionId={tab.connectionId}
+            databaseName={tab.db}
+            onCreated={(viewName) => {
+              setCollectionMutationTrigger(prev => prev + 1);
+              handleSelectCollection(tab.connectionId, tab.db, viewName);
+            }}
+          />
+        )}
+        {tab.type === 'validation' && (
+          <ValidationRulesView
+            connectionId={tab.connectionId}
+            databaseName={tab.db}
+            collectionName={tab.collection}
+            onApplied={() => setCollectionMutationTrigger(prev => prev + 1)}
+          />
+        )}
+        {tab.type === 'gridfs' && (
+          <GridFsView
+            connectionId={tab.connectionId}
+            databaseName={tab.db}
+            bucket={tab.collection}
+            onNamespaceMutated={() => setCollectionMutationTrigger((prev) => prev + 1)}
+          />
+        )}
+        {tab.type === 'monitoring' && (
+          <MonitoringView connectionId={tab.connectionId} />
+        )}
+        {tab.type === 'users' && (
+          <UserManagementView connectionId={tab.connectionId} database={tab.db || undefined} />
+        )}
+        {tab.type === 'export' && (() => {
+          const activeConnection = activeConnections.find(c => c.id === tab.connectionId);
+          const connectionName = activeConnection ? activeConnection.name : tab.connectionId;
+          const sourceTab = deriveExportSourceTab(tab);
+          return (
+            <ExportView
+              key={`export:${tab.connectionId}:${tab.db}:${tab.collection}`}
+              connectionId={tab.connectionId}
+              connectionName={connectionName}
+              databaseName={tab.db}
+              collectionName={tab.collection}
+              currentResultCount={sourceTab?.results.length || 0}
+              availableFields={fieldsFromResults(sourceTab?.results)}
+              filtered={buildFilteredExportSeed(sourceTab)}
+              onExport={(format, scope, options, query) =>
+                handleExportForTab(sourceTab || tab, format, scope, options, query)
+              }
+              onCountFilter={(filter) =>
+                invoke<number>('count_documents', {
+                  id: tab.connectionId,
+                  database: tab.db,
+                  collection: tab.collection,
+                  filter,
+                })
+              }
+              onOpenTasks={handleOpenTasksTab}
+              onScanFields={handleScanExportFields}
+              onCopyCurrent={handleCopyCurrentExport}
+              onPreview={handlePreviewExport}
+            />
+          );
+        })()}
+        {tab.type === 'import' && (() => {
+          const activeConnection = activeConnections.find(c => c.id === tab.connectionId);
+          const connectionName = activeConnection ? activeConnection.name : tab.connectionId;
+          return (
+            <ImportView
+              key={`import:${tab.connectionId}:${tab.db}:${tab.collection}`}
+              connectionName={connectionName}
+              databaseName={tab.db}
+              collectionName={tab.collection}
+              onOpenTasks={handleOpenTasksTab}
+              onPickFile={async () => {
+                const p = await open({
+                  multiple: false,
+                  filters: [{ name: 'Data', extensions: ['json', 'jsonl', 'ndjson', 'csv', 'bson'] }],
+                });
+                return typeof p === 'string' ? p : null;
+              }}
+              onPreview={(source, format, csvOptions) =>
+                invoke<ImportPreviewData>('preview_import', { source, format, csvOptions, limit: 20 })
+              }
+              onRunImport={async (source, format, csvOptions, mode) => {
+                try {
+                  const task = await invoke<ExportTaskInfo>('start_import_task', {
+                    id: tab.connectionId,
+                    database: tab.db,
+                    collection: tab.collection,
+                    source,
+                    format,
+                    csvOptions,
+                    mode,
+                  });
+                  pendingImportRefreshRef.current.set(task.id, {
+                    connectionId: tab.connectionId,
+                    db: tab.db,
+                    collection: tab.collection,
+                  });
+                  insertExportTasks([task]);
+                  handleOpenTasksTab();
+                  await loadExportTasks();
+                } catch (err: any) {
+                  toast(`Import failed to start: ${err?.message || err}`, 'error');
+                }
+              }}
+            />
+          );
+        })()}
+        {tab.type === 'dump' && (() => {
+          const activeConnection = activeConnections.find(c => c.id === tab.connectionId);
+          const connectionName = activeConnection ? activeConnection.name : tab.connectionId;
+          const initialScope: DumpScopeUi = tab.collection
+            ? { kind: 'collection', db: tab.db, coll: tab.collection }
+            : tab.db
+              ? { kind: 'db', db: tab.db }
+              : { kind: 'server' };
+          return (
+            <DumpView
+              key={tab.id}
+              connectionName={connectionName}
+              databases={dumpDbTrees[tab.connectionId] ?? []}
+              initialScope={initialScope}
+              tools={mongoTools}
+              onOpenSettings={handleOpenToolsSettings}
+              onInstallTools={handleOpenToolSetup}
+              onPickFolder={async () => {
+                const p = await open({ directory: true });
+                return typeof p === 'string' ? p : null;
+              }}
+              onPickArchiveFile={async (defaultName) => {
+                const p = await save({ defaultPath: defaultName });
+                return p ?? null;
+              }}
+              onPreviewCommand={(options) =>
+                invoke<string>('preview_dump_command', {
+                  id: tab.connectionId,
+                  toolPath: mongoTools?.mongodump?.path ?? '',
+                  options,
+                })
+              }
+              onRunDump={(options) => handleRunDump(tab, options)}
+              onOpenTasks={handleOpenTasksTab}
+            />
+          );
+        })()}
+        {tab.type === 'restore' && (() => {
+          const activeConnection = activeConnections.find(c => c.id === tab.connectionId);
+          const connectionName = activeConnection ? activeConnection.name : tab.connectionId;
+          return (
+            <RestoreView
+              key={tab.id}
+              connectionName={connectionName}
+              tools={mongoTools}
+              onOpenSettings={handleOpenToolsSettings}
+              onInstallTools={handleOpenToolSetup}
+              onPickFolder={async () => {
+                const p = await open({ directory: true });
+                return typeof p === 'string' ? p : null;
+              }}
+              onPickArchiveFile={async () => {
+                const p = await open({ multiple: false });
+                return typeof p === 'string' ? p : null;
+              }}
+              onBrowseFolder={(path) => invoke<DumpTreeUi>('browse_dump_folder', { path })}
+              onPreviewCommand={(options) =>
+                invoke<string>('preview_restore_command', {
+                  id: tab.connectionId,
+                  toolPath: mongoTools?.mongorestore?.path ?? '',
+                  options,
+                })
+              }
+              onRunRestore={(options) => handleRunRestore(tab, options)}
+              onOpenTasks={handleOpenTasksTab}
+            />
+          );
+        })()}
+        {tab.type === 'tasks' && (
+          <div className="flex h-full flex-col overflow-auto p-4" data-testid="tasks-view">
+            <header className="mb-3">
+              <h2 className="text-sm font-semibold text-foreground">Tasks</h2>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Background copy and export jobs.
+              </p>
+            </header>
+            <TaskManager
+              tasks={exportTasks}
+              onRefresh={loadExportTasks}
+              onClearFinished={handleClearFinishedTasks}
+              onCancel={handleCancelTask}
+              variant="embedded"
+            />
+          </div>
+        )}
+        {tab.type === 'shell' && (() => {
+          const activeConnection = activeConnections.find(c => c.id === tab.connectionId);
+          const connectionName = activeConnection ? activeConnection.name : tab.connectionId;
+          return (
+            <MongoShell
+              key={`${tab.id}:${tab.initialShellCommand || ''}`}
+              connectionId={tab.connectionId}
+              connectionName={connectionName}
+              connectionUri={activeConnection?.uri || ''}
+              databaseName={tab.db}
+              collectionName={tab.collection || undefined}
+              initialCommand={tab.initialShellCommand}
+              density={density}
+              onOpenSettings={handleOpenToolsSettings}
+              onInstallTools={handleOpenToolSetup}
+              reconnectSignal={shellReconnectNonce}
+            />
+          );
+        })()}
+        {tab.type === 'settings' && (
+          <SettingsView
+            initialTab={settingsInitialTab}
+            onInstallTools={handleOpenToolSetup}
+            toolStatusRefreshNonce={toolStatusRefreshNonce}
+          />
+        )}
+        {tab.type === 'quickstart' && (
+          <QuickStart
+            onConnect={() => setIsConnectionModalOpen(true)}
+            onOpenSettings={handleOpenSettingsTab}
+            onOpenShortcuts={handleOpenShortcutsReference}
+            onQuickConnect={async (profile) => {
+              await handleQuickConnect(profile);
+            }}
+            onLoadSampleData={handleLoadSampleData}
+            activeConnections={activeConnections}
+            profilesRefreshKey={profilesRefreshKey}
+          />
+        )}
+      </>
+    );
+  };
+
+  const renderEmptyPane = () => (
+    /* Empty/Welcome Dashboard Panel */
+    <div className="flex h-full flex-col items-center justify-center gap-4 bg-background p-8 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10">
+        <img src={logoMark} alt="" className="h-10 w-10 animate-pulse" />
+      </div>
+      <h1 className="text-2xl font-semibold text-foreground">MQLens</h1>
+      <p className="max-w-md text-sm text-muted-foreground">
+        No active connection. Connect to a MongoDB cluster to browse collections and run queries.
+      </p>
+
+      <Button onClick={() => setIsConnectionModalOpen(true)}>
+        <Play size={14} className="mr-1.5" fill="currentColor" />
+        Connect to Database...
+      </Button>
+    </div>
   );
 
   return (
@@ -2086,7 +2437,7 @@ function Workspace() {
             connectionId={indexModalTarget?.connectionId}
             databaseName={indexModalTarget?.db}
             collectionName={indexModalTarget?.collection}
-            availableFields={availableFields}
+            availableFields={fieldsFromResults(activeTab?.results)}
             initialData={indexModalTarget?.initialData}
             prefill={indexModalTarget?.prefill}
           />
@@ -2170,373 +2521,7 @@ function Workspace() {
         </>
       }
     >
-      {tabs.length > 0 ? (
-        <>
-              {activeTab && activeTab.type === 'index' && (
-                <IndexViewer
-                  connectionId={activeTab.connectionId}
-                  databaseName={activeTab.db}
-                  collectionName={activeTab.collection}
-                  indexName={activeTab.indexName || ''}
-                  onEditIndex={(indexName, keys, unique, sparse) => 
-                    handleOpenIndexModalForEdit(
-                      activeTab.connectionId,
-                      activeTab.db,
-                      activeTab.collection,
-                      indexName,
-                      keys,
-                      unique,
-                      sparse
-                    )
-                  }
-                  onDeleteIndex={(indexName) => 
-                    handleDeleteIndex(
-                      activeTab.connectionId,
-                      activeTab.db,
-                      activeTab.collection,
-                      indexName
-                    )
-                  }
-                />
-              )}
-              {activeTab && activeTab.type === 'collection' && (() => {
-                const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
-                const connectionName = activeConnection ? activeConnection.name : 'cmi-dev';
-                const connectionUser = activeConnection ? usernameFromUri(activeConnection.uri) : '';
-                return (
-                  <DocumentViewer
-                    key={activeTab.id}
-                    connectionId={activeTab.connectionId}
-                    connectionName={connectionName}
-                    connectionUser={connectionUser}
-                    databaseName={activeTab.db}
-                    collectionName={activeTab.collection}
-                    initialBuilderState={
-                      tabBuilderStateCache.current.get(activeTab.id)
-                      ?? builderStateFromQueryTab(activeTab.lastQuery, activeTab.lastAggregate)
-                    }
-                    onBuilderStateChange={(state) => handleBuilderStateChange(activeTab.id, state)}
-                    onExecute={handleExecuteQuery}
-                    onExecuteAggregate={handleExecuteAggregate}
-                    onExplain={handleExplainQuery}
-                    onExplainAggregate={handleExplainAggregate}
-                    onOpenShell={(command) => handleOpenShell(activeTab.connectionId, activeTab.db, activeTab.collection, command)}
-                    onOpenExport={() => handleOpenExportTab(activeTab)}
-                    onImport={handleImport}
-                    loading={activeTab.loading}
-                    availableFields={availableFields}
-                  >
-                    <div className="flex min-h-0 flex-1 flex-col min-w-0 overflow-hidden">
-                      {activeTab.error && (
-                        <div className="p-3 bg-destructive/10 border-b border-border text-destructive font-mono text-xs select-text flex items-start gap-2">
-                          <span className="flex-grow">Error loading dataset: {activeTab.error}</span>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="shrink-0"
-                            title="Copy error message"
-                            onClick={() => { try { navigator.clipboard?.writeText(String(activeTab.error)); } catch { /* clipboard unavailable */ } }}
-                          >
-                            <Copy size={11} />
-                            Copy
-                          </Button>
-                        </div>
-                      )}
-                      {activeTab.loading ? (
-                        <div className="flex-grow flex items-center justify-center text-muted-foreground bg-background">
-                          <div className="flex flex-col items-center gap-2 select-none">
-                            <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary"></div>
-                            <span className="text-xs">Streaming documents asynchronously...</span>
-                          </div>
-                        </div>
-                      ) : (
-                        <DataGrid
-                          documents={activeTab.results}
-                          density={density}
-                          explainResult={activeTab.explainResult}
-                          querySpec={buildTabQuerySpec(activeTab)}
-                          onInsertDocument={handleInsertDocument}
-                          onEditDocument={handleEditDocument}
-                          onDuplicateDocument={handleDuplicateDocument}
-                          onDeleteDocument={handleDeleteDocument}
-                          onAnalyzeSchema={() => handleOpenSchemaTab(activeTab.connectionId, activeTab.db, activeTab.collection)}
-                          onUpdateMany={handleUpdateMany}
-                          onDeleteMany={handleDeleteMany}
-                          totalCount={activeTab.totalCount}
-                          estimated={activeTab.estimated}
-                          countLoading={activeTab.countLoading}
-                          skip={activeTab.lastQuery?.skip ?? 0}
-                          limit={activeTab.lastQuery?.limit ?? 50}
-                          onCreateSuggestedIndex={handleCreateSuggestedIndex}
-                          {...(!activeTab.lastAggregate ? {
-                            onPageChange: handlePageChange,
-                            onPageSizeChange: handlePageSizeChange,
-                          } : {})}
-                        />
-                      )}
-                    </div>
-                  </DocumentViewer>
-                );
-              })()}
-              {activeTab && activeTab.type === 'schema' && (
-                <SchemaView
-                  connectionId={activeTab.connectionId}
-                  databaseName={activeTab.db}
-                  collectionName={activeTab.collection}
-                />
-              )}
-              {activeTab && activeTab.type === 'create-view' && (
-                <CreateViewView
-                  connectionId={activeTab.connectionId}
-                  databaseName={activeTab.db}
-                  onCreated={(viewName) => {
-                    setCollectionMutationTrigger(prev => prev + 1);
-                    handleSelectCollection(activeTab.connectionId, activeTab.db, viewName);
-                  }}
-                />
-              )}
-              {activeTab && activeTab.type === 'validation' && (
-                <ValidationRulesView
-                  connectionId={activeTab.connectionId}
-                  databaseName={activeTab.db}
-                  collectionName={activeTab.collection}
-                  onApplied={() => setCollectionMutationTrigger(prev => prev + 1)}
-                />
-              )}
-              {activeTab && activeTab.type === 'gridfs' && (
-                <GridFsView
-                  connectionId={activeTab.connectionId}
-                  databaseName={activeTab.db}
-                  bucket={activeTab.collection}
-                  onNamespaceMutated={() => setCollectionMutationTrigger((prev) => prev + 1)}
-                />
-              )}
-              {activeTab && activeTab.type === 'monitoring' && (
-                <MonitoringView connectionId={activeTab.connectionId} />
-              )}
-              {activeTab && activeTab.type === 'users' && (
-                <UserManagementView connectionId={activeTab.connectionId} database={activeTab.db || undefined} />
-              )}
-              {activeTab && activeTab.type === 'export' && (() => {
-                const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
-                const connectionName = activeConnection ? activeConnection.name : activeTab.connectionId;
-                const sourceTab = exportSourceTab;
-                return (
-                  <ExportView
-                    key={`export:${activeTab.connectionId}:${activeTab.db}:${activeTab.collection}`}
-                    connectionId={activeTab.connectionId}
-                    connectionName={connectionName}
-                    databaseName={activeTab.db}
-                    collectionName={activeTab.collection}
-                    currentResultCount={sourceTab?.results.length || 0}
-                    availableFields={fieldsFromResults(sourceTab?.results)}
-                    filtered={buildFilteredExportSeed(sourceTab)}
-                    onExport={(format, scope, options, query) =>
-                      handleExportForTab(sourceTab || activeTab, format, scope, options, query)
-                    }
-                    onCountFilter={(filter) =>
-                      invoke<number>('count_documents', {
-                        id: activeTab.connectionId,
-                        database: activeTab.db,
-                        collection: activeTab.collection,
-                        filter,
-                      })
-                    }
-                    onOpenTasks={handleOpenTasksTab}
-                    onScanFields={handleScanExportFields}
-                    onCopyCurrent={handleCopyCurrentExport}
-                    onPreview={handlePreviewExport}
-                  />
-                );
-              })()}
-              {activeTab && activeTab.type === 'import' && (() => {
-                const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
-                const connectionName = activeConnection ? activeConnection.name : activeTab.connectionId;
-                return (
-                  <ImportView
-                    key={`import:${activeTab.connectionId}:${activeTab.db}:${activeTab.collection}`}
-                    connectionName={connectionName}
-                    databaseName={activeTab.db}
-                    collectionName={activeTab.collection}
-                    onOpenTasks={handleOpenTasksTab}
-                    onPickFile={async () => {
-                      const p = await open({
-                        multiple: false,
-                        filters: [{ name: 'Data', extensions: ['json', 'jsonl', 'ndjson', 'csv', 'bson'] }],
-                      });
-                      return typeof p === 'string' ? p : null;
-                    }}
-                    onPreview={(source, format, csvOptions) =>
-                      invoke<ImportPreviewData>('preview_import', { source, format, csvOptions, limit: 20 })
-                    }
-                    onRunImport={async (source, format, csvOptions, mode) => {
-                      try {
-                        const task = await invoke<ExportTaskInfo>('start_import_task', {
-                          id: activeTab.connectionId,
-                          database: activeTab.db,
-                          collection: activeTab.collection,
-                          source,
-                          format,
-                          csvOptions,
-                          mode,
-                        });
-                        pendingImportRefreshRef.current.set(task.id, {
-                          connectionId: activeTab.connectionId,
-                          db: activeTab.db,
-                          collection: activeTab.collection,
-                        });
-                        insertExportTasks([task]);
-                        handleOpenTasksTab();
-                        await loadExportTasks();
-                      } catch (err: any) {
-                        toast(`Import failed to start: ${err?.message || err}`, 'error');
-                      }
-                    }}
-                  />
-                );
-              })()}
-              {activeTab && activeTab.type === 'dump' && (() => {
-                const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
-                const connectionName = activeConnection ? activeConnection.name : activeTab.connectionId;
-                const initialScope: DumpScopeUi = activeTab.collection
-                  ? { kind: 'collection', db: activeTab.db, coll: activeTab.collection }
-                  : activeTab.db
-                    ? { kind: 'db', db: activeTab.db }
-                    : { kind: 'server' };
-                return (
-                  <DumpView
-                    key={activeTab.id}
-                    connectionName={connectionName}
-                    databases={dumpDbTrees[activeTab.connectionId] ?? []}
-                    initialScope={initialScope}
-                    tools={mongoTools}
-                    onOpenSettings={handleOpenToolsSettings}
-                    onInstallTools={handleOpenToolSetup}
-                    onPickFolder={async () => {
-                      const p = await open({ directory: true });
-                      return typeof p === 'string' ? p : null;
-                    }}
-                    onPickArchiveFile={async (defaultName) => {
-                      const p = await save({ defaultPath: defaultName });
-                      return p ?? null;
-                    }}
-                    onPreviewCommand={(options) =>
-                      invoke<string>('preview_dump_command', {
-                        id: activeTab.connectionId,
-                        toolPath: mongoTools?.mongodump?.path ?? '',
-                        options,
-                      })
-                    }
-                    onRunDump={(options) => handleRunDump(activeTab, options)}
-                    onOpenTasks={handleOpenTasksTab}
-                  />
-                );
-              })()}
-              {activeTab && activeTab.type === 'restore' && (() => {
-                const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
-                const connectionName = activeConnection ? activeConnection.name : activeTab.connectionId;
-                return (
-                  <RestoreView
-                    key={activeTab.id}
-                    connectionName={connectionName}
-                    tools={mongoTools}
-                    onOpenSettings={handleOpenToolsSettings}
-                    onInstallTools={handleOpenToolSetup}
-                    onPickFolder={async () => {
-                      const p = await open({ directory: true });
-                      return typeof p === 'string' ? p : null;
-                    }}
-                    onPickArchiveFile={async () => {
-                      const p = await open({ multiple: false });
-                      return typeof p === 'string' ? p : null;
-                    }}
-                    onBrowseFolder={(path) => invoke<DumpTreeUi>('browse_dump_folder', { path })}
-                    onPreviewCommand={(options) =>
-                      invoke<string>('preview_restore_command', {
-                        id: activeTab.connectionId,
-                        toolPath: mongoTools?.mongorestore?.path ?? '',
-                        options,
-                      })
-                    }
-                    onRunRestore={(options) => handleRunRestore(activeTab, options)}
-                    onOpenTasks={handleOpenTasksTab}
-                  />
-                );
-              })()}
-              {activeTab && activeTab.type === 'tasks' && (
-                <div className="flex h-full flex-col overflow-auto p-4" data-testid="tasks-view">
-                  <header className="mb-3">
-                    <h2 className="text-sm font-semibold text-foreground">Tasks</h2>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      Background copy and export jobs.
-                    </p>
-                  </header>
-                  <TaskManager
-                    tasks={exportTasks}
-                    onRefresh={loadExportTasks}
-                    onClearFinished={handleClearFinishedTasks}
-                    onCancel={handleCancelTask}
-                    variant="embedded"
-                  />
-                </div>
-              )}
-              {activeTab && activeTab.type === 'shell' && (() => {
-                const activeConnection = activeConnections.find(c => c.id === activeTab.connectionId);
-                const connectionName = activeConnection ? activeConnection.name : activeTab.connectionId;
-                return (
-                  <MongoShell
-                    key={`${activeTab.id}:${activeTab.initialShellCommand || ''}`}
-                    connectionId={activeTab.connectionId}
-                    connectionName={connectionName}
-                    connectionUri={activeConnection?.uri || ''}
-                    databaseName={activeTab.db}
-                    collectionName={activeTab.collection || undefined}
-                    initialCommand={activeTab.initialShellCommand}
-                    density={density}
-                    onOpenSettings={handleOpenToolsSettings}
-                    onInstallTools={handleOpenToolSetup}
-                    reconnectSignal={shellReconnectNonce}
-                  />
-                );
-              })()}
-              {activeTab && activeTab.type === 'settings' && (
-                <SettingsView
-                  initialTab={settingsInitialTab}
-                  onInstallTools={handleOpenToolSetup}
-                  toolStatusRefreshNonce={toolStatusRefreshNonce}
-                />
-              )}
-              {activeTab && activeTab.type === 'quickstart' && (
-                <QuickStart
-                  onConnect={() => setIsConnectionModalOpen(true)}
-                  onOpenSettings={handleOpenSettingsTab}
-                  onOpenShortcuts={handleOpenShortcutsReference}
-                  onQuickConnect={async (profile) => {
-                    await handleQuickConnect(profile);
-                  }}
-                  onLoadSampleData={handleLoadSampleData}
-                  activeConnections={activeConnections}
-                  profilesRefreshKey={profilesRefreshKey}
-                />
-              )}
-        </>
-      ) : (
-        /* Empty/Welcome Dashboard Panel */
-        <div className="flex h-full flex-col items-center justify-center gap-4 bg-background p-8 text-center">
-          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10">
-            <img src={logoMark} alt="" className="h-10 w-10 animate-pulse" />
-          </div>
-          <h1 className="text-2xl font-semibold text-foreground">MQLens</h1>
-          <p className="max-w-md text-sm text-muted-foreground">
-            No active connection. Connect to a MongoDB cluster to browse collections and run queries.
-          </p>
-
-          <Button onClick={() => setIsConnectionModalOpen(true)}>
-            <Play size={14} className="mr-1.5" fill="currentColor" />
-            Connect to Database...
-          </Button>
-        </div>
-      )}
+      {activeTabId ? renderTabContent(activeTabId) : renderEmptyPane()}
     </AppShell>
   );
 }

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -1448,6 +1448,63 @@ describe('App Component', () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('name\nA\n'));
   });
 
+  it('routes a pane-scoped export handler to the rendered pane\'s tab, not the focused pane (#97 review Fix 1)', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'execute_mql_query') {
+        return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+      }
+      if (cmd === 'load_collection_queries') {
+        return Promise.resolve({ saved: [], history: [], default: null });
+      }
+      if (cmd === 'sample_export_fields') {
+        return Promise.resolve(['_id', 'name']);
+      }
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    // Pane A: open "customers", then its Export tab (becomes the active tab).
+    fireEvent.click(screen.getByTestId('select-collection-btn'));
+    expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('export-btn'));
+    expect(await screen.findByTestId('export-view')).toBeInTheDocument();
+
+    // Split the active "Export: customers" tab into a new pane B. split_pane
+    // focuses the fresh pane, and leaves pane A re-activated on "customers".
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    fireEvent.change(await screen.findByTestId('command-palette-input'), { target: { value: 'Split Right' } });
+    fireEvent.click(await screen.findByText('Split Right'));
+
+    // Refocus pane A (mousedown on an unfocused pane dispatches focus_pane).
+    // PaneView's own testid is `pane-${pane.id}` (e.g. "pane-pane-1"); react-resizable-panels
+    // also auto-sets `data-testid={id}` (e.g. "pane-1") on its wrapping Panel, so the
+    // "pane-pane-" prefix is needed to select only PaneView's own element.
+    const panes = screen.getAllByTestId(/^pane-pane-/);
+    expect(panes).toHaveLength(2);
+    fireEvent.mouseDown(panes[0]);
+
+    // With pane A focused, open a DIFFERENT collection there. Pre-fix, the export
+    // handlers read `activeTab`/the focused pane's state, so this is exactly the
+    // (wrong) state they would have leaked into pane B's still-visible export tab.
+    fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
+    expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
+
+    // Trigger pane B's (unfocused) ExportView. It must act on ITS OWN rendered
+    // tab ("customers"), not the focused pane's active tab ("orders").
+    fireEvent.click(screen.getByTestId('export-scan-fields-btn'));
+
+    await waitFor(() => {
+      const scan = calls.find((c) => c.cmd === 'sample_export_fields');
+      expect(scan).toBeTruthy();
+      expect(scan.args).toMatchObject({ database: 'sales_db', collection: 'customers' });
+    });
+  });
+
   it('does not load profiles until the vault is unlocked', async () => {
     const vault = await import('../../lib/vault');
     (vault.getVaultStatus as any).mockResolvedValueOnce('locked');

--- a/src/components/layout/WorkspaceTabBar.tsx
+++ b/src/components/layout/WorkspaceTabBar.tsx
@@ -39,9 +39,10 @@ export function WorkspaceTabBar({
   return (
     <TooltipProvider delayDuration={400}>
       <div
+        data-testid="workspace-tab-strip"
         className="flex h-9 shrink-0 items-end gap-0 border-b border-border bg-sidebar/60 mql-chrome"
-        onDragOver={(e) => { if (onTabStripDrop) e.preventDefault(); }}
-        onDrop={onTabStripDrop}
+        onDragOver={(e) => { if (onTabStripDrop) { e.preventDefault(); e.stopPropagation(); } }}
+        onDrop={(e) => { if (onTabStripDrop) { e.stopPropagation(); onTabStripDrop(e); } }}
       >
         <ScrollArea className="w-full">
           <div className="flex h-9 items-end px-1">

--- a/src/components/layout/WorkspaceTabBar.tsx
+++ b/src/components/layout/WorkspaceTabBar.tsx
@@ -20,6 +20,11 @@ interface WorkspaceTabBarProps {
   activeTabId: string | null;
   onSelectTab: (id: string) => void;
   onCloseTab: (id: string) => void;
+  /** Marks tabs draggable and sets TAB_DRAG_MIME data on drag start. */
+  draggable?: boolean;
+  onTabDragStart?: (id: string, e: React.DragEvent) => void;
+  /** Drop on the tab strip itself = move-to-end of this pane. */
+  onTabStripDrop?: (e: React.DragEvent) => void;
 }
 
 export function WorkspaceTabBar({
@@ -27,10 +32,17 @@ export function WorkspaceTabBar({
   activeTabId,
   onSelectTab,
   onCloseTab,
+  draggable,
+  onTabDragStart,
+  onTabStripDrop,
 }: WorkspaceTabBarProps) {
   return (
     <TooltipProvider delayDuration={400}>
-      <div className="flex h-9 shrink-0 items-end gap-0 border-b border-border bg-sidebar/60 mql-chrome">
+      <div
+        className="flex h-9 shrink-0 items-end gap-0 border-b border-border bg-sidebar/60 mql-chrome"
+        onDragOver={(e) => { if (onTabStripDrop) e.preventDefault(); }}
+        onDrop={onTabStripDrop}
+      >
         <ScrollArea className="w-full">
           <div className="flex h-9 items-end px-1">
             {tabs.map((tab) => {
@@ -45,6 +57,8 @@ export function WorkspaceTabBar({
                       : "border-transparent bg-transparent text-muted-foreground hover:bg-accent/50 hover:text-foreground"
                   )}
                   onClick={() => onSelectTab(tab.id)}
+                  draggable={draggable}
+                  onDragStart={(e) => onTabDragStart?.(tab.id, e)}
                 >
                   <span className="shrink-0">{tab.icon}</span>
                   <span className="truncate font-medium">{tab.label}</span>

--- a/src/components/layout/WorkspaceTabBar.tsx
+++ b/src/components/layout/WorkspaceTabBar.tsx
@@ -8,6 +8,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
+/** Custom MIME used to mark drags originating from a workspace tab (as opposed to
+ *  OS file/text drags). Owned here; re-exported from workspace/PaneView.tsx. */
+export const TAB_DRAG_MIME = 'application/x-mqlens-tab';
+
 export interface WorkspaceTab {
   id: string;
   label: string;
@@ -41,8 +45,18 @@ export function WorkspaceTabBar({
       <div
         data-testid="workspace-tab-strip"
         className="flex h-9 shrink-0 items-end gap-0 border-b border-border bg-sidebar/60 mql-chrome"
-        onDragOver={(e) => { if (onTabStripDrop) { e.preventDefault(); e.stopPropagation(); } }}
-        onDrop={(e) => { if (onTabStripDrop) { e.stopPropagation(); onTabStripDrop(e); } }}
+        onDragOver={(e) => {
+          if (onTabStripDrop && e.dataTransfer.types.includes(TAB_DRAG_MIME)) {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }}
+        onDrop={(e) => {
+          if (onTabStripDrop && e.dataTransfer.types.includes(TAB_DRAG_MIME)) {
+            e.stopPropagation();
+            onTabStripDrop(e);
+          }
+        }}
       >
         <ScrollArea className="w-full">
           <div className="flex h-9 items-end px-1">

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -11,3 +11,19 @@ globalThis.ResizeObserver = MockResizeObserver;
 
 // cmdk and Radix scroll areas call scrollIntoView; jsdom does not implement it.
 Element.prototype.scrollIntoView = function scrollIntoView() {};
+
+// jsdom does not implement DragEvent (https://github.com/jsdom/jsdom/issues/2913),
+// so @testing-library/dom's fireEvent.dragOver/drop/dragStart fall back to the
+// base Event constructor and silently drop clientX/clientY/dataTransfer from the
+// event init. Polyfill it as a MouseEvent subclass so drag-and-drop tests observe
+// real coordinates on the synthetic event.
+if (typeof globalThis.DragEvent === 'undefined') {
+  class DragEventPolyfill extends MouseEvent {
+    dataTransfer: DataTransfer | null;
+    constructor(type: string, eventInitDict: MouseEventInit & { dataTransfer?: DataTransfer | null } = {}) {
+      super(type, eventInitDict);
+      this.dataTransfer = eventInitDict.dataTransfer ?? null;
+    }
+  }
+  globalThis.DragEvent = DragEventPolyfill;
+}

--- a/src/workspace/PaneView.tsx
+++ b/src/workspace/PaneView.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useCallback } from 'react';
-import { WorkspaceTabBar, type WorkspaceTab } from '../components/layout/WorkspaceTabBar';
+import { WorkspaceTabBar, TAB_DRAG_MIME, type WorkspaceTab } from '../components/layout/WorkspaceTabBar';
 import type { PaneNode, WorkspaceAction, SplitDir, SplitSide } from './model';
 
-export const TAB_DRAG_MIME = 'application/x-mqlens-tab';
+// Re-exported so existing `import { TAB_DRAG_MIME } from '../PaneView'` call sites
+// (e.g. tests) keep working. Owned by WorkspaceTabBar.tsx — see that file.
+export { TAB_DRAG_MIME };
 
 type DropZone = 'center' | 'left' | 'right' | 'top' | 'bottom';
 

--- a/src/workspace/PaneView.tsx
+++ b/src/workspace/PaneView.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useCallback } from 'react';
+import { WorkspaceTabBar, type WorkspaceTab } from '../components/layout/WorkspaceTabBar';
+import type { PaneNode, WorkspaceAction, SplitDir, SplitSide } from './model';
+
+export const TAB_DRAG_MIME = 'application/x-mqlens-tab';
+
+type DropZone = 'center' | 'left' | 'right' | 'top' | 'bottom';
+
+const EDGE = 0.2; // outer 20% of each axis is an edge zone
+
+function zoneFor(e: React.DragEvent, el: HTMLElement): DropZone {
+  const r = el.getBoundingClientRect();
+  const x = (e.clientX - r.left) / r.width;
+  const y = (e.clientY - r.top) / r.height;
+  if (x < EDGE) return 'left';
+  if (x > 1 - EDGE) return 'right';
+  if (y < EDGE) return 'top';
+  if (y > 1 - EDGE) return 'bottom';
+  return 'center';
+}
+
+const ZONE_SPLIT: Record<Exclude<DropZone, 'center'>, { dir: SplitDir; side: SplitSide }> = {
+  left: { dir: 'row', side: 'start' },
+  right: { dir: 'row', side: 'end' },
+  top: { dir: 'col', side: 'start' },
+  bottom: { dir: 'col', side: 'end' },
+};
+
+export interface PaneViewProps {
+  pane: PaneNode;
+  focused: boolean;
+  multiPane: boolean;
+  tabs: WorkspaceTab[];
+  dispatch: (action: WorkspaceAction) => void;
+  renderTabContent: (tabId: string) => React.ReactNode;
+  renderEmptyPane: () => React.ReactNode;
+}
+
+export function PaneView({
+  pane, focused, multiPane, tabs, dispatch, renderTabContent, renderEmptyPane,
+}: PaneViewProps) {
+  const [zone, setZone] = useState<DropZone | null>(null);
+
+  const onDragOver = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes(TAB_DRAG_MIME)) return;
+    e.preventDefault();
+    setZone(zoneFor(e, e.currentTarget as HTMLElement));
+  }, []);
+
+  const onDrop = useCallback((e: React.DragEvent) => {
+    const tabId = e.dataTransfer.getData(TAB_DRAG_MIME);
+    setZone(null);
+    if (!tabId) return;
+    e.preventDefault();
+    const z = zoneFor(e, e.currentTarget as HTMLElement);
+    if (z === 'center') {
+      dispatch({ type: 'move_tab', tabId, targetPaneId: pane.id });
+    } else {
+      const { dir, side } = ZONE_SPLIT[z];
+      dispatch({ type: 'split_pane', paneId: pane.id, dir, side, moveTabId: tabId });
+    }
+  }, [dispatch, pane.id]);
+
+  return (
+    <div
+      data-testid={`pane-${pane.id}`}
+      className={`flex h-full min-h-0 flex-col ${multiPane && focused ? 'ring-1 ring-primary/40' : ''}`}
+      onMouseDownCapture={() => { if (multiPane && !focused) dispatch({ type: 'focus_pane', paneId: pane.id }); }}
+      onDragOver={onDragOver}
+      onDragLeave={() => setZone(null)}
+      onDrop={onDrop}
+    >
+      {tabs.length > 0 && (
+        <WorkspaceTabBar
+          tabs={tabs}
+          activeTabId={pane.activeTabId}
+          onSelectTab={id => dispatch({ type: 'set_active', paneId: pane.id, tabId: id })}
+          onCloseTab={id => dispatch({ type: 'close_tab', tabId: id })}
+          draggable
+          onTabDragStart={(id, e) => { e.dataTransfer.setData(TAB_DRAG_MIME, id); e.dataTransfer.effectAllowed = 'move'; }}
+          onTabStripDrop={e => {
+            const tabId = e.dataTransfer.getData(TAB_DRAG_MIME);
+            if (tabId) { e.preventDefault(); dispatch({ type: 'move_tab', tabId, targetPaneId: pane.id }); }
+          }}
+        />
+      )}
+      <div className="relative min-h-0 flex-1">
+        {pane.activeTabId ? renderTabContent(pane.activeTabId) : renderEmptyPane()}
+        {zone && (
+          <div
+            data-testid={`drop-indicator-${zone}`}
+            className={`pointer-events-none absolute z-40 bg-primary/20 border border-primary/50 ${
+              zone === 'center' ? 'inset-0'
+              : zone === 'left' ? 'inset-y-0 left-0 w-1/2'
+              : zone === 'right' ? 'inset-y-0 right-0 w-1/2'
+              : zone === 'top' ? 'inset-x-0 top-0 h-1/2'
+              : 'inset-x-0 bottom-0 h-1/2'
+            }`}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/workspace/PaneView.tsx
+++ b/src/workspace/PaneView.tsx
@@ -80,7 +80,11 @@ export function PaneView({
           onTabDragStart={(id, e) => { e.dataTransfer.setData(TAB_DRAG_MIME, id); e.dataTransfer.effectAllowed = 'move'; }}
           onTabStripDrop={e => {
             const tabId = e.dataTransfer.getData(TAB_DRAG_MIME);
-            if (tabId) { e.preventDefault(); dispatch({ type: 'move_tab', tabId, targetPaneId: pane.id }); }
+            if (tabId) {
+              e.preventDefault();
+              e.stopPropagation();
+              dispatch({ type: 'move_tab', tabId, targetPaneId: pane.id });
+            }
           }}
         />
       )}

--- a/src/workspace/WorkspaceRoot.tsx
+++ b/src/workspace/WorkspaceRoot.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import type { Layout } from 'react-resizable-panels';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '../components/ui/resizable';
+import { PaneView } from './PaneView';
+import type { WorkspaceTab } from '../components/layout/WorkspaceTabBar';
+import { allPanes, type LayoutNode, type PaneNode, type WorkspaceAction, type WorkspaceLayout } from './model';
+
+export interface WorkspaceRootProps {
+  layout: WorkspaceLayout;
+  dispatch: (action: WorkspaceAction) => void;
+  tabsFor: (pane: PaneNode) => WorkspaceTab[];
+  renderTabContent: (tabId: string) => React.ReactNode;
+  renderEmptyPane: () => React.ReactNode;
+}
+
+function NodeView({ node, props }: { node: LayoutNode; props: WorkspaceRootProps }) {
+  const { layout, dispatch, tabsFor, renderTabContent, renderEmptyPane } = props;
+  if (node.kind === 'pane') {
+    return (
+      <PaneView
+        pane={node}
+        focused={layout.focusedPaneId === node.id}
+        multiPane={allPanes(layout.root).length > 1}
+        tabs={tabsFor(node)}
+        dispatch={dispatch}
+        renderTabContent={renderTabContent}
+        renderEmptyPane={renderEmptyPane}
+      />
+    );
+  }
+  const [first, second] = node.children;
+  const firstSize = Math.round(node.ratio * 100);
+  return (
+    <ResizablePanelGroup
+      key={node.id}
+      id={node.id}
+      orientation={node.dir === 'row' ? 'horizontal' : 'vertical'}
+      onLayoutChanged={(nextLayout: Layout) => {
+        const size = nextLayout[first.id];
+        if (typeof size === 'number') {
+          dispatch({ type: 'resize_split', splitId: node.id, ratio: size / 100 });
+        }
+      }}
+    >
+      <ResizablePanel id={first.id} defaultSize={firstSize} minSize={15}>
+        <NodeView node={first} props={props} />
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel id={second.id} defaultSize={100 - firstSize} minSize={15}>
+        <NodeView node={second} props={props} />
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}
+
+export function WorkspaceRoot(props: WorkspaceRootProps) {
+  return <div className="h-full min-h-0">{<NodeView node={props.layout.root} props={props} />}</div>;
+}

--- a/src/workspace/__tests__/WorkspaceRoot.test.tsx
+++ b/src/workspace/__tests__/WorkspaceRoot.test.tsx
@@ -101,4 +101,28 @@ describe('WorkspaceRoot', () => {
     expect(dispatch).toHaveBeenCalledWith({ type: 'move_tab', tabId: 'b', targetPaneId: paneA.id });
     void paneB;
   });
+
+  it('dispatches move_tab exactly once when a tab is dropped on the tab strip, without the drop bubbling into a pane split zone', () => {
+    const l = createInitialLayout(['a', 'b'], 'a');
+    const dispatch = renderLayout(l);
+    const pane = screen.getByTestId(`pane-${l.root.id}`);
+    const strip = screen.getByTestId('workspace-tab-strip');
+    const data: Record<string, string> = { [TAB_DRAG_MIME]: 'b' };
+    const dt = {
+      getData: (k: string) => data[k] ?? '',
+      setData: (k: string, v: string) => { data[k] = v; },
+      types: [TAB_DRAG_MIME],
+    };
+    // The strip sits in the top ~36px of the pane, which is within the pane's
+    // top 20% edge zone at this stubbed size — if the drop were to bubble up
+    // to the pane's own onDrop, zoneFor would compute 'top' and dispatch a
+    // split_pane in addition to (or instead of) the strip's move_tab.
+    Object.defineProperty(pane, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 1000, height: 500, right: 1000, bottom: 500 }),
+    });
+    fireEvent.dragOver(strip, { dataTransfer: dt, clientX: 500, clientY: 10 });
+    fireEvent.drop(strip, { dataTransfer: dt, clientX: 500, clientY: 10 });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'move_tab', tabId: 'b', targetPaneId: l.root.id });
+  });
 });

--- a/src/workspace/__tests__/WorkspaceRoot.test.tsx
+++ b/src/workspace/__tests__/WorkspaceRoot.test.tsx
@@ -125,4 +125,18 @@ describe('WorkspaceRoot', () => {
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith({ type: 'move_tab', tabId: 'b', targetPaneId: l.root.id });
   });
+
+  it('ignores foreign (OS file) drags on the tab strip: no preventDefault on dragOver, no dispatch on drop', () => {
+    const l = createInitialLayout(['a', 'b'], 'a');
+    const dispatch = renderLayout(l);
+    const strip = screen.getByTestId('workspace-tab-strip');
+    // A real OS file drag: no TAB_DRAG_MIME entry in dataTransfer.types.
+    const dt = { getData: () => '', setData: () => {}, types: ['Files'] };
+    // dispatchEvent (which fireEvent returns) is true only when the cancelable
+    // event was NOT preventDefault()'d — i.e. the strip let this foreign drag pass.
+    const notPrevented = fireEvent.dragOver(strip, { dataTransfer: dt, clientX: 500, clientY: 10 });
+    expect(notPrevented).toBe(true);
+    fireEvent.drop(strip, { dataTransfer: dt, clientX: 500, clientY: 10 });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });

--- a/src/workspace/__tests__/WorkspaceRoot.test.tsx
+++ b/src/workspace/__tests__/WorkspaceRoot.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WorkspaceRoot } from '../WorkspaceRoot';
+import { TAB_DRAG_MIME } from '../PaneView';
+import {
+  createInitialLayout, workspaceReducer, resetLayoutIds,
+  type WorkspaceLayout, type PaneNode,
+} from '../model';
+
+const tabsFor = (pane: PaneNode) =>
+  pane.tabIds.map(id => ({ id, label: id.toUpperCase(), icon: null }));
+
+function renderLayout(layout: WorkspaceLayout, dispatch = vi.fn()) {
+  render(
+    <WorkspaceRoot
+      layout={layout}
+      dispatch={dispatch}
+      tabsFor={tabsFor}
+      renderTabContent={tabId => <div data-testid={`content-${tabId}`} />}
+      renderEmptyPane={() => <div data-testid="empty-pane" />}
+    />,
+  );
+  return dispatch;
+}
+
+beforeEach(() => resetLayoutIds());
+
+describe('WorkspaceRoot', () => {
+  it('renders a single pane with its active tab content', () => {
+    renderLayout(createInitialLayout(['a', 'b'], 'a'));
+    expect(screen.getByTestId('content-a')).toBeInTheDocument();
+    expect(screen.queryByTestId('content-b')).toBeNull();
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('renders both panes of a split with their own content simultaneously', () => {
+    let l = createInitialLayout(['a', 'b'], 'a');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    renderLayout(l);
+    expect(screen.getByTestId('content-a')).toBeInTheDocument();
+    expect(screen.getByTestId('content-b')).toBeInTheDocument();
+  });
+
+  it('renders the empty-pane slot for an empty root pane', () => {
+    renderLayout(createInitialLayout([], null));
+    expect(screen.getByTestId('empty-pane')).toBeInTheDocument();
+  });
+
+  it('dispatches set_active when a tab is clicked', () => {
+    const l = createInitialLayout(['a', 'b'], 'a');
+    const dispatch = renderLayout(l);
+    fireEvent.click(screen.getByText('B'));
+    expect(dispatch).toHaveBeenCalledWith({ type: 'set_active', paneId: l.root.id, tabId: 'b' });
+  });
+
+  it('dispatches focus_pane on pane mousedown when multiple panes exist', () => {
+    let l = createInitialLayout(['a', 'b'], 'a');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    const dispatch = renderLayout(l);
+    fireEvent.mouseDown(screen.getByTestId('content-a'));
+    const paneA = (l.root as any).children[0] as PaneNode;
+    expect(dispatch).toHaveBeenCalledWith({ type: 'focus_pane', paneId: paneA.id });
+  });
+
+  it('dispatches split_pane when a tab is dropped on a pane edge zone', () => {
+    const l = createInitialLayout(['a', 'b'], 'a');
+    const dispatch = renderLayout(l);
+    const pane = screen.getByTestId(`pane-${l.root.id}`);
+    const data: Record<string, string> = { [TAB_DRAG_MIME]: 'b' };
+    const dt = {
+      getData: (k: string) => data[k] ?? '',
+      setData: (k: string, v: string) => { data[k] = v; },
+      types: [TAB_DRAG_MIME],
+    };
+    // Right-edge drop: clientX at 95% of the pane width.
+    Object.defineProperty(pane, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 1000, height: 500, right: 1000, bottom: 500 }),
+    });
+    fireEvent.dragOver(pane, { dataTransfer: dt, clientX: 950, clientY: 250 });
+    fireEvent.drop(pane, { dataTransfer: dt, clientX: 950, clientY: 250 });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b',
+    });
+  });
+
+  it('dispatches move_tab when a tab is dropped on the pane center', () => {
+    let l = createInitialLayout(['a', 'b'], 'a');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    const dispatch = renderLayout(l);
+    const paneA = (l.root as any).children[0] as PaneNode;
+    const paneB = (l.root as any).children[1] as PaneNode;
+    const el = screen.getByTestId(`pane-${paneA.id}`);
+    const data: Record<string, string> = { [TAB_DRAG_MIME]: 'b' };
+    const dt = { getData: (k: string) => data[k] ?? '', setData: () => {}, types: [TAB_DRAG_MIME] };
+    Object.defineProperty(el, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 1000, height: 500, right: 1000, bottom: 500 }),
+    });
+    fireEvent.dragOver(el, { dataTransfer: dt, clientX: 500, clientY: 250 });
+    fireEvent.drop(el, { dataTransfer: dt, clientX: 500, clientY: 250 });
+    expect(dispatch).toHaveBeenCalledWith({ type: 'move_tab', tabId: 'b', targetPaneId: paneA.id });
+    void paneB;
+  });
+});

--- a/src/workspace/__tests__/model.test.ts
+++ b/src/workspace/__tests__/model.test.ts
@@ -118,6 +118,13 @@ describe('close_tab', () => {
     expect(allPanes(l.root)).toHaveLength(2);
     expect(findPane(l.root, emptyPaneId)).not.toBeNull();
   });
+  it('closing a middle active tab activates its right-hand neighbor', () => {
+    let l = layoutWith('a', 'b', 'c');
+    l = workspaceReducer(l, { type: 'set_active', paneId: l.root.id, tabId: 'b' });
+    l = workspaceReducer(l, { type: 'close_tab', tabId: 'b' });
+    expect((l.root as PaneNode).tabIds).toEqual(['a', 'c']);
+    expect((l.root as PaneNode).activeTabId).toBe('c');
+  });
 });
 
 describe('close_many', () => {

--- a/src/workspace/__tests__/model.test.ts
+++ b/src/workspace/__tests__/model.test.ts
@@ -101,8 +101,19 @@ describe('close_tab', () => {
     l = workspaceReducer(l, { type: 'split_pane', paneId: paneB.id, dir: 'col', side: 'end', moveTabId: 'c' });
     expect(allPanes(l.root)).toHaveLength(3);
     l = workspaceReducer(l, { type: 'close_tab', tabId: 'c' });
-    expect(allPanes(l.root)).toHaveLength(2);
+    expect(allPanes(l.root)).toHaveLength(3);
     expect(paneOfTab(l.root, 'b')).not.toBeNull();
+  });
+  it('empty panes created by split_pane persist across unrelated tab closes', () => {
+    // Create empty pane via split without moveTabId
+    let l = layoutWith('a', 'b');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end' });
+    expect(allPanes(l.root)).toHaveLength(2);
+    const emptyPaneId = allPanes(l.root).find(p => p.tabIds.length === 0)!.id;
+    // Close a tab in the other pane — empty pane should still exist
+    l = workspaceReducer(l, { type: 'close_tab', tabId: 'b' });
+    expect(allPanes(l.root)).toHaveLength(2);
+    expect(findPane(l.root, emptyPaneId)).not.toBeNull();
   });
 });
 

--- a/src/workspace/__tests__/model.test.ts
+++ b/src/workspace/__tests__/model.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createInitialLayout, workspaceReducer, findPane, paneOfTab, allPanes,
+  allTabIds, resetLayoutIds, type WorkspaceLayout, type SplitNode, type PaneNode,
+} from '../model';
+
+const layoutWith = (...tabIds: string[]): WorkspaceLayout =>
+  createInitialLayout(tabIds, tabIds[0] ?? null);
+
+beforeEach(() => resetLayoutIds());
+
+describe('createInitialLayout', () => {
+  it('creates a single root pane holding the tabs', () => {
+    const l = layoutWith('a', 'b');
+    expect(l.root.kind).toBe('pane');
+    expect((l.root as PaneNode).tabIds).toEqual(['a', 'b']);
+    expect((l.root as PaneNode).activeTabId).toBe('a');
+    expect(l.focusedPaneId).toBe(l.root.id);
+  });
+});
+
+describe('open_tab', () => {
+  it('appends a new tab to the focused pane and activates it', () => {
+    const l = workspaceReducer(layoutWith('a'), { type: 'open_tab', tabId: 'b' });
+    const pane = l.root as PaneNode;
+    expect(pane.tabIds).toEqual(['a', 'b']);
+    expect(pane.activeTabId).toBe('b');
+  });
+  it('focuses + activates an already-open tab instead of duplicating (namespace dedupe)', () => {
+    let l = layoutWith('a', 'b');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    const paneA = paneOfTab(l.root, 'a')!;
+    l = workspaceReducer(l, { type: 'focus_pane', paneId: paneA.id });
+    l = workspaceReducer(l, { type: 'open_tab', tabId: 'b' });
+    expect(paneOfTab(l.root, 'b')!.tabIds).toEqual(['b']); // still exactly one 'b'
+    expect(l.focusedPaneId).toBe(paneOfTab(l.root, 'b')!.id);
+    expect(allTabIds(l).filter(id => id === 'b')).toHaveLength(1);
+  });
+});
+
+describe('split_pane', () => {
+  it('splits into a row with ratio 0.5 and focuses the new pane', () => {
+    const l0 = layoutWith('a', 'b');
+    const l = workspaceReducer(l0, { type: 'split_pane', paneId: l0.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    const root = l.root as SplitNode;
+    expect(root.kind).toBe('split');
+    expect(root.dir).toBe('row');
+    expect(root.ratio).toBe(0.5);
+    const [left, right] = root.children as [PaneNode, PaneNode];
+    expect(left.tabIds).toEqual(['a']);
+    expect(right.tabIds).toEqual(['b']);
+    expect(right.activeTabId).toBe('b');
+    expect(l.focusedPaneId).toBe(right.id);
+  });
+  it("side 'start' puts the new pane first", () => {
+    const l0 = layoutWith('a', 'b');
+    const l = workspaceReducer(l0, { type: 'split_pane', paneId: l0.root.id, dir: 'col', side: 'start', moveTabId: 'b' });
+    const [first] = (l.root as SplitNode).children as [PaneNode, PaneNode];
+    expect(first.tabIds).toEqual(['b']);
+  });
+  it('is a no-op when moving the only tab of a pane (split would leave it empty)', () => {
+    const l0 = layoutWith('a');
+    const l = workspaceReducer(l0, { type: 'split_pane', paneId: l0.root.id, dir: 'row', side: 'end', moveTabId: 'a' });
+    expect(l).toBe(l0);
+  });
+  it('splits without moving a tab (empty new pane) when moveTabId is omitted', () => {
+    const l0 = layoutWith('a');
+    const l = workspaceReducer(l0, { type: 'split_pane', paneId: l0.root.id, dir: 'row', side: 'end' });
+    const [, right] = (l.root as SplitNode).children as [PaneNode, PaneNode];
+    expect(right.tabIds).toEqual([]);
+    expect(right.activeTabId).toBeNull();
+  });
+});
+
+describe('close_tab', () => {
+  it('activates the last remaining tab of the pane', () => {
+    let l = layoutWith('a', 'b', 'c');
+    l = workspaceReducer(l, { type: 'set_active', paneId: l.root.id, tabId: 'c' });
+    l = workspaceReducer(l, { type: 'close_tab', tabId: 'c' });
+    expect((l.root as PaneNode).tabIds).toEqual(['a', 'b']);
+    expect((l.root as PaneNode).activeTabId).toBe('b');
+  });
+  it('folds an emptied non-root pane back into its sibling', () => {
+    let l = layoutWith('a', 'b');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    l = workspaceReducer(l, { type: 'close_tab', tabId: 'b' });
+    expect(l.root.kind).toBe('pane');
+    expect((l.root as PaneNode).tabIds).toEqual(['a']);
+    expect(l.focusedPaneId).toBe(l.root.id);
+  });
+  it("leaves an empty root pane in place (quickstart resurrection is the caller's job)", () => {
+    const l = workspaceReducer(layoutWith('a'), { type: 'close_tab', tabId: 'a' });
+    expect(l.root.kind).toBe('pane');
+    expect((l.root as PaneNode).tabIds).toEqual([]);
+    expect((l.root as PaneNode).activeTabId).toBeNull();
+  });
+  it('folds nested splits correctly (close in a 3-pane tree)', () => {
+    let l = layoutWith('a', 'b', 'c');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    const paneB = paneOfTab(l.root, 'b')!;
+    l = workspaceReducer(l, { type: 'split_pane', paneId: paneB.id, dir: 'col', side: 'end', moveTabId: 'c' });
+    expect(allPanes(l.root)).toHaveLength(3);
+    l = workspaceReducer(l, { type: 'close_tab', tabId: 'c' });
+    expect(allPanes(l.root)).toHaveLength(2);
+    expect(paneOfTab(l.root, 'b')).not.toBeNull();
+  });
+});
+
+describe('close_many', () => {
+  it('closes all listed tabs and folds emptied panes', () => {
+    let l = layoutWith('a', 'b', 'c');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'c' });
+    l = workspaceReducer(l, { type: 'close_many', tabIds: ['b', 'c'] });
+    expect(l.root.kind).toBe('pane');
+    expect(allTabIds(l)).toEqual(['a']);
+  });
+});
+
+describe('move_tab', () => {
+  it('moves a tab to another pane, activates and focuses it there', () => {
+    let l = layoutWith('a', 'b', 'c');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'c' });
+    const target = paneOfTab(l.root, 'c')!;
+    l = workspaceReducer(l, { type: 'move_tab', tabId: 'b', targetPaneId: target.id });
+    expect(paneOfTab(l.root, 'b')!.id).toBe(target.id);
+    expect(findPane(l.root, target.id)!.tabIds).toEqual(['c', 'b']);
+    expect(findPane(l.root, target.id)!.activeTabId).toBe('b');
+    expect(l.focusedPaneId).toBe(target.id);
+  });
+  it('folds the source pane when the move empties it', () => {
+    let l = layoutWith('a', 'b');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    const sourceB = paneOfTab(l.root, 'b')!;
+    const targetA = paneOfTab(l.root, 'a')!;
+    l = workspaceReducer(l, { type: 'move_tab', tabId: 'b', targetPaneId: targetA.id });
+    expect(l.root.kind).toBe('pane');
+    expect((l.root as PaneNode).tabIds).toEqual(['a', 'b']);
+    expect(findPane(l.root, sourceB.id)).toBeNull();
+  });
+  it('reorders within the same pane using index', () => {
+    let l = layoutWith('a', 'b', 'c');
+    l = workspaceReducer(l, { type: 'move_tab', tabId: 'c', targetPaneId: l.root.id, index: 0 });
+    expect((l.root as PaneNode).tabIds).toEqual(['c', 'a', 'b']);
+  });
+});
+
+describe('resize_split', () => {
+  it('sets and clamps the ratio to [0.15, 0.85]', () => {
+    let l = layoutWith('a', 'b');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    const splitId = (l.root as SplitNode).id;
+    expect((workspaceReducer(l, { type: 'resize_split', splitId, ratio: 0.3 }).root as SplitNode).ratio).toBe(0.3);
+    expect((workspaceReducer(l, { type: 'resize_split', splitId, ratio: 0.01 }).root as SplitNode).ratio).toBe(0.15);
+    expect((workspaceReducer(l, { type: 'resize_split', splitId, ratio: 0.99 }).root as SplitNode).ratio).toBe(0.85);
+  });
+});
+
+describe('rename_tab', () => {
+  it('rewrites the id everywhere including activeTabId', () => {
+    let l = layoutWith('conn.db.old');
+    l = workspaceReducer(l, { type: 'rename_tab', oldId: 'conn.db.old', newId: 'conn.db.new' });
+    expect((l.root as PaneNode).tabIds).toEqual(['conn.db.new']);
+    expect((l.root as PaneNode).activeTabId).toBe('conn.db.new');
+  });
+});
+
+describe('robustness', () => {
+  it('unknown ids are no-ops returning the same reference', () => {
+    const l = layoutWith('a');
+    expect(workspaceReducer(l, { type: 'close_tab', tabId: 'nope' })).toBe(l);
+    expect(workspaceReducer(l, { type: 'set_active', paneId: 'nope', tabId: 'a' })).toBe(l);
+    expect(workspaceReducer(l, { type: 'move_tab', tabId: 'a', targetPaneId: 'nope' })).toBe(l);
+    expect(workspaceReducer(l, { type: 'resize_split', splitId: 'nope', ratio: 0.5 })).toBe(l);
+  });
+});

--- a/src/workspace/__tests__/model.test.ts
+++ b/src/workspace/__tests__/model.test.ts
@@ -98,11 +98,14 @@ describe('close_tab', () => {
     let l = layoutWith('a', 'b', 'c');
     l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
     const paneB = paneOfTab(l.root, 'b')!;
+    // 'c' must belong to paneB before it can be split off from it.
+    l = workspaceReducer(l, { type: 'move_tab', tabId: 'c', targetPaneId: paneB.id });
     l = workspaceReducer(l, { type: 'split_pane', paneId: paneB.id, dir: 'col', side: 'end', moveTabId: 'c' });
     expect(allPanes(l.root)).toHaveLength(3);
-    l = workspaceReducer(l, { type: 'close_tab', tabId: 'c' });
-    expect(allPanes(l.root)).toHaveLength(3);
+    l = workspaceReducer(l, { type: 'close_tab', tabId: 'c' }); // pane empties → depth-2 fold
+    expect(allPanes(l.root)).toHaveLength(2);
     expect(paneOfTab(l.root, 'b')).not.toBeNull();
+    expect(paneOfTab(l.root, 'a')).not.toBeNull();
   });
   it('empty panes created by split_pane persist across unrelated tab closes', () => {
     // Create empty pane via split without moveTabId

--- a/src/workspace/model.ts
+++ b/src/workspace/model.ts
@@ -51,6 +51,12 @@ export function resetLayoutIds(): void {
   splitCounter = 0;
 }
 
+// newPaneId/newSplitId mutate module-level counters even though workspaceReducer is
+// otherwise a pure reducer. This is safe: generated ids are only ever referenced
+// within the same returned layout object, so React StrictMode's double-invoke of the
+// reducer just skips a number (e.g. pane-3 then pane-5) rather than colliding or
+// leaking across renders. Phase 2's backend port (workspace_apply, see the design doc
+// referenced above) will generate ids server-side and remove these counters.
 function newPaneId(): string {
   return `pane-${++paneCounter}`;
 }

--- a/src/workspace/model.ts
+++ b/src/workspace/model.ts
@@ -1,0 +1,267 @@
+// Pure workspace layout tree: panes hold tab IDs (the flat QueryTab[] stays in
+// App). Action names mirror the future backend workspace_apply ops (see
+// docs/superpowers/specs/2026-07-16-multi-panel-workspace-design.md) so Phase 2
+// can lift this reducer server-side without renaming anything.
+
+export type SplitDir = 'row' | 'col';
+export type SplitSide = 'start' | 'end';
+
+export interface PaneNode {
+  kind: 'pane';
+  id: string;
+  tabIds: string[];
+  activeTabId: string | null;
+}
+
+export interface SplitNode {
+  kind: 'split';
+  id: string;
+  dir: SplitDir;
+  ratio: number; // share of the first child, clamped to [0.15, 0.85]
+  children: [LayoutNode, LayoutNode];
+}
+
+export type LayoutNode = PaneNode | SplitNode;
+
+export interface WorkspaceLayout {
+  root: LayoutNode;
+  focusedPaneId: string;
+}
+
+export type WorkspaceAction =
+  | { type: 'open_tab'; tabId: string; paneId?: string }
+  | { type: 'close_tab'; tabId: string }
+  | { type: 'close_many'; tabIds: string[] }
+  | { type: 'move_tab'; tabId: string; targetPaneId: string; index?: number }
+  | { type: 'split_pane'; paneId: string; dir: SplitDir; side: SplitSide; moveTabId?: string }
+  | { type: 'resize_split'; splitId: string; ratio: number }
+  | { type: 'set_active'; paneId: string; tabId: string }
+  | { type: 'focus_pane'; paneId: string }
+  | { type: 'rename_tab'; oldId: string; newId: string };
+
+const MIN_RATIO = 0.15;
+const MAX_RATIO = 0.85;
+
+let paneCounter = 0;
+let splitCounter = 0;
+
+/** Test-only: make generated ids deterministic per test. */
+export function resetLayoutIds(): void {
+  paneCounter = 0;
+  splitCounter = 0;
+}
+
+function newPaneId(): string {
+  return `pane-${++paneCounter}`;
+}
+
+function newSplitId(): string {
+  return `split-${++splitCounter}`;
+}
+
+export function createInitialLayout(tabIds: string[], activeTabId: string | null): WorkspaceLayout {
+  const pane: PaneNode = { kind: 'pane', id: newPaneId(), tabIds: [...tabIds], activeTabId };
+  return { root: pane, focusedPaneId: pane.id };
+}
+
+export function allPanes(node: LayoutNode): PaneNode[] {
+  return node.kind === 'pane' ? [node] : node.children.flatMap(allPanes);
+}
+
+export function findPane(node: LayoutNode, paneId: string): PaneNode | null {
+  return allPanes(node).find(p => p.id === paneId) ?? null;
+}
+
+export function paneOfTab(node: LayoutNode, tabId: string): PaneNode | null {
+  return allPanes(node).find(p => p.tabIds.includes(tabId)) ?? null;
+}
+
+export function allTabIds(layout: WorkspaceLayout): string[] {
+  return allPanes(layout.root).flatMap(p => p.tabIds);
+}
+
+/** Replace the pane with the given id via fn; fn returning null folds the pane
+ *  (its parent split collapses into the sibling). Root panes never fold. */
+function mapPane(node: LayoutNode, paneId: string, fn: (p: PaneNode) => PaneNode | null): LayoutNode {
+  if (node.kind === 'pane') {
+    if (node.id !== paneId) return node;
+    return fn(node) ?? node; // root-level fold is ignored: root pane persists
+  }
+  const [a, b] = node.children;
+  const paneIn = (n: LayoutNode): boolean => findPane(n, paneId) !== null;
+  if (paneIn(a)) {
+    if (a.kind === 'pane' && a.id === paneId) {
+      const next = fn(a);
+      if (next === null) return b; // fold: parent split replaced by sibling
+      return { ...node, children: [next, b] };
+    }
+    return { ...node, children: [mapPane(a, paneId, fn), b] };
+  }
+  if (paneIn(b)) {
+    if (b.kind === 'pane' && b.id === paneId) {
+      const next = fn(b);
+      if (next === null) return a;
+      return { ...node, children: [a, next] };
+    }
+    return { ...node, children: [a, mapPane(b, paneId, fn)] };
+  }
+  return node;
+}
+
+function withFocusRepaired(layout: WorkspaceLayout): WorkspaceLayout {
+  if (findPane(layout.root, layout.focusedPaneId)) return layout;
+  return { ...layout, focusedPaneId: allPanes(layout.root)[0].id };
+}
+
+/** Collapse splits where one child is an empty pane and the other is not. */
+function collapseEmptySplits(node: LayoutNode): LayoutNode {
+  if (node.kind === 'pane') return node;
+  const [a, b] = node.children;
+  const aRecursed = collapseEmptySplits(a);
+  const bRecursed = collapseEmptySplits(b);
+
+  // Check if one child is an empty pane and the other isn't
+  const aIsEmptyPane = aRecursed.kind === 'pane' && aRecursed.tabIds.length === 0;
+  const bIsEmptyPane = bRecursed.kind === 'pane' && bRecursed.tabIds.length === 0;
+
+  if (aIsEmptyPane && !bIsEmptyPane) return bRecursed;
+  if (bIsEmptyPane && !aIsEmptyPane) return aRecursed;
+
+  // Neither or both are empty, return the split with recursively processed children
+  if (aRecursed === a && bRecursed === b) return node;
+  return { ...node, children: [aRecursed, bRecursed] };
+}
+
+function removeTabFromPane(pane: PaneNode, tabId: string): PaneNode | null {
+  const idx = pane.tabIds.indexOf(tabId);
+  if (idx === -1) return pane;
+  const tabIds = pane.tabIds.filter(id => id !== tabId);
+  if (tabIds.length === 0) return null; // request fold (ignored at root)
+  const activeTabId =
+    pane.activeTabId === tabId ? tabIds[Math.min(idx, tabIds.length - 1)] : pane.activeTabId;
+  return { ...pane, tabIds, activeTabId };
+}
+
+function closeTab(layout: WorkspaceLayout, tabId: string): WorkspaceLayout {
+  const pane = paneOfTab(layout.root, tabId);
+  if (!pane) return layout;
+  let root = mapPane(layout.root, pane.id, p => removeTabFromPane(p, tabId));
+  if (root === layout.root && pane.tabIds.length === 1 && pane.tabIds[0] === tabId) {
+    // Root pane emptied: keep the pane, clear it.
+    root = { ...pane, tabIds: [], activeTabId: null };
+  }
+  // Collapse splits with one empty pane
+  root = collapseEmptySplits(root);
+  return withFocusRepaired({ ...layout, root });
+}
+
+export function workspaceReducer(layout: WorkspaceLayout, action: WorkspaceAction): WorkspaceLayout {
+  switch (action.type) {
+    case 'open_tab': {
+      const existing = paneOfTab(layout.root, action.tabId);
+      if (existing) {
+        const root = mapPane(layout.root, existing.id, p => ({ ...p, activeTabId: action.tabId }));
+        return { root, focusedPaneId: existing.id };
+      }
+      const targetId =
+        (action.paneId && findPane(layout.root, action.paneId)?.id) || layout.focusedPaneId;
+      const root = mapPane(layout.root, targetId, p => ({
+        ...p,
+        tabIds: [...p.tabIds, action.tabId],
+        activeTabId: action.tabId,
+      }));
+      return { root, focusedPaneId: targetId };
+    }
+
+    case 'close_tab':
+      return closeTab(layout, action.tabId);
+
+    case 'close_many':
+      return action.tabIds.reduce(closeTab, layout);
+
+    case 'move_tab': {
+      const source = paneOfTab(layout.root, action.tabId);
+      const target = findPane(layout.root, action.targetPaneId);
+      if (!source || !target) return layout;
+      if (source.id === target.id) {
+        // Reorder within the pane.
+        const without = source.tabIds.filter(id => id !== action.tabId);
+        const at = Math.min(action.index ?? without.length, without.length);
+        const tabIds = [...without.slice(0, at), action.tabId, ...without.slice(at)];
+        const root = mapPane(layout.root, source.id, p => ({ ...p, tabIds }));
+        return { ...layout, root };
+      }
+      let root = mapPane(layout.root, source.id, p => removeTabFromPane(p, action.tabId));
+      // Source may have folded; the target pane still exists (folding only
+      // removes the emptied pane itself).
+      root = mapPane(root, target.id, p => {
+        const at = Math.min(action.index ?? p.tabIds.length, p.tabIds.length);
+        return {
+          ...p,
+          tabIds: [...p.tabIds.slice(0, at), action.tabId, ...p.tabIds.slice(at)],
+          activeTabId: action.tabId,
+        };
+      });
+      return withFocusRepaired({ root, focusedPaneId: target.id });
+    }
+
+    case 'split_pane': {
+      const pane = findPane(layout.root, action.paneId);
+      if (!pane) return layout;
+      if (action.moveTabId && pane.tabIds.length === 1 && pane.tabIds[0] === action.moveTabId) {
+        return layout; // would empty the source pane — pointless split
+      }
+      const moving = action.moveTabId && pane.tabIds.includes(action.moveTabId) ? action.moveTabId : undefined;
+      const fresh: PaneNode = {
+        kind: 'pane',
+        id: newPaneId(),
+        tabIds: moving ? [moving] : [],
+        activeTabId: moving ?? null,
+      };
+      const root = mapPane(layout.root, pane.id, p => {
+        const remaining = moving ? (removeTabFromPane(p, moving) as PaneNode) : p;
+        const children: [LayoutNode, LayoutNode] =
+          action.side === 'start' ? [fresh, remaining] : [remaining, fresh];
+        // mapPane expects a PaneNode return; widen through a split wrapper:
+        return { kind: 'split', id: newSplitId(), dir: action.dir, ratio: 0.5, children } as unknown as PaneNode;
+      });
+      return { root, focusedPaneId: fresh.id };
+    }
+
+    case 'resize_split': {
+      const clamped = Math.min(MAX_RATIO, Math.max(MIN_RATIO, action.ratio));
+      let found = false;
+      const visit = (node: LayoutNode): LayoutNode => {
+        if (node.kind === 'pane') return node;
+        if (node.id === action.splitId) {
+          found = true;
+          return { ...node, ratio: clamped };
+        }
+        return { ...node, children: [visit(node.children[0]), visit(node.children[1])] };
+      };
+      const root = visit(layout.root);
+      return found ? { ...layout, root } : layout;
+    }
+
+    case 'set_active': {
+      const pane = findPane(layout.root, action.paneId);
+      if (!pane || !pane.tabIds.includes(action.tabId)) return layout;
+      const root = mapPane(layout.root, action.paneId, p => ({ ...p, activeTabId: action.tabId }));
+      return { root, focusedPaneId: action.paneId };
+    }
+
+    case 'focus_pane':
+      return findPane(layout.root, action.paneId) ? { ...layout, focusedPaneId: action.paneId } : layout;
+
+    case 'rename_tab': {
+      const pane = paneOfTab(layout.root, action.oldId);
+      if (!pane) return layout;
+      const root = mapPane(layout.root, pane.id, p => ({
+        ...p,
+        tabIds: p.tabIds.map(id => (id === action.oldId ? action.newId : id)),
+        activeTabId: p.activeTabId === action.oldId ? action.newId : p.activeTabId,
+      }));
+      return { ...layout, root };
+    }
+  }
+}

--- a/src/workspace/model.ts
+++ b/src/workspace/model.ts
@@ -113,25 +113,6 @@ function withFocusRepaired(layout: WorkspaceLayout): WorkspaceLayout {
   return { ...layout, focusedPaneId: allPanes(layout.root)[0].id };
 }
 
-/** Collapse splits where one child is an empty pane and the other is not. */
-function collapseEmptySplits(node: LayoutNode): LayoutNode {
-  if (node.kind === 'pane') return node;
-  const [a, b] = node.children;
-  const aRecursed = collapseEmptySplits(a);
-  const bRecursed = collapseEmptySplits(b);
-
-  // Check if one child is an empty pane and the other isn't
-  const aIsEmptyPane = aRecursed.kind === 'pane' && aRecursed.tabIds.length === 0;
-  const bIsEmptyPane = bRecursed.kind === 'pane' && bRecursed.tabIds.length === 0;
-
-  if (aIsEmptyPane && !bIsEmptyPane) return bRecursed;
-  if (bIsEmptyPane && !aIsEmptyPane) return aRecursed;
-
-  // Neither or both are empty, return the split with recursively processed children
-  if (aRecursed === a && bRecursed === b) return node;
-  return { ...node, children: [aRecursed, bRecursed] };
-}
-
 function removeTabFromPane(pane: PaneNode, tabId: string): PaneNode | null {
   const idx = pane.tabIds.indexOf(tabId);
   if (idx === -1) return pane;
@@ -150,8 +131,6 @@ function closeTab(layout: WorkspaceLayout, tabId: string): WorkspaceLayout {
     // Root pane emptied: keep the pane, clear it.
     root = { ...pane, tabIds: [], activeTabId: null };
   }
-  // Collapse splits with one empty pane
-  root = collapseEmptySplits(root);
   return withFocusRepaired({ ...layout, root });
 }
 


### PR DESCRIPTION
## Summary
Phase 1 of the multi-panel workspace (#97, spec-driven): binary split panes in a single window.

- **Pure layout tree + reducer** (`src/workspace/model.ts`): panes hold tab IDs; action names mirror the future backend `workspace_apply` ops so Phase 2 (persistence/restore) lifts it server-side unchanged. 20 unit tests.
- **WorkspaceRoot / PaneView** render the tree with react-resizable-panels; five drop zones per pane (center = move, edges = split), drag between panes, per-pane tab strips.
- **App.tsx refactor**: flat `activeTabId` replaced by the reducer (derived focus), tab content + all handlers parameterized by tab so multiple panes render concurrently. All 16 tab types work in any pane.
- Palette commands: Split Right, Split Down, Focus Next Pane.

## Review trail
Subagent-driven: per-task spec+quality reviews plus a whole-branch final review ("Ready to merge: Yes"). Notable catches fixed en route: strip-drop event bubbling (double dispatch), pane-scoped export handlers (wrong-collection clipboard via keyboard path), foreign OS-drag rejection, tabs/builder-cache leak on pane close-button.

## Intentional behavior change
Closing a tab now activates its **right-hand neighbor** (VS Code/browser convention) instead of the last tab in the strip — locked by a unit test.

## Verification
- vitest **795/795** (68 files, with coverage), `tsc --noEmit` clean, `cargo test` 260/260, production build clean
- **Outstanding before release**: GUI manual checklist (8 items in the phase plan) — especially shell-tab behavior across split/fold (content remounts when the tree position changes) and one real divider drag (`resize_split` wiring has no automated coverage).

## Follow-ups (non-blocking)
Drag-leave highlight flicker; drop indicator shown for invalid single-tab self-drop; O(n²) tree walks in the reducer (dissolved by Phase 2 backend port); act() stderr noise in one new App test.

Squash-merge recommended (single `feat:` line for release notes).