### PR TITLE
feat: session restore — workspace persistence with one-click reconnect (#97 phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ queries actually do — from a single cross-platform desktop app.
   derivation).
 - **Split panes** — drag a tab to any pane edge to split the workspace; compare
   collections side by side, keep a shell under your results.
+- **Session restore** — your splits and tabs come back after a restart;
+  reconnect per connection with one click.
 
 ## Install
 

--- a/fixtures/workspace-golden.json
+++ b/fixtures/workspace-golden.json
@@ -226,6 +226,70 @@
       ],
       "expected": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
         "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } } ], "tabs": [] }
+    },
+    {
+      "name": "set_active_tab_not_in_pane_is_noop",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] },
+      "ops": [
+        { "type": "set_active", "pane_id": "pane-1", "tab_id": "b" }
+      ],
+      "expected": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "move_tab_clamps_out_of_range_index",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b", "c"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["d"], "activeTabId": "d" } ] } } ], "tabs": [] },
+      "ops": [
+        { "type": "move_tab", "tab_id": "a", "target_pane_id": "pane-1", "index": 99 },
+        { "type": "move_tab", "tab_id": "b", "target_pane_id": "pane-2", "index": 99 }
+      ],
+      "expected": { "revision": 2, "windows": [ { "id": "main", "focusedPaneId": "pane-2",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["c", "a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["d", "b"], "activeTabId": "b" } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "open_tab_missing_explicit_pane_falls_back_to_focused",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-2",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] },
+      "ops": [
+        { "type": "open_tab", "tab_id": "c", "pane_id": "nope", "tab": {
+          "id": "c", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } }
+      ],
+      "expected": { "revision": 1, "windows": [ { "id": "main", "focusedPaneId": "pane-2",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b", "c"], "activeTabId": "c" } ] } } ], "tabs": [
+        { "id": "c", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] }
+    },
+    {
+      "name": "resize_split_exact_bounds_inclusive",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] },
+      "ops": [
+        { "type": "resize_split", "split_id": "split-1", "ratio": 0.15 },
+        { "type": "resize_split", "split_id": "split-1", "ratio": 0.85 }
+      ],
+      "expected": { "revision": 2, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.85, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] }
     }
   ]
 }

--- a/fixtures/workspace-golden.json
+++ b/fixtures/workspace-golden.json
@@ -1,0 +1,231 @@
+{
+  "vectors": [
+    {
+      "name": "open_tab_appends_and_activates",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "open_tab", "tab_id": "b" }
+      ],
+      "expected": { "revision": 1, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b"], "activeTabId": "b" } } ], "tabs": [] }
+    },
+    {
+      "name": "open_tab_dedupe_focuses_existing_no_duplicate",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] },
+      "ops": [
+        { "type": "open_tab", "tab_id": "b" }
+      ],
+      "expected": { "revision": 1, "windows": [ { "id": "main", "focusedPaneId": "pane-2",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "open_tab_into_explicit_pane_id",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] },
+      "ops": [
+        { "type": "open_tab", "tab_id": "c", "pane_id": "pane-2" }
+      ],
+      "expected": { "revision": 1, "windows": [ { "id": "main", "focusedPaneId": "pane-2",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b", "c"], "activeTabId": "c" } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "open_tab_with_tab_payload_upserts_tabs_array",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "open_tab", "tab_id": "b", "tab": {
+          "id": "b", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } }
+      ],
+      "expected": { "revision": 1, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b"], "activeTabId": "b" } } ], "tabs": [
+        { "id": "b", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] }
+    },
+    {
+      "name": "split_pane_start_side_puts_new_pane_first",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "col", "side": "start", "move_tab_id": "b" }
+      ],
+      "expected": { "revision": 1, "windows": [ { "id": "main", "focusedPaneId": "pane-2",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "col", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" },
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "split_then_close_folds_depth2",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b", "c"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "row", "side": "end", "move_tab_id": "b" },
+        { "type": "move_tab", "tab_id": "c", "target_pane_id": "pane-2" },
+        { "type": "split_pane", "pane_id": "pane-2", "dir": "col", "side": "end", "move_tab_id": "c" },
+        { "type": "close_tab", "tab_id": "c" }
+      ],
+      "expected": { "revision": 4, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "split_pane_noop_when_moving_only_tab",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "row", "side": "end", "move_tab_id": "a" }
+      ],
+      "expected": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } } ], "tabs": [] }
+    },
+    {
+      "name": "split_without_move_persists_empty_pane_across_unrelated_close",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "row", "side": "end" },
+        { "type": "close_tab", "tab_id": "b" }
+      ],
+      "expected": { "revision": 2, "windows": [ { "id": "main", "focusedPaneId": "pane-2",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": [], "activeTabId": null } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "close_tab_activates_right_hand_neighbor",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b", "c"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "set_active", "pane_id": "pane-1", "tab_id": "b" },
+        { "type": "close_tab", "tab_id": "b" }
+      ],
+      "expected": { "revision": 2, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "c"], "activeTabId": "c" } } ], "tabs": [] }
+    },
+    {
+      "name": "close_many_folds_emptied_panes",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b", "c"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "row", "side": "end", "move_tab_id": "c" },
+        { "type": "close_many", "tab_ids": ["b", "c"] }
+      ],
+      "expected": { "revision": 2, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } } ], "tabs": [] }
+    },
+    {
+      "name": "move_tab_reorders_within_same_pane_using_index",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b", "c"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "move_tab", "tab_id": "c", "target_pane_id": "pane-1", "index": 0 }
+      ],
+      "expected": { "revision": 1, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["c", "a", "b"], "activeTabId": "a" } } ], "tabs": [] }
+    },
+    {
+      "name": "move_tab_folds_source_pane_when_emptied",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "row", "side": "end", "move_tab_id": "b" },
+        { "type": "move_tab", "tab_id": "b", "target_pane_id": "pane-1" }
+      ],
+      "expected": { "revision": 2, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b"], "activeTabId": "b" } } ], "tabs": [] }
+    },
+    {
+      "name": "resize_split_clamps_both_bounds",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b", "c"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "row", "side": "end", "move_tab_id": "c" },
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "col", "side": "end", "move_tab_id": "b" },
+        { "type": "resize_split", "split_id": "split-2", "ratio": 0.01 },
+        { "type": "resize_split", "split_id": "split-1", "ratio": 0.99 }
+      ],
+      "expected": { "revision": 4, "windows": [ { "id": "main", "focusedPaneId": "pane-3",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.85, "children": [
+          { "kind": "split", "id": "split-2", "dir": "col", "ratio": 0.15, "children": [
+            { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+            { "kind": "pane", "id": "pane-3", "tabIds": ["b"], "activeTabId": "b" } ] },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["c"], "activeTabId": "c" } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "focus_repair_after_fold",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b", "c"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "row", "side": "end", "move_tab_id": "c" },
+        { "type": "split_pane", "pane_id": "pane-1", "dir": "col", "side": "end", "move_tab_id": "b" },
+        { "type": "focus_pane", "pane_id": "pane-2" },
+        { "type": "close_tab", "tab_id": "c" }
+      ],
+      "expected": { "revision": 4, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "split", "id": "split-2", "dir": "col", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-3", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "rename_tab_rewrites_tree_and_tabs",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["conn.db.old"], "activeTabId": "conn.db.old" } } ], "tabs": [
+        { "id": "conn.db.old", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] },
+      "ops": [
+        { "type": "rename_tab", "old_id": "conn.db.old", "new_id": "conn.db.new" }
+      ],
+      "expected": { "revision": 1, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["conn.db.new"], "activeTabId": "conn.db.new" } } ], "tabs": [
+        { "id": "conn.db.new", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] }
+    },
+    {
+      "name": "update_tab_state_patches_and_identical_patch_no_bump",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["t1"], "activeTabId": "t1" } } ], "tabs": [
+        { "id": "t1", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] },
+      "ops": [
+        { "type": "update_tab_state", "tab_id": "t1", "last_query": { "filter": "{}" } },
+        { "type": "update_tab_state", "tab_id": "t1", "last_query": { "filter": "{}" } }
+      ],
+      "expected": { "revision": 1, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["t1"], "activeTabId": "t1" } } ], "tabs": [
+        { "id": "t1", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": { "filter": "{}" }, "lastAggregate": null, "builderState": null } ] }
+    },
+    {
+      "name": "unknown_id_ops_are_noops_without_revision_bump",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } } ], "tabs": [] },
+      "ops": [
+        { "type": "close_tab", "tab_id": "nope" },
+        { "type": "set_active", "pane_id": "nope", "tab_id": "a" },
+        { "type": "move_tab", "tab_id": "a", "target_pane_id": "nope" },
+        { "type": "resize_split", "split_id": "nope", "ratio": 0.5 },
+        { "type": "focus_pane", "pane_id": "nope" },
+        { "type": "rename_tab", "old_id": "nope", "new_id": "x" }
+      ],
+      "expected": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } } ], "tabs": [] }
+    }
+  ]
+}

--- a/fixtures/workspace-golden.json
+++ b/fixtures/workspace-golden.json
@@ -290,6 +290,23 @@
         "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.85, "children": [
           { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
           { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] }
+    },
+    {
+      "name": "update_tab_state_null_clears_field",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["t1"], "activeTabId": "t1" } } ], "tabs": [
+        { "id": "t1", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] },
+      "ops": [
+        { "type": "update_tab_state", "tab_id": "t1", "last_aggregate": [{ "$match": {} }] },
+        { "type": "update_tab_state", "tab_id": "t1", "last_aggregate": null }
+      ],
+      "expected": { "revision": 2, "windows": [ { "id": "main", "focusedPaneId": "pane-1",
+        "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["t1"], "activeTabId": "t1" } } ], "tabs": [
+        { "id": "t1", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] }
     }
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub mod toolsetup;
 pub mod updater;
 mod vault;
 mod window;
+mod workspace;
 pub mod biometric;
 pub use db::aggregate::{execute_aggregate_impl, explain_aggregate_query_impl};
 pub use db::ddl::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1951,6 +1951,8 @@ pub fn run() {
             queries::record_history,
             queries::set_default_query,
             queries::list_all_saved_queries,
+            workspace::workspace_get,
+            workspace::workspace_apply,
             server_status,
             current_ops,
             repl_set_status,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,9 +1,9 @@
 //! Shared application state and a poison-safe mutex helper.
 
-use crate::{ssh_tunnel, IndexInfo, MongoshSession, TaskInfo};
+use crate::{ssh_tunnel, workspace, IndexInfo, MongoshSession, TaskInfo};
 use mongodb::Client;
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -38,6 +38,15 @@ pub struct AppState {
     /// connection id, for tools that need to hand a URI to an external
     /// process (mongodump/mongorestore). Never populated for mock connections.
     pub conn_uris: Mutex<HashMap<String, String>>,
+    /// In-memory cache of the workspace.json document. `None` until the
+    /// first `workspace_get`/`workspace_apply` call populates it (see
+    /// `workspace::get_impl`/`workspace::apply_impl`).
+    pub workspace: Mutex<Option<workspace::Workspace>>,
+    /// Monotonic generation counter for debounced workspace saves —
+    /// `workspace::apply_impl` mints a new generation per real change; a
+    /// spawned save only writes if its captured generation is still current,
+    /// collapsing bursts of changes into a single-flight write.
+    pub workspace_write_gen: Arc<AtomicU64>,
 }
 
 impl AppState {
@@ -55,6 +64,8 @@ impl AppState {
             resource_tree_at: Mutex::new(Instant::now()),
             vault_key: Mutex::new(None),
             conn_uris: Mutex::new(HashMap::new()),
+            workspace: Mutex::new(None),
+            workspace_write_gen: Arc::new(AtomicU64::new(0)),
         }
     }
 

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1218,3 +1218,50 @@ mod tests {
         assert!(load_from_file(&p).is_none());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Golden parity vectors — shared with src/workspace/__tests__/golden.test.ts
+// via fixtures/workspace-golden.json. That TS runner asserts the layout half
+// only (splitTree/focusedPaneId); this runner applies the exact same ops
+// through `apply` and asserts full `Workspace` equality, including
+// `revision` and `tabs[]` (Rust-only bookkeeping the TS side has no
+// equivalent for). If a vector fails here but passes in TS, the TS reducer
+// is the spec — investigate this port, don't adjust the vector to paper over
+// the divergence.
+//
+// A sibling of `mod tests` (not nested in it) so `cargo test workspace::golden`
+// matches this module's path directly.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod golden {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct GoldenVector {
+        name: String,
+        initial: Workspace,
+        ops: Vec<WorkspaceOp>,
+        expected: Workspace,
+    }
+
+    #[derive(Deserialize)]
+    struct GoldenFixture {
+        vectors: Vec<GoldenVector>,
+    }
+
+    #[test]
+    fn golden_vectors_match_fixture() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../fixtures/workspace-golden.json");
+        let data = fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("failed to read golden fixture at {path}: {e}"));
+        let fixture: GoldenFixture = serde_json::from_str(&data)
+            .unwrap_or_else(|e| panic!("failed to parse golden fixture: {e}"));
+        for vector in fixture.vectors {
+            let mut ws = vector.initial.clone();
+            for op in vector.ops {
+                apply(&mut ws, op);
+            }
+            assert_eq!(ws, vector.expected, "golden vector `{}` diverged", vector.name);
+        }
+    }
+}

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1,0 +1,239 @@
+//! Multi-panel workspace store: layout tree, tabs, and the workspace.json
+//! document. This module owns the data model and best-effort file IO only —
+//! the reducer (`apply`) and Tauri commands land in later tasks.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// One open query tab. `profile_id` identifies a saved connection profile,
+/// NEVER a live session connectionId — tabs must survive reconnects.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TabModel {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub tab_type: String, // the 16 QueryTab kinds
+    pub profile_id: String, // NEVER a session connectionId
+    pub profile_name: String,
+    pub db: String,
+    pub collection: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_query: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_aggregate: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builder_state: Option<serde_json::Value>,
+}
+
+/// A node in the split-pane layout tree.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum LayoutNode {
+    // `rename_all` on the enum container only renames the `kind` tag values
+    // (Pane -> pane, Split -> split); it does NOT cascade into struct-variant
+    // fields. Each variant needs its own `rename_all` so `tab_ids` etc.
+    // serialize as camelCase to match the frontend document.
+    #[serde(rename = "pane", rename_all = "camelCase")]
+    Pane {
+        id: String,
+        tab_ids: Vec<String>,
+        active_tab_id: Option<String>,
+    },
+    #[serde(rename = "split", rename_all = "camelCase")]
+    Split {
+        id: String,
+        dir: String,
+        ratio: f64,
+        children: Vec<LayoutNode>, // len==2 invariant
+    },
+}
+
+/// One window's layout tree plus which pane currently has focus.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowModel {
+    pub id: String,
+    pub split_tree: LayoutNode,
+    pub focused_pane_id: String,
+}
+
+/// The whole workspace.json document.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Workspace {
+    #[serde(default)]
+    pub revision: u64,
+    #[serde(default)]
+    pub windows: Vec<WindowModel>,
+    #[serde(default)]
+    pub tabs: Vec<TabModel>, // flat, mirrors frontend tabs[]
+}
+
+/// A single workspace mutation. The `type` discriminator is snake_case to
+/// match the frontend reducer's action `type` strings exactly (e.g.
+/// `split_pane`, `update_tab_state`).
+// Variant fields are populated by serde from frontend action payloads and
+// matched on in Task 2's `apply` reducer; until that lands, rustc can't see
+// any reads and flags every field as dead code.
+#[allow(dead_code)]
+#[derive(Deserialize, Clone, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkspaceOp {
+    OpenTab {
+        tab_id: String,
+        #[serde(default)]
+        pane_id: Option<String>,
+        #[serde(default)]
+        tab: Option<TabModel>,
+    },
+    CloseTab {
+        tab_id: String,
+    },
+    CloseMany {
+        tab_ids: Vec<String>,
+    },
+    MoveTab {
+        tab_id: String,
+        target_pane_id: String,
+        #[serde(default)]
+        index: Option<usize>,
+    },
+    SplitPane {
+        pane_id: String,
+        dir: String,
+        side: String,
+        #[serde(default)]
+        move_tab_id: Option<String>,
+    },
+    ResizeSplit {
+        split_id: String,
+        ratio: f64,
+    },
+    SetActive {
+        pane_id: String,
+        tab_id: String,
+    },
+    FocusPane {
+        pane_id: String,
+    },
+    RenameTab {
+        old_id: String,
+        new_id: String,
+    },
+    UpdateTabState {
+        tab_id: String,
+        #[serde(default)]
+        last_query: Option<serde_json::Value>,
+        #[serde(default)]
+        last_aggregate: Option<serde_json::Value>,
+        #[serde(default)]
+        builder_state: Option<serde_json::Value>,
+    },
+}
+
+/// Apply one op to the workspace. Implemented in Task 2 (the reducer port);
+/// referenced here only by the op-decoding test above.
+#[allow(dead_code)] // consumed by Task 2's reducer + Task 4's Tauri commands
+pub fn apply(_ws: &mut Workspace, _op: WorkspaceOp) {
+    unimplemented!("workspace reducer lands in Task 2")
+}
+
+/// Load the workspace document. A missing or corrupt file yields `None` —
+/// persistence must never block startup — mirroring queries.rs:83-84.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+pub fn load_from_file(path: &Path) -> Option<Workspace> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+}
+
+/// Save the workspace document, pretty-printed. Errors are stringified so
+/// callers (Tauri commands) can surface them without leaking IO types.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+pub fn save_to_file(path: &Path, ws: &Workspace) -> Result<(), String> {
+    let content = serde_json::to_string_pretty(ws)
+        .map_err(|e| format!("Failed to serialize workspace: {}", e))?;
+    fs::write(path, content).map_err(|e| format!("Failed to write workspace file: {}", e))
+}
+
+/// Where workspace.json lives, mirroring `queries::get_queries_path`
+/// (queries.rs:72-81).
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn workspace_path(app_handle: &tauri::AppHandle) -> PathBuf {
+    use tauri::Manager;
+    match app_handle.path().app_config_dir() {
+        Ok(mut path) => {
+            let _ = fs::create_dir_all(&path);
+            path.push("workspace.json");
+            path
+        }
+        Err(_) => PathBuf::from("workspace.json"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn op_json_tags_match_frontend_action_types() {
+        let op: WorkspaceOp = serde_json::from_str(
+            r#"{"type":"split_pane","pane_id":"pane-1","dir":"row","side":"end","move_tab_id":"a"}"#,
+        )
+        .expect("split_pane decodes");
+        assert!(matches!(op, WorkspaceOp::SplitPane { .. }));
+        let op: WorkspaceOp = serde_json::from_str(
+            r#"{"type":"update_tab_state","tab_id":"a","last_query":{"filter":"{}"}}"#,
+        )
+        .expect("update_tab_state decodes");
+        assert!(matches!(op, WorkspaceOp::UpdateTabState { .. }));
+    }
+
+    #[test]
+    fn workspace_document_roundtrips_camel_case() {
+        let ws = Workspace {
+            revision: 3,
+            windows: vec![WindowModel {
+                id: "main".into(),
+                focused_pane_id: "pane-1".into(),
+                split_tree: LayoutNode::Split {
+                    id: "split-1".into(),
+                    dir: "row".into(),
+                    ratio: 0.5,
+                    children: vec![
+                        LayoutNode::Pane {
+                            id: "pane-1".into(),
+                            tab_ids: vec!["a".into()],
+                            active_tab_id: Some("a".into()),
+                        },
+                        LayoutNode::Pane {
+                            id: "pane-2".into(),
+                            tab_ids: vec![],
+                            active_tab_id: None,
+                        },
+                    ],
+                },
+            }],
+            tabs: vec![],
+        };
+        let json = serde_json::to_string(&ws).unwrap();
+        assert!(json.contains(r#""focusedPaneId":"pane-1""#));
+        assert!(json.contains(r#""kind":"split""#));
+        assert!(json.contains(r#""tabIds":["a"]"#));
+        let back: Workspace = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ws);
+    }
+
+    #[test]
+    fn load_missing_or_corrupt_file_yields_none() {
+        assert!(load_from_file(Path::new("/nonexistent/workspace.json")).is_none());
+        let dir = std::env::temp_dir().join("mqlens-ws-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join("corrupt.json");
+        std::fs::write(&p, "not json").unwrap();
+        assert!(load_from_file(&p).is_none());
+    }
+}

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -75,12 +75,9 @@ pub struct Workspace {
 /// A single workspace mutation. The `type` discriminator is snake_case to
 /// match the frontend reducer's action `type` strings exactly (e.g.
 /// `split_pane`, `update_tab_state`).
-// Variant fields are populated by serde from frontend action payloads and
-// matched on in Task 2's `apply` reducer; until that lands, rustc can't see
-// any reads and flags every field as dead code.
-#[allow(dead_code)]
 #[derive(Deserialize, Clone, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
 pub enum WorkspaceOp {
     OpenTab {
         tab_id: String,
@@ -134,11 +131,535 @@ pub enum WorkspaceOp {
     },
 }
 
-/// Apply one op to the workspace. Implemented in Task 2 (the reducer port);
-/// referenced here only by the op-decoding test above.
-#[allow(dead_code)] // consumed by Task 2's reducer + Task 4's Tauri commands
-pub fn apply(_ws: &mut Workspace, _op: WorkspaceOp) {
-    unimplemented!("workspace reducer lands in Task 2")
+// ---------------------------------------------------------------------------
+// Reducer internals — a 1:1 port of src/workspace/model.ts. Helper names
+// mirror the TS ones exactly (mapPane -> map_pane, removeTabFromPane ->
+// remove_tab_from_pane, withFocusRepaired -> with_focus_repaired,
+// workspaceReducer -> workspace_reducer, closeTab -> close_tab) so the two
+// implementations can be diffed function-by-function across the language
+// boundary.
+// ---------------------------------------------------------------------------
+
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+const MIN_RATIO: f64 = 0.15;
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+const MAX_RATIO: f64 = 0.85;
+
+/// The id of any layout node, pane or split (TS accesses `.id` directly on
+/// the `LayoutNode` union; Rust needs a match since the two variants don't
+/// share a common field).
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn node_id(node: &LayoutNode) -> &str {
+    match node {
+        LayoutNode::Pane { id, .. } => id,
+        LayoutNode::Split { id, .. } => id,
+    }
+}
+
+/// Port of TS `allPanes`.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn all_panes<'a>(node: &'a LayoutNode, out: &mut Vec<&'a LayoutNode>) {
+    match node {
+        LayoutNode::Pane { .. } => out.push(node),
+        LayoutNode::Split { children, .. } => {
+            for c in children {
+                all_panes(c, out);
+            }
+        }
+    }
+}
+
+/// Port of TS `findPane`.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn find_pane<'a>(node: &'a LayoutNode, pane_id: &str) -> Option<&'a LayoutNode> {
+    match node {
+        LayoutNode::Pane { id, .. } => {
+            if id == pane_id {
+                Some(node)
+            } else {
+                None
+            }
+        }
+        LayoutNode::Split { children, .. } => children.iter().find_map(|c| find_pane(c, pane_id)),
+    }
+}
+
+/// Port of TS `paneOfTab`.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn pane_of_tab<'a>(node: &'a LayoutNode, tab_id: &str) -> Option<&'a LayoutNode> {
+    match node {
+        LayoutNode::Pane { tab_ids, .. } => {
+            if tab_ids.iter().any(|t| t == tab_id) {
+                Some(node)
+            } else {
+                None
+            }
+        }
+        LayoutNode::Split { children, .. } => children.iter().find_map(|c| pane_of_tab(c, tab_id)),
+    }
+}
+
+/// Port of TS `mapPane`: replaces the pane with `pane_id` via `f`. `f`
+/// returning `None` requests a fold (its parent split collapses into the
+/// sibling). The outermost call special-cases a lone-root pane: a fold
+/// request there is ignored (`f(node).unwrap_or_else(|| node.clone())`),
+/// mirroring TS's `fn(node) ?? node` — "root-level fold is ignored: root
+/// pane persists". Every *recursive* self-call only ever re-enters this
+/// function with a Split node (the branch that would recurse into a
+/// directly-matching pane instead folds inline), so nested folds always
+/// take effect; only the true top-level call can hit the "ignore" path.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn map_pane(
+    node: &LayoutNode,
+    pane_id: &str,
+    f: &mut dyn FnMut(&LayoutNode) -> Option<LayoutNode>,
+) -> LayoutNode {
+    match node {
+        LayoutNode::Pane { id, .. } => {
+            if id != pane_id {
+                return node.clone();
+            }
+            f(node).unwrap_or_else(|| node.clone())
+        }
+        LayoutNode::Split { id, dir, ratio, children } => {
+            let (a, b) = (&children[0], &children[1]);
+            if find_pane(a, pane_id).is_some() {
+                if let LayoutNode::Pane { id: aid, .. } = a {
+                    if aid == pane_id {
+                        return match f(a) {
+                            None => b.clone(), // fold: parent split replaced by sibling
+                            Some(next) => LayoutNode::Split {
+                                id: id.clone(),
+                                dir: dir.clone(),
+                                ratio: *ratio,
+                                children: vec![next, b.clone()],
+                            },
+                        };
+                    }
+                }
+                return LayoutNode::Split {
+                    id: id.clone(),
+                    dir: dir.clone(),
+                    ratio: *ratio,
+                    children: vec![map_pane(a, pane_id, f), b.clone()],
+                };
+            }
+            if find_pane(b, pane_id).is_some() {
+                if let LayoutNode::Pane { id: bid, .. } = b {
+                    if bid == pane_id {
+                        return match f(b) {
+                            None => a.clone(),
+                            Some(next) => LayoutNode::Split {
+                                id: id.clone(),
+                                dir: dir.clone(),
+                                ratio: *ratio,
+                                children: vec![a.clone(), next],
+                            },
+                        };
+                    }
+                }
+                return LayoutNode::Split {
+                    id: id.clone(),
+                    dir: dir.clone(),
+                    ratio: *ratio,
+                    children: vec![a.clone(), map_pane(b, pane_id, f)],
+                };
+            }
+            node.clone()
+        }
+    }
+}
+
+/// Port of TS `withFocusRepaired`.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn with_focus_repaired(root: &LayoutNode, focused_pane_id: &str) -> String {
+    if find_pane(root, focused_pane_id).is_some() {
+        return focused_pane_id.to_string();
+    }
+    let mut panes = Vec::new();
+    all_panes(root, &mut panes);
+    node_id(panes[0]).to_string() // a tree always has at least one pane
+}
+
+/// Port of TS `removeTabFromPane`. `None` signals "fold" (the pane became
+/// empty); the pane is returned unchanged (`Some`) if `tab_id` wasn't
+/// present, matching TS's `if (idx === -1) return pane;`.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn remove_tab_from_pane(pane: &LayoutNode, tab_id: &str) -> Option<LayoutNode> {
+    let LayoutNode::Pane { id, tab_ids, active_tab_id } = pane else {
+        unreachable!("remove_tab_from_pane is only ever called with a pane node");
+    };
+    let Some(idx) = tab_ids.iter().position(|t| t == tab_id) else {
+        return Some(pane.clone());
+    };
+    let new_tab_ids: Vec<String> = tab_ids.iter().filter(|t| *t != tab_id).cloned().collect();
+    if new_tab_ids.is_empty() {
+        return None; // request fold (ignored at root)
+    }
+    let new_active = if active_tab_id.as_deref() == Some(tab_id) {
+        Some(new_tab_ids[idx.min(new_tab_ids.len() - 1)].clone())
+    } else {
+        active_tab_id.clone()
+    };
+    Some(LayoutNode::Pane { id: id.clone(), tab_ids: new_tab_ids, active_tab_id: new_active })
+}
+
+/// Port of TS `closeTab`.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn close_tab(root: &LayoutNode, focused_pane_id: &str, tab_id: &str) -> (LayoutNode, String) {
+    let Some(pane) = pane_of_tab(root, tab_id) else {
+        return (root.clone(), focused_pane_id.to_string());
+    };
+    let pane_id = node_id(pane).to_string();
+    let LayoutNode::Pane { tab_ids: pane_tab_ids, .. } = pane else {
+        unreachable!("pane_of_tab only ever returns a pane node");
+    };
+    let pane_tab_ids = pane_tab_ids.clone();
+    let tab_id_owned = tab_id.to_string();
+    let mut new_root = map_pane(root, &pane_id, &mut |p| remove_tab_from_pane(p, &tab_id_owned));
+    // Root pane emptied: TS detects this via `root === layout.root` (the
+    // fold request bubbled all the way to mapPane's ignore-at-root case,
+    // meaning the whole tree IS that one pane); we detect the equivalent
+    // condition directly: the pane found by pane_of_tab is the tree root
+    // and held exactly this one tab.
+    let root_is_target_pane = matches!(root, LayoutNode::Pane { id, .. } if *id == pane_id);
+    if root_is_target_pane && pane_tab_ids.len() == 1 && pane_tab_ids[0] == tab_id_owned {
+        new_root = LayoutNode::Pane { id: pane_id, tab_ids: vec![], active_tab_id: None };
+    }
+    let new_focused = with_focus_repaired(&new_root, focused_pane_id);
+    (new_root, new_focused)
+}
+
+/// Port of TS `workspaceReducer`'s `switch`, operating on the (root,
+/// focusedPaneId) pair that TS calls `WorkspaceLayout`. Layout-only: the
+/// Rust-only `tabs[]` bookkeeping (OpenTab's tab model, CloseTab/CloseMany/
+/// RenameTab mirroring, UpdateTabState) is applied separately by `apply`.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp) -> (LayoutNode, String) {
+    match op {
+        WorkspaceOp::OpenTab { tab_id, pane_id, .. } => {
+            if let Some(existing) = pane_of_tab(root, tab_id) {
+                let existing_id = node_id(existing).to_string();
+                let tab_id_owned = tab_id.clone();
+                let new_root = map_pane(root, &existing_id, &mut |p| {
+                    let LayoutNode::Pane { id, tab_ids, .. } = p else { return None };
+                    Some(LayoutNode::Pane {
+                        id: id.clone(),
+                        tab_ids: tab_ids.clone(),
+                        active_tab_id: Some(tab_id_owned.clone()),
+                    })
+                });
+                return (new_root, existing_id);
+            }
+            let target_id = pane_id
+                .as_deref()
+                .and_then(|pid| find_pane(root, pid))
+                .map(|p| node_id(p).to_string())
+                .unwrap_or_else(|| focused_pane_id.to_string());
+            let tab_id_owned = tab_id.clone();
+            let new_root = map_pane(root, &target_id, &mut |p| {
+                let LayoutNode::Pane { id, tab_ids, .. } = p else { return None };
+                let mut new_tab_ids = tab_ids.clone();
+                new_tab_ids.push(tab_id_owned.clone());
+                Some(LayoutNode::Pane { id: id.clone(), tab_ids: new_tab_ids, active_tab_id: Some(tab_id_owned.clone()) })
+            });
+            (new_root, target_id)
+        }
+
+        WorkspaceOp::CloseTab { tab_id } => close_tab(root, focused_pane_id, tab_id),
+
+        WorkspaceOp::CloseMany { tab_ids } => {
+            let mut r = root.clone();
+            let mut f = focused_pane_id.to_string();
+            for t in tab_ids {
+                let (nr, nf) = close_tab(&r, &f, t);
+                r = nr;
+                f = nf;
+            }
+            (r, f)
+        }
+
+        WorkspaceOp::MoveTab { tab_id, target_pane_id, index } => {
+            let (Some(source), Some(target)) = (pane_of_tab(root, tab_id), find_pane(root, target_pane_id)) else {
+                return (root.clone(), focused_pane_id.to_string());
+            };
+            let source_id = node_id(source).to_string();
+            let target_id = node_id(target).to_string();
+            if source_id == target_id {
+                // Reorder within the pane.
+                let LayoutNode::Pane { tab_ids, .. } = source else { unreachable!() };
+                let without: Vec<String> = tab_ids.iter().filter(|t| **t != *tab_id).cloned().collect();
+                let at = index.unwrap_or(without.len()).min(without.len());
+                let mut new_tab_ids = without[..at].to_vec();
+                new_tab_ids.push(tab_id.clone());
+                new_tab_ids.extend_from_slice(&without[at..]);
+                let new_root = map_pane(root, &source_id, &mut |p| {
+                    let LayoutNode::Pane { id, active_tab_id, .. } = p else { return None };
+                    Some(LayoutNode::Pane { id: id.clone(), tab_ids: new_tab_ids.clone(), active_tab_id: active_tab_id.clone() })
+                });
+                return (new_root, focused_pane_id.to_string());
+            }
+            let tab_id_owned = tab_id.clone();
+            let mut new_root = map_pane(root, &source_id, &mut |p| remove_tab_from_pane(p, &tab_id_owned));
+            // Source may have folded; the target pane still exists (folding
+            // only removes the emptied pane itself).
+            let index_owned = *index;
+            new_root = map_pane(&new_root, &target_id, &mut |p| {
+                let LayoutNode::Pane { id, tab_ids, .. } = p else { return None };
+                let at = index_owned.unwrap_or(tab_ids.len()).min(tab_ids.len());
+                let mut new_tab_ids = tab_ids[..at].to_vec();
+                new_tab_ids.push(tab_id_owned.clone());
+                new_tab_ids.extend_from_slice(&tab_ids[at..]);
+                Some(LayoutNode::Pane { id: id.clone(), tab_ids: new_tab_ids, active_tab_id: Some(tab_id_owned.clone()) })
+            });
+            let new_focused = with_focus_repaired(&new_root, &target_id);
+            (new_root, new_focused)
+        }
+
+        WorkspaceOp::SplitPane { pane_id, dir, side, move_tab_id } => {
+            let Some(pane) = find_pane(root, pane_id) else {
+                return (root.clone(), focused_pane_id.to_string());
+            };
+            let LayoutNode::Pane { tab_ids: existing_tab_ids, .. } = pane else { unreachable!() };
+            if let Some(mv) = move_tab_id {
+                if existing_tab_ids.len() == 1 && existing_tab_ids[0] == *mv {
+                    return (root.clone(), focused_pane_id.to_string()); // would empty the source pane — pointless split
+                }
+            }
+            let moving: Option<String> =
+                move_tab_id.as_ref().filter(|mv| existing_tab_ids.contains(mv)).cloned();
+            let fresh_id = next_pane_id(root);
+            let fresh = LayoutNode::Pane {
+                id: fresh_id.clone(),
+                tab_ids: moving.clone().map(|m| vec![m]).unwrap_or_default(),
+                active_tab_id: moving.clone(),
+            };
+            let split_id = next_split_id(root);
+            let side_is_start = side.as_str() == "start";
+            let dir_owned = dir.clone();
+            let new_root = map_pane(root, pane_id, &mut |p| {
+                let remaining = match &moving {
+                    Some(m) => remove_tab_from_pane(p, m)
+                        .expect("split_pane's no-op guard above ensures removing `moving` never empties the pane"),
+                    None => p.clone(),
+                };
+                let children = if side_is_start {
+                    vec![fresh.clone(), remaining]
+                } else {
+                    vec![remaining, fresh.clone()]
+                };
+                Some(LayoutNode::Split { id: split_id.clone(), dir: dir_owned.clone(), ratio: 0.5, children })
+            });
+            (new_root, fresh_id)
+        }
+
+        WorkspaceOp::ResizeSplit { split_id, ratio } => {
+            let clamped = ratio.clamp(MIN_RATIO, MAX_RATIO);
+            let mut found = false;
+            fn visit(node: &LayoutNode, split_id: &str, clamped: f64, found: &mut bool) -> LayoutNode {
+                match node {
+                    LayoutNode::Pane { .. } => node.clone(),
+                    LayoutNode::Split { id, dir, ratio, children } => {
+                        if id == split_id {
+                            *found = true;
+                            LayoutNode::Split { id: id.clone(), dir: dir.clone(), ratio: clamped, children: children.clone() }
+                        } else {
+                            LayoutNode::Split {
+                                id: id.clone(),
+                                dir: dir.clone(),
+                                ratio: *ratio,
+                                children: children.iter().map(|c| visit(c, split_id, clamped, found)).collect(),
+                            }
+                        }
+                    }
+                }
+            }
+            let new_root = visit(root, split_id, clamped, &mut found);
+            if found {
+                (new_root, focused_pane_id.to_string())
+            } else {
+                (root.clone(), focused_pane_id.to_string())
+            }
+        }
+
+        WorkspaceOp::SetActive { pane_id, tab_id } => {
+            let ok = matches!(find_pane(root, pane_id), Some(LayoutNode::Pane { tab_ids, .. }) if tab_ids.contains(tab_id));
+            if !ok {
+                return (root.clone(), focused_pane_id.to_string());
+            }
+            let tab_id_owned = tab_id.clone();
+            let new_root = map_pane(root, pane_id, &mut |p| {
+                let LayoutNode::Pane { id, tab_ids, .. } = p else { return None };
+                Some(LayoutNode::Pane { id: id.clone(), tab_ids: tab_ids.clone(), active_tab_id: Some(tab_id_owned.clone()) })
+            });
+            (new_root, pane_id.clone())
+        }
+
+        WorkspaceOp::FocusPane { pane_id } => {
+            if find_pane(root, pane_id).is_some() {
+                (root.clone(), pane_id.clone())
+            } else {
+                (root.clone(), focused_pane_id.to_string())
+            }
+        }
+
+        WorkspaceOp::RenameTab { old_id, new_id } => {
+            let Some(pane) = pane_of_tab(root, old_id) else {
+                return (root.clone(), focused_pane_id.to_string());
+            };
+            let pane_id = node_id(pane).to_string();
+            let (old_owned, new_owned) = (old_id.clone(), new_id.clone());
+            let new_root = map_pane(root, &pane_id, &mut |p| {
+                let LayoutNode::Pane { id, tab_ids, active_tab_id } = p else { return None };
+                let new_tab_ids: Vec<String> =
+                    tab_ids.iter().map(|t| if *t == old_owned { new_owned.clone() } else { t.clone() }).collect();
+                let new_active = if active_tab_id.as_deref() == Some(old_owned.as_str()) {
+                    Some(new_owned.clone())
+                } else {
+                    active_tab_id.clone()
+                };
+                Some(LayoutNode::Pane { id: id.clone(), tab_ids: new_tab_ids, active_tab_id: new_active })
+            });
+            (new_root, focused_pane_id.to_string())
+        }
+
+        // Tabs-only op — no layout-tree effect. Handled by `apply`.
+        WorkspaceOp::UpdateTabState { .. } => (root.clone(), focused_pane_id.to_string()),
+    }
+}
+
+/// Scans the tree for the highest numeric suffix among ids sharing `prefix`
+/// (e.g. `"pane-"` or `"split-"`), regardless of node kind — ids of the
+/// other kind never share a prefix so they simply don't match.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn max_numeric_suffix(node: &LayoutNode, prefix: &str) -> u64 {
+    let mut best = node_id(node).strip_prefix(prefix).and_then(|r| r.parse::<u64>().ok()).unwrap_or(0);
+    if let LayoutNode::Split { children, .. } = node {
+        for c in children {
+            best = best.max(max_numeric_suffix(c, prefix));
+        }
+    }
+    best
+}
+
+/// Mints `pane-N` / `split-N` ids by scanning the live tree for the current
+/// max suffix at call time, rather than keeping a counter on `Workspace`.
+///
+/// Deliberate divergence from TS: `model.ts` keeps module-level
+/// `paneCounter`/`splitCounter` mutable statics (reset per-test via
+/// `resetLayoutIds`) with no file-load case — a fresh page load starts both
+/// counters at 0 because the in-memory layout is always freshly built from
+/// `tabIds`. The Rust store, by contrast, *restores* a tree from
+/// `workspace.json` that may already contain `pane-7`/`split-3`; a
+/// process-local counter seeded at 0 would immediately collide with ids
+/// already in the restored tree. Scanning the tree at mint time is
+/// stateless (nothing to seed on load, nothing to serialize, nothing to get
+/// out of sync with the actual tree) and cheap at these tree sizes.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn next_pane_id(root: &LayoutNode) -> String {
+    format!("pane-{}", max_numeric_suffix(root, "pane-") + 1)
+}
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn next_split_id(root: &LayoutNode) -> String {
+    format!("split-{}", max_numeric_suffix(root, "split-") + 1)
+}
+
+/// The single main window's initial state: one root pane, no tabs. Mirrors
+/// TS `createInitialLayout([], null)` plus the window wrapper Phase 2 adds.
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+fn default_window() -> WindowModel {
+    WindowModel {
+        id: "main".into(),
+        split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec![], active_tab_id: None },
+        focused_pane_id: "pane-1".into(),
+    }
+}
+
+/// Apply one op to the workspace, mutating `windows[0]` (Phase 2: exactly
+/// one window; seeded with `default_window()` on first use) and `tabs`.
+/// `revision` bumps only when something actually changed — TS returns the
+/// same object reference for a no-op action; Rust mutates in place, so we
+/// mirror that by comparing old vs. new values (both `LayoutNode` and
+/// `WindowModel` derive `PartialEq`) rather than tracking reference
+/// identity. See the Task 2 report for the semantic-choice writeup of edge
+/// cases (e.g. `open_tab` re-activating an already-active+focused tab) where
+/// this differs from "TS would have returned a new object".
+#[allow(dead_code)] // wired up by Task 4's Tauri commands
+pub fn apply(ws: &mut Workspace, op: WorkspaceOp) {
+    if ws.windows.is_empty() {
+        ws.windows.push(default_window());
+    }
+
+    let mut changed = false;
+
+    if !matches!(op, WorkspaceOp::UpdateTabState { .. }) {
+        let win = &mut ws.windows[0];
+        let (new_root, new_focused) = workspace_reducer(&win.split_tree, &win.focused_pane_id, &op);
+        if new_root != win.split_tree || new_focused != win.focused_pane_id {
+            win.split_tree = new_root;
+            win.focused_pane_id = new_focused;
+            changed = true;
+        }
+    }
+
+    // Rust-only tabs[] bookkeeping — TS has no `tabs` array (the frontend
+    // keeps QueryTab[] in App); these mirror the tree op above.
+    match &op {
+        WorkspaceOp::OpenTab { tab: Some(model), .. } => match ws.tabs.iter_mut().find(|t| t.id == model.id) {
+            Some(existing) if existing != model => {
+                *existing = model.clone();
+                changed = true;
+            }
+            Some(_) => {}
+            None => {
+                ws.tabs.push(model.clone());
+                changed = true;
+            }
+        },
+        WorkspaceOp::CloseTab { tab_id } => {
+            let before = ws.tabs.len();
+            ws.tabs.retain(|t| &t.id != tab_id);
+            changed |= ws.tabs.len() != before;
+        }
+        WorkspaceOp::CloseMany { tab_ids } => {
+            let before = ws.tabs.len();
+            ws.tabs.retain(|t| !tab_ids.contains(&t.id));
+            changed |= ws.tabs.len() != before;
+        }
+        WorkspaceOp::RenameTab { old_id, new_id } => {
+            if let Some(t) = ws.tabs.iter_mut().find(|t| &t.id == old_id) {
+                t.id = new_id.clone();
+                changed = true;
+            }
+        }
+        WorkspaceOp::UpdateTabState { tab_id, last_query, last_aggregate, builder_state } => {
+            if let Some(t) = ws.tabs.iter_mut().find(|t| &t.id == tab_id) {
+                if let Some(v) = last_query {
+                    if t.last_query.as_ref() != Some(v) {
+                        t.last_query = Some(v.clone());
+                        changed = true;
+                    }
+                }
+                if let Some(v) = last_aggregate {
+                    if t.last_aggregate.as_ref() != Some(v) {
+                        t.last_aggregate = Some(v.clone());
+                        changed = true;
+                    }
+                }
+                if let Some(v) = builder_state {
+                    if t.builder_state.as_ref() != Some(v) {
+                        t.builder_state = Some(v.clone());
+                        changed = true;
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    if changed {
+        ws.revision += 1;
+    }
 }
 
 /// Load the workspace document. A missing or corrupt file yields `None` —
@@ -177,6 +698,466 @@ fn workspace_path(app_handle: &tauri::AppHandle) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------
+    // Reducer tests — ported 1:1 from src/workspace/__tests__/model.test.ts
+    // (same scenario names, snake_case). Where TS asserts `toBe(l0)`
+    // (same object reference for a no-op), Rust mutates in place, so we
+    // instead clone the workspace beforehand and assert full equality —
+    // an equivalent check since `apply`'s changed-flag guarantees no
+    // mutation happened at all when nothing changed.
+    // -----------------------------------------------------------------
+
+    fn ws_with(tab_ids: &[&str]) -> Workspace {
+        let ids: Vec<String> = tab_ids.iter().map(|s| s.to_string()).collect();
+        let active = ids.first().cloned();
+        Workspace {
+            revision: 0,
+            windows: vec![WindowModel {
+                id: "main".into(),
+                focused_pane_id: "pane-1".into(),
+                split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: ids, active_tab_id: active },
+            }],
+            tabs: vec![],
+        }
+    }
+
+    fn root(ws: &Workspace) -> &LayoutNode {
+        &ws.windows[0].split_tree
+    }
+
+    fn pane_fields(node: &LayoutNode) -> (&str, &[String], Option<&str>) {
+        match node {
+            LayoutNode::Pane { id, tab_ids, active_tab_id } => (id.as_str(), tab_ids.as_slice(), active_tab_id.as_deref()),
+            LayoutNode::Split { .. } => panic!("expected a pane node, got a split"),
+        }
+    }
+
+    fn split_fields(node: &LayoutNode) -> (&str, &str, f64, &[LayoutNode]) {
+        match node {
+            LayoutNode::Split { id, dir, ratio, children } => (id.as_str(), dir.as_str(), *ratio, children.as_slice()),
+            LayoutNode::Pane { .. } => panic!("expected a split node, got a pane"),
+        }
+    }
+
+    fn collect_ids(node: &LayoutNode, out: &mut Vec<String>) {
+        out.push(node_id(node).to_string());
+        if let LayoutNode::Split { children, .. } = node {
+            for c in children {
+                collect_ids(c, out);
+            }
+        }
+    }
+
+    #[test]
+    fn creates_single_root_pane_holding_the_tabs() {
+        // Port of the TS `createInitialLayout` test. Rust has no standalone
+        // "create initial layout" entry point — the equivalent is `apply`'s
+        // lazy default-window initialization, exercised here via a no-op-ish
+        // op on an empty `Workspace`.
+        let mut ws = Workspace::default();
+        apply(&mut ws, WorkspaceOp::FocusPane { pane_id: "pane-1".into() });
+        assert_eq!(ws.windows.len(), 1);
+        assert_eq!(ws.windows[0].id, "main");
+        let (id, tab_ids, active_tab_id) = pane_fields(root(&ws));
+        assert_eq!(id, "pane-1");
+        assert!(tab_ids.is_empty());
+        assert_eq!(active_tab_id, None);
+        assert_eq!(ws.windows[0].focused_pane_id, "pane-1");
+    }
+
+    #[test]
+    fn open_tab_appends_new_tab_and_activates_it() {
+        let mut ws = ws_with(&["a"]);
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "b".into(), pane_id: None, tab: None });
+        let (_, tab_ids, active_tab_id) = pane_fields(root(&ws));
+        assert_eq!(tab_ids, ["a", "b"]);
+        assert_eq!(active_tab_id, Some("b"));
+        assert_eq!(ws.revision, 1);
+    }
+
+    #[test]
+    fn open_tab_focuses_and_activates_existing_tab_dedupe() {
+        let mut ws = ws_with(&["a", "b"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+        );
+        let pane_a = node_id(pane_of_tab(root(&ws), "a").unwrap()).to_string();
+        apply(&mut ws, WorkspaceOp::FocusPane { pane_id: pane_a });
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "b".into(), pane_id: None, tab: None });
+        let pane_b_id = node_id(pane_of_tab(root(&ws), "b").unwrap()).to_string();
+        let (_, tab_ids, _) = pane_fields(find_pane(root(&ws), &pane_b_id).unwrap());
+        assert_eq!(tab_ids, ["b"]); // still exactly one 'b' in that pane
+        assert_eq!(ws.windows[0].focused_pane_id, pane_b_id);
+        let mut all = Vec::new();
+        all_panes(root(&ws), &mut all);
+        let b_count: usize = all.iter().map(|p| pane_fields(p).1.iter().filter(|t| **t == "b").count()).sum();
+        assert_eq!(b_count, 1);
+    }
+
+    #[test]
+    fn split_pane_splits_into_row_ratio_0_5_and_focuses_new_pane() {
+        let mut ws = ws_with(&["a", "b"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+        );
+        let (id, dir, ratio, children) = split_fields(root(&ws));
+        assert_eq!(id, "split-1");
+        assert_eq!(dir, "row");
+        assert_eq!(ratio, 0.5);
+        let (_, left_tabs, _) = pane_fields(&children[0]);
+        let (right_id, right_tabs, right_active) = pane_fields(&children[1]);
+        assert_eq!(left_tabs, ["a"]);
+        assert_eq!(right_tabs, ["b"]);
+        assert_eq!(right_active, Some("b"));
+        assert_eq!(ws.windows[0].focused_pane_id, right_id);
+    }
+
+    #[test]
+    fn split_pane_side_start_puts_new_pane_first() {
+        let mut ws = ws_with(&["a", "b"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "col".into(), side: "start".into(), move_tab_id: Some("b".into()) },
+        );
+        let (_, _, _, children) = split_fields(root(&ws));
+        let (_, first_tabs, _) = pane_fields(&children[0]);
+        assert_eq!(first_tabs, ["b"]);
+    }
+
+    #[test]
+    fn split_pane_is_noop_when_moving_only_tab() {
+        let mut ws = ws_with(&["a"]);
+        let before = ws.clone();
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("a".into()) },
+        );
+        assert_eq!(ws, before);
+        assert_eq!(ws.revision, 0);
+    }
+
+    #[test]
+    fn split_pane_without_moving_tab_creates_empty_pane() {
+        let mut ws = ws_with(&["a"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(&mut ws, WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: None });
+        let (_, _, _, children) = split_fields(root(&ws));
+        let (_, right_tabs, right_active) = pane_fields(&children[1]);
+        assert!(right_tabs.is_empty());
+        assert_eq!(right_active, None);
+    }
+
+    #[test]
+    fn close_tab_activates_last_remaining_tab() {
+        let mut ws = ws_with(&["a", "b", "c"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(&mut ws, WorkspaceOp::SetActive { pane_id: root_id, tab_id: "c".into() });
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "c".into() });
+        let (_, tab_ids, active) = pane_fields(root(&ws));
+        assert_eq!(tab_ids, ["a", "b"]);
+        assert_eq!(active, Some("b"));
+    }
+
+    #[test]
+    fn close_tab_folds_emptied_non_root_pane_into_sibling() {
+        let mut ws = ws_with(&["a", "b"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+        );
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "b".into() });
+        let (id, tab_ids, _) = pane_fields(root(&ws));
+        assert_eq!(tab_ids, ["a"]);
+        assert_eq!(ws.windows[0].focused_pane_id, id);
+    }
+
+    #[test]
+    fn close_tab_leaves_empty_root_pane_in_place() {
+        let mut ws = ws_with(&["a"]);
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "a".into() });
+        let (_, tab_ids, active) = pane_fields(root(&ws));
+        assert!(tab_ids.is_empty());
+        assert_eq!(active, None);
+    }
+
+    #[test]
+    fn close_tab_folds_nested_splits_depth_2() {
+        let mut ws = ws_with(&["a", "b", "c"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+        );
+        let pane_b = node_id(pane_of_tab(root(&ws), "b").unwrap()).to_string();
+        // 'c' must belong to pane_b before it can be split off from it.
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "c".into(), target_pane_id: pane_b.clone(), index: None });
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: pane_b, dir: "col".into(), side: "end".into(), move_tab_id: Some("c".into()) },
+        );
+        let mut all = Vec::new();
+        all_panes(root(&ws), &mut all);
+        assert_eq!(all.len(), 3);
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "c".into() }); // pane empties -> depth-2 fold
+        let mut all2 = Vec::new();
+        all_panes(root(&ws), &mut all2);
+        assert_eq!(all2.len(), 2);
+        assert!(pane_of_tab(root(&ws), "b").is_some());
+        assert!(pane_of_tab(root(&ws), "a").is_some());
+    }
+
+    #[test]
+    fn close_tab_empty_pane_persists_across_unrelated_close() {
+        // Phase 1 Critical regression: an empty pane created by split_pane
+        // (no move_tab_id) must NOT be swept away by an unrelated close_tab.
+        let mut ws = ws_with(&["a", "b"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(&mut ws, WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: None });
+        let mut all = Vec::new();
+        all_panes(root(&ws), &mut all);
+        assert_eq!(all.len(), 2);
+        let empty_pane_id = all.iter().find(|p| pane_fields(p).1.is_empty()).map(|p| node_id(p).to_string()).unwrap();
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "b".into() });
+        let mut all2 = Vec::new();
+        all_panes(root(&ws), &mut all2);
+        assert_eq!(all2.len(), 2);
+        assert!(find_pane(root(&ws), &empty_pane_id).is_some());
+    }
+
+    #[test]
+    fn close_tab_activates_right_hand_neighbor() {
+        let mut ws = ws_with(&["a", "b", "c"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(&mut ws, WorkspaceOp::SetActive { pane_id: root_id, tab_id: "b".into() });
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "b".into() });
+        let (_, tab_ids, active) = pane_fields(root(&ws));
+        assert_eq!(tab_ids, ["a", "c"]);
+        assert_eq!(active, Some("c"));
+    }
+
+    #[test]
+    fn close_many_closes_all_and_folds_emptied_panes() {
+        let mut ws = ws_with(&["a", "b", "c"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("c".into()) },
+        );
+        apply(&mut ws, WorkspaceOp::CloseMany { tab_ids: vec!["b".into(), "c".into()] });
+        let mut all = Vec::new();
+        all_panes(root(&ws), &mut all);
+        assert_eq!(all.len(), 1);
+        let (_, tab_ids, _) = pane_fields(root(&ws));
+        assert_eq!(tab_ids, ["a"]);
+    }
+
+    #[test]
+    fn move_tab_moves_to_another_pane_activates_and_focuses() {
+        let mut ws = ws_with(&["a", "b", "c"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("c".into()) },
+        );
+        let target = node_id(pane_of_tab(root(&ws), "c").unwrap()).to_string();
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "b".into(), target_pane_id: target.clone(), index: None });
+        assert_eq!(node_id(pane_of_tab(root(&ws), "b").unwrap()), target);
+        let (_, tab_ids, active) = pane_fields(find_pane(root(&ws), &target).unwrap());
+        assert_eq!(tab_ids, ["c", "b"]);
+        assert_eq!(active, Some("b"));
+        assert_eq!(ws.windows[0].focused_pane_id, target);
+    }
+
+    #[test]
+    fn move_tab_folds_source_pane_when_emptied() {
+        let mut ws = ws_with(&["a", "b"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+        );
+        let source_b = node_id(pane_of_tab(root(&ws), "b").unwrap()).to_string();
+        let target_a = node_id(pane_of_tab(root(&ws), "a").unwrap()).to_string();
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "b".into(), target_pane_id: target_a, index: None });
+        let (_, tab_ids, _) = pane_fields(root(&ws));
+        assert_eq!(tab_ids, ["a", "b"]);
+        assert!(find_pane(root(&ws), &source_b).is_none());
+    }
+
+    #[test]
+    fn move_tab_reorders_within_same_pane_using_index() {
+        let mut ws = ws_with(&["a", "b", "c"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "c".into(), target_pane_id: root_id, index: Some(0) });
+        let (_, tab_ids, _) = pane_fields(root(&ws));
+        assert_eq!(tab_ids, ["c", "a", "b"]);
+    }
+
+    #[test]
+    fn resize_split_sets_and_clamps_ratio() {
+        let mut ws = ws_with(&["a", "b"]);
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+        );
+        let split_id = node_id(root(&ws)).to_string();
+
+        let mut a = ws.clone();
+        apply(&mut a, WorkspaceOp::ResizeSplit { split_id: split_id.clone(), ratio: 0.3 });
+        assert_eq!(split_fields(root(&a)).2, 0.3);
+
+        let mut b = ws.clone();
+        apply(&mut b, WorkspaceOp::ResizeSplit { split_id: split_id.clone(), ratio: 0.01 });
+        assert_eq!(split_fields(root(&b)).2, 0.15);
+
+        let mut c = ws.clone();
+        apply(&mut c, WorkspaceOp::ResizeSplit { split_id, ratio: 0.99 });
+        assert_eq!(split_fields(root(&c)).2, 0.85);
+    }
+
+    #[test]
+    fn rename_tab_rewrites_id_everywhere_including_active() {
+        let mut ws = ws_with(&["conn.db.old"]);
+        apply(&mut ws, WorkspaceOp::RenameTab { old_id: "conn.db.old".into(), new_id: "conn.db.new".into() });
+        let (_, tab_ids, active) = pane_fields(root(&ws));
+        assert_eq!(tab_ids, ["conn.db.new"]);
+        assert_eq!(active, Some("conn.db.new"));
+    }
+
+    #[test]
+    fn unknown_ids_are_noops_without_revision_bump() {
+        let mut ws = ws_with(&["a"]);
+        let before = ws.clone();
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "nope".into() });
+        assert_eq!(ws, before);
+        apply(&mut ws, WorkspaceOp::SetActive { pane_id: "nope".into(), tab_id: "a".into() });
+        assert_eq!(ws, before);
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "a".into(), target_pane_id: "nope".into(), index: None });
+        assert_eq!(ws, before);
+        apply(&mut ws, WorkspaceOp::ResizeSplit { split_id: "nope".into(), ratio: 0.5 });
+        assert_eq!(ws, before);
+        assert_eq!(ws.revision, 0);
+    }
+
+    // -- Rust-only: tabs[] bookkeeping and id-counter seeding -----------
+
+    fn sample_tab(id: &str) -> TabModel {
+        TabModel {
+            id: id.into(),
+            tab_type: "documents".into(),
+            profile_id: "p1".into(),
+            profile_name: "Profile 1".into(),
+            db: "mydb".into(),
+            collection: "mycoll".into(),
+            index_name: None,
+            last_query: None,
+            last_aggregate: None,
+            builder_state: None,
+        }
+    }
+
+    #[test]
+    fn open_tab_upserts_tab_model_into_tabs() {
+        let mut ws = ws_with(&[]);
+        let tab = sample_tab("t1");
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "t1".into(), pane_id: None, tab: Some(tab.clone()) });
+        assert_eq!(ws.tabs, vec![tab.clone()]);
+        assert_eq!(ws.revision, 1);
+
+        // Re-opening with an identical model is a true no-op: no revision bump.
+        let rev_before = ws.revision;
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "t1".into(), pane_id: None, tab: Some(tab.clone()) });
+        assert_eq!(ws.revision, rev_before);
+
+        // A changed model (e.g. renamed profile) upserts in place, replacing not duplicating.
+        let mut renamed = tab.clone();
+        renamed.profile_name = "Renamed".into();
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "t1".into(), pane_id: None, tab: Some(renamed.clone()) });
+        assert_eq!(ws.tabs, vec![renamed]);
+        assert_eq!(ws.revision, rev_before + 1);
+    }
+
+    #[test]
+    fn update_tab_state_patches_selected_fields_only() {
+        let mut ws = ws_with(&["t1"]);
+        let mut tab = sample_tab("t1");
+        tab.last_query = Some(serde_json::json!({"filter": "{}"}));
+        ws.tabs.push(tab);
+        let root_before = root(&ws).clone();
+
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: "t1".into(),
+                last_query: None,
+                last_aggregate: Some(serde_json::json!([{"$match": {}}])),
+                builder_state: None,
+            },
+        );
+        let t = &ws.tabs[0];
+        assert_eq!(t.last_query, Some(serde_json::json!({"filter": "{}"}))); // untouched (None in the patch)
+        assert_eq!(t.last_aggregate, Some(serde_json::json!([{"$match": {}}]))); // patched
+        assert_eq!(t.builder_state, None);
+        assert_eq!(ws.revision, 1);
+        assert_eq!(root(&ws), &root_before); // a tabs-only op never touches the layout tree
+
+        // Re-applying the identical patch is a true no-op.
+        let rev_before = ws.revision;
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: "t1".into(),
+                last_query: None,
+                last_aggregate: Some(serde_json::json!([{"$match": {}}])),
+                builder_state: None,
+            },
+        );
+        assert_eq!(ws.revision, rev_before);
+    }
+
+    #[test]
+    fn pane_and_split_id_counters_seed_past_max_existing_suffix() {
+        // A tree restored from workspace.json already contains pane-7 /
+        // split-2; freshly minted ids must not collide with them.
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![WindowModel {
+                id: "main".into(),
+                focused_pane_id: "pane-3".into(),
+                split_tree: LayoutNode::Split {
+                    id: "split-2".into(),
+                    dir: "row".into(),
+                    ratio: 0.5,
+                    children: vec![
+                        LayoutNode::Pane {
+                            id: "pane-3".into(),
+                            tab_ids: vec!["a".into(), "x".into()],
+                            active_tab_id: Some("a".into()),
+                        },
+                        LayoutNode::Pane { id: "pane-7".into(), tab_ids: vec!["b".into()], active_tab_id: Some("b".into()) },
+                    ],
+                },
+            }],
+            tabs: vec![],
+        };
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane { pane_id: "pane-3".into(), dir: "row".into(), side: "end".into(), move_tab_id: Some("x".into()) },
+        );
+        let mut ids = Vec::new();
+        collect_ids(root(&ws), &mut ids);
+        assert!(ids.contains(&"pane-8".to_string()), "expected pane-8 past existing pane-7, got {ids:?}");
+        assert!(ids.contains(&"split-3".to_string()), "expected split-3 past existing split-2, got {ids:?}");
+    }
 
     #[test]
     fn op_json_tags_match_frontend_action_types() {

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -99,7 +99,6 @@ pub struct Workspace {
 /// `split_pane`, `update_tab_state`).
 #[derive(Deserialize, Clone, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 pub enum WorkspaceOp {
     OpenTab {
         tab_id: String,
@@ -164,15 +163,12 @@ pub enum WorkspaceOp {
 // boundary.
 // ---------------------------------------------------------------------------
 
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 const MIN_RATIO: f64 = 0.15;
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 const MAX_RATIO: f64 = 0.85;
 
 /// The id of any layout node, pane or split (TS accesses `.id` directly on
 /// the `LayoutNode` union; Rust needs a match since the two variants don't
 /// share a common field).
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn node_id(node: &LayoutNode) -> &str {
     match node {
         LayoutNode::Pane { id, .. } => id,
@@ -181,7 +177,6 @@ fn node_id(node: &LayoutNode) -> &str {
 }
 
 /// Port of TS `allPanes`.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn all_panes<'a>(node: &'a LayoutNode, out: &mut Vec<&'a LayoutNode>) {
     match node {
         LayoutNode::Pane { .. } => out.push(node),
@@ -194,7 +189,6 @@ fn all_panes<'a>(node: &'a LayoutNode, out: &mut Vec<&'a LayoutNode>) {
 }
 
 /// Port of TS `findPane`.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn find_pane<'a>(node: &'a LayoutNode, pane_id: &str) -> Option<&'a LayoutNode> {
     match node {
         LayoutNode::Pane { id, .. } => {
@@ -209,7 +203,6 @@ fn find_pane<'a>(node: &'a LayoutNode, pane_id: &str) -> Option<&'a LayoutNode> 
 }
 
 /// Port of TS `paneOfTab`.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn pane_of_tab<'a>(node: &'a LayoutNode, tab_id: &str) -> Option<&'a LayoutNode> {
     match node {
         LayoutNode::Pane { tab_ids, .. } => {
@@ -232,7 +225,6 @@ fn pane_of_tab<'a>(node: &'a LayoutNode, tab_id: &str) -> Option<&'a LayoutNode>
 /// function with a Split node (the branch that would recurse into a
 /// directly-matching pane instead folds inline), so nested folds always
 /// take effect; only the true top-level call can hit the "ignore" path.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn map_pane(
     node: &LayoutNode,
     pane_id: &str,
@@ -295,7 +287,6 @@ fn map_pane(
 }
 
 /// Port of TS `withFocusRepaired`.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn with_focus_repaired(root: &LayoutNode, focused_pane_id: &str) -> String {
     if find_pane(root, focused_pane_id).is_some() {
         return focused_pane_id.to_string();
@@ -308,7 +299,6 @@ fn with_focus_repaired(root: &LayoutNode, focused_pane_id: &str) -> String {
 /// Port of TS `removeTabFromPane`. `None` signals "fold" (the pane became
 /// empty); the pane is returned unchanged (`Some`) if `tab_id` wasn't
 /// present, matching TS's `if (idx === -1) return pane;`.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn remove_tab_from_pane(pane: &LayoutNode, tab_id: &str) -> Option<LayoutNode> {
     let LayoutNode::Pane { id, tab_ids, active_tab_id } = pane else {
         unreachable!("remove_tab_from_pane is only ever called with a pane node");
@@ -329,7 +319,6 @@ fn remove_tab_from_pane(pane: &LayoutNode, tab_id: &str) -> Option<LayoutNode> {
 }
 
 /// Port of TS `closeTab`.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn close_tab(root: &LayoutNode, focused_pane_id: &str, tab_id: &str) -> (LayoutNode, String) {
     let Some(pane) = pane_of_tab(root, tab_id) else {
         return (root.clone(), focused_pane_id.to_string());
@@ -358,7 +347,6 @@ fn close_tab(root: &LayoutNode, focused_pane_id: &str, tab_id: &str) -> (LayoutN
 /// focusedPaneId) pair that TS calls `WorkspaceLayout`. Layout-only: the
 /// Rust-only `tabs[]` bookkeeping (OpenTab's tab model, CloseTab/CloseMany/
 /// RenameTab mirroring, UpdateTabState) is applied separately by `apply`.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp) -> (LayoutNode, String) {
     match op {
         WorkspaceOp::OpenTab { tab_id, pane_id, .. } => {
@@ -555,7 +543,6 @@ fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp)
 /// Scans the tree for the highest numeric suffix among ids sharing `prefix`
 /// (e.g. `"pane-"` or `"split-"`), regardless of node kind — ids of the
 /// other kind never share a prefix so they simply don't match.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn max_numeric_suffix(node: &LayoutNode, prefix: &str) -> u64 {
     let mut best = node_id(node).strip_prefix(prefix).and_then(|r| r.parse::<u64>().ok()).unwrap_or(0);
     if let LayoutNode::Split { children, .. } = node {
@@ -579,18 +566,15 @@ fn max_numeric_suffix(node: &LayoutNode, prefix: &str) -> u64 {
 /// already in the restored tree. Scanning the tree at mint time is
 /// stateless (nothing to seed on load, nothing to serialize, nothing to get
 /// out of sync with the actual tree) and cheap at these tree sizes.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn next_pane_id(root: &LayoutNode) -> String {
     format!("pane-{}", max_numeric_suffix(root, "pane-") + 1)
 }
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn next_split_id(root: &LayoutNode) -> String {
     format!("split-{}", max_numeric_suffix(root, "split-") + 1)
 }
 
 /// The single main window's initial state: one root pane, no tabs. Mirrors
 /// TS `createInitialLayout([], null)` plus the window wrapper Phase 2 adds.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn default_window() -> WindowModel {
     WindowModel {
         id: "main".into(),
@@ -608,7 +592,6 @@ fn default_window() -> WindowModel {
 /// identity. See the Task 2 report for the semantic-choice writeup of edge
 /// cases (e.g. `open_tab` re-activating an already-active+focused tab) where
 /// this differs from "TS would have returned a new object".
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 pub fn apply(ws: &mut Workspace, op: WorkspaceOp) {
     if ws.windows.is_empty() {
         ws.windows.push(default_window());
@@ -689,20 +672,113 @@ pub fn apply(ws: &mut Workspace, op: WorkspaceOp) {
     }
 }
 
-/// Load the workspace document. A missing or corrupt file yields `None` —
-/// persistence must never block startup — mirroring queries.rs:83-84.
+/// Port of TS's tab-id collection helpers (`allTabIds`), used only by
+/// `validate` below — flattens every `tabIds` entry across an entire
+/// `LayoutNode` tree, panes and splits alike.
+fn collect_tab_ids(node: &LayoutNode, out: &mut Vec<String>) {
+    match node {
+        LayoutNode::Pane { tab_ids, .. } => out.extend(tab_ids.iter().cloned()),
+        LayoutNode::Split { children, .. } => {
+            for c in children {
+                collect_tab_ids(c, out);
+            }
+        }
+    }
+}
+
+/// True if `ws` is structurally sound enough to hydrate the frontend
+/// without crashing render, or panicking `map_pane`/`workspace_reducer`
+/// deep inside the reducer the moment any op touches a malformed node —
+/// which, since every mutation runs inside `AppState.workspace`'s held
+/// mutex, would poison it and kill persistence for the rest of the
+/// session. None of this is reachable through this app's own reducers
+/// (every `Split` they ever mint has exactly 2 children, every `ratio`
+/// they ever write is clamped to `[MIN_RATIO, MAX_RATIO]`) — only a
+/// hand-edited file or a future format regression can produce it. Checked
+/// once at load time so a broken file degrades to "start fresh" instead of
+/// "crash on next click".
+///
+/// Checks, per window: every `Split` node has exactly 2 children; every
+/// `ratio` is finite and strictly between 0 and 1; the tree resolves to at
+/// least one pane; `focused_pane_id` names a pane that actually exists in
+/// that same tree; and, across ALL windows combined, no tab id appears
+/// twice (a reducer op can never produce that — `open_tab` on an
+/// already-placed id just re-focuses it — so a duplicate can only mean a
+/// corrupt file).
+///
+/// A dangling `focused_pane_id` is treated as invalid here rather than
+/// silently repaired to the tree's first pane: `validate` takes `&Workspace`
+/// and only ever reports a yes/no, so "repair" would mean a second, mutable
+/// pass threaded through `load_from_file` for a case a hand-edited/corrupt
+/// file already put in serious doubt — simpler, and consistent with every
+/// other check here, to just reject and start fresh.
+fn validate(ws: &Workspace) -> bool {
+    fn shape(node: &LayoutNode) -> Option<usize> {
+        match node {
+            LayoutNode::Pane { .. } => Some(1),
+            LayoutNode::Split { ratio, children, .. } => {
+                if !ratio.is_finite() || *ratio <= 0.0 || *ratio >= 1.0 || children.len() != 2 {
+                    return None;
+                }
+                Some(shape(&children[0])? + shape(&children[1])?)
+            }
+        }
+    }
+
+    let mut seen_tab_ids = std::collections::HashSet::new();
+    for win in &ws.windows {
+        match shape(&win.split_tree) {
+            Some(n) if n >= 1 => {}
+            _ => return false,
+        }
+        if find_pane(&win.split_tree, &win.focused_pane_id).is_none() {
+            return false;
+        }
+        let mut ids = Vec::new();
+        collect_tab_ids(&win.split_tree, &mut ids);
+        for id in ids {
+            if !seen_tab_ids.insert(id) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Load the workspace document. A missing file, one that fails to parse as
+/// JSON, or one that parses but fails `validate` (valid JSON, broken
+/// document — see `validate`'s doc comment) all yield `None` — persistence
+/// must never block startup, and fresh boot beats crashed boot — mirroring
+/// queries.rs:83-84.
 pub fn load_from_file(path: &Path) -> Option<Workspace> {
-    fs::read_to_string(path)
+    let ws: Workspace = fs::read_to_string(path)
         .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())?;
+    if !validate(&ws) {
+        return None;
+    }
+    Some(ws)
 }
 
 /// Save the workspace document, pretty-printed. Errors are stringified so
 /// callers (Tauri commands) can surface them without leaking IO types.
+///
+/// Written to `<path>.tmp` first, then renamed into place (Fix 5, #97 phase
+/// 2 final review): `rename` within the same directory is atomic on every
+/// platform this app ships for, so a crash or power loss mid-write can never
+/// leave a truncated/corrupt `workspace.json` on disk — the file is always
+/// either the fully-old or the fully-new content. Before this, a crash
+/// mid-`fs::write` left a corrupt file that `load_from_file` would then fail
+/// to parse (or fail `validate`) on every future boot, until the user
+/// deleted it by hand.
 pub fn save_to_file(path: &Path, ws: &Workspace) -> Result<(), String> {
     let content = serde_json::to_string_pretty(ws)
         .map_err(|e| format!("Failed to serialize workspace: {}", e))?;
-    fs::write(path, content).map_err(|e| format!("Failed to write workspace file: {}", e))
+    let mut tmp_os = path.as_os_str().to_os_string();
+    tmp_os.push(".tmp");
+    let tmp_path = PathBuf::from(tmp_os);
+    fs::write(&tmp_path, content).map_err(|e| format!("Failed to write workspace file: {}", e))?;
+    fs::rename(&tmp_path, path).map_err(|e| format!("Failed to finalize workspace file: {}", e))
 }
 
 /// Where workspace.json lives, mirroring `queries::get_queries_path`
@@ -1401,6 +1477,153 @@ mod tests {
         assert!(load_from_file(&p).is_none());
     }
 
+    // -----------------------------------------------------------------
+    // `validate`/`load_from_file` malformed-document tests (#97 phase 2
+    // final review Fix 4). Each fixture is valid JSON but a document no
+    // reducer op could ever have produced — hand-edited or from a future
+    // format regression — and must degrade to "start fresh" (`None`)
+    // rather than surviving to crash the frontend's render or panic the
+    // reducer later, inside the store's held mutex.
+    // -----------------------------------------------------------------
+
+    fn validate_fixture_path(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("mqlens-ws-validate-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join(name)
+    }
+
+    #[test]
+    fn load_rejects_split_with_wrong_child_count() {
+        let p = validate_fixture_path("bad-split-arity.json");
+        let json = r#"{
+            "revision": 1,
+            "windows": [{
+                "id": "main",
+                "focusedPaneId": "pane-1",
+                "splitTree": {
+                    "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5,
+                    "children": [
+                        { "kind": "pane", "id": "pane-1", "tabIds": [], "activeTabId": null }
+                    ]
+                }
+            }],
+            "tabs": []
+        }"#;
+        std::fs::write(&p, json).unwrap();
+        assert!(load_from_file(&p).is_none(), "a split with != 2 children must not load");
+    }
+
+    #[test]
+    fn load_rejects_non_finite_ratio() {
+        let p = validate_fixture_path("nonfinite-ratio.json");
+        // `1e400` is syntactically a valid JSON number that overflows f64 to
+        // infinity on parse — the only way to get serde_json to actually
+        // deserialize a non-finite float. It can't parse a bare `NaN` token
+        // (not valid JSON), and serde_json's own serializer writes `null`
+        // for a Rust-side NaN/Infinity value, so this fixture can't be
+        // produced by round-tripping a `Workspace` — it has to be authored
+        // as raw JSON text.
+        let json = r#"{
+            "revision": 1,
+            "windows": [{
+                "id": "main",
+                "focusedPaneId": "pane-1",
+                "splitTree": {
+                    "kind": "split", "id": "split-1", "dir": "row", "ratio": 1e400,
+                    "children": [
+                        { "kind": "pane", "id": "pane-1", "tabIds": [], "activeTabId": null },
+                        { "kind": "pane", "id": "pane-2", "tabIds": [], "activeTabId": null }
+                    ]
+                }
+            }],
+            "tabs": []
+        }"#;
+        std::fs::write(&p, json).unwrap();
+        assert!(load_from_file(&p).is_none(), "a non-finite ratio must not load");
+    }
+
+    #[test]
+    fn load_rejects_out_of_range_ratio() {
+        let p = validate_fixture_path("out-of-range-ratio.json");
+        let json = r#"{
+            "revision": 1,
+            "windows": [{
+                "id": "main",
+                "focusedPaneId": "pane-1",
+                "splitTree": {
+                    "kind": "split", "id": "split-1", "dir": "row", "ratio": 1.5,
+                    "children": [
+                        { "kind": "pane", "id": "pane-1", "tabIds": [], "activeTabId": null },
+                        { "kind": "pane", "id": "pane-2", "tabIds": [], "activeTabId": null }
+                    ]
+                }
+            }],
+            "tabs": []
+        }"#;
+        std::fs::write(&p, json).unwrap();
+        assert!(load_from_file(&p).is_none(), "a ratio outside (0, 1) must not load");
+    }
+
+    #[test]
+    fn load_rejects_dangling_focused_pane_id() {
+        let p = validate_fixture_path("dangling-focus.json");
+        let json = r#"{
+            "revision": 1,
+            "windows": [{
+                "id": "main",
+                "focusedPaneId": "pane-missing",
+                "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": [], "activeTabId": null }
+            }],
+            "tabs": []
+        }"#;
+        std::fs::write(&p, json).unwrap();
+        assert!(load_from_file(&p).is_none(), "a dangling focusedPaneId must not load");
+    }
+
+    #[test]
+    fn load_rejects_duplicate_tab_id_across_panes() {
+        let p = validate_fixture_path("duplicate-tab-id.json");
+        let json = r#"{
+            "revision": 1,
+            "windows": [{
+                "id": "main",
+                "focusedPaneId": "pane-1",
+                "splitTree": {
+                    "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5,
+                    "children": [
+                        { "kind": "pane", "id": "pane-1", "tabIds": ["dup"], "activeTabId": "dup" },
+                        { "kind": "pane", "id": "pane-2", "tabIds": ["dup"], "activeTabId": "dup" }
+                    ]
+                }
+            }],
+            "tabs": []
+        }"#;
+        std::fs::write(&p, json).unwrap();
+        assert!(load_from_file(&p).is_none(), "a tab id duplicated across panes must not load");
+    }
+
+    #[test]
+    fn load_accepts_a_well_formed_document() {
+        let p = validate_fixture_path("well-formed.json");
+        let json = r#"{
+            "revision": 3,
+            "windows": [{
+                "id": "main",
+                "focusedPaneId": "pane-1",
+                "splitTree": {
+                    "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5,
+                    "children": [
+                        { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+                        { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" }
+                    ]
+                }
+            }],
+            "tabs": []
+        }"#;
+        std::fs::write(&p, json).unwrap();
+        assert!(load_from_file(&p).is_some(), "a structurally valid document must load");
+    }
+
     /// End-to-end regression for the id-space bug fixed in caa117c: the
     /// frontend mirror now translates EVERY id-bearing op field into
     /// `profile:<profileId>` space before it ever reaches `workspace_apply`
@@ -1658,6 +1881,26 @@ mod store {
             second, first,
             "second call must return the cached in-memory copy, not re-read the mutated file"
         );
+    }
+
+    #[test]
+    fn save_to_file_writes_atomically_via_tmp_rename() {
+        // Fix 5 (#97 phase 2 final review): `save_to_file` must land the
+        // final content directly at `path` with no stray `<path>.tmp` left
+        // behind — the tmp file is an implementation detail of the
+        // write-then-rename, never a durable artifact.
+        let path = tmp_path("atomic-save.json");
+        let mut tmp_os = path.as_os_str().to_os_string();
+        tmp_os.push(".tmp");
+        let tmp_path_for_this_save = PathBuf::from(tmp_os);
+        let _ = fs::remove_file(&tmp_path_for_this_save);
+
+        let ws = sample_ws();
+        save_to_file(&path, &ws).unwrap();
+
+        assert!(path.exists(), "the real path must exist after save");
+        assert!(!tmp_path_for_this_save.exists(), "the .tmp file must not survive a successful save");
+        assert_eq!(load_from_file(&path), Some(ws));
     }
 
     #[test]

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -3,12 +3,30 @@
 //! the reducer (`apply`) and Tauri commands land in later tasks.
 
 use crate::state::{AppState, LockExt};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+
+/// The "double Option" pattern: distinguishes a field that was absent from
+/// the JSON payload (outer `None` — leave untouched) from one that was
+/// present with an explicit `null` (outer `Some`, inner `None` — clear it)
+/// from one present with a value (outer `Some`, inner `Some(v)` — set it).
+/// Plain `#[serde(default)]` on `Option<Option<T>>` can't express this on its
+/// own: serde's stock `Option<T>` deserializer collapses a JSON `null`
+/// straight into the outer `None`, the same as a missing key. Wrapping the
+/// inner deserialize in an extra `Some(..)` here is what keeps `null`
+/// distinguishable from "absent" once combined with `#[serde(default)]` on
+/// the field (which only supplies the fallback for a truly missing key).
+fn deserialize_some<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).map(Some)
+}
 
 /// One open query tab. `profile_id` identifies a saved connection profile,
 /// NEVER a live session connectionId — tabs must survive reconnects.
@@ -126,12 +144,14 @@ pub enum WorkspaceOp {
     },
     UpdateTabState {
         tab_id: String,
-        #[serde(default)]
-        last_query: Option<serde_json::Value>,
-        #[serde(default)]
-        last_aggregate: Option<serde_json::Value>,
-        #[serde(default)]
-        builder_state: Option<serde_json::Value>,
+        // `Option<Option<Value>>`: outer `None` = key absent (untouched),
+        // `Some(None)` = explicit `null` (clear), `Some(Some(v))` = set.
+        #[serde(default, deserialize_with = "deserialize_some")]
+        last_query: Option<Option<serde_json::Value>>,
+        #[serde(default, deserialize_with = "deserialize_some")]
+        last_aggregate: Option<Option<serde_json::Value>>,
+        #[serde(default, deserialize_with = "deserialize_some")]
+        builder_state: Option<Option<serde_json::Value>>,
     },
 }
 
@@ -638,21 +658,24 @@ pub fn apply(ws: &mut Workspace, op: WorkspaceOp) {
         }
         WorkspaceOp::UpdateTabState { tab_id, last_query, last_aggregate, builder_state } => {
             if let Some(t) = ws.tabs.iter_mut().find(|t| &t.id == tab_id) {
-                if let Some(v) = last_query {
-                    if t.last_query.as_ref() != Some(v) {
-                        t.last_query = Some(v.clone());
+                // `patch` is `&Option<Value>` here: present-but-null (`Some(None)`
+                // on the op) clears the field; present-with-value sets it.
+                // Outer `None` (key absent) leaves the field untouched entirely.
+                if let Some(patch) = last_query {
+                    if &t.last_query != patch {
+                        t.last_query = patch.clone();
                         changed = true;
                     }
                 }
-                if let Some(v) = last_aggregate {
-                    if t.last_aggregate.as_ref() != Some(v) {
-                        t.last_aggregate = Some(v.clone());
+                if let Some(patch) = last_aggregate {
+                    if &t.last_aggregate != patch {
+                        t.last_aggregate = patch.clone();
                         changed = true;
                     }
                 }
-                if let Some(v) = builder_state {
-                    if t.builder_state.as_ref() != Some(v) {
-                        t.builder_state = Some(v.clone());
+                if let Some(patch) = builder_state {
+                    if &t.builder_state != patch {
+                        t.builder_state = patch.clone();
                         changed = true;
                     }
                 }
@@ -1197,13 +1220,13 @@ mod tests {
             &mut ws,
             WorkspaceOp::UpdateTabState {
                 tab_id: "t1".into(),
-                last_query: None,
-                last_aggregate: Some(serde_json::json!([{"$match": {}}])),
+                last_query: None, // absent from the patch: untouched
+                last_aggregate: Some(Some(serde_json::json!([{"$match": {}}]))), // present: set
                 builder_state: None,
             },
         );
         let t = &ws.tabs[0];
-        assert_eq!(t.last_query, Some(serde_json::json!({"filter": "{}"}))); // untouched (None in the patch)
+        assert_eq!(t.last_query, Some(serde_json::json!({"filter": "{}"}))); // untouched (absent from the patch)
         assert_eq!(t.last_aggregate, Some(serde_json::json!([{"$match": {}}]))); // patched
         assert_eq!(t.builder_state, None);
         assert_eq!(ws.revision, 1);
@@ -1216,11 +1239,72 @@ mod tests {
             WorkspaceOp::UpdateTabState {
                 tab_id: "t1".into(),
                 last_query: None,
-                last_aggregate: Some(serde_json::json!([{"$match": {}}])),
+                last_aggregate: Some(Some(serde_json::json!([{"$match": {}}]))),
                 builder_state: None,
             },
         );
         assert_eq!(ws.revision, rev_before);
+    }
+
+    #[test]
+    fn update_tab_state_explicit_null_clears_a_previously_set_field() {
+        // Reviewer-flagged CRITICAL: absent and explicit-null both used to
+        // decode to `None` (single Option), so there was no way to clear a
+        // field once set. The double-Option `Some(None)` patch must clear it.
+        let mut ws = ws_with(&["t1"]);
+        let mut tab = sample_tab("t1");
+        tab.last_aggregate = Some(serde_json::json!([{"$match": {}}]));
+        ws.tabs.push(tab);
+
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: "t1".into(),
+                last_query: None,
+                last_aggregate: Some(None), // explicit null: clear
+                builder_state: None,
+            },
+        );
+        assert_eq!(ws.tabs[0].last_aggregate, None);
+        assert_eq!(ws.revision, 1);
+    }
+
+    #[test]
+    fn update_tab_state_absent_field_leaves_it_untouched() {
+        let mut ws = ws_with(&["t1"]);
+        let mut tab = sample_tab("t1");
+        tab.last_query = Some(serde_json::json!({"filter": "{}"}));
+        ws.tabs.push(tab);
+
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: "t1".into(),
+                last_query: None, // absent: untouched, NOT cleared
+                last_aggregate: None,
+                builder_state: None,
+            },
+        );
+        assert_eq!(ws.tabs[0].last_query, Some(serde_json::json!({"filter": "{}"})));
+        assert_eq!(ws.revision, 0);
+    }
+
+    #[test]
+    fn update_tab_state_clearing_an_already_none_field_does_not_bump_revision() {
+        let mut ws = ws_with(&["t1"]);
+        ws.tabs.push(sample_tab("t1")); // last_aggregate already None
+
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: "t1".into(),
+                last_query: None,
+                last_aggregate: Some(None), // explicit null on an already-None field: no-op
+                builder_state: None,
+            },
+        );
+        assert_eq!(ws.tabs[0].last_aggregate, None);
+        assert_eq!(ws.revision, 0);
     }
 
     #[test]

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1400,6 +1400,158 @@ mod tests {
         std::fs::write(&p, "not json").unwrap();
         assert!(load_from_file(&p).is_none());
     }
+
+    /// End-to-end regression for the id-space bug fixed in caa117c: the
+    /// frontend mirror now translates EVERY id-bearing op field into
+    /// `profile:<profileId>` space before it ever reaches `workspace_apply`
+    /// (persistence.ts's Global Constraint), so a realistic session stream
+    /// never contains a live connectionId anywhere in the tree. This test
+    /// replays such a stream — 3 tabs across 2 profiles, a split, a
+    /// `set_active`, a `update_tab_state` patch, and a `close_tab` — through
+    /// `apply`, round-trips the result through disk via `save_to_file` /
+    /// `load_from_file`, and checks the coherence invariant that bug broke:
+    /// every tab id the layout tree references must actually exist in
+    /// `tabs[]`.
+    #[test]
+    fn realistic_session_stream_round_trips_through_disk() {
+        fn tab(id: &str, profile_id: &str, profile_name: &str, db: &str, collection: &str) -> TabModel {
+            TabModel {
+                id: id.into(),
+                tab_type: "collection".into(),
+                profile_id: profile_id.into(),
+                profile_name: profile_name.into(),
+                db: db.into(),
+                collection: collection.into(),
+                index_name: None,
+                last_query: Some(serde_json::json!({ "filter": {} })),
+                last_aggregate: None,
+                builder_state: None,
+            }
+        }
+
+        fn collect_tab_ids(node: &LayoutNode, out: &mut Vec<String>) {
+            match node {
+                LayoutNode::Pane { tab_ids, .. } => out.extend(tab_ids.iter().cloned()),
+                LayoutNode::Split { children, .. } => {
+                    for c in children {
+                        collect_tab_ids(c, out);
+                    }
+                }
+            }
+        }
+
+        let tab1_id = "profile:p1.mydb.customers".to_string();
+        let tab2_id = "profile:p1.mydb.orders".to_string();
+        let tab3_id = "profile:p2.otherdb.items".to_string();
+
+        let mut ws = Workspace::default();
+
+        // 3 open_tab ops across 2 profiles — mirrors the frontend opening
+        // tabs against two different saved connections.
+        apply(
+            &mut ws,
+            WorkspaceOp::OpenTab {
+                tab_id: tab1_id.clone(),
+                pane_id: None,
+                tab: Some(tab(&tab1_id, "p1", "Prod Cluster", "mydb", "customers")),
+            },
+        );
+        apply(
+            &mut ws,
+            WorkspaceOp::OpenTab {
+                tab_id: tab2_id.clone(),
+                pane_id: None,
+                tab: Some(tab(&tab2_id, "p1", "Prod Cluster", "mydb", "orders")),
+            },
+        );
+        apply(
+            &mut ws,
+            WorkspaceOp::OpenTab {
+                tab_id: tab3_id.clone(),
+                pane_id: None,
+                tab: Some(tab(&tab3_id, "p2", "Analytics", "otherdb", "items")),
+            },
+        );
+
+        // split_pane, moving the p2 tab into its own pane.
+        let root_id = node_id(root(&ws)).to_string();
+        apply(
+            &mut ws,
+            WorkspaceOp::SplitPane {
+                pane_id: root_id,
+                dir: "row".into(),
+                side: "end".into(),
+                move_tab_id: Some(tab3_id.clone()),
+            },
+        );
+
+        // set_active on the pane that still holds tab1/tab2.
+        let left_pane_id = node_id(pane_of_tab(root(&ws), &tab1_id).unwrap()).to_string();
+        apply(&mut ws, WorkspaceOp::SetActive { pane_id: left_pane_id, tab_id: tab2_id.clone() });
+
+        // update_tab_state patches tab1's lastQuery.
+        let patched_query = serde_json::json!({ "filter": { "active": true } });
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: tab1_id.clone(),
+                last_query: Some(Some(patched_query.clone())),
+                last_aggregate: None,
+                builder_state: None,
+            },
+        );
+
+        // close_tab drops tab2.
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: tab2_id.clone() });
+
+        // Save to a temp-dir file and load it back.
+        let dir = std::env::temp_dir().join("mqlens-ws-realistic-roundtrip-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("workspace.json");
+        let _ = std::fs::remove_file(&path);
+        save_to_file(&path, &ws).unwrap();
+        let loaded = load_from_file(&path).expect("a freshly-saved workspace file must load back");
+
+        assert_eq!(loaded, ws, "round trip through disk must be lossless");
+
+        // Coherence invariant the id-space bug broke: every tab id the
+        // layout tree references must exist in tabs[].
+        let known_tab_ids: std::collections::HashSet<&str> =
+            loaded.tabs.iter().map(|t| t.id.as_str()).collect();
+        let mut tree_tab_ids = Vec::new();
+        collect_tab_ids(&loaded.windows[0].split_tree, &mut tree_tab_ids);
+        assert!(!tree_tab_ids.is_empty(), "sanity: the tree must reference at least one tab");
+        for id in &tree_tab_ids {
+            assert!(known_tab_ids.contains(id.as_str()), "layout references unknown tab id `{id}`");
+        }
+
+        // tab2 was closed: 2 tabs remain, and tab1's patched lastQuery
+        // survived the save/load round trip.
+        assert_eq!(loaded.tabs.len(), 2);
+        let restored_tab1 = loaded.tabs.iter().find(|t| t.id == tab1_id).expect("tab1 must survive the close");
+        assert_eq!(restored_tab1.last_query, Some(patched_query));
+        assert!(loaded.tabs.iter().any(|t| t.id == tab3_id), "tab3 must survive the close");
+        assert!(!loaded.tabs.iter().any(|t| t.id == tab2_id), "tab2 was closed and must not survive");
+
+        // Id-space invariant: every id anywhere in the tree is either
+        // profile-space (a tab id) or connectionless (a structural
+        // pane/split id, minted deterministically by the reducer — see
+        // persistence.ts: "Pane/split ids are NOT part of this constraint").
+        // A live connectionId (e.g. a bare Mongo connection UUID) must never
+        // appear — that's precisely what caa117c fixed.
+        let mut structural_ids = Vec::new();
+        collect_ids(&loaded.windows[0].split_tree, &mut structural_ids);
+        let mut all_ids = structural_ids;
+        all_ids.extend(tree_tab_ids.iter().cloned());
+        for id in &all_ids {
+            let is_profile_space = id.starts_with("profile:");
+            let is_connectionless = id.starts_with("pane-") || id.starts_with("split-");
+            assert!(
+                is_profile_space || is_connectionless,
+                "id `{id}` is neither profile-space nor a connectionless structural id"
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -2,9 +2,13 @@
 //! document. This module owns the data model and best-effort file IO only —
 //! the reducer (`apply`) and Tauri commands land in later tasks.
 
+use crate::state::{AppState, LockExt};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
 
 /// One open query tab. `profile_id` identifies a saved connection profile,
 /// NEVER a live session connectionId — tabs must survive reconnects.
@@ -664,7 +668,6 @@ pub fn apply(ws: &mut Workspace, op: WorkspaceOp) {
 
 /// Load the workspace document. A missing or corrupt file yields `None` —
 /// persistence must never block startup — mirroring queries.rs:83-84.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 pub fn load_from_file(path: &Path) -> Option<Workspace> {
     fs::read_to_string(path)
         .ok()
@@ -673,7 +676,6 @@ pub fn load_from_file(path: &Path) -> Option<Workspace> {
 
 /// Save the workspace document, pretty-printed. Errors are stringified so
 /// callers (Tauri commands) can surface them without leaking IO types.
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 pub fn save_to_file(path: &Path, ws: &Workspace) -> Result<(), String> {
     let content = serde_json::to_string_pretty(ws)
         .map_err(|e| format!("Failed to serialize workspace: {}", e))?;
@@ -682,7 +684,6 @@ pub fn save_to_file(path: &Path, ws: &Workspace) -> Result<(), String> {
 
 /// Where workspace.json lives, mirroring `queries::get_queries_path`
 /// (queries.rs:72-81).
-#[allow(dead_code)] // wired up by Task 4's Tauri commands
 fn workspace_path(app_handle: &tauri::AppHandle) -> PathBuf {
     use tauri::Manager;
     match app_handle.path().app_config_dir() {
@@ -693,6 +694,104 @@ fn workspace_path(app_handle: &tauri::AppHandle) -> PathBuf {
         }
         Err(_) => PathBuf::from("workspace.json"),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Store commands — in-memory cache of the workspace document plus a
+// debounced, single-flight save. `get_impl`/`apply_impl` take `&AppState`
+// and a plain `&Path` (rather than an `AppHandle`) so they're testable with
+// temp-dir paths and no live Tauri app; `workspace_get`/`workspace_apply`
+// are thin `#[tauri::command]` wrappers that resolve the real
+// `workspace_path()` and delegate, mirroring the connect_db/connect_db_impl
+// idiom in lib.rs.
+// ---------------------------------------------------------------------------
+
+/// Return the in-memory workspace, populating it from `path` on first call.
+/// "First-get-loads-file-once": once `state.workspace` holds a value (even
+/// `None` was never stored — only `Some` counts as populated), later calls
+/// return the cached copy and never re-read the file, so an external edit to
+/// the file after the first call has no effect on subsequent gets.
+pub fn get_impl(state: &AppState, path: &Path) -> Result<Option<Workspace>, String> {
+    let mut guard = state.workspace.lock_safe()?;
+    if guard.is_none() {
+        *guard = load_from_file(path);
+    }
+    Ok(guard.clone())
+}
+
+/// True if `own_gen` is still the most recently minted write generation —
+/// i.e. no later `apply_impl` call has superseded this debounced save since
+/// it was scheduled. Pulled out as a pure function so the single-flight
+/// decision is unit-testable without spinning up a tokio runtime.
+fn should_write(current_gen: u64, own_gen: u64) -> bool {
+    current_gen == own_gen
+}
+
+/// Apply one op to the in-memory workspace — initializing it (and its
+/// default `main` window) on first use — and, if anything actually changed,
+/// schedule a debounced save.
+///
+/// Single-flight, last-writer-wins: every real change mints a new
+/// generation via `state.workspace_write_gen.fetch_add`, *inside* the same
+/// critical section that mutated the workspace, so generation order matches
+/// mutation order even under concurrent callers. The spawned task sleeps
+/// 500ms then only writes if its captured generation still equals the
+/// current one; a burst of N changes therefore mints N generations but at
+/// most one of the N spawned tasks ever finds its generation still current,
+/// so at most one write hits disk. That surviving task writes a snapshot
+/// cloned synchronously right after its own mutation (while the lock was
+/// still held) rather than re-locking after the sleep — the two are
+/// provably equivalent here: if its generation still compares equal after
+/// the sleep, no later `apply_impl` call has run (that would have minted a
+/// higher generation), so the workspace cannot have changed since the
+/// snapshot was taken.
+///
+/// The `std::sync::MutexGuard` above is dropped before this function ever
+/// spawns or awaits anything — required for correctness, since a std guard
+/// is `!Send` and cannot cross an `.await` point.
+pub fn apply_impl(state: &AppState, path: &Path, op: WorkspaceOp) -> Result<(), String> {
+    let scheduled: Option<(Workspace, u64)> = {
+        let mut guard = state.workspace.lock_safe()?;
+        let ws = guard.get_or_insert_with(Workspace::default);
+        let before_revision = ws.revision;
+        apply(ws, op);
+        if ws.revision != before_revision {
+            let gen = state.workspace_write_gen.fetch_add(1, Ordering::SeqCst) + 1;
+            Some((ws.clone(), gen))
+        } else {
+            None
+        }
+    }; // guard dropped here, before any spawn/await.
+
+    if let Some((snapshot, gen)) = scheduled {
+        let gen_counter = Arc::clone(&state.workspace_write_gen);
+        let path_owned = path.to_path_buf();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            if should_write(gen_counter.load(Ordering::SeqCst), gen) {
+                let _ = save_to_file(&path_owned, &snapshot);
+            }
+        });
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn workspace_get(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<Workspace>, String> {
+    get_impl(&state, &workspace_path(&app_handle))
+}
+
+#[tauri::command]
+pub async fn workspace_apply(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    op: WorkspaceOp,
+) -> Result<(), String> {
+    apply_impl(&state, &workspace_path(&app_handle), op)
 }
 
 #[cfg(test)]
@@ -1263,5 +1362,152 @@ mod golden {
             }
             assert_eq!(ws, vector.expected, "golden vector `{}` diverged", vector.name);
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Store command tests — impl-level (bypass the Tauri command wrappers, no
+// `AppHandle`), per the Task 4 brief. A sibling of `mod tests`/`mod golden`
+// so `cargo test workspace::store` targets this module directly.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod store {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    /// A fresh, unique-per-test path under the OS temp dir. Removes any
+    /// leftover file from a prior run so each test starts from a clean disk
+    /// state; distinct filenames keep parallel test threads from colliding.
+    fn tmp_path(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("mqlens-ws-store-tests");
+        fs::create_dir_all(&dir).unwrap();
+        let p = dir.join(name);
+        let _ = fs::remove_file(&p);
+        p
+    }
+
+    fn sample_ws() -> Workspace {
+        Workspace {
+            revision: 5,
+            windows: vec![WindowModel {
+                id: "main".into(),
+                focused_pane_id: "pane-1".into(),
+                split_tree: LayoutNode::Pane {
+                    id: "pane-1".into(),
+                    tab_ids: vec!["a".into()],
+                    active_tab_id: Some("a".into()),
+                },
+            }],
+            tabs: vec![],
+        }
+    }
+
+    #[test]
+    fn workspace_get_loads_file_once() {
+        let path = tmp_path("get-loads-once.json");
+        let on_disk = sample_ws();
+        save_to_file(&path, &on_disk).unwrap();
+
+        let state = AppState::new();
+        let first = get_impl(&state, &path).unwrap();
+        assert_eq!(first, Some(on_disk.clone()));
+
+        // Mutate the file on disk after the first load.
+        let mut mutated = on_disk.clone();
+        mutated.revision = 999;
+        save_to_file(&path, &mutated).unwrap();
+
+        let second = get_impl(&state, &path).unwrap();
+        assert_eq!(
+            second, first,
+            "second call must return the cached in-memory copy, not re-read the mutated file"
+        );
+    }
+
+    #[test]
+    fn apply_initializes_default_main_window() {
+        let state = AppState::new();
+        let path = tmp_path("apply-init.json");
+        assert!(state.workspace.lock_safe().unwrap().is_none(), "precondition: no workspace loaded yet");
+
+        apply_impl(&state, &path, WorkspaceOp::FocusPane { pane_id: "pane-1".into() }).unwrap();
+
+        let ws = state.workspace.lock_safe().unwrap().clone().unwrap();
+        assert_eq!(ws.windows.len(), 1);
+        let win = &ws.windows[0];
+        assert_eq!(win.id, "main");
+        assert_eq!(win.focused_pane_id, "pane-1");
+        assert_eq!(
+            win.split_tree,
+            LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec![], active_tab_id: None }
+        );
+    }
+
+    #[test]
+    fn apply_noop_does_not_schedule_write() {
+        let state = AppState::new();
+        let path = tmp_path("apply-noop.json");
+
+        // Unknown tab id on a freshly-initialized (empty) window: the
+        // reducer returns the same layout and the tabs[] retain is a no-op,
+        // so `apply`'s revision never bumps (see
+        // `unknown_ids_are_noops_without_revision_bump` in `mod tests`).
+        apply_impl(&state, &path, WorkspaceOp::CloseTab { tab_id: "nope".into() }).unwrap();
+
+        assert_eq!(
+            state.workspace_write_gen.load(Ordering::SeqCst),
+            0,
+            "a true no-op must not mint a write generation or schedule a save"
+        );
+    }
+
+    #[test]
+    fn should_write_only_when_generation_is_still_current() {
+        assert!(should_write(1, 1));
+        assert!(should_write(0, 0));
+        assert!(!should_write(2, 1), "an earlier generation was superseded by a later apply");
+        assert!(!should_write(1, 2), "a not-yet-minted generation can never be current");
+    }
+
+    // Exercises the real spawn/sleep path. `tauri::async_runtime::spawn`
+    // lazily starts its own dedicated background Tokio runtime the first
+    // time it's called (tauri-2.11.2's `async_runtime::default_runtime`),
+    // independent of whatever runtime is driving this test — so it works
+    // the same whether called from a plain `#[test]` or, as here, from a
+    // `#[tokio::test]` (used only so this test can `.await` its own sleep
+    // while polling for the debounced write to land). Existing precedent
+    // for `#[tokio::test]` + `tokio::time::sleep` polling a background
+    // mutation: `toolsetup.rs`'s `wait_for_task_done`, `tests.rs`.
+    #[tokio::test]
+    async fn apply_debounces_a_burst_into_a_single_final_write() {
+        let state = AppState::new();
+        let path = tmp_path("debounce-burst.json");
+
+        for i in 0..10 {
+            apply_impl(&state, &path, WorkspaceOp::OpenTab { tab_id: format!("t{i}"), pane_id: None, tab: None })
+                .unwrap();
+        }
+
+        // 10 distinct real changes mint 10 generations; only the last
+        // scheduled task can ever find its generation still current, so at
+        // most 1 of the 10 debounced writes actually lands (see
+        // `should_write_only_when_generation_is_still_current` for the
+        // pure-function proof of that invalidation). None of them have
+        // fired yet — they all sleep 500ms before checking.
+        assert_eq!(state.workspace_write_gen.load(Ordering::SeqCst), 10);
+        assert!(!path.exists(), "must not write before the debounce window elapses");
+
+        tokio::time::sleep(Duration::from_millis(700)).await;
+
+        let saved = load_from_file(&path).expect("the last-scheduled write must have landed by now");
+        let in_memory = state.workspace.lock_safe().unwrap().clone().unwrap();
+        assert_eq!(
+            saved, in_memory,
+            "the surviving write must reflect the fully-applied burst, not a stale intermediate snapshot"
+        );
+        let LayoutNode::Pane { tab_ids, .. } = &saved.windows[0].split_tree else {
+            panic!("expected a pane, got a split");
+        };
+        assert_eq!(tab_ids.len(), 10);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ import { SchemaView } from './components/SchemaView';
 import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, type WorkspaceAction } from './workspace/model';
 import { WorkspaceRoot } from './workspace/WorkspaceRoot';
 import { workspaceApply, updateTabState, actionToOp, workspaceGet } from './workspace/workspaceStore';
-import { toPersistedTab, toDisconnectedSnapshot, rebindConnection } from './workspace/persistence';
+import { toPersistedTab, toDisconnectedSnapshot, rebindConnection, toProfileSpaceId } from './workspace/persistence';
 import { ReconnectBanner } from './workspace/ReconnectBanner';
 import { CreateViewView } from './components/CreateViewView';
 import { ValidationRulesView } from './components/ValidationRulesView';
@@ -304,13 +304,38 @@ function Workspace() {
   // close_tab/close_many/move_tab/rename_tab consult this so they never
   // reference a tab id the backend has no record of.
   const unmirroredTabIdsRef = useRef(new Set<string>());
+  const [activeConnections, setActiveConnections] = useState<ActiveConnection[]>([]);
+  // `handleBuilderStateChange` below is a `useCallback` with an empty deps
+  // array (a stable identity for DocumentViewer), so it can never see a
+  // fresh `activeConnections` STATE value from its closure — it would stay
+  // pinned at mount's `[]` forever. A ref mirrors the state on every change
+  // so the callback can read the current connections via `.current` instead.
+  const activeConnectionsRef = useRef<ActiveConnection[]>(activeConnections);
+  useEffect(() => {
+    activeConnectionsRef.current = activeConnections;
+  }, [activeConnections]);
+  // Shared by every `update_tab_state` emission site (handleBuilderStateChange
+  // here, plus handleExecuteQuery/handleExecuteAggregate below): skips
+  // unmirrored tabs and translates the live id to profile-space before
+  // handing off to `updateTabState`, exactly like `dispatchWorkspace`'s
+  // `actionToOp(..., activeConnections)` calls do for layout ops — see
+  // persistence.ts's "Global Constraint" note. `connections` is threaded in
+  // by each call site rather than closed over here so the memoized
+  // `handleBuilderStateChange` below can supply the always-fresh
+  // `activeConnectionsRef.current` instead of a potentially-stale closure.
+  const mirrorUpdateTabState = (
+    tabId: string,
+    connections: ActiveConnection[],
+    patch: Parameters<typeof updateTabState>[1]
+  ) => {
+    if (unmirroredTabIdsRef.current.has(tabId)) return;
+    updateTabState(toProfileSpaceId(tabId, connections), patch);
+  };
   const handleBuilderStateChange = useCallback((tabId: string, state: BuilderState) => {
     tabBuilderStateCache.current.set(tabId, state);
-    if (!unmirroredTabIdsRef.current.has(tabId)) {
-      updateTabState(tabId, { builderState: state });
-    }
+    mirrorUpdateTabState(tabId, activeConnectionsRef.current, { builderState: state });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  const [activeConnections, setActiveConnections] = useState<ActiveConnection[]>([]);
   const [profilesRefreshKey, setProfilesRefreshKey] = useState(0);
   const [isConnectionModalOpen, setIsConnectionModalOpen] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTabId | undefined>();
@@ -342,6 +367,16 @@ function Workspace() {
   const [reconnectState, setReconnectState] = useState<Map<string, { busy: boolean; error: string | null }>>(
     new Map()
   );
+  // `reconnectState` is a render-captured snapshot — two ReconnectBanners for
+  // the same profile (or a fast double-click on one) can both read `busy:
+  // false` before either's `setReconnectState({busy:true})` has committed and
+  // re-rendered, so the `reconnectState.get(profileId)?.busy` check alone
+  // lets both calls through and fires `connect_db` twice (a leaked
+  // connection). This ref is checked-and-set synchronously at the top of
+  // `handleReconnectProfile`, before any `await`, so the second caller in the
+  // same microtask/click burst sees it immediately — `reconnectState` stays
+  // as the UI-facing (render-driven) busy/error source of truth.
+  const reconnectBusyRef = useRef(new Set<string>());
   const patchReconnectState = (profileId: string, patch: Partial<{ busy: boolean; error: string | null }>) => {
     setReconnectState((prev) => {
       const next = new Map(prev);
@@ -380,6 +415,13 @@ function Workspace() {
         if (ws && Array.isArray(ws.tabs) && ws.tabs.length > 0) {
           const snapshot = toDisconnectedSnapshot(ws);
           setTabs(snapshot.tabs as QueryTab[]);
+          // Clear first: `hydrate` wholesale-replaces `tabs` (see the
+          // "hydrate wins" note above), but the builder-state cache is a
+          // ref keyed by tab id — if the user opened a builder on any
+          // pre-restore tab (e.g. the default Quick Start render) before
+          // this settled, that stale entry would otherwise survive under an
+          // id that may now belong to a completely different restored tab.
+          tabBuilderStateCache.current.clear();
           for (const [tabId, state] of snapshot.builderStates) {
             tabBuilderStateCache.current.set(tabId, state as BuilderState);
           }
@@ -1506,6 +1548,12 @@ function Workspace() {
       return;
     }
 
+    // Every `actionToOp` call below passes `activeConnections` so live
+    // connection-id fields translate to `profile:<profileId>` form before
+    // reaching `workspace_apply` — see persistence.ts's "Global Constraint"
+    // note. `unmirroredTabIdsRef` bookkeeping below always compares against
+    // the RAW action id (pre-translation, i.e. the frontend's own id space),
+    // since that's the space the ref is populated and queried in throughout.
     switch (action.type) {
       case 'open_tab': {
         if (options?.tab) {
@@ -1517,11 +1565,11 @@ function Workspace() {
             return;
           }
           unmirroredTabIdsRef.current.delete(action.tabId);
-          workspaceApply(actionToOp(action, persisted));
+          workspaceApply(actionToOp(action, persisted, activeConnections));
           return;
         }
         if (unmirroredTabIdsRef.current.has(action.tabId)) return;
-        workspaceApply(actionToOp(action));
+        workspaceApply(actionToOp(action, undefined, activeConnections));
         return;
       }
       case 'close_tab':
@@ -1529,18 +1577,18 @@ function Workspace() {
           unmirroredTabIdsRef.current.delete(action.tabId);
           return;
         }
-        workspaceApply(actionToOp(action));
+        workspaceApply(actionToOp(action, undefined, activeConnections));
         return;
       case 'close_many': {
         const tabIds = action.tabIds.filter(id => !unmirroredTabIdsRef.current.has(id));
         action.tabIds.forEach(id => unmirroredTabIdsRef.current.delete(id));
         if (tabIds.length === 0) return;
-        workspaceApply(actionToOp({ ...action, tabIds }));
+        workspaceApply(actionToOp({ ...action, tabIds }, undefined, activeConnections));
         return;
       }
       case 'move_tab':
         if (unmirroredTabIdsRef.current.has(action.tabId)) return;
-        workspaceApply(actionToOp(action));
+        workspaceApply(actionToOp(action, undefined, activeConnections));
         return;
       case 'rename_tab':
         if (unmirroredTabIdsRef.current.has(action.oldId)) {
@@ -1548,10 +1596,10 @@ function Workspace() {
           unmirroredTabIdsRef.current.add(action.newId);
           return;
         }
-        workspaceApply(actionToOp(action));
+        workspaceApply(actionToOp(action, undefined, activeConnections));
         return;
       default:
-        workspaceApply(actionToOp(action));
+        workspaceApply(actionToOp(action, undefined, activeConnections));
     }
   };
 
@@ -1723,12 +1771,10 @@ function Workspace() {
 
       const parsedResults = resultStrs.map(s => JSON.parse(s));
       setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, results: parsedResults, loading: false, lastQuery: query, lastAggregate: undefined } : t));
-      if (!unmirroredTabIdsRef.current.has(tab.id)) {
-        // `lastAggregate: null` (not omitted) explicitly clears any
-        // previously-mirrored aggregate on the backend tab, matching the
-        // local `lastAggregate: undefined` above.
-        updateTabState(tab.id, { lastQuery: query, lastAggregate: null });
-      }
+      // `lastAggregate: null` (not omitted) explicitly clears any
+      // previously-mirrored aggregate on the backend tab, matching the
+      // local `lastAggregate: undefined` above.
+      mirrorUpdateTabState(tab.id, activeConnections, { lastQuery: query, lastAggregate: null });
       // History is best-effort: never surface an error after a successful run.
       recordHistory(connectionNameFor(tab.connectionId), tab.db, tab.collection, {
         queryType: 'find',
@@ -1781,9 +1827,7 @@ function Workspace() {
 
       const parsedResults = resultStrs.map(s => JSON.parse(s));
       setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, results: parsedResults, loading: false, lastAggregate: pipeline } : t));
-      if (!unmirroredTabIdsRef.current.has(tab.id)) {
-        updateTabState(tab.id, { lastAggregate: pipeline });
-      }
+      mirrorUpdateTabState(tab.id, activeConnections, { lastAggregate: pipeline });
       recordHistory(connectionNameFor(tab.connectionId), tab.db, tab.collection, {
         queryType: 'aggregate',
         pipeline,
@@ -1831,7 +1875,13 @@ function Workspace() {
   // clicked — since they share the same `profile:<profileId>` prefix and the
   // same underlying connection.
   const handleReconnectProfile = async (profileId: string, profileName: string) => {
-    if (reconnectState.get(profileId)?.busy) return; // a reconnect for this profile is already in flight
+    // Synchronous check-and-set on a ref, not `reconnectState` (React state
+    // reads/writes are render-batched — two banners for the same profile, or
+    // a fast double-click, can both observe `busy: false` before either's
+    // `setReconnectState` commits). This is the actual guard; `reconnectState`
+    // stays purely for the UI's busy/error display.
+    if (reconnectBusyRef.current.has(profileId)) return;
+    reconnectBusyRef.current.add(profileId);
     patchReconnectState(profileId, { busy: true, error: null });
     try {
       const profiles = await invoke<ConnectionProfile[]>('load_connection_profiles');
@@ -1894,6 +1944,8 @@ function Workspace() {
       }
     } catch (err: any) {
       patchReconnectState(profileId, { busy: false, error: err?.message || String(err) });
+    } finally {
+      reconnectBusyRef.current.delete(profileId);
     }
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,8 @@ import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
 import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, type WorkspaceAction } from './workspace/model';
 import { WorkspaceRoot } from './workspace/WorkspaceRoot';
+import { workspaceApply, updateTabState, actionToOp } from './workspace/workspaceStore';
+import { toPersistedTab } from './workspace/persistence';
 import { CreateViewView } from './components/CreateViewView';
 import { ValidationRulesView } from './components/ValidationRulesView';
 import { GridFsView } from './components/GridFsView';
@@ -288,8 +290,21 @@ function Workspace() {
     }
   }
   const tabBuilderStateCache = useRef(new Map<string, BuilderState>());
+  // Workspace-store mirroring plumbing (Phase 2 Task 5). Mirroring starts
+  // enabled; Task 6's restore-on-boot effect flips this off until the
+  // restored snapshot settles, so the initial hydration doesn't bounce
+  // straight back to the backend as a stream of "new" ops.
+  const mirroringEnabledRef = useRef(true);
+  // Tab ids whose open_tab was never mirrored (toPersistedTab returned null
+  // — export/import tabs) or that were themselves rebound out of mirroring.
+  // close_tab/close_many/move_tab/rename_tab consult this so they never
+  // reference a tab id the backend has no record of.
+  const unmirroredTabIdsRef = useRef(new Set<string>());
   const handleBuilderStateChange = useCallback((tabId: string, state: BuilderState) => {
     tabBuilderStateCache.current.set(tabId, state);
+    if (!unmirroredTabIdsRef.current.has(tabId)) {
+      updateTabState(tabId, { builderState: state });
+    }
   }, []);
   const [activeConnections, setActiveConnections] = useState<ActiveConnection[]>([]);
   const [profilesRefreshKey, setProfilesRefreshKey] = useState(0);
@@ -569,8 +584,9 @@ function Workspace() {
   // Never sit on a blank canvas — if every tab is closed, bring back Quick Start.
   useEffect(() => {
     if (tabs.length === 0) {
-      setTabs([createQuickStartTab()]);
-      dispatchLayout({ type: 'open_tab', tabId: QUICK_START_TAB_ID });
+      const qs = createQuickStartTab();
+      setTabs([qs]);
+      dispatchWorkspace({ type: 'open_tab', tabId: QUICK_START_TAB_ID }, { tab: qs });
     }
   }, [tabs.length]);
 
@@ -583,8 +599,9 @@ function Workspace() {
     const tabExists = tabs.some(t => t.id === tabId);
 
     if (!tabExists || savedQuery) {
+      let newTab: QueryTab | undefined;
       if (!tabExists) {
-        const newTab: QueryTab = {
+        newTab = {
           id: tabId,
           type: 'collection',
           connectionId,
@@ -596,11 +613,11 @@ function Workspace() {
           explainResult: null,
           lastQuery: DEFAULT_QUERY,
         };
-        setTabs(prev => [...prev, newTab]);
+        setTabs(prev => [...prev, newTab as QueryTab]);
       } else {
         setTabs(prev => prev.map(t => t.id === tabId ? { ...t, loading: true, error: null } : t));
       }
-      dispatchLayout({ type: 'open_tab', tabId });
+      dispatchWorkspace({ type: 'open_tab', tabId }, newTab ? { tab: newTab } : undefined);
 
       try {
         // A saved query (palette) wins; otherwise a pinned default query loads
@@ -674,7 +691,7 @@ function Workspace() {
         setTabs(prev => prev.map(t => t.id === tabId ? { ...t, error: String(err), loading: false } : t));
       }
     } else {
-      dispatchLayout({ type: 'open_tab', tabId });
+      dispatchWorkspace({ type: 'open_tab', tabId });
     }
   };
 
@@ -698,9 +715,9 @@ function Workspace() {
         explainResult: null
       };
       setTabs(prev => [...prev, newTab]);
-      dispatchLayout({ type: 'open_tab', tabId });
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
     } else {
-      dispatchLayout({ type: 'open_tab', tabId });
+      dispatchWorkspace({ type: 'open_tab', tabId });
     }
   };
 
@@ -724,18 +741,21 @@ function Workspace() {
         explainResult: null
       };
       setTabs(prev => [...prev, newTab]);
-    } else if (initialCommand) {
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+      return;
+    }
+    if (initialCommand) {
       setTabs(prev => prev.map(t => t.id === tabId ? { ...t, initialShellCommand: initialCommand } : t));
     }
-
-    dispatchLayout({ type: 'open_tab', tabId });
+    dispatchWorkspace({ type: 'open_tab', tabId });
   };
 
   const openSettingsTab = (section: SettingsTabId = 'appearance') => {
     const tabId = 'settings';
     const tabExists = tabs.some(t => t.id === tabId);
+    setSettingsInitialTab(section);
     if (!tabExists) {
-      setTabs(prev => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'settings',
         connectionId: '',
@@ -745,10 +765,12 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs(prev => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+      return;
     }
-    setSettingsInitialTab(section);
-    dispatchLayout({ type: 'open_tab', tabId });
+    dispatchWorkspace({ type: 'open_tab', tabId });
   };
 
   const handleOpenSettingsTab = () => openSettingsTab('appearance');
@@ -759,9 +781,12 @@ function Workspace() {
 
   const handleOpenTasksTab = () => {
     if (!tabs.some(t => t.id === TASKS_TAB_ID)) {
-      setTabs(prev => [...prev, createTasksTab()]);
+      const tasksTab = createTasksTab();
+      setTabs(prev => [...prev, tasksTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId: TASKS_TAB_ID }, { tab: tasksTab });
+      return;
     }
-    dispatchLayout({ type: 'open_tab', tabId: TASKS_TAB_ID });
+    dispatchWorkspace({ type: 'open_tab', tabId: TASKS_TAB_ID });
   };
 
   const handleOpenExportTab = (sourceTab: QueryTab) => {
@@ -769,7 +794,7 @@ function Workspace() {
     const tabId = `export.${sourceTab.connectionId}.${sourceTab.db}.${sourceTab.collection}`;
     const tabExists = tabs.some(t => t.id === tabId);
     if (!tabExists) {
-      setTabs(prev => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'export',
         connectionId: sourceTab.connectionId,
@@ -780,9 +805,12 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs(prev => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+    } else {
+      dispatchWorkspace({ type: 'open_tab', tabId });
     }
-    dispatchLayout({ type: 'open_tab', tabId });
     loadExportTasks();
   };
 
@@ -791,7 +819,7 @@ function Workspace() {
     const tabId = `import.${sourceTab.connectionId}.${sourceTab.db}.${sourceTab.collection}`;
     const tabExists = tabs.some(t => t.id === tabId);
     if (!tabExists) {
-      setTabs(prev => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'import',
         connectionId: sourceTab.connectionId,
@@ -801,9 +829,12 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs(prev => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+    } else {
+      dispatchWorkspace({ type: 'open_tab', tabId });
     }
-    dispatchLayout({ type: 'open_tab', tabId });
     loadExportTasks();
   };
 
@@ -940,7 +971,7 @@ function Workspace() {
     const idParts = ['dump', connectionId, db, coll].filter((p): p is string => !!p);
     const tabId = idParts.join('.');
     if (!tabs.some(t => t.id === tabId)) {
-      setTabs(prev => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'dump',
         connectionId,
@@ -950,9 +981,12 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs(prev => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+    } else {
+      dispatchWorkspace({ type: 'open_tab', tabId });
     }
-    dispatchLayout({ type: 'open_tab', tabId });
     void loadMongoTools();
     void loadDumpDbTree(connectionId);
   };
@@ -960,7 +994,7 @@ function Workspace() {
   const handleOpenRestoreTab = (connectionId: string) => {
     const tabId = `restore.${connectionId}`;
     if (!tabs.some(t => t.id === tabId)) {
-      setTabs(prev => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'restore',
         connectionId,
@@ -970,9 +1004,12 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs(prev => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+    } else {
+      dispatchWorkspace({ type: 'open_tab', tabId });
     }
-    dispatchLayout({ type: 'open_tab', tabId });
     void loadMongoTools();
   };
 
@@ -1014,7 +1051,7 @@ function Workspace() {
   const handleOpenCreateViewTab = (connectionId: string, db: string) => {
     const tabId = `create-view.${connectionId}.${db}`;
     if (!tabs.some(t => t.id === tabId)) {
-      setTabs(prev => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'create-view',
         connectionId,
@@ -1024,16 +1061,19 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs(prev => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+      return;
     }
-    dispatchLayout({ type: 'open_tab', tabId });
+    dispatchWorkspace({ type: 'open_tab', tabId });
   };
 
   // #93: open a Validation Rules tab for a collection.
   const handleOpenValidationTab = (connectionId: string, db: string, collection: string) => {
     const tabId = `validation.${connectionId}.${db}.${collection}`;
     if (!tabs.some(t => t.id === tabId)) {
-      setTabs(prev => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'validation',
         connectionId,
@@ -1043,16 +1083,19 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs(prev => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+      return;
     }
-    dispatchLayout({ type: 'open_tab', tabId });
+    dispatchWorkspace({ type: 'open_tab', tabId });
   };
 
   // M7: open a GridFS browser tab for a bucket (bucket stored in `collection`).
   const handleOpenGridfsTab = (connectionId: string, db: string, bucket: string) => {
     const tabId = `gridfs.${connectionId}.${db}.${bucket}`;
     if (!tabs.some(t => t.id === tabId)) {
-      setTabs(prev => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'gridfs',
         connectionId,
@@ -1062,9 +1105,12 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs(prev => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+      return;
     }
-    dispatchLayout({ type: 'open_tab', tabId });
+    dispatchWorkspace({ type: 'open_tab', tabId });
   };
 
   // M6: open a schema-analysis tab for a collection.
@@ -1072,7 +1118,7 @@ function Workspace() {
     const tabId = `schema.${connectionId}.${db}.${collection}`;
     const tabExists = tabs.some(t => t.id === tabId);
     if (!tabExists) {
-      setTabs(prev => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'schema',
         connectionId,
@@ -1082,15 +1128,18 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs(prev => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+      return;
     }
-    dispatchLayout({ type: 'open_tab', tabId });
+    dispatchWorkspace({ type: 'open_tab', tabId });
   };
 
   const handleOpenMonitoringTab = (connectionId: string) => {
     const tabId = `monitoring.${connectionId}`;
     if (!tabs.some((t) => t.id === tabId)) {
-      setTabs((prev) => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'monitoring',
         connectionId,
@@ -1100,15 +1149,18 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
+      };
+      setTabs((prev) => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+      return;
     }
-    dispatchLayout({ type: 'open_tab', tabId });
+    dispatchWorkspace({ type: 'open_tab', tabId });
   };
 
   const handleOpenUsersTab = (connectionId: string, db?: string) => {
     const tabId = `users.${connectionId}`;
     if (!tabs.some((t) => t.id === tabId)) {
-      setTabs((prev) => [...prev, {
+      const newTab: QueryTab = {
         id: tabId,
         type: 'users',
         connectionId,
@@ -1118,12 +1170,16 @@ function Workspace() {
         loading: false,
         error: null,
         explainResult: null,
-      }]);
-    } else if (db) {
+      };
+      setTabs((prev) => [...prev, newTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId }, { tab: newTab });
+      return;
+    }
+    if (db) {
       // Re-opened scoped to a database (sidebar db menu): refocus the scope.
       setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, db } : t)));
     }
-    dispatchLayout({ type: 'open_tab', tabId });
+    dispatchWorkspace({ type: 'open_tab', tabId });
   };
 
   const handleCollectionRenamed = (
@@ -1152,7 +1208,7 @@ function Workspace() {
       .map(t => ({ oldId: t.id, newId: renameTab(t).id }))
       .filter(p => p.oldId !== p.newId);
     setTabs(prev => prev.map(renameTab));
-    renamedPairs.forEach(({ oldId, newId }) => dispatchLayout({ type: 'rename_tab', oldId, newId }));
+    renamedPairs.forEach(({ oldId, newId }) => dispatchWorkspace({ type: 'rename_tab', oldId, newId }));
     invalidatePaletteNamespaceIndex(connectionId);
   };
 
@@ -1162,7 +1218,7 @@ function Workspace() {
       .filter(t => t.connectionId === connectionId && t.db === dbName)
       .map(t => t.id);
     setTabs(prev => prev.filter(t => t.connectionId !== connectionId || t.db !== dbName));
-    dispatchLayout({ type: 'close_many', tabIds: removed });
+    dispatchWorkspace({ type: 'close_many', tabIds: removed });
   };
 
   const handleDatabaseRenamed = (connectionId: string, oldName: string, newName: string) => {
@@ -1202,7 +1258,7 @@ function Workspace() {
       .map(t => ({ oldId: t.id, newId: renameTab(t).id }))
       .filter(p => p.oldId !== p.newId);
     setTabs(prev => prev.map(renameTab));
-    renamedPairs.forEach(({ oldId, newId }) => dispatchLayout({ type: 'rename_tab', oldId, newId }));
+    renamedPairs.forEach(({ oldId, newId }) => dispatchWorkspace({ type: 'rename_tab', oldId, newId }));
     invalidatePaletteNamespaceIndex(connectionId);
   };
 
@@ -1273,8 +1329,7 @@ function Workspace() {
 
         // Close/rename tab
         const oldTabId = `${connectionId}.${db}.${collection}.${initialData.name}`;
-        setTabs(prev => prev.filter(t => t.id !== oldTabId));
-        dispatchLayout({ type: 'close_tab', tabId: oldTabId });
+        closeTabById(oldTabId);
       }
 
       // Create new index
@@ -1312,8 +1367,7 @@ function Workspace() {
 
       // Close the deleted index tab
       const tabId = `${connectionId}.${dbName}.${collName}.${indexName}`;
-      setTabs(prev => prev.filter(t => t.id !== tabId));
-      dispatchLayout({ type: 'close_tab', tabId });
+      closeTabById(tabId);
 
       // Trigger sidebar refresh
       setIndexMutationTrigger(prev => prev + 1);
@@ -1323,22 +1377,96 @@ function Workspace() {
   };
 
   const closeTabById = (tabId: string) => {
-    tabBuilderStateCache.current.delete(tabId);
-    const updatedTabs = tabs.filter(t => t.id !== tabId);
-    setTabs(updatedTabs);
-    dispatchLayout({ type: 'close_tab', tabId });
+    dispatchWorkspace({ type: 'close_tab', tabId });
   };
 
-  // Passed to WorkspaceRoot/PaneView as their `dispatch`. Panes close their own
-  // tabs by dispatching `close_tab` directly (drag/drop and split ops only need
-  // the layout reducer), so we intercept that one action to also keep `tabs`
-  // state and the builder-state cache in sync — mirroring closeTabById.
-  const dispatchWorkspace = (action: WorkspaceAction) => {
+  // Passed to WorkspaceRoot/PaneView as their `dispatch`, and the single
+  // choke point every other workspace action flows through — the ONLY place
+  // `dispatchLayout` is called. Two responsibilities beyond forwarding to the
+  // layout reducer:
+  //  1. `close_tab` also needs `tabs` state and the builder-state cache kept
+  //     in sync (panes close their own tabs by dispatching `close_tab`
+  //     directly — drag/drop and split ops only touch the layout reducer;
+  //     `closeTabById` above is just a thin wrapper for other call sites).
+  //  2. Every action is mirrored to the backend store via `workspaceApply`
+  //     (fire-and-forget), unless `options.mirror` is false or mirroring is
+  //     globally suppressed (`mirroringEnabledRef` — Task 6 flips this off
+  //     until the restore-on-boot snapshot settles). `open_tab` is enriched
+  //     with the persisted tab payload when `options.tab` is supplied (i.e.
+  //     this call just created a brand-new frontend tab); reopening/
+  //     refocusing an already-open tab omits it — the backend already has
+  //     that tab's model. `toPersistedTab` returning null (export/import)
+  //     means this tab id must never exist in the backend store at all — its
+  //     open_tab is dropped entirely (sending it without a tab payload would
+  //     create a dangling backend layout entry) and the id is tracked in
+  //     `unmirroredTabIdsRef` so its later close/move/rename mirrors are
+  //     skipped consistently too. A move_tab of an unmirrored tab is also
+  //     skipped entirely — it only relocates that one id, so skipping keeps
+  //     the backend tree valid at the cost of losing that tab's pane
+  //     placement on restore, which is acceptable since the tab itself was
+  //     never going to be restored anyway.
+  const dispatchWorkspace = (
+    action: WorkspaceAction,
+    options?: { tab?: QueryTab; mirror?: boolean }
+  ) => {
     if (action.type === 'close_tab') {
-      closeTabById(action.tabId);
-      return;
+      tabBuilderStateCache.current.delete(action.tabId);
+      setTabs(prev => prev.filter(t => t.id !== action.tabId));
     }
     dispatchLayout(action);
+
+    if (options?.mirror === false || !mirroringEnabledRef.current) {
+      if (action.type === 'close_tab') unmirroredTabIdsRef.current.delete(action.tabId);
+      return;
+    }
+
+    switch (action.type) {
+      case 'open_tab': {
+        if (options?.tab) {
+          const conn = activeConnections.find(c => c.id === options.tab!.connectionId);
+          const builderState = tabBuilderStateCache.current.get(options.tab.id);
+          const persisted = toPersistedTab(options.tab, conn, builderState);
+          if (persisted === null) {
+            unmirroredTabIdsRef.current.add(action.tabId);
+            return;
+          }
+          unmirroredTabIdsRef.current.delete(action.tabId);
+          workspaceApply(actionToOp(action, persisted));
+          return;
+        }
+        if (unmirroredTabIdsRef.current.has(action.tabId)) return;
+        workspaceApply(actionToOp(action));
+        return;
+      }
+      case 'close_tab':
+        if (unmirroredTabIdsRef.current.has(action.tabId)) {
+          unmirroredTabIdsRef.current.delete(action.tabId);
+          return;
+        }
+        workspaceApply(actionToOp(action));
+        return;
+      case 'close_many': {
+        const tabIds = action.tabIds.filter(id => !unmirroredTabIdsRef.current.has(id));
+        action.tabIds.forEach(id => unmirroredTabIdsRef.current.delete(id));
+        if (tabIds.length === 0) return;
+        workspaceApply(actionToOp({ ...action, tabIds }));
+        return;
+      }
+      case 'move_tab':
+        if (unmirroredTabIdsRef.current.has(action.tabId)) return;
+        workspaceApply(actionToOp(action));
+        return;
+      case 'rename_tab':
+        if (unmirroredTabIdsRef.current.has(action.oldId)) {
+          unmirroredTabIdsRef.current.delete(action.oldId);
+          unmirroredTabIdsRef.current.add(action.newId);
+          return;
+        }
+        workspaceApply(actionToOp(action));
+        return;
+      default:
+        workspaceApply(actionToOp(action));
+    }
   };
 
   const cycleTab = (dir: 1 | -1) => {
@@ -1346,12 +1474,18 @@ function Workspace() {
     if (!p || p.tabIds.length < 2) return;
     const i = p.tabIds.indexOf(p.activeTabId ?? '');
     const next = p.tabIds[(i + dir + p.tabIds.length) % p.tabIds.length];
-    dispatchLayout({ type: 'set_active', paneId: p.id, tabId: next });
+    dispatchWorkspace({ type: 'set_active', paneId: p.id, tabId: next });
   };
 
   const openQuickStartTab = () => {
-    setTabs(prev => prev.some(t => t.id === QUICK_START_TAB_ID) ? prev : [...prev, createQuickStartTab()]);
-    dispatchLayout({ type: 'open_tab', tabId: QUICK_START_TAB_ID });
+    const alreadyOpen = tabs.some(t => t.id === QUICK_START_TAB_ID);
+    if (!alreadyOpen) {
+      const qs = createQuickStartTab();
+      setTabs(prev => prev.some(t => t.id === QUICK_START_TAB_ID) ? prev : [...prev, qs]);
+      dispatchWorkspace({ type: 'open_tab', tabId: QUICK_START_TAB_ID }, { tab: qs });
+      return;
+    }
+    dispatchWorkspace({ type: 'open_tab', tabId: QUICK_START_TAB_ID });
   };
 
   // Command palette: Cmd/Ctrl+K from anywhere in the workspace.
@@ -1459,14 +1593,14 @@ function Workspace() {
       { id: 'prev-tab', title: 'Previous Tab', keywords: 'tab switch', run: () => cycleTab(-1) },
     ] : []),
     ...(activeTabId && focusedPane && focusedPane.tabIds.length > 1 ? [
-      { id: 'workspace.split-right', title: 'Split Right', keywords: 'workspace pane layout', run: () => dispatchLayout({ type: 'split_pane', paneId: focusedPane.id, dir: 'row', side: 'end', moveTabId: activeTabId }) },
-      { id: 'workspace.split-down', title: 'Split Down', keywords: 'workspace pane layout', run: () => dispatchLayout({ type: 'split_pane', paneId: focusedPane.id, dir: 'col', side: 'end', moveTabId: activeTabId }) },
+      { id: 'workspace.split-right', title: 'Split Right', keywords: 'workspace pane layout', run: () => dispatchWorkspace({ type: 'split_pane', paneId: focusedPane.id, dir: 'row', side: 'end', moveTabId: activeTabId }) },
+      { id: 'workspace.split-down', title: 'Split Down', keywords: 'workspace pane layout', run: () => dispatchWorkspace({ type: 'split_pane', paneId: focusedPane.id, dir: 'col', side: 'end', moveTabId: activeTabId }) },
     ] : []),
     ...(allPanes(layout.root).length > 1 ? [
       { id: 'workspace.focus-next-pane', title: 'Focus Next Pane', keywords: 'workspace pane layout switch', run: () => {
         const panes = allPanes(layout.root);
         const i = panes.findIndex(p => p.id === layout.focusedPaneId);
-        dispatchLayout({ type: 'focus_pane', paneId: panes[(i + 1) % panes.length].id });
+        dispatchWorkspace({ type: 'focus_pane', paneId: panes[(i + 1) % panes.length].id });
       } },
     ] : []),
     ...activeConnections.map(c => ({
@@ -1503,6 +1637,12 @@ function Workspace() {
 
       const parsedResults = resultStrs.map(s => JSON.parse(s));
       setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, results: parsedResults, loading: false, lastQuery: query, lastAggregate: undefined } : t));
+      if (!unmirroredTabIdsRef.current.has(tab.id)) {
+        // `lastAggregate: null` (not omitted) explicitly clears any
+        // previously-mirrored aggregate on the backend tab, matching the
+        // local `lastAggregate: undefined` above.
+        updateTabState(tab.id, { lastQuery: query, lastAggregate: null });
+      }
       // History is best-effort: never surface an error after a successful run.
       recordHistory(connectionNameFor(tab.connectionId), tab.db, tab.collection, {
         queryType: 'find',
@@ -1555,6 +1695,9 @@ function Workspace() {
 
       const parsedResults = resultStrs.map(s => JSON.parse(s));
       setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, results: parsedResults, loading: false, lastAggregate: pipeline } : t));
+      if (!unmirroredTabIdsRef.current.has(tab.id)) {
+        updateTabState(tab.id, { lastAggregate: pipeline });
+      }
       recordHistory(connectionNameFor(tab.connectionId), tab.db, tab.collection, {
         queryType: 'aggregate',
         pipeline,
@@ -2398,7 +2541,7 @@ function Workspace() {
             setActiveConnections(prev => prev.filter(c => c.id !== connId));
             const removed = tabs.filter(t => t.connectionId === connId).map(t => t.id);
             setTabs(prev => prev.filter(t => t.connectionId !== connId));
-            dispatchLayout({ type: 'close_many', tabIds: removed });
+            dispatchWorkspace({ type: 'close_many', tabIds: removed });
           }}
           onOpenSettings={handleOpenSettingsTab}
           onCopyCollections={handleCopyCollections}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ import {
 } from './components/RestoreView';
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
-import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, type WorkspaceAction } from './workspace/model';
+import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, snapshotLayoutIds, restoreLayoutIds, type WorkspaceAction } from './workspace/model';
 import { WorkspaceRoot } from './workspace/WorkspaceRoot';
 import { workspaceApply, updateTabState, actionToOp, workspaceGet } from './workspace/workspaceStore';
 import { toPersistedTab, toDisconnectedSnapshot, rebindConnection, toProfileSpaceId } from './workspace/persistence';
@@ -1641,8 +1641,29 @@ function Workspace() {
     // land in one synchronous handler (rename storms) — see layoutRef's
     // declaration above for why the closure value would be stale for the
     // second and later calls in that case.
+    // The trial reducer call below must not itself mint pane/split ids that
+    // never actually get used (amended after a closing-review regression):
+    // `workspaceReducer` mints them via `newPaneId`/`newSplitId`'s
+    // module-level counters (model.ts), and this trial's return value is
+    // discarded except for reference-identity comparison. Left unchecked, a
+    // real `split_pane` mints TWICE per dispatch — once here, once more when
+    // React actually applies the action during render — so the id React
+    // commits ends up one generation ahead of what the mirrored op causes
+    // the backend to mint from its own, separately-counted id space,
+    // silently desyncing every later op that addresses that pane/split by
+    // id. `snapshotLayoutIds`/`restoreLayoutIds` bracket the trial so it's
+    // side-effect-free; the one real, render-time reducer application is the
+    // only one that actually advances the counters, and it starts from the
+    // exact same (restored) counter state the trial did — so it mints the
+    // SAME ids the trial minted and discarded. `nextLayout` below is a
+    // different object than what React eventually commits, but its
+    // pane/split ids are identical, so using it for the optimistic
+    // `layoutRef.current` advance (compared against by later same-tick
+    // dispatches) stays accurate.
     const currentLayout = layoutRef.current;
+    const idSnapshot = snapshotLayoutIds();
     const nextLayout = workspaceReducer(currentLayout, action);
+    restoreLayoutIds(idSnapshot);
     layoutRef.current = nextLayout;
     const isNoOp = nextLayout === currentLayout;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,8 +39,9 @@ import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
 import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, type WorkspaceAction } from './workspace/model';
 import { WorkspaceRoot } from './workspace/WorkspaceRoot';
-import { workspaceApply, updateTabState, actionToOp } from './workspace/workspaceStore';
-import { toPersistedTab } from './workspace/persistence';
+import { workspaceApply, updateTabState, actionToOp, workspaceGet } from './workspace/workspaceStore';
+import { toPersistedTab, toDisconnectedSnapshot, rebindConnection } from './workspace/persistence';
+import { ReconnectBanner } from './workspace/ReconnectBanner';
 import { CreateViewView } from './components/CreateViewView';
 import { ValidationRulesView } from './components/ValidationRulesView';
 import { GridFsView } from './components/GridFsView';
@@ -291,10 +292,13 @@ function Workspace() {
   }
   const tabBuilderStateCache = useRef(new Map<string, BuilderState>());
   // Workspace-store mirroring plumbing (Phase 2 Task 5). Mirroring starts
-  // enabled; Task 6's restore-on-boot effect flips this off until the
-  // restored snapshot settles, so the initial hydration doesn't bounce
-  // straight back to the backend as a stream of "new" ops.
-  const mirroringEnabledRef = useRef(true);
+  // DISABLED — the restore effect below is the only thing allowed to turn it
+  // on, once workspace_get has resolved (snapshot applied or none found).
+  // Starting it true would let the initial-render quickstart state (or
+  // anything the user clicks before the restore settles) mirror to the
+  // backend store as "new" ops, potentially clobbering a legitimate snapshot
+  // a previous session already wrote before this GET resolves.
+  const mirroringEnabledRef = useRef(false);
   // Tab ids whose open_tab was never mirrored (toPersistedTab returned null
   // — export/import tabs) or that were themselves rebound out of mirroring.
   // close_tab/close_many/move_tab/rename_tab consult this so they never
@@ -324,6 +328,88 @@ function Workspace() {
         : [...prev, { id, profileId, name, uri, color_tag }]
     );
   };
+
+  // profileId -> profileName for every restored-but-not-yet-reconnected tab,
+  // captured from the persisted snapshot at restore time. RestoredTab (what
+  // toDisconnectedSnapshot hands back) deliberately drops profileName — it's
+  // a structural subset of QueryTab, which has no such field — so this is the
+  // only place ReconnectBanner's label can come from until the tab reconnects.
+  const [restoredProfileNames, setRestoredProfileNames] = useState<Map<string, string>>(new Map());
+  // Per-profile Reconnect busy/error state, keyed by profileId. Shared across
+  // every ReconnectBanner instance for that profile (a profile's tabs can be
+  // spread across multiple panes), so one click's busy/error state is visible
+  // on all of them, and a second click while busy is a no-op (guarded below).
+  const [reconnectState, setReconnectState] = useState<Map<string, { busy: boolean; error: string | null }>>(
+    new Map()
+  );
+  const patchReconnectState = (profileId: string, patch: Partial<{ busy: boolean; error: string | null }>) => {
+    setReconnectState((prev) => {
+      const next = new Map(prev);
+      const cur = next.get(profileId) ?? { busy: false, error: null };
+      next.set(profileId, { ...cur, ...patch });
+      return next;
+    });
+  };
+
+  // Session restore (Phase 2 Task 6). Runs once on mount: pulls whatever
+  // workspace.json snapshot the backend has and, if it holds at least one
+  // persisted tab, swaps the default Quick Start state for it — every
+  // restored tab renders disconnected (ReconnectBanner) until its profile
+  // reconnects. `restoredRef` guards against React 18 StrictMode's double-
+  // invoke of effects in dev: the ref is set synchronously before the first
+  // await, so a second invocation of this same effect (same component
+  // instance, refs persist across it) returns immediately instead of firing
+  // a second workspace_get / hydrate / mirroring-enable.
+  //
+  // Chosen behavior for a "slow disk" race (snapshot resolves AFTER the user
+  // has already clicked around while mirroring was still suppressed): hydrate
+  // wins and clobbers whatever the user did. workspace_get is a local file
+  // read the backend caches after the first call, so the realistic window is
+  // milliseconds at app boot, and merging "whatever the user did in that
+  // window" with a persisted snapshot is a lot of complexity for an edge case
+  // this narrow — losing a few clicks from before the very first paint has
+  // settled is an acceptable trade for a wholesale, easy-to-reason-about
+  // restore.
+  const restoredRef = useRef(false);
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+    (async () => {
+      try {
+        const ws = await workspaceGet();
+        if (ws && Array.isArray(ws.tabs) && ws.tabs.length > 0) {
+          const snapshot = toDisconnectedSnapshot(ws);
+          setTabs(snapshot.tabs as QueryTab[]);
+          for (const [tabId, state] of snapshot.builderStates) {
+            tabBuilderStateCache.current.set(tabId, state as BuilderState);
+          }
+          const profileNames = new Map<string, string>();
+          for (const t of ws.tabs) {
+            if (t.profileId) profileNames.set(t.profileId, t.profileName || t.profileId);
+          }
+          setRestoredProfileNames(profileNames);
+          // `hydrate` is a frontend-only reducer action — there is no backend
+          // op for "replace my whole layout". Dispatched via raw
+          // `dispatchLayout`, bypassing `dispatchWorkspace`'s mirror-to-
+          // backend choke point entirely, so this restore is never echoed
+          // back to workspace_apply as a stream of synthetic ops (mirroring
+          // is still disabled here regardless — see mirroringEnabledRef's
+          // init above — but the direct dispatch documents the exception
+          // even once mirroring flips on below).
+          dispatchLayout({ type: 'hydrate', layout: snapshot.layout });
+        }
+        // No snapshot (or an empty one): the default Quick Start state from
+        // this component's initializers stands as-is.
+      } catch {
+        // workspace_get failing (corrupt file, IO error) is not fatal —
+        // fall back to the default Quick Start state exactly as if there
+        // were no snapshot at all.
+      } finally {
+        mirroringEnabledRef.current = true;
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleQuickConnect = async (profile: ConnectionProfile): Promise<string | null> => {
     const existing = activeConnections.find(
@@ -1740,6 +1826,77 @@ function Workspace() {
     }
   };
 
+  // Reconnect flow for a ReconnectBanner (Phase 2 Task 6). One click revives
+  // EVERY restored tab for this profile — not just the tab whose banner was
+  // clicked — since they share the same `profile:<profileId>` prefix and the
+  // same underlying connection.
+  const handleReconnectProfile = async (profileId: string, profileName: string) => {
+    if (reconnectState.get(profileId)?.busy) return; // a reconnect for this profile is already in flight
+    patchReconnectState(profileId, { busy: true, error: null });
+    try {
+      const profiles = await invoke<ConnectionProfile[]>('load_connection_profiles');
+      const profile = profiles.find((p) => p.id === profileId);
+      if (!profile) {
+        patchReconnectState(profileId, { busy: false, error: 'Connection profile no longer exists' });
+        return;
+      }
+
+      const newId = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
+      addActiveConnection(newId, profileName, profile.uri, profile.id, profile.color_tag ?? undefined);
+
+      // Captured before any state updates below — `tabs`/`layout` in this
+      // closure still reflect the profile: id space this reconnect started
+      // from, which is exactly what rebindConnection/oldTabsSnapshot need.
+      const oldPrefix = `profile:${profileId}`;
+      const pairs = rebindConnection(oldPrefix, newId, allTabIds(layout));
+      const idMap = new Map(pairs.map((p) => [p.oldId, p.newId]));
+      const oldTabsSnapshot = tabs;
+      const activeOldIds = new Set(
+        allPanes(layout.root)
+          .map((p) => p.activeTabId)
+          .filter((id): id is string => !!id)
+      );
+
+      if (pairs.length > 0) {
+        setTabs((prev) =>
+          prev.map((t) => {
+            const renamedId = idMap.get(t.id);
+            return renamedId ? { ...t, id: renamedId, connectionId: newId } : t;
+          })
+        );
+        // Dispatched straight to the layout reducer via `dispatchLayout`,
+        // bypassing `dispatchWorkspace`'s mirror entirely — NOT a `mirror:
+        // false` option on dispatchWorkspace, a raw dispatch, same exception
+        // as hydrate above. The backend store must stay in `profile:<id>` id
+        // space (see persistence.ts's Global Constraint note): that's what
+        // the NEXT restart needs to restore from. Mirroring these renames
+        // would leave the backend holding this session's live connection id,
+        // which is worthless the moment the app closes.
+        pairs.forEach(({ oldId, newId: renamedId }) =>
+          dispatchLayout({ type: 'rename_tab', oldId, newId: renamedId })
+        );
+      }
+
+      patchReconnectState(profileId, { busy: false, error: null });
+
+      // Eagerly reload every revived collection tab's last query/aggregate so
+      // the grid isn't left empty post-reconnect (index/shell/etc. tabs have
+      // no query to re-run). Sequential, not Promise.all — a burst of
+      // concurrent queries against a connection that just finished dialing is
+      // unfriendly; whichever tab was visible (its pane's active tab) before
+      // the reconnect goes first, since that's what the user is looking at.
+      const revived = oldTabsSnapshot
+        .filter((t) => idMap.has(t.id) && t.type === 'collection')
+        .map((t) => ({ oldId: t.id, tab: { ...t, id: idMap.get(t.id)!, connectionId: newId } }));
+      revived.sort((a, b) => Number(activeOldIds.has(b.oldId)) - Number(activeOldIds.has(a.oldId)));
+      for (const { tab } of revived) {
+        await refreshTabResults(tab);
+      }
+    } catch (err: any) {
+      patchReconnectState(profileId, { busy: false, error: err?.message || String(err) });
+    }
+  };
+
   // When a tracked import task (started from the Import tab) is observed
   // completed by the task poll, refresh the matching open collection tab so
   // newly-imported documents show up without a manual re-run.
@@ -2134,6 +2291,26 @@ function Workspace() {
   const renderTabContent = (tabId: string): React.ReactNode => {
     const tab = tabs.find(t => t.id === tabId);
     if (!tab) return null;
+    // A restored-but-not-yet-reconnected tab (see the session-restore effect
+    // above) still carries its `profile:<profileId>` connectionId — render
+    // the Reconnect banner INSTEAD of the tab's normal content, for every
+    // tab type (collection, index, shell, ...), checked before the type
+    // switch below so no branch there ever sees a `profile:` connectionId.
+    if (tab.connectionId.startsWith('profile:')) {
+      const profileId = tab.connectionId.slice('profile:'.length);
+      const profileName = restoredProfileNames.get(profileId) || profileId;
+      const namespace = [tab.db, tab.collection, tab.indexName].filter(Boolean).join('.');
+      const state = reconnectState.get(profileId);
+      return (
+        <ReconnectBanner
+          profileName={profileName}
+          namespace={namespace}
+          busy={!!state?.busy}
+          error={state?.error ?? null}
+          onReconnect={() => handleReconnectProfile(profileId, profileName)}
+        />
+      );
+    }
     return (
       <>
         {tab.type === 'index' && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -276,6 +276,20 @@ function Workspace() {
     undefined,
     () => createInitialLayout([QUICK_START_TAB_ID], QUICK_START_TAB_ID),
   );
+  // `dispatchWorkspace` (below) needs to know, synchronously, whether an
+  // action it's about to mirror to the backend is one the frontend reducer
+  // itself no-opped on — but `layout` above is a render-scope closure value,
+  // stale for every dispatch after the first in a single synchronous handler
+  // (multiple `dispatchWorkspace` calls in one tick, e.g. a rename storm,
+  // all fire before React re-renders and refreshes `layout`). `layoutRef`
+  // mirrors `layout` on every render (assignment during render, not an
+  // effect — the correct value once React settles) AND is advanced
+  // optimistically inside `dispatchWorkspace` itself right after each
+  // dispatch, so a second dispatch in the same tick compares against the
+  // first dispatch's result, not the stale pre-tick value. #97 phase 2 final
+  // review Fix 3.
+  const layoutRef = useRef(layout);
+  layoutRef.current = layout;
   const focusedPane = findPane(layout.root, layout.focusedPaneId);
   const activeTabId = focusedPane?.activeTabId ?? null;
   if (import.meta.env.DEV) {
@@ -328,6 +342,12 @@ function Workspace() {
     connections: ActiveConnection[],
     patch: Parameters<typeof updateTabState>[1]
   ) => {
+    // Mirroring gate (#97 phase 2 final review Fix 5): airtight against the
+    // same restore-race `dispatchWorkspace` guards against below — before
+    // the session-restore effect flips `mirroringEnabledRef` on, an
+    // `update_tab_state` mirror (builder-state edits, query/aggregate
+    // refreshes) must be dropped too, not just layout ops.
+    if (!mirroringEnabledRef.current) return;
     if (unmirroredTabIdsRef.current.has(tabId)) return;
     updateTabState(toProfileSpaceId(tabId, connections), patch);
   };
@@ -352,6 +372,64 @@ function Workspace() {
         ? prev
         : [...prev, { id, profileId, name, uri, color_tag }]
     );
+  };
+
+  // Shared by every path that can hand a profile its first live connection
+  // id in a session — `handleReconnectProfile`, `handleQuickConnect`, and the
+  // ConnectionManager `onConnect` handler (#97 phase 2 final review Fix 1 /
+  // Fix 2). Any restored-but-disconnected tab for `profileId` still carries
+  // a `profile:<profileId>` id/connectionId (see persistence.ts's Global
+  // Constraint note) and renders a ReconnectBanner (App.tsx's
+  // `renderTabContent` keys the banner purely off that prefix) until it's
+  // rebound onto `liveId`. Calling this from all three connect paths — not
+  // just the banner's own onReconnect — means a normal quick-connect/
+  // ConnectionManager connect clears those banners immediately instead of
+  // leaving them stale until clicked; a stale banner click would otherwise
+  // call `connect_db` a SECOND time for a profile that's already connected
+  // (`addActiveConnection` dedupes by profileId, so that second id would
+  // never land in `activeConnections` — every tab rebound to it becomes
+  // unreachable, and every later mirror for those tabs ships a live id the
+  // backend can't translate back to profile-space).
+  const rebindProfileTabs = (
+    profileId: string,
+    liveId: string
+  ): { pairs: Array<{ oldId: string; newId: string }>; idMap: Map<string, string> } => {
+    const oldPrefix = `profile:${profileId}`;
+    const pairs = rebindConnection(oldPrefix, liveId, allTabIds(layout));
+    if (pairs.length === 0) return { pairs, idMap: new Map() };
+
+    const idMap = new Map(pairs.map((p) => [p.oldId, p.newId]));
+    setTabs((prev) =>
+      prev.map((t) => {
+        const renamedId = idMap.get(t.id);
+        return renamedId ? { ...t, id: renamedId, connectionId: liveId } : t;
+      })
+    );
+
+    // Re-key any cached builder state (Fix 2): the session-restore effect
+    // seeds `tabBuilderStateCache` under profile-space tab ids. Without
+    // re-keying here, a rebind silently drops as-typed query-builder state
+    // for the rebound tab — a cache MISS under the new id, and a leaked
+    // entry under the now-dead old one — in the only flow that could ever
+    // surface it (a restored tab that still has unsaved builder state).
+    for (const { oldId, newId } of pairs) {
+      const bs = tabBuilderStateCache.current.get(oldId);
+      if (bs) {
+        tabBuilderStateCache.current.set(newId, bs);
+        tabBuilderStateCache.current.delete(oldId);
+      }
+    }
+
+    // Dispatched straight to the layout reducer via `dispatchLayout`,
+    // bypassing `dispatchWorkspace`'s mirror entirely — not a "skip mirror"
+    // option, a raw dispatch. The backend store must stay in
+    // `profile:<id>` id space (persistence.ts's Global Constraint note):
+    // that's what the NEXT restart needs to restore from. Mirroring these
+    // renames would leave the backend holding this session's live
+    // connection id, which is worthless the moment the app closes.
+    pairs.forEach(({ oldId, newId }) => dispatchLayout({ type: 'rename_tab', oldId, newId }));
+
+    return { pairs, idMap };
   };
 
   // profileId -> profileName for every restored-but-not-yet-reconnected tab,
@@ -461,6 +539,9 @@ function Workspace() {
     try {
       const id = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
       addActiveConnection(id, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined);
+      // Clear any ReconnectBanner this profile still has showing (#97 phase
+      // 2 final review Fix 1) — see `rebindProfileTabs`'s doc comment.
+      rebindProfileTabs(profile.id, id);
       return id;
     } catch (e) {
       toast(`Could not connect to ${profile.name}: ${(e as any)?.message || String(e)}`, 'error');
@@ -1517,25 +1598,30 @@ function Workspace() {
   //     directly — drag/drop and split ops only touch the layout reducer;
   //     `closeTabById` above is just a thin wrapper for other call sites).
   //  2. Every action is mirrored to the backend store via `workspaceApply`
-  //     (fire-and-forget), unless `options.mirror` is false or mirroring is
-  //     globally suppressed (`mirroringEnabledRef` — Task 6 flips this off
-  //     until the restore-on-boot snapshot settles). `open_tab` is enriched
-  //     with the persisted tab payload when `options.tab` is supplied (i.e.
-  //     this call just created a brand-new frontend tab); reopening/
-  //     refocusing an already-open tab omits it — the backend already has
-  //     that tab's model. `toPersistedTab` returning null (export/import)
-  //     means this tab id must never exist in the backend store at all — its
-  //     open_tab is dropped entirely (sending it without a tab payload would
-  //     create a dangling backend layout entry) and the id is tracked in
-  //     `unmirroredTabIdsRef` so its later close/move/rename mirrors are
-  //     skipped consistently too. A move_tab of an unmirrored tab is also
-  //     skipped entirely — it only relocates that one id, so skipping keeps
-  //     the backend tree valid at the cost of losing that tab's pane
-  //     placement on restore, which is acceptable since the tab itself was
-  //     never going to be restored anyway.
+  //     (fire-and-forget), unless mirroring is globally suppressed
+  //     (`mirroringEnabledRef` — Task 6 flips this off until the
+  //     restore-on-boot snapshot settles) OR the frontend reducer itself
+  //     no-opped the action (#97 phase 2 final review Fix 3 — see the
+  //     no-op check below; there is no longer an `options.mirror` escape
+  //     hatch, nothing ever used one — hydrate/reconnect renames bypass
+  //     this function entirely via a raw `dispatchLayout`, same as
+  //     `open_tab`'s persisted-payload enrichment below). `open_tab` is
+  //     enriched with the persisted tab payload when `options.tab` is
+  //     supplied (i.e. this call just created a brand-new frontend tab);
+  //     reopening/refocusing an already-open tab omits it — the backend
+  //     already has that tab's model. `toPersistedTab` returning null
+  //     (export/import) means this tab id must never exist in the backend
+  //     store at all — its open_tab is dropped entirely (sending it without
+  //     a tab payload would create a dangling backend layout entry) and the
+  //     id is tracked in `unmirroredTabIdsRef` so its later close/move/
+  //     rename mirrors are skipped consistently too. A move_tab of an
+  //     unmirrored tab is also skipped entirely — it only relocates that
+  //     one id, so skipping keeps the backend tree valid at the cost of
+  //     losing that tab's pane placement on restore, which is acceptable
+  //     since the tab itself was never going to be restored anyway.
   const dispatchWorkspace = (
     action: WorkspaceAction,
-    options?: { tab?: QueryTab; mirror?: boolean }
+    options?: { tab?: QueryTab }
   ) => {
     if (action.type === 'close_tab') {
       tabBuilderStateCache.current.delete(action.tabId);
@@ -1543,7 +1629,24 @@ function Workspace() {
     }
     dispatchLayout(action);
 
-    if (options?.mirror === false || !mirroringEnabledRef.current) {
+    // Skip mirroring an action the frontend reducer itself no-opped on —
+    // e.g. `split_pane` moving a pane's only tab (reachable via unmirrored
+    // export/import tabs, which never get a backend-side pane to move out
+    // of). The reducer is pure and returns the SAME layout object reference
+    // for a no-op, so identity comparison is exact, no deep-equal needed.
+    // React still sees the dispatch above (a harmless no-op there too) —
+    // only the backend mirror is skipped: backend only sees ops the
+    // frontend actually applied. `layoutRef.current` (not the `layout`
+    // render-scope closure) because multiple `dispatchWorkspace` calls can
+    // land in one synchronous handler (rename storms) — see layoutRef's
+    // declaration above for why the closure value would be stale for the
+    // second and later calls in that case.
+    const currentLayout = layoutRef.current;
+    const nextLayout = workspaceReducer(currentLayout, action);
+    layoutRef.current = nextLayout;
+    const isNoOp = nextLayout === currentLayout;
+
+    if (isNoOp || !mirroringEnabledRef.current) {
       if (action.type === 'close_tab') unmirroredTabIdsRef.current.delete(action.tabId);
       return;
     }
@@ -1884,22 +1987,34 @@ function Workspace() {
     reconnectBusyRef.current.add(profileId);
     patchReconnectState(profileId, { busy: true, error: null });
     try {
-      const profiles = await invoke<ConnectionProfile[]>('load_connection_profiles');
-      const profile = profiles.find((p) => p.id === profileId);
-      if (!profile) {
-        patchReconnectState(profileId, { busy: false, error: 'Connection profile no longer exists' });
-        return;
-      }
+      // Already connected — via quick-connect or the ConnectionManager,
+      // whose banners now clear themselves on a normal connect (Fix 1
+      // above), but a banner click racing that rebind, or a session from
+      // before this fix, can still land here with a live connection already
+      // in `activeConnections`. Reuse it instead of minting a duplicate:
+      // `addActiveConnection` dedupes by profileId, so a second `connect_db`
+      // here would produce an id that never lands in `activeConnections` —
+      // every tab rebound to it would be unreachable, and no profile lookup
+      // (`load_connection_profiles`) is needed to reuse it either.
+      const existing = activeConnections.find((c) => c.profileId === profileId);
+      let newId: string;
+      if (existing) {
+        newId = existing.id;
+      } else {
+        const profiles = await invoke<ConnectionProfile[]>('load_connection_profiles');
+        const profile = profiles.find((p) => p.id === profileId);
+        if (!profile) {
+          patchReconnectState(profileId, { busy: false, error: 'Connection profile no longer exists' });
+          return;
+        }
 
-      const newId = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
-      addActiveConnection(newId, profileName, profile.uri, profile.id, profile.color_tag ?? undefined);
+        newId = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
+        addActiveConnection(newId, profileName, profile.uri, profile.id, profile.color_tag ?? undefined);
+      }
 
       // Captured before any state updates below — `tabs`/`layout` in this
       // closure still reflect the profile: id space this reconnect started
-      // from, which is exactly what rebindConnection/oldTabsSnapshot need.
-      const oldPrefix = `profile:${profileId}`;
-      const pairs = rebindConnection(oldPrefix, newId, allTabIds(layout));
-      const idMap = new Map(pairs.map((p) => [p.oldId, p.newId]));
+      // from, which is exactly what `rebindProfileTabs`/oldTabsSnapshot need.
       const oldTabsSnapshot = tabs;
       const activeOldIds = new Set(
         allPanes(layout.root)
@@ -1907,25 +2022,7 @@ function Workspace() {
           .filter((id): id is string => !!id)
       );
 
-      if (pairs.length > 0) {
-        setTabs((prev) =>
-          prev.map((t) => {
-            const renamedId = idMap.get(t.id);
-            return renamedId ? { ...t, id: renamedId, connectionId: newId } : t;
-          })
-        );
-        // Dispatched straight to the layout reducer via `dispatchLayout`,
-        // bypassing `dispatchWorkspace`'s mirror entirely — NOT a `mirror:
-        // false` option on dispatchWorkspace, a raw dispatch, same exception
-        // as hydrate above. The backend store must stay in `profile:<id>` id
-        // space (see persistence.ts's Global Constraint note): that's what
-        // the NEXT restart needs to restore from. Mirroring these renames
-        // would leave the backend holding this session's live connection id,
-        // which is worthless the moment the app closes.
-        pairs.forEach(({ oldId, newId: renamedId }) =>
-          dispatchLayout({ type: 'rename_tab', oldId, newId: renamedId })
-        );
-      }
+      const { idMap } = rebindProfileTabs(profileId, newId);
 
       patchReconnectState(profileId, { busy: false, error: null });
 
@@ -2815,6 +2912,10 @@ function Workspace() {
             onClose={() => { setIsConnectionModalOpen(false); setProfilesRefreshKey((k) => k + 1); }}
             onConnect={(id, name, uri, profileId, colorTag) => {
               addActiveConnection(id, name, uri, profileId, colorTag ?? undefined);
+              // Clear any ReconnectBanner this profile still has showing
+              // (#97 phase 2 final review Fix 1) — see `rebindProfileTabs`'s
+              // doc comment.
+              rebindProfileTabs(profileId, id);
               setIsConnectionModalOpen(false);
               setProfilesRefreshKey((k) => k + 1);
             }}

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -59,13 +59,19 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 
 // Mock Sidebar component
 vi.mock('../Sidebar', () => ({
-  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings, onOpenDump, onOpenRestore, onEditValidation }: any) => (
+  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings, onOpenDump, onOpenRestore, onEditValidation, onDatabaseRenamed }: any) => (
     <div data-testid="mock-sidebar">
       <button data-testid="select-collection-btn" onClick={() => onSelectCollection('conn-1', 'sales_db', 'customers')}>
         Select Collection
       </button>
       <button data-testid="select-orders-collection-btn" onClick={() => onSelectCollection('conn-1', 'sales_db', 'orders')}>
         Select Orders
+      </button>
+      <button
+        data-testid="rename-db-btn"
+        onClick={() => onDatabaseRenamed && onDatabaseRenamed('conn-1', 'sales_db', 'sales_db2')}
+      >
+        Rename sales_db
       </button>
       <button data-testid="select-index-btn" onClick={() => onSelectIndex('conn-1', 'sales_db', 'customers', 'email_1')}>
         Select Index
@@ -1836,6 +1842,254 @@ describe('App Component', () => {
       renderWithProviders(<App />);
       expect(await screen.findByTestId('quickstart-tab')).toBeInTheDocument();
       expect(screen.queryByTestId('reconnect-banner')).not.toBeInTheDocument();
+    });
+
+    it('(d) banner click while the profile is already connected reuses the live connection — quick-connecting a profile that still has a ReconnectBanner clears it without a second connect_db (#97 phase 2 final review Fix 1)', async () => {
+      // One window, two panes: pane-1 shows the Quick Start tab (so its
+      // ConnectionCard is available to drive a quick-connect), pane-2 shows a
+      // restored-but-disconnected tab for the same profile p1.
+      const quickConnectSnapshot = {
+        revision: 1,
+        windows: [
+          {
+            id: 'main',
+            focusedPaneId: 'pane-1',
+            splitTree: {
+              kind: 'split',
+              id: 'split-1',
+              dir: 'row',
+              ratio: 0.5,
+              children: [
+                { kind: 'pane', id: 'pane-1', tabIds: ['quickstart'], activeTabId: 'quickstart' },
+                {
+                  kind: 'pane',
+                  id: 'pane-2',
+                  tabIds: ['profile:p1.sales_db.customers'],
+                  activeTabId: 'profile:p1.sales_db.customers',
+                },
+              ],
+            },
+          },
+        ],
+        tabs: [
+          { id: 'quickstart', type: 'quickstart', profileId: '', profileName: '', db: '', collection: '' },
+          {
+            id: 'profile:p1.sales_db.customers',
+            type: 'collection',
+            profileId: 'p1',
+            profileName: 'Prod Cluster',
+            db: 'sales_db',
+            collection: 'customers',
+          },
+        ],
+      };
+
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(quickConnectSnapshot);
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('live-1');
+        if (cmd === 'execute_mql_query') return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      expect(await screen.findByTestId('reconnect-banner')).toBeInTheDocument();
+
+      // Quick-connect the SAME profile from the Quick Start pane, not the
+      // banner itself — this is the path that used to leave the banner
+      // showing (it only rebound tabs on an explicit banner click), so a
+      // later banner click would mint a duplicate `connect_db` for a
+      // profile that's already connected.
+      const connectCard = await screen.findByTestId('conn-card-p1');
+      fireEvent.click(connectCard);
+
+      // The rebind fires as part of the quick-connect itself — the banner
+      // must be gone WITHOUT ever needing a click on it.
+      await waitFor(() => {
+        expect(screen.queryByTestId('reconnect-banner')).not.toBeInTheDocument();
+      });
+
+      const connectCalls = calls.filter((c) => c.cmd === 'connect_db');
+      expect(connectCalls).toHaveLength(1); // NOT 2 — no duplicate backend connection for p1
+    });
+
+    it('(e) builder state seeded under the profile-space tab id survives reconnect (#97 phase 2 final review Fix 2)', async () => {
+      const seededBuilderState = {
+        queryMode: 'find',
+        filterQuery: '{"seeded":true}',
+        sortQuery: '{}',
+        projectionQuery: '{}',
+        limit: '50',
+        skip: '0',
+        stages: [{ id: 'stage-1', operator: '$match', content: '{\n  \n}' }],
+      };
+      const snapshotWithBuilderState = {
+        revision: 1,
+        windows: [
+          {
+            id: 'main',
+            focusedPaneId: 'pane-1',
+            splitTree: {
+              kind: 'pane',
+              id: 'pane-1',
+              tabIds: ['profile:p1.sales_db.customers'],
+              activeTabId: 'profile:p1.sales_db.customers',
+            },
+          },
+        ],
+        tabs: [
+          {
+            id: 'profile:p1.sales_db.customers',
+            type: 'collection',
+            profileId: 'p1',
+            profileName: 'Prod Cluster',
+            db: 'sales_db',
+            collection: 'customers',
+            builderState: seededBuilderState,
+          },
+        ],
+      };
+
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'workspace_get') return Promise.resolve(snapshotWithBuilderState);
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('new-conn-1');
+        if (cmd === 'execute_mql_query') return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      const [firstBtn] = await screen.findAllByRole('button', { name: /Reconnect Prod Cluster/ });
+      fireEvent.click(firstBtn);
+
+      await waitFor(() => {
+        expect(screen.queryAllByTestId('reconnect-banner')).toHaveLength(0);
+      });
+
+      // The tab's id (and the builder-state cache entry seeded under its old
+      // profile-space id) must both have been rebound onto the live
+      // connection id — DocumentViewer's `initialBuilderState` reads the
+      // cache under the tab's CURRENT id, so a filter of "{}" here would
+      // mean the seeded state was dropped (leaked under the dead old id)
+      // instead of re-keyed.
+      const filterInput = await screen.findByTestId('query-filter-input');
+      expect((filterInput as HTMLInputElement).value).toBe('{"seeded":true}');
+    });
+  });
+
+  describe('dispatchWorkspace no-op mirror gate (#97 phase 2 final review Fix 3)', () => {
+    it('does not mirror split_pane when it moves a pane\'s only tab (a frontend reducer no-op)', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      const { TAB_DRAG_MIME } = await import('../../workspace/PaneView');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // Open one collection tab, then close Quick Start — pane-1 now holds
+      // exactly one tab ("customers"), which is also its active tab. (The
+      // command palette's own "Split Right"/"Split Down" entries only ever
+      // appear when a pane has MORE than one tab, so this exact reproduction
+      // — a self-drop drag of a pane's only tab onto its own edge — is the
+      // one the UI actually lets through to `dispatchWorkspace`.)
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await screen.findByTestId('mock-sidebar');
+      fireEvent.click(screen.getByRole('button', { name: 'Close Quick Start' }));
+      await waitFor(() => {
+        expect(screen.queryByTestId('quickstart-tab')).not.toBeInTheDocument();
+      });
+      expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
+
+      calls.length = 0; // only care about ops mirrored from the drop below
+
+      // Drag the pane's own (only) tab and drop it on the pane's own right
+      // edge — model.ts's split_pane case returns the SAME layout reference
+      // for this ("would empty the source pane — pointless split"), so
+      // dispatchWorkspace must skip the mirror.
+      const pane = screen.getByTestId(/^pane-pane-/);
+      const data: Record<string, string> = { [TAB_DRAG_MIME]: 'conn-1.sales_db.customers' };
+      const dt = { getData: (k: string) => data[k] ?? '', setData: () => {}, types: [TAB_DRAG_MIME] };
+      Object.defineProperty(pane, 'getBoundingClientRect', {
+        value: () => ({ left: 0, top: 0, width: 1000, height: 500, right: 1000, bottom: 500 }),
+      });
+      fireEvent.dragOver(pane, { dataTransfer: dt, clientX: 950, clientY: 250 });
+      fireEvent.drop(pane, { dataTransfer: dt, clientX: 950, clientY: 250 });
+
+      // No second pane ever appears (the frontend reducer itself no-opped).
+      expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
+      const splitCalls = calls.filter((c) => c.cmd === 'workspace_apply' && (c.args?.op as any)?.type === 'split_pane');
+      expect(splitCalls).toHaveLength(0);
+    });
+
+    it('does mirror a normal split_pane (pane has more than one tab)', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // pane-1 now holds two tabs: Quick Start and "customers" (active).
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findAllByText(/"Ada"/)).toBeTruthy();
+
+      fireEvent.keyDown(window, { key: 'k', metaKey: true });
+      fireEvent.change(await screen.findByTestId('command-palette-input'), { target: { value: 'Split Right' } });
+      fireEvent.click(await screen.findByText('Split Right'));
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(2);
+      });
+      const splitCalls = calls.filter((c) => c.cmd === 'workspace_apply' && (c.args?.op as any)?.type === 'split_pane');
+      expect(splitCalls).toHaveLength(1);
+    });
+
+    it('mirrors both rename_tab dispatches from a single-tick rename storm', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // Two collection tabs under the same connection+db — renaming the
+      // database renames BOTH tabs, dispatched back-to-back in one
+      // synchronous `forEach` (App.tsx's `handleDatabaseRenamed`).
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findAllByText(/"Ada"/)).toBeTruthy();
+      fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
+      expect(await screen.findAllByText(/"Ada"/)).toBeTruthy();
+
+      calls.length = 0; // only care about ops mirrored from the rename storm below
+
+      fireEvent.click(screen.getByTestId('rename-db-btn'));
+
+      const renameCalls = calls.filter((c) => c.cmd === 'workspace_apply' && (c.args?.op as any)?.type === 'rename_tab');
+      expect(renameCalls).toHaveLength(2);
+      const newIds = renameCalls.map((c) => (c.args.op as any).new_id).sort();
+      expect(newIds).toEqual(['conn-1.sales_db2.customers', 'conn-1.sales_db2.orders']);
     });
   });
 });

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -1645,4 +1645,146 @@ describe('App Component', () => {
     const ordersFilterAgain = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
     expect(ordersFilterAgain.value).toContain('"shipped"');
   });
+
+  describe('session restore + Reconnect banner (#97 phase 2 Task 6)', () => {
+    // Two collection tabs, both on profile p1, split into a row of two panes —
+    // matches persistence.ts's toDisconnectedSnapshot wire shape (camelCase,
+    // `profile:<profileId>` connection ids already baked into the tab ids).
+    const workspaceSnapshot = {
+      revision: 1,
+      windows: [
+        {
+          id: 'main',
+          focusedPaneId: 'pane-1',
+          splitTree: {
+            kind: 'split',
+            id: 'split-1',
+            dir: 'row',
+            ratio: 0.5,
+            children: [
+              {
+                kind: 'pane',
+                id: 'pane-1',
+                tabIds: ['profile:p1.sales_db.customers'],
+                activeTabId: 'profile:p1.sales_db.customers',
+              },
+              {
+                kind: 'pane',
+                id: 'pane-2',
+                tabIds: ['profile:p1.sales_db.orders'],
+                activeTabId: 'profile:p1.sales_db.orders',
+              },
+            ],
+          },
+        },
+      ],
+      tabs: [
+        {
+          id: 'profile:p1.sales_db.customers',
+          type: 'collection',
+          profileId: 'p1',
+          profileName: 'Prod Cluster',
+          db: 'sales_db',
+          collection: 'customers',
+        },
+        {
+          id: 'profile:p1.sales_db.orders',
+          type: 'collection',
+          profileId: 'p1',
+          profileName: 'Prod Cluster',
+          db: 'sales_db',
+          collection: 'orders',
+        },
+      ],
+    };
+
+    it('(a) restores a disconnected snapshot as ReconnectBanners, with no query invokes', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        return Promise.resolve([]);
+      });
+
+      renderWithProviders(<App />);
+
+      const banners = await screen.findAllByTestId('reconnect-banner');
+      expect(banners).toHaveLength(2);
+      expect(screen.getAllByRole('button', { name: /Reconnect Prod Cluster/ })).toHaveLength(2);
+
+      expect(mockInvoke).not.toHaveBeenCalledWith('execute_mql_query', expect.anything());
+      expect(mockInvoke).not.toHaveBeenCalledWith('execute_aggregate', expect.anything());
+    });
+
+    it('(b) clicking Reconnect resolves profiles + connect_db, revives all of the profile\'s tabs, and eagerly re-runs their queries', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('new-conn-1');
+        if (cmd === 'execute_mql_query') {
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      const banners = await screen.findAllByTestId('reconnect-banner');
+      expect(banners).toHaveLength(2);
+
+      const [firstBtn] = screen.getAllByRole('button', { name: /Reconnect Prod Cluster/ });
+      fireEvent.click(firstBtn);
+
+      // One click on either pane's banner revives ALL tabs of that profile —
+      // both panes' banners disappear and both mount real content.
+      await waitFor(() => {
+        expect(screen.queryAllByTestId('reconnect-banner')).toHaveLength(0);
+      });
+      expect(await screen.findAllByText(/"Ada"/)).toHaveLength(2);
+
+      await waitFor(() => {
+        const execCalls = calls.filter((c) => c.cmd === 'execute_mql_query');
+        expect(execCalls).toHaveLength(2);
+        expect(execCalls.every((c) => c.args?.id === 'new-conn-1')).toBe(true);
+      });
+
+      const connectCalls = calls.filter((c) => c.cmd === 'connect_db');
+      expect(connectCalls).toHaveLength(1); // one connect_db for the whole profile, not per-tab
+    });
+
+    it('(b2) a missing profile surfaces "no longer exists" as the banner error, without connecting', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        if (cmd === 'load_connection_profiles') return Promise.resolve([]); // p1 is gone
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      const [firstBtn] = await screen.findAllByRole('button', { name: /Reconnect Prod Cluster/ });
+      fireEvent.click(firstBtn);
+
+      // Both panes share the same profileId's error state — the error surfaces
+      // on every banner for that profile, not just the one that was clicked.
+      expect(await screen.findAllByText('Connection profile no longer exists')).toHaveLength(2);
+      expect(mockInvoke).not.toHaveBeenCalledWith('connect_db', expect.anything());
+      // Still disconnected — both banners remain.
+      expect(screen.getAllByTestId('reconnect-banner')).toHaveLength(2);
+    });
+
+    it('(c) a null snapshot keeps the default Quick Start tab', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'workspace_get') return Promise.resolve(null);
+        return Promise.resolve([]);
+      });
+
+      renderWithProviders(<App />);
+      expect(await screen.findByTestId('quickstart-tab')).toBeInTheDocument();
+      expect(screen.queryByTestId('reconnect-banner')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -2092,4 +2092,48 @@ describe('App Component', () => {
       expect(newIds).toEqual(['conn-1.sales_db2.customers', 'conn-1.sales_db2.orders']);
     });
   });
+
+  describe('dispatchWorkspace trial-run id-counter parity (closing review amendment)', () => {
+    it('a real split_pane commits pane-pane-2, not pane-pane-3 — the no-op mirror gate\'s trial reducer call must not itself consume a pane id', async () => {
+      // The gate's trial run (see the previous describe block) calls
+      // `workspaceReducer` purely for reference-identity comparison and
+      // discards its result — but `workspaceReducer` mints pane/split ids
+      // via model.ts's module-level counters as a SIDE EFFECT. Reset here so
+      // this test's own split is the first mint since module load,
+      // regardless of what earlier tests in this file minted.
+      const { resetLayoutIds } = await import('../../workspace/model');
+      resetLayoutIds();
+
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // pane-1 (root) now holds two tabs: Quick Start and "customers" (active).
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findAllByText(/"Ada"/)).toBeTruthy();
+
+      fireEvent.keyDown(window, { key: 'k', metaKey: true });
+      fireEvent.change(await screen.findByTestId('command-palette-input'), { target: { value: 'Split Right' } });
+      fireEvent.click(await screen.findByText('Split Right'));
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(2);
+      });
+
+      // Pre-fix: the discarded trial minted pane-2/split-1 for nothing, and
+      // the real (render-time) application then minted pane-3/split-2 —
+      // THAT is what got committed, one generation ahead of what the
+      // mirrored op causes the backend to mint from its own, separately-
+      // counted id space. Post-fix, the trial's mint is undone before the
+      // real application runs, so the real one mints pane-2 — the same id a
+      // single reducer application (matching the backend) would produce.
+      expect(screen.getByTestId('pane-pane-2')).toBeInTheDocument();
+      expect(screen.queryByTestId('pane-pane-3')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -1755,6 +1755,57 @@ describe('App Component', () => {
       expect(connectCalls).toHaveLength(1); // one connect_db for the whole profile, not per-tab
     });
 
+    it('(b1) clicking two banners for the same profile back-to-back only connects once — IMPORTANT fix regression guard', async () => {
+      // Both panes' banners share profileId p1. A synchronous double-click
+      // (or two banners firing before either's setReconnectState commits) used
+      // to both pass the busy check — reconnectState is render-captured, so
+      // neither call could see the other's in-flight state yet — and each
+      // called connect_db, leaking a connection. reconnectBusyRef is checked
+      // and set synchronously at the top of handleReconnectProfile, before
+      // any state update or await, so the second call must bail out.
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('new-conn-1');
+        if (cmd === 'execute_mql_query') {
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      const banners = await screen.findAllByTestId('reconnect-banner');
+      expect(banners).toHaveLength(2);
+      const buttons = screen.getAllByRole('button', { name: /Reconnect Prod Cluster/ });
+      expect(buttons).toHaveLength(2);
+
+      // Both clicks inside ONE `act()` so React defers re-rendering (and
+      // therefore re-committing `reconnectState`) until after BOTH
+      // synchronous handler prefixes have already run — reproducing the
+      // real race: two banner clicks that each observe the SAME
+      // pre-click `reconnectState` snapshot. Two separate `fireEvent.click`
+      // calls (each with its own implicit act()) would let the first
+      // click's state update flush and re-render before the second
+      // fires, masking the race this test exists to catch.
+      act(() => {
+        fireEvent.click(buttons[0]);
+        fireEvent.click(buttons[1]);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryAllByTestId('reconnect-banner')).toHaveLength(0);
+      });
+
+      const connectCalls = calls.filter((c) => c.cmd === 'connect_db');
+      expect(connectCalls).toHaveLength(1); // NOT 2 — the second click must have been dropped
+    });
+
     it('(b2) a missing profile surfaces "no longer exists" as the banner error, without connecting', async () => {
       mockInvoke.mockImplementation((cmd: string) => {
         if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);

--- a/src/workspace/ReconnectBanner.tsx
+++ b/src/workspace/ReconnectBanner.tsx
@@ -1,0 +1,57 @@
+// Rendered by App.tsx's renderTabContent INSTEAD of a tab's normal content
+// whenever its connectionId is still in `profile:<profileId>` space — i.e. a
+// tab restored from a session-restore snapshot (see persistence.ts /
+// toDisconnectedSnapshot) whose connection hasn't been re-established yet.
+
+import React from 'react';
+import { Loader2, PlugZap } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export interface ReconnectBannerProps {
+  profileName: string;
+  /** db[.collection[.indexName]] the disconnected tab points at, for context
+   *  when several disconnected tabs share the same profile. */
+  namespace: string;
+  onReconnect: () => void;
+  busy: boolean;
+  /** Last reconnect failure for this tab's profile (missing profile, vault
+   *  locked, connect_db failure) — surfaced verbatim from the invoke error. */
+  error?: string | null;
+}
+
+export const ReconnectBanner: React.FC<ReconnectBannerProps> = ({
+  profileName,
+  namespace,
+  onReconnect,
+  busy,
+  error,
+}) => (
+  <div
+    className="flex h-full flex-col items-center justify-center gap-3 bg-background p-8 text-center"
+    data-testid="reconnect-banner"
+  >
+    <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-muted">
+      <PlugZap size={20} className="text-muted-foreground" />
+    </div>
+    <div>
+      <p className="text-sm font-medium text-foreground">Disconnected</p>
+      <p className="mt-1 max-w-xs text-xs text-muted-foreground">
+        {namespace ? <>{namespace} was</> : 'This tab was'} restored from your last session.
+        Reconnect to {profileName} to load it.
+      </p>
+    </div>
+    <Button onClick={onReconnect} disabled={busy} size="sm">
+      {busy ? (
+        <Loader2 size={14} className="mr-1.5 animate-spin" />
+      ) : (
+        <PlugZap size={14} className="mr-1.5" />
+      )}
+      Reconnect {profileName}
+    </Button>
+    {error && (
+      <p className="max-w-xs text-ui-2xs text-destructive" data-testid="reconnect-error">
+        {error}
+      </p>
+    )}
+  </div>
+);

--- a/src/workspace/__tests__/golden.test.ts
+++ b/src/workspace/__tests__/golden.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import goldenFixture from '../../../fixtures/workspace-golden.json';
+import {
+  workspaceReducer,
+  resetLayoutIds,
+  seedLayoutIds,
+  type WorkspaceLayout,
+  type WorkspaceAction,
+  type LayoutNode,
+  type SplitDir,
+  type SplitSide,
+} from '../model';
+
+// Golden parity vectors shared with the Rust reducer (src-tauri/src/workspace.rs,
+// `mod tests` — the `golden_*` tests read the same fixture). This runner
+// asserts the LAYOUT half only (splitTree + focusedPaneId): `revision` and
+// `tabs[]` are Rust-only bookkeeping with no TS equivalent (the frontend
+// keeps QueryTab[] in App, not in this reducer) — the Rust runner asserts
+// those against the same fixture's `expected`.
+
+interface RawOp {
+  type: string;
+  pane_id?: string;
+  tab_id?: string;
+  tab_ids?: string[];
+  target_pane_id?: string;
+  index?: number;
+  dir?: SplitDir;
+  side?: SplitSide;
+  move_tab_id?: string;
+  split_id?: string;
+  ratio?: number;
+  old_id?: string;
+  new_id?: string;
+  // `tab` (open_tab's TabModel payload) and `last_query`/`last_aggregate`/
+  // `builder_state` (update_tab_state) are Rust-only tabs[] bookkeeping with
+  // no TS reducer field — deliberately untyped/unused here.
+}
+
+interface FixtureWindow {
+  id: string;
+  focusedPaneId: string;
+  splitTree: LayoutNode;
+}
+
+interface FixtureDoc {
+  revision: number;
+  windows: FixtureWindow[];
+  tabs: unknown[];
+}
+
+interface Vector {
+  name: string;
+  initial: FixtureDoc;
+  ops: RawOp[];
+  expected: FixtureDoc;
+}
+
+const { vectors } = goldenFixture as unknown as { vectors: Vector[] };
+
+function layoutOf(doc: FixtureDoc): WorkspaceLayout {
+  const win = doc.windows[0];
+  return { root: win.splitTree, focusedPaneId: win.focusedPaneId };
+}
+
+/** Maps a fixture op (snake_case type + keys, matching the Rust `WorkspaceOp`
+ *  wire format exactly) to the TS reducer's camelCase action. `update_tab_state`
+ *  has no TS equivalent — it only mutates Rust's tabs[] — so it maps to `null`,
+ *  meaning "layout unchanged"; the Rust runner asserts its effects separately. */
+function opToAction(op: RawOp): WorkspaceAction | null {
+  switch (op.type) {
+    case 'open_tab':
+      return { type: 'open_tab', tabId: op.tab_id!, paneId: op.pane_id };
+    case 'close_tab':
+      return { type: 'close_tab', tabId: op.tab_id! };
+    case 'close_many':
+      return { type: 'close_many', tabIds: op.tab_ids! };
+    case 'move_tab':
+      return { type: 'move_tab', tabId: op.tab_id!, targetPaneId: op.target_pane_id!, index: op.index };
+    case 'split_pane':
+      return { type: 'split_pane', paneId: op.pane_id!, dir: op.dir!, side: op.side!, moveTabId: op.move_tab_id };
+    case 'resize_split':
+      return { type: 'resize_split', splitId: op.split_id!, ratio: op.ratio! };
+    case 'set_active':
+      return { type: 'set_active', paneId: op.pane_id!, tabId: op.tab_id! };
+    case 'focus_pane':
+      return { type: 'focus_pane', paneId: op.pane_id! };
+    case 'rename_tab':
+      return { type: 'rename_tab', oldId: op.old_id!, newId: op.new_id! };
+    case 'update_tab_state':
+      return null;
+    default:
+      throw new Error(`golden.test.ts: unhandled op type "${op.type}"`);
+  }
+}
+
+describe('workspace golden parity vectors (layout half)', () => {
+  it('fixture parses into an array of vectors', () => {
+    expect(Array.isArray(vectors)).toBe(true);
+  });
+
+  for (const vector of vectors) {
+    it(vector.name, () => {
+      resetLayoutIds();
+      let layout = layoutOf(vector.initial);
+      seedLayoutIds(layout);
+      for (const op of vector.ops) {
+        const action = opToAction(op);
+        if (action) layout = workspaceReducer(layout, action);
+      }
+      expect(layout).toEqual(layoutOf(vector.expected));
+    });
+  }
+});

--- a/src/workspace/__tests__/model.test.ts
+++ b/src/workspace/__tests__/model.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   createInitialLayout, workspaceReducer, findPane, paneOfTab, allPanes,
-  allTabIds, resetLayoutIds, type WorkspaceLayout, type SplitNode, type PaneNode,
+  allTabIds, resetLayoutIds, seedLayoutIds, type WorkspaceLayout, type SplitNode, type PaneNode,
 } from '../model';
 
 const layoutWith = (...tabIds: string[]): WorkspaceLayout =>
@@ -182,6 +182,33 @@ describe('rename_tab', () => {
     l = workspaceReducer(l, { type: 'rename_tab', oldId: 'conn.db.old', newId: 'conn.db.new' });
     expect((l.root as PaneNode).tabIds).toEqual(['conn.db.new']);
     expect((l.root as PaneNode).activeTabId).toBe('conn.db.new');
+  });
+});
+
+describe('seedLayoutIds', () => {
+  it('seeds counters past the max numeric suffix already present in the tree', () => {
+    // A tree "loaded" from a fixture already containing pane-7 / split-2.
+    const layout: WorkspaceLayout = {
+      focusedPaneId: 'pane-3',
+      root: {
+        kind: 'split',
+        id: 'split-2',
+        dir: 'row',
+        ratio: 0.5,
+        children: [
+          { kind: 'pane', id: 'pane-3', tabIds: ['a', 'x'], activeTabId: 'a' },
+          { kind: 'pane', id: 'pane-7', tabIds: ['b'], activeTabId: 'b' },
+        ],
+      },
+    };
+    seedLayoutIds(layout);
+    const l = workspaceReducer(layout, {
+      type: 'split_pane', paneId: 'pane-3', dir: 'row', side: 'end', moveTabId: 'x',
+    });
+    const paneIds = allPanes(l.root).map(p => p.id);
+    expect(paneIds).toContain('pane-8'); // past existing pane-7, not colliding with pane-1
+    const nestedSplit = (l.root as SplitNode).children[0] as SplitNode;
+    expect(nestedSplit.id).toBe('split-3'); // past existing split-2
   });
 });
 

--- a/src/workspace/__tests__/model.test.ts
+++ b/src/workspace/__tests__/model.test.ts
@@ -212,6 +212,29 @@ describe('seedLayoutIds', () => {
   });
 });
 
+describe('hydrate', () => {
+  it('replaces the layout wholesale', () => {
+    const incoming: WorkspaceLayout = {
+      focusedPaneId: 'pane-7',
+      root: { kind: 'pane', id: 'pane-7', tabIds: ['a', 'b'], activeTabId: 'a' },
+    };
+    const l = workspaceReducer(layoutWith('placeholder'), { type: 'hydrate', layout: incoming });
+    expect(l).toEqual(incoming);
+  });
+
+  it('seeds id counters from the incoming layout so a later split does not collide', () => {
+    const incoming: WorkspaceLayout = {
+      focusedPaneId: 'pane-7',
+      root: { kind: 'pane', id: 'pane-7', tabIds: ['a', 'b'], activeTabId: 'a' },
+    };
+    let l = workspaceReducer(layoutWith('placeholder'), { type: 'hydrate', layout: incoming });
+    l = workspaceReducer(l, { type: 'split_pane', paneId: 'pane-7', dir: 'row', side: 'end', moveTabId: 'b' });
+    const paneIds = allPanes(l.root).map(p => p.id);
+    expect(paneIds).toContain('pane-8'); // seeded past the incoming pane-7
+    expect(paneIds).not.toContain('pane-1'); // would collide with the pre-hydrate counter state
+  });
+});
+
 describe('robustness', () => {
   it('unknown ids are no-ops returning the same reference', () => {
     const l = layoutWith('a');

--- a/src/workspace/__tests__/model.test.ts
+++ b/src/workspace/__tests__/model.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   createInitialLayout, workspaceReducer, findPane, paneOfTab, allPanes,
-  allTabIds, resetLayoutIds, seedLayoutIds, type WorkspaceLayout, type SplitNode, type PaneNode,
+  allTabIds, resetLayoutIds, seedLayoutIds, snapshotLayoutIds, restoreLayoutIds,
+  type WorkspaceLayout, type SplitNode, type PaneNode,
 } from '../model';
 
 const layoutWith = (...tabIds: string[]): WorkspaceLayout =>
@@ -209,6 +210,34 @@ describe('seedLayoutIds', () => {
     expect(paneIds).toContain('pane-8'); // past existing pane-7, not colliding with pane-1
     const nestedSplit = (l.root as SplitNode).children[0] as SplitNode;
     expect(nestedSplit.id).toBe('split-3'); // past existing split-2
+  });
+});
+
+describe('snapshotLayoutIds / restoreLayoutIds', () => {
+  it('a restored snapshot makes the next mint reuse the same id as a discarded trial run', () => {
+    // Simulates App.tsx's dispatchWorkspace no-op mirror gate: a "trial"
+    // reducer call whose minted ids must never actually be consumed.
+    const layout = layoutWith('a', 'b');
+    const snap = snapshotLayoutIds();
+
+    // Trial run: mints pane-2/split-1 for the new pane, then is discarded.
+    const trial = workspaceReducer(layout, {
+      type: 'split_pane', paneId: layout.root.id, dir: 'row', side: 'end', moveTabId: 'b',
+    });
+    const trialPaneIds = allPanes(trial.root).map(p => p.id);
+    expect(trialPaneIds).toContain('pane-2');
+
+    restoreLayoutIds(snap);
+
+    // The real (render-time) application starts from the restored counters
+    // and must mint the EXACT SAME ids the trial did, not the next ones up.
+    const real = workspaceReducer(layout, {
+      type: 'split_pane', paneId: layout.root.id, dir: 'row', side: 'end', moveTabId: 'b',
+    });
+    const realPaneIds = allPanes(real.root).map(p => p.id);
+    expect(realPaneIds).toEqual(trialPaneIds);
+    expect(realPaneIds).toContain('pane-2');
+    expect(realPaneIds).not.toContain('pane-3');
   });
 });
 

--- a/src/workspace/__tests__/persistence.test.ts
+++ b/src/workspace/__tests__/persistence.test.ts
@@ -231,14 +231,23 @@ describe('actionToOp', () => {
   });
 
   it('move_tab with an explicit index', () => {
-    const expected = opsByType.get('move_tab'); // { type: 'move_tab', tab_id, target_pane_id, index }
+    // `opsByType.get('move_tab')` would grab the FIRST move_tab op across all
+    // vectors — that's `split_then_close_folds_depth2`'s, which has no
+    // `index` key at all and would silently duplicate the "no index" test
+    // below. Target the vector whose op actually carries an index instead.
+    const vector = goldenFixture.vectors.find((v) => v.name === 'move_tab_reorders_within_same_pane_using_index')!;
+    const expected = vector.ops[0] as Record<string, unknown>; // { type: 'move_tab', tab_id: 'c', target_pane_id: 'pane-1', index: 0 }
+    expect(expected.index).toBeDefined();
     const action: WorkspaceAction = {
       type: 'move_tab',
-      tabId: expected!.tab_id as string,
-      targetPaneId: expected!.target_pane_id as string,
-      index: expected!.index as number,
+      tabId: expected.tab_id as string,
+      targetPaneId: expected.target_pane_id as string,
+      index: expected.index as number,
     };
-    expect(actionToOp(action)).toEqual(expected);
+    const op = actionToOp(action);
+    expect(op).toEqual(expected);
+    expect('index' in op).toBe(true);
+    expect(op.index).toBe(expected.index);
   });
 
   it('move_tab without an index omits the key rather than sending undefined', () => {

--- a/src/workspace/__tests__/persistence.test.ts
+++ b/src/workspace/__tests__/persistence.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toPersistedTab,
+  toDisconnectedSnapshot,
+  rebindConnection,
+  type PersistableTab,
+  type PersistableConnection,
+  type PersistedWorkspace,
+} from '../persistence';
+import { actionToOp } from '../workspaceStore';
+import type { WorkspaceAction } from '../model';
+import goldenFixture from '../../../fixtures/workspace-golden.json';
+
+const conn: PersistableConnection = { id: 'conn-uuid', profileId: 'p1', name: 'Profile 1' };
+
+const collectionTab: PersistableTab = {
+  id: 'conn-uuid.mydb.mycoll',
+  type: 'collection',
+  connectionId: 'conn-uuid',
+  db: 'mydb',
+  collection: 'mycoll',
+};
+
+describe('toPersistedTab', () => {
+  it('returns null for export tabs — in-flight task state does not survive a restart', () => {
+    const tab: PersistableTab = { ...collectionTab, id: 'export.conn-uuid.mydb.mycoll', type: 'export' };
+    expect(toPersistedTab(tab, conn, undefined)).toBeNull();
+  });
+
+  it('returns null for import tabs', () => {
+    const tab: PersistableTab = { ...collectionTab, id: 'import.conn-uuid.mydb.mycoll', type: 'import' };
+    expect(toPersistedTab(tab, conn, undefined)).toBeNull();
+  });
+
+  it('substitutes the leading connectionId segment with profile:<profileId> at save time', () => {
+    const persisted = toPersistedTab(collectionTab, conn, undefined);
+    expect(persisted?.id).toBe('profile:p1.mydb.mycoll');
+    expect(persisted?.profileId).toBe('p1');
+    expect(persisted?.profileName).toBe('Profile 1');
+  });
+
+  it('substitutes the connection segment inside a type-prefixed id (shell)', () => {
+    const tab: PersistableTab = {
+      id: 'shell.conn-uuid.mydb.x',
+      type: 'shell',
+      connectionId: 'conn-uuid',
+      db: 'mydb',
+      collection: 'x',
+    };
+    const persisted = toPersistedTab(tab, conn, undefined);
+    expect(persisted?.id).toBe('shell.profile:p1.mydb.x');
+  });
+
+  it('passes settings/quickstart/tasks tabs through unchanged with empty profile fields', () => {
+    for (const type of ['settings', 'quickstart', 'tasks'] as const) {
+      const tab: PersistableTab = { id: type, type, connectionId: '', db: '', collection: '' };
+      const persisted = toPersistedTab(tab, undefined, undefined);
+      expect(persisted).toEqual({
+        id: type,
+        type,
+        profileId: '',
+        profileName: '',
+        db: '',
+        collection: '',
+        indexName: undefined,
+        lastQuery: undefined,
+        lastAggregate: undefined,
+        builderState: undefined,
+      });
+    }
+  });
+
+  it('carries builderState and lastQuery/lastAggregate through untouched', () => {
+    const tab: PersistableTab = { ...collectionTab, lastQuery: { filter: '{}' } };
+    const persisted = toPersistedTab(tab, conn, { queryMode: 'find' });
+    expect(persisted?.lastQuery).toEqual({ filter: '{}' });
+    expect(persisted?.builderState).toEqual({ queryMode: 'find' });
+  });
+});
+
+describe('toDisconnectedSnapshot', () => {
+  const ws: PersistedWorkspace = {
+    revision: 3,
+    windows: [
+      {
+        id: 'main',
+        focusedPaneId: 'pane-1',
+        splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.mydb.mycoll'], activeTabId: 'profile:p1.mydb.mycoll' },
+      },
+    ],
+    tabs: [
+      {
+        id: 'profile:p1.mydb.mycoll',
+        type: 'collection',
+        profileId: 'p1',
+        profileName: 'Profile 1',
+        db: 'mydb',
+        collection: 'mycoll',
+        lastQuery: { filter: '{}' },
+        builderState: { queryMode: 'find' },
+      },
+    ],
+  };
+
+  it('produces empty-results tabs with profile: connectionIds', () => {
+    const snapshot = toDisconnectedSnapshot(ws);
+    expect(snapshot.tabs).toHaveLength(1);
+    const tab = snapshot.tabs[0];
+    expect(tab.id).toBe('profile:p1.mydb.mycoll'); // no id surgery — already in profile: form
+    expect(tab.connectionId).toBe('profile:p1');
+    expect(tab.results).toEqual([]);
+    expect(tab.loading).toBe(false);
+    expect(tab.error).toBeNull();
+    expect(tab.explainResult).toBeNull();
+  });
+
+  it('seeds builderStates from persisted tabs that have one', () => {
+    const snapshot = toDisconnectedSnapshot(ws);
+    expect(snapshot.builderStates.get('profile:p1.mydb.mycoll')).toEqual({ queryMode: 'find' });
+    expect(snapshot.builderStates.size).toBe(1);
+  });
+
+  it('reconstructs the layout tree as-is when every layout tab id has a matching persisted tab', () => {
+    const snapshot = toDisconnectedSnapshot(ws);
+    expect(snapshot.layout).toEqual({
+      root: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.mydb.mycoll'], activeTabId: 'profile:p1.mydb.mycoll' },
+      focusedPaneId: 'pane-1',
+    });
+  });
+
+  it('drops a layout tab id (and folds the layout) that has no matching persisted tab', () => {
+    // Simulates legacy/corrupt data: the layout references an id absent from
+    // tabs[] (the case a never-mirrored export/import tab would be in, were
+    // it ever to end up in the tree). The reducer's close_tab must fold the
+    // pane exactly like a normal close would.
+    const dangling: PersistedWorkspace = {
+      revision: 1,
+      windows: [
+        {
+          id: 'main',
+          focusedPaneId: 'pane-1',
+          splitTree: {
+            kind: 'split',
+            id: 'split-1',
+            dir: 'row',
+            ratio: 0.5,
+            children: [
+              { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.mydb.mycoll'], activeTabId: 'profile:p1.mydb.mycoll' },
+              { kind: 'pane', id: 'pane-2', tabIds: ['export.conn-uuid.mydb.mycoll'], activeTabId: 'export.conn-uuid.mydb.mycoll' },
+            ],
+          },
+        },
+      ],
+      tabs: ws.tabs,
+    };
+    const snapshot = toDisconnectedSnapshot(dangling);
+    expect(snapshot.tabs.map((t) => t.id)).toEqual(['profile:p1.mydb.mycoll']);
+    // pane-2 held only the dangling id, so it folds away entirely.
+    expect(snapshot.layout).toEqual({
+      root: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.mydb.mycoll'], activeTabId: 'profile:p1.mydb.mycoll' },
+      focusedPaneId: 'pane-1',
+    });
+  });
+
+  it('falls back to a fresh empty pane when there are no windows', () => {
+    const empty: PersistedWorkspace = { revision: 0, windows: [], tabs: [] };
+    const snapshot = toDisconnectedSnapshot(empty);
+    expect(snapshot.tabs).toEqual([]);
+    expect(snapshot.layout.root).toEqual({ kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null });
+  });
+});
+
+describe('rebindConnection', () => {
+  it('maps every id containing the old profile prefix to the new connection id', () => {
+    const pairs = rebindConnection('profile:p1', 'new-uuid', [
+      'profile:p1.mydb.mycoll',
+      'shell.profile:p1.mydb.x',
+      'settings',
+    ]);
+    expect(pairs).toEqual([
+      { oldId: 'profile:p1.mydb.mycoll', newId: 'new-uuid.mydb.mycoll' },
+      { oldId: 'shell.profile:p1.mydb.x', newId: 'shell.new-uuid.mydb.x' },
+    ]);
+  });
+
+  it('leaves ids without the prefix out of the result entirely', () => {
+    const pairs = rebindConnection('profile:p1', 'new-uuid', ['profile:p2.mydb.mycoll', 'tasks']);
+    expect(pairs).toEqual([]);
+  });
+});
+
+describe('actionToOp', () => {
+  // Ground truth: reuse a handful of ops from the golden parity fixture
+  // (fixtures/workspace-golden.json) that the Rust backend's WorkspaceOp
+  // deserializer was built and tested against.
+  const opsByType = new Map<string, Record<string, unknown>>();
+  for (const vector of goldenFixture.vectors) {
+    for (const op of vector.ops) {
+      if (!opsByType.has(op.type)) opsByType.set(op.type, op as Record<string, unknown>);
+    }
+  }
+
+  it('open_tab without a pane_id or tab payload', () => {
+    const expected = opsByType.get('open_tab'); // { type: 'open_tab', tab_id: 'b' }
+    const action: WorkspaceAction = { type: 'open_tab', tabId: 'b' };
+    expect(actionToOp(action)).toEqual(expected);
+  });
+
+  it('open_tab with an explicit pane_id', () => {
+    const action: WorkspaceAction = { type: 'open_tab', tabId: 'c', paneId: 'pane-2' };
+    expect(actionToOp(action)).toEqual({ type: 'open_tab', tab_id: 'c', pane_id: 'pane-2' });
+  });
+
+  it('open_tab enriched with a persisted tab payload keeps TabModel camelCase fields', () => {
+    const vector = goldenFixture.vectors.find((v) => v.name === 'open_tab_with_tab_payload_upserts_tabs_array')!;
+    const expected = vector.ops[0] as Record<string, unknown>; // { type: 'open_tab', tab_id: 'b', tab: {...camelCase...} }
+    const persisted = expected.tab as Record<string, unknown>;
+    const action: WorkspaceAction = { type: 'open_tab', tabId: expected.tab_id as string };
+    expect(actionToOp(action, persisted as any)).toEqual(expected);
+  });
+
+  it('close_tab', () => {
+    const action: WorkspaceAction = { type: 'close_tab', tabId: 'nope' };
+    expect(actionToOp(action)).toEqual({ type: 'close_tab', tab_id: 'nope' });
+  });
+
+  it('close_many', () => {
+    const expected = opsByType.get('close_many'); // { type: 'close_many', tab_ids: [...] }
+    const action: WorkspaceAction = { type: 'close_many', tabIds: expected!.tab_ids as string[] };
+    expect(actionToOp(action)).toEqual(expected);
+  });
+
+  it('move_tab with an explicit index', () => {
+    const expected = opsByType.get('move_tab'); // { type: 'move_tab', tab_id, target_pane_id, index }
+    const action: WorkspaceAction = {
+      type: 'move_tab',
+      tabId: expected!.tab_id as string,
+      targetPaneId: expected!.target_pane_id as string,
+      index: expected!.index as number,
+    };
+    expect(actionToOp(action)).toEqual(expected);
+  });
+
+  it('move_tab without an index omits the key rather than sending undefined', () => {
+    const action: WorkspaceAction = { type: 'move_tab', tabId: 'a', targetPaneId: 'nope' };
+    const op = actionToOp(action);
+    expect(op).toEqual({ type: 'move_tab', tab_id: 'a', target_pane_id: 'nope' });
+    expect('index' in op).toBe(false);
+  });
+
+  it('split_pane with a move_tab_id', () => {
+    const expected = opsByType.get('split_pane'); // { type, pane_id, dir, side, move_tab_id }
+    const action: WorkspaceAction = {
+      type: 'split_pane',
+      paneId: expected!.pane_id as string,
+      dir: expected!.dir as 'row' | 'col',
+      side: expected!.side as 'start' | 'end',
+      moveTabId: expected!.move_tab_id as string,
+    };
+    expect(actionToOp(action)).toEqual(expected);
+  });
+
+  it('split_pane without a move_tab_id', () => {
+    const action: WorkspaceAction = { type: 'split_pane', paneId: 'pane-1', dir: 'row', side: 'end' };
+    const op = actionToOp(action);
+    expect(op).toEqual({ type: 'split_pane', pane_id: 'pane-1', dir: 'row', side: 'end' });
+    expect('move_tab_id' in op).toBe(false);
+  });
+
+  it('resize_split', () => {
+    const expected = opsByType.get('resize_split'); // { type, split_id, ratio }
+    const action: WorkspaceAction = { type: 'resize_split', splitId: expected!.split_id as string, ratio: expected!.ratio as number };
+    expect(actionToOp(action)).toEqual(expected);
+  });
+
+  it('set_active', () => {
+    const expected = opsByType.get('set_active'); // { type, pane_id, tab_id }
+    const action: WorkspaceAction = { type: 'set_active', paneId: expected!.pane_id as string, tabId: expected!.tab_id as string };
+    expect(actionToOp(action)).toEqual(expected);
+  });
+
+  it('focus_pane', () => {
+    const expected = opsByType.get('focus_pane'); // { type, pane_id }
+    const action: WorkspaceAction = { type: 'focus_pane', paneId: expected!.pane_id as string };
+    expect(actionToOp(action)).toEqual(expected);
+  });
+
+  it('rename_tab', () => {
+    const expected = opsByType.get('rename_tab'); // { type, old_id, new_id }
+    const action: WorkspaceAction = { type: 'rename_tab', oldId: expected!.old_id as string, newId: expected!.new_id as string };
+    expect(actionToOp(action)).toEqual(expected);
+  });
+});

--- a/src/workspace/__tests__/persistence.test.ts
+++ b/src/workspace/__tests__/persistence.test.ts
@@ -3,12 +3,14 @@ import {
   toPersistedTab,
   toDisconnectedSnapshot,
   rebindConnection,
+  toProfileSpaceId,
   type PersistableTab,
   type PersistableConnection,
+  type PersistedTab,
   type PersistedWorkspace,
 } from '../persistence';
 import { actionToOp } from '../workspaceStore';
-import type { WorkspaceAction } from '../model';
+import { createInitialLayout, workspaceReducer, allTabIds, type WorkspaceAction, type WorkspaceLayout } from '../model';
 import goldenFixture from '../../../fixtures/workspace-golden.json';
 
 const conn: PersistableConnection = { id: 'conn-uuid', profileId: 'p1', name: 'Profile 1' };
@@ -167,6 +169,119 @@ describe('toDisconnectedSnapshot', () => {
     const snapshot = toDisconnectedSnapshot(empty);
     expect(snapshot.tabs).toEqual([]);
     expect(snapshot.layout.root).toEqual({ kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null });
+  });
+});
+
+describe('toProfileSpaceId', () => {
+  const connections: PersistableConnection[] = [
+    { id: 'live-conn-1', profileId: 'p1', name: 'Profile 1' },
+    { id: 'live-conn-2', profileId: 'p2', name: 'Profile 2' },
+  ];
+
+  it('rewrites the live connection segment to profile:<profileId>', () => {
+    expect(toProfileSpaceId('live-conn-1.mydb.mycoll', connections)).toBe('profile:p1.mydb.mycoll');
+  });
+
+  it('finds the right connection out of several (a close_many-style batch)', () => {
+    expect(toProfileSpaceId('shell.live-conn-2.mydb.x', connections)).toBe('shell.profile:p2.mydb.x');
+  });
+
+  it('passes through an id with no matching live connection unchanged', () => {
+    expect(toProfileSpaceId('live-conn-9.mydb.mycoll', connections)).toBe('live-conn-9.mydb.mycoll');
+  });
+
+  it('passes through an id already in profile: form unchanged (no live id matches it)', () => {
+    expect(toProfileSpaceId('profile:p1.mydb.mycoll', connections)).toBe('profile:p1.mydb.mycoll');
+  });
+
+  it('passes through connectionless/pane ids unchanged', () => {
+    expect(toProfileSpaceId('settings', connections)).toBe('settings');
+    expect(toProfileSpaceId('pane-1', connections)).toBe('pane-1');
+  });
+
+  it('an empty connections list is a no-op passthrough', () => {
+    expect(toProfileSpaceId('live-conn-1.mydb.mycoll', [])).toBe('live-conn-1.mydb.mycoll');
+  });
+});
+
+// CRITICAL regression coverage: before this fix, `dispatchWorkspace`'s
+// mirror sent op ids VERBATIM (live-connection space) while `toPersistedTab`
+// rewrote the nested `open_tab.tab` payload into profile-space — splitting
+// the backend's layout tree and its `tabs[]` into two id spaces that never
+// resolved to each other again. On a real restart, `toDisconnectedSnapshot`'s
+// defensive "drop layout ids absent from tabs[]" fold would silently empty
+// the restored layout; post-reconnect, further mirrors (update_tab_state,
+// close_tab, ...) would carry live ids matching no backend tab, so state
+// stopped persisting and closed tabs would resurrect on the next boot.
+describe('mirror translation round-trip (CRITICAL fix regression guard)', () => {
+  it('a translated op stream keeps the backend layout and tabs[] in the same id space, so toDisconnectedSnapshot restores a non-empty layout', () => {
+    const liveConn: PersistableConnection = { id: 'live-conn-1', profileId: 'p1', name: 'Profile 1' };
+    const connections = [liveConn];
+
+    // 1. The user opens a brand-new collection tab against the live connection.
+    const liveTabId = 'live-conn-1.mydb.mycoll';
+    const liveTab: PersistableTab = {
+      id: liveTabId,
+      type: 'collection',
+      connectionId: 'live-conn-1',
+      db: 'mydb',
+      collection: 'mycoll',
+    };
+    const persisted = toPersistedTab(liveTab, liveConn, undefined)!;
+    expect(persisted.id).toBe('profile:p1.mydb.mycoll');
+
+    // 2. dispatchWorkspace's mirror step builds the wire op — this is the
+    //    exact call site that used to leak the live id.
+    const openOp = actionToOp({ type: 'open_tab', tabId: liveTabId }, persisted, connections);
+    expect(openOp.tab_id).toBe('profile:p1.mydb.mycoll');
+    // The bug, precisely: the op's own top-level tab_id and its nested tab
+    // payload's id must be the SAME id (same tab, same id space) — before
+    // the fix, `openOp.tab_id` would have been the live id while
+    // `(openOp.tab as PersistedTab).id` was already profile-space.
+    expect(openOp.tab_id).toBe((openOp.tab as PersistedTab).id);
+
+    // 3. Apply the *translated* op to a scratch backend-shaped layout tree —
+    //    workspaceReducer is the TS port of the Rust reducer; the real
+    //    backend receives `tab_id: 'profile:p1.mydb.mycoll'` on the wire and
+    //    mutates its tree with that id, never the live one.
+    let layout: WorkspaceLayout = createInitialLayout([], null);
+    layout = workspaceReducer(layout, { type: 'open_tab', tabId: openOp.tab_id as string });
+    const backendTabs: PersistedTab[] = [persisted];
+
+    // 4. Round-trip exactly like a real restart: workspace_get -> toDisconnectedSnapshot.
+    const ws: PersistedWorkspace = {
+      revision: 1,
+      windows: [{ id: 'main', splitTree: layout.root, focusedPaneId: layout.focusedPaneId }],
+      tabs: backendTabs,
+    };
+    const snapshot = toDisconnectedSnapshot(ws);
+
+    // Before the fix this would be `[]` — the defensive fold in
+    // toDisconnectedSnapshot strips any layout id absent from tabs[], and a
+    // live id would never match the profile-space id in tabs[].
+    expect(allTabIds(snapshot.layout)).toEqual(['profile:p1.mydb.mycoll']);
+    expect(snapshot.tabs.map((t) => t.id)).toEqual(['profile:p1.mydb.mycoll']);
+  });
+
+  it('update_tab_state after a simulated reconnect rebind translates back to the SAME profile-space tab_id the store already has', () => {
+    const profileId = 'p1';
+    const oldPrefix = `profile:${profileId}`;
+    // Before reconnect: a restored, disconnected tab — already profile-space.
+    const restoredTabId = `${oldPrefix}.mydb.mycoll`;
+
+    // Reconnect mints a fresh live connection id and rebinds every restored
+    // tab id under this profile to it (App.tsx's handleReconnectProfile).
+    const newLiveConnId = 'fresh-conn-uuid';
+    const pairs = rebindConnection(oldPrefix, newLiveConnId, [restoredTabId]);
+    expect(pairs).toEqual([{ oldId: restoredTabId, newId: `${newLiveConnId}.mydb.mycoll` }]);
+    const reboundTabId = pairs[0].newId;
+
+    // Post-reconnect, a query runs against the tab under its NEW live id;
+    // the mirror choke point must translate it back before it reaches the
+    // wire — landing on the EXACT id the backend's ws.tabs already has.
+    const newConn: PersistableConnection = { id: newLiveConnId, profileId, name: 'Profile 1' };
+    const translatedBack = toProfileSpaceId(reboundTabId, [newConn]);
+    expect(translatedBack).toBe(restoredTabId);
   });
 });
 

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -3,7 +3,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
 
-import { updateTabState, resetUpdateTabStateDebounce, workspaceApply, workspaceGet } from '../workspaceStore';
+import { updateTabState, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
+import { toPersistedTab, toProfileSpaceId, type PersistableConnection } from '../persistence';
+import type { WorkspaceAction } from '../model';
 
 describe('workspaceStore', () => {
   beforeEach(() => {
@@ -97,5 +99,103 @@ describe('workspaceStore', () => {
     expect(invokeMock).toHaveBeenLastCalledWith('workspace_apply', {
       op: { type: 'update_tab_state', tab_id: 't2', last_query: { b: 2 } },
     });
+  });
+
+  it('update_tab_state after a simulated reconnect rebind lands on the ORIGINAL profile-space tab_id — CRITICAL fix, wired end-to-end', () => {
+    // Mirrors persistence.test.ts's pure version of this check, but through
+    // the actual `updateTabState` -> `invoke` path, so the assertion is on
+    // what would really cross the Tauri IPC boundary.
+    const restoredTabId = 'profile:p1.mydb.mycoll';
+    const newLiveConnId = 'fresh-conn-uuid';
+    const reboundTabId = `${newLiveConnId}.mydb.mycoll`; // what rebindConnection would have produced
+    const newConn: PersistableConnection = { id: newLiveConnId, profileId: 'p1', name: 'Profile 1' };
+
+    updateTabState(toProfileSpaceId(reboundTabId, [newConn]), { lastQuery: { filter: '{}' } });
+    vi.advanceTimersByTime(500);
+
+    expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
+      op: { type: 'update_tab_state', tab_id: restoredTabId, last_query: { filter: '{}' } },
+    });
+  });
+});
+
+// CRITICAL regression coverage (see persistence.test.ts for the pure/
+// round-trip version): `dispatchWorkspace`'s mirror choke point now passes
+// `activeConnections` into `actionToOp` so every tab-id-bearing op field
+// translates to profile-space before it reaches `workspace_apply`. This
+// block asserts, for every op type, that none of them ever carry the raw
+// live connection id — a captured-op-stream / regex sweep, exactly the kind
+// of check that would have caught the original bug (the old code passed
+// `action.tabId` etc. straight through unchanged).
+describe('actionToOp id translation (CRITICAL fix)', () => {
+  const LIVE_UUID = '5f1c9b3a-aaaa-4fff-8888-abcdefabcdef';
+  const conn: PersistableConnection = { id: LIVE_UUID, profileId: 'p1', name: 'Profile 1' };
+  const connections = [conn];
+  const liveUuidPattern = new RegExp(LIVE_UUID);
+
+  it('translates every tab-id-bearing field across every op type — no op ever contains the live connection id', () => {
+    const actions: WorkspaceAction[] = [
+      { type: 'open_tab', tabId: `${LIVE_UUID}.db.coll` },
+      { type: 'open_tab', tabId: `${LIVE_UUID}.db.coll`, paneId: 'pane-1' },
+      { type: 'close_tab', tabId: `${LIVE_UUID}.db.coll` },
+      { type: 'close_many', tabIds: [`${LIVE_UUID}.db.a`, `${LIVE_UUID}.db.b`] },
+      { type: 'move_tab', tabId: `${LIVE_UUID}.db.coll`, targetPaneId: 'pane-2' },
+      { type: 'move_tab', tabId: `${LIVE_UUID}.db.coll`, targetPaneId: 'pane-2', index: 1 },
+      { type: 'split_pane', paneId: 'pane-1', dir: 'row', side: 'end', moveTabId: `${LIVE_UUID}.db.coll` },
+      { type: 'split_pane', paneId: 'pane-1', dir: 'row', side: 'end' },
+      { type: 'resize_split', splitId: 'split-1', ratio: 0.5 },
+      { type: 'set_active', paneId: 'pane-1', tabId: `${LIVE_UUID}.db.coll` },
+      { type: 'focus_pane', paneId: 'pane-1' },
+      { type: 'rename_tab', oldId: `${LIVE_UUID}.db.old`, newId: `${LIVE_UUID}.db.new` },
+    ];
+
+    // captured-op-stream: every op the mirror would actually send, in order.
+    const capturedOps = actions.map((action) => actionToOp(action, undefined, connections));
+
+    for (const op of capturedOps) {
+      const wire = JSON.stringify(op);
+      expect(wire).not.toMatch(liveUuidPattern);
+    }
+  });
+
+  it('open_tab: the op-level tab_id and the nested tab payload id agree, both profile-space', () => {
+    const tabId = `${LIVE_UUID}.mydb.mycoll`;
+    const persisted = toPersistedTab(
+      { id: tabId, type: 'collection', connectionId: LIVE_UUID, db: 'mydb', collection: 'mycoll' },
+      conn,
+      undefined
+    )!;
+    const op = actionToOp({ type: 'open_tab', tabId }, persisted, connections);
+    expect(op.tab_id).toBe('profile:p1.mydb.mycoll');
+    expect(op.tab_id).toBe((op.tab as { id: string }).id);
+  });
+
+  it('pane/split ids are left untranslated even when they contain a live connection id', () => {
+    const paneId = `${LIVE_UUID}-pane`; // contrived, but proves pane_id is never scanned
+    const op = actionToOp({ type: 'focus_pane', paneId }, undefined, connections);
+    expect(op.pane_id).toBe(paneId);
+  });
+
+  it('close_many translates every id in the array', () => {
+    const op = actionToOp(
+      { type: 'close_many', tabIds: [`${LIVE_UUID}.db.a`, `${LIVE_UUID}.db.b`, 'settings'] },
+      undefined,
+      connections
+    );
+    expect(op.tab_ids).toEqual(['profile:p1.db.a', 'profile:p1.db.b', 'settings']);
+  });
+
+  it('rename_tab translates both old_id and new_id', () => {
+    const op = actionToOp(
+      { type: 'rename_tab', oldId: `${LIVE_UUID}.db.old`, newId: `${LIVE_UUID}.db.new` },
+      undefined,
+      connections
+    );
+    expect(op).toEqual({ type: 'rename_tab', old_id: 'profile:p1.db.old', new_id: 'profile:p1.db.new' });
+  });
+
+  it('omitting connections is a passthrough — the raw (untranslated) op shape', () => {
+    const op = actionToOp({ type: 'close_tab', tabId: `${LIVE_UUID}.db.coll` });
+    expect(op.tab_id).toBe(`${LIVE_UUID}.db.coll`);
   });
 });

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const invokeMock = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
+
+import { updateTabState, resetUpdateTabStateDebounce, workspaceApply, workspaceGet } from '../workspaceStore';
+
+describe('workspaceStore', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetUpdateTabStateDebounce();
+    vi.useRealTimers();
+  });
+
+  it('workspaceGet invokes workspace_get', async () => {
+    invokeMock.mockResolvedValueOnce(null);
+    const result = await workspaceGet();
+    expect(invokeMock).toHaveBeenCalledWith('workspace_get');
+    expect(result).toBeNull();
+  });
+
+  it('workspaceApply fire-and-forgets workspace_apply with the op wrapped', () => {
+    workspaceApply({ type: 'focus_pane', pane_id: 'pane-1' });
+    expect(invokeMock).toHaveBeenCalledWith('workspace_apply', { op: { type: 'focus_pane', pane_id: 'pane-1' } });
+  });
+
+  it('workspaceApply swallows a rejected invoke rather than throwing', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('boom'));
+    expect(() => workspaceApply({ type: 'focus_pane', pane_id: 'pane-1' })).not.toThrow();
+    // Let the rejection's microtask settle so it doesn't surface as an
+    // unhandled rejection in the test run.
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalled());
+  });
+
+  it('updateTabState sends the wire op after the debounce window elapses', () => {
+    updateTabState('t1', { lastQuery: { filter: '{}' } });
+    expect(invokeMock).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(500);
+    expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
+      op: { type: 'update_tab_state', tab_id: 't1', last_query: { filter: '{}' } },
+    });
+  });
+
+  it('omits fields never passed to updateTabState (no key at all, not undefined)', () => {
+    updateTabState('t1', { lastQuery: { filter: '{}' } });
+    vi.advanceTimersByTime(500);
+    const [, { op }] = invokeMock.mock.calls[0];
+    expect('last_aggregate' in op).toBe(false);
+    expect('builder_state' in op).toBe(false);
+  });
+
+  it('sends an explicit null (own property) for a field cleared with null — CRITICAL wire regression guard', () => {
+    // The backend's WorkspaceOp::UpdateTabState now distinguishes "absent"
+    // (untouched) from "present but null" (clear) via a double-Option — the
+    // frontend must actually serialize `null`, not drop the key, or the
+    // clear never reaches the backend.
+    updateTabState('t1', { lastQuery: { filter: '{}' }, lastAggregate: null });
+    vi.advanceTimersByTime(500);
+    const [, { op }] = invokeMock.mock.calls[0];
+    expect('last_aggregate' in op).toBe(true);
+    expect(op.last_aggregate).toBeNull();
+    // JSON.stringify keeps explicit null (only `undefined` keys are dropped),
+    // so this also verifies what actually crosses the Tauri IPC boundary.
+    expect(JSON.parse(JSON.stringify(op)).last_aggregate).toBeNull();
+  });
+
+  it('merges patches from repeated calls within the debounce window (later fields win)', () => {
+    updateTabState('t1', { builderState: { queryMode: 'find' } });
+    updateTabState('t1', { lastAggregate: null });
+    vi.advanceTimersByTime(500);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    const [, { op }] = invokeMock.mock.calls[0];
+    expect(op).toEqual({
+      type: 'update_tab_state',
+      tab_id: 't1',
+      builder_state: { queryMode: 'find' },
+      last_aggregate: null,
+    });
+  });
+
+  it('debounces independently per tab id', () => {
+    updateTabState('t1', { lastQuery: { a: 1 } });
+    vi.advanceTimersByTime(250);
+    updateTabState('t2', { lastQuery: { b: 2 } });
+    vi.advanceTimersByTime(250); // t1's window elapses; t2's has 250ms left
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
+      op: { type: 'update_tab_state', tab_id: 't1', last_query: { a: 1 } },
+    });
+    vi.advanceTimersByTime(250);
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+    expect(invokeMock).toHaveBeenLastCalledWith('workspace_apply', {
+      op: { type: 'update_tab_state', tab_id: 't2', last_query: { b: 2 } },
+    });
+  });
+});

--- a/src/workspace/model.ts
+++ b/src/workspace/model.ts
@@ -56,6 +56,38 @@ export function resetLayoutIds(): void {
   splitCounter = 0;
 }
 
+/**
+ * Snapshot the two id counters — for App.tsx's `dispatchWorkspace` no-op
+ * mirror gate (#97 phase 2 final review Fix 3, amended). That gate runs
+ * `workspaceReducer` once as a side-channel "trial" to check whether an
+ * action is a no-op, purely for identity comparison — its RETURN VALUE
+ * (including any freshly-minted pane/split id) is discarded, but
+ * `newPaneId`/`newSplitId` still mutate the module counters as a side
+ * effect of that trial call. Left unchecked, every real `split_pane`
+ * mints twice — once in the trial, once more when React actually applies
+ * the action during render — so the id that ends up committed to state is
+ * ONE GENERATION AHEAD of what a single reducer application would have
+ * produced. That mismatches the backend, which mints its own pane/split id
+ * from the mirrored op exactly once: the frontend's committed id and the
+ * backend's stored id diverge, and every later op addressing that pane/
+ * split by id (`resize_split`, `set_active`, `focus_pane`, `move_tab`)
+ * silently no-ops on the backend side forever after.
+ *
+ * `snapshotLayoutIds`/`restoreLayoutIds` bracket that trial call so it's
+ * side-effect-free: whatever the trial minted and discarded, the counters
+ * end up exactly where they'd have been if the trial had never run, and
+ * the one real, render-time reducer application is the only one that ever
+ * actually advances them — matching the backend's single mint per op.
+ */
+export function snapshotLayoutIds(): { pane: number; split: number } {
+  return { pane: paneCounter, split: splitCounter };
+}
+
+export function restoreLayoutIds(snap: { pane: number; split: number }): void {
+  paneCounter = snap.pane;
+  splitCounter = snap.split;
+}
+
 /** Test-only: seed the id counters past the max numeric suffix already present
  *  in `layout` (e.g. after loading a fixture containing `pane-7`/`split-3`),
  *  so newly minted ids never collide with ones already in the tree. Mirrors
@@ -77,11 +109,15 @@ export function seedLayoutIds(layout: WorkspaceLayout): void {
 }
 
 // newPaneId/newSplitId mutate module-level counters even though workspaceReducer is
-// otherwise a pure reducer. This is safe: generated ids are only ever referenced
-// within the same returned layout object, so React StrictMode's double-invoke of the
-// reducer just skips a number (e.g. pane-3 then pane-5) rather than colliding or
-// leaking across renders. Phase 2's backend port (workspace_apply, see the design doc
-// referenced above) will generate ids server-side and remove these counters.
+// otherwise a pure reducer. This is safe for React StrictMode's OWN double-invoke of
+// the reducer: generated ids are only ever referenced within the same returned layout
+// object, so that just skips a number (e.g. pane-3 then pane-5) rather than colliding
+// or leaking across renders. It is NOT safe for a caller that runs the reducer as a
+// side-channel trial and discards the result while React separately, later, applies
+// the same action for real — see snapshotLayoutIds/restoreLayoutIds above, which exist
+// precisely to make such a trial call side-effect-free. Phase 2's backend port
+// (workspace_apply, see the design doc referenced above) will generate ids server-side
+// and remove these counters.
 function newPaneId(): string {
   return `pane-${++paneCounter}`;
 }

--- a/src/workspace/model.ts
+++ b/src/workspace/model.ts
@@ -37,7 +37,12 @@ export type WorkspaceAction =
   | { type: 'resize_split'; splitId: string; ratio: number }
   | { type: 'set_active'; paneId: string; tabId: string }
   | { type: 'focus_pane'; paneId: string }
-  | { type: 'rename_tab'; oldId: string; newId: string };
+  | { type: 'rename_tab'; oldId: string; newId: string }
+  // Frontend-only: replaces the whole layout wholesale (Phase 2 Task 6 restore-
+  // on-boot). There is no backend `workspace_apply` op for this — App.tsx MUST
+  // dispatch it via raw `dispatchLayout`, never through the mirrored
+  // `dispatchWorkspace` choke point (see App.tsx's restore effect for why).
+  | { type: 'hydrate'; layout: WorkspaceLayout };
 
 const MIN_RATIO = 0.15;
 const MAX_RATIO = 0.85;
@@ -268,5 +273,15 @@ export function workspaceReducer(layout: WorkspaceLayout, action: WorkspaceActio
       }));
       return { ...layout, root };
     }
+
+    case 'hydrate':
+      // Seed the id counters past whatever the incoming layout already
+      // contains, same as loading a fixture — otherwise the next split_pane/
+      // open_tab after a restore could mint a `pane-1`/`split-1` that
+      // collides with an id already in the restored tree. Safe to call every
+      // time hydrate fires (including a StrictMode double-invoke): the
+      // module counters only ever move forward via Math.max.
+      seedLayoutIds(action.layout);
+      return action.layout;
   }
 }

--- a/src/workspace/model.ts
+++ b/src/workspace/model.ts
@@ -51,6 +51,26 @@ export function resetLayoutIds(): void {
   splitCounter = 0;
 }
 
+/** Test-only: seed the id counters past the max numeric suffix already present
+ *  in `layout` (e.g. after loading a fixture containing `pane-7`/`split-3`),
+ *  so newly minted ids never collide with ones already in the tree. Mirrors
+ *  the Rust store's stateless per-call tree scan (see `next_pane_id`/
+ *  `next_split_id` in workspace.rs) — TS instead seeds once, up front, since
+ *  its counters are already module-level mutable state. */
+export function seedLayoutIds(layout: WorkspaceLayout): void {
+  const visit = (node: LayoutNode): void => {
+    if (node.kind === 'pane') {
+      const m = /^pane-(\d+)$/.exec(node.id);
+      if (m) paneCounter = Math.max(paneCounter, Number(m[1]));
+      return;
+    }
+    const m = /^split-(\d+)$/.exec(node.id);
+    if (m) splitCounter = Math.max(splitCounter, Number(m[1]));
+    node.children.forEach(visit);
+  };
+  visit(layout.root);
+}
+
 // newPaneId/newSplitId mutate module-level counters even though workspaceReducer is
 // otherwise a pure reducer. This is safe: generated ids are only ever referenced
 // within the same returned layout object, so React StrictMode's double-invoke of the

--- a/src/workspace/persistence.ts
+++ b/src/workspace/persistence.ts
@@ -1,0 +1,218 @@
+// Pure helpers that translate between the live App.tsx tab/layout state and
+// the persisted (backend) workspace document shape. No `invoke` calls here —
+// see workspaceStore.ts for the IO side. Keeping this pure makes it trivial
+// to unit test the profile-prefix id substitution and snapshot shaping
+// without mocking Tauri or React.
+
+import {
+  workspaceReducer,
+  allTabIds,
+  type LayoutNode,
+  type WorkspaceLayout,
+} from './model';
+
+// Mirrors src-tauri's `TabModel` wire shape (camelCase field names — see
+// workspace.rs). `type` covers all 16 QueryTab kinds from App.tsx.
+export type QueryTabType =
+  | 'collection'
+  | 'index'
+  | 'shell'
+  | 'settings'
+  | 'quickstart'
+  | 'export'
+  | 'import'
+  | 'tasks'
+  | 'schema'
+  | 'create-view'
+  | 'gridfs'
+  | 'monitoring'
+  | 'users'
+  | 'dump'
+  | 'restore'
+  | 'validation';
+
+export interface PersistedTab {
+  id: string;
+  type: QueryTabType;
+  profileId: string;
+  profileName: string;
+  db: string;
+  collection: string;
+  indexName?: string;
+  lastQuery?: unknown;
+  lastAggregate?: unknown;
+  builderState?: unknown;
+}
+
+export interface PersistedWindow {
+  id: string;
+  splitTree: LayoutNode;
+  focusedPaneId: string;
+}
+
+export interface PersistedWorkspace {
+  revision: number;
+  windows: PersistedWindow[];
+  tabs: PersistedTab[];
+}
+
+// Structural subsets of App.tsx's private `QueryTab`/`ActiveConnection` types
+// — keeping persistence.ts free of an import from App.tsx (which itself
+// imports this module). Any object satisfying these shapes (App's real
+// QueryTab/ActiveConnection included) can be passed in directly.
+export interface PersistableTab {
+  id: string;
+  type: QueryTabType;
+  connectionId: string;
+  db: string;
+  collection: string;
+  indexName?: string;
+  lastQuery?: unknown;
+  lastAggregate?: unknown;
+}
+
+export interface PersistableConnection {
+  id: string;
+  profileId: string;
+  name: string;
+}
+
+// The shape App.tsx's `tabs` state needs after a restore — a structural
+// subset of App's `QueryTab` (extra optional QueryTab fields are simply
+// absent, which is fine for assignment into `QueryTab[]`).
+export interface RestoredTab {
+  id: string;
+  type: QueryTabType;
+  connectionId: string;
+  db: string;
+  collection: string;
+  indexName?: string;
+  results: unknown[];
+  loading: boolean;
+  error: string | null;
+  explainResult: string | null;
+  lastQuery?: unknown;
+  lastAggregate?: unknown;
+}
+
+// export/import tabs reference in-flight task state that no longer exists
+// after a restart — they must never be persisted.
+const NON_PERSISTED_TYPES = new Set<QueryTabType>(['export', 'import']);
+// These tab kinds carry no connection at all; pass their id through as-is.
+const CONNECTIONLESS_TYPES = new Set<QueryTabType>(['settings', 'quickstart', 'tasks']);
+
+/**
+ * Build the persisted (wire) form of a live tab, or `null` if this tab kind
+ * never survives a restart (export/import). Connection-scoped tab ids are
+ * rewritten at save time: the live id's leading `<connectionId>` segment
+ * (a session-scoped id from `connect_db`) is replaced by the stable
+ * `profile:<profileId>` prefix, so a saved tab id never depends on a live
+ * connection session that won't exist after restart.
+ */
+export function toPersistedTab(
+  tab: PersistableTab,
+  conn: PersistableConnection | undefined,
+  builderState: unknown
+): PersistedTab | null {
+  if (NON_PERSISTED_TYPES.has(tab.type)) return null;
+
+  if (CONNECTIONLESS_TYPES.has(tab.type)) {
+    return {
+      id: tab.id,
+      type: tab.type,
+      profileId: '',
+      profileName: '',
+      db: tab.db,
+      collection: tab.collection,
+      indexName: tab.indexName,
+      lastQuery: tab.lastQuery,
+      lastAggregate: tab.lastAggregate,
+      builderState,
+    };
+  }
+
+  const profileId = conn?.profileId ?? '';
+  const profileName = conn?.name ?? '';
+  const id = conn ? tab.id.replace(conn.id, `profile:${profileId}`) : tab.id;
+  return {
+    id,
+    type: tab.type,
+    profileId,
+    profileName,
+    db: tab.db,
+    collection: tab.collection,
+    indexName: tab.indexName,
+    lastQuery: tab.lastQuery,
+    lastAggregate: tab.lastAggregate,
+    builderState,
+  };
+}
+
+/**
+ * Rehydrate a persisted workspace document into the shape App.tsx needs
+ * before any profile has reconnected: empty-results tabs (so the UI shows a
+ * "reconnect to load" state rather than stale data), plus the layout tree
+ * and any cached builder states. Tab ids are used exactly as stored —
+ * `toPersistedTab` already rewrote them into `profile:<profileId>` form at
+ * save time, so no further id surgery happens here.
+ */
+export function toDisconnectedSnapshot(ws: PersistedWorkspace): {
+  tabs: RestoredTab[];
+  layout: WorkspaceLayout;
+  builderStates: Map<string, unknown>;
+} {
+  const tabs: RestoredTab[] = ws.tabs.map((t) => ({
+    id: t.id,
+    type: t.type,
+    connectionId: t.profileId ? `profile:${t.profileId}` : '',
+    db: t.db,
+    collection: t.collection,
+    indexName: t.indexName,
+    results: [],
+    loading: false,
+    error: null,
+    explainResult: null,
+    lastQuery: t.lastQuery,
+    lastAggregate: t.lastAggregate,
+  }));
+
+  const builderStates = new Map<string, unknown>();
+  for (const t of ws.tabs) {
+    if (t.builderState != null) builderStates.set(t.id, t.builderState);
+  }
+
+  const win = ws.windows[0];
+  let layout: WorkspaceLayout = win
+    ? { root: win.splitTree, focusedPaneId: win.focusedPaneId }
+    : { root: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null }, focusedPaneId: 'pane-1' };
+
+  // Defensive: fold out any layout tab id with no matching persisted tab
+  // (e.g. legacy/corrupt workspace.json) using the same reducer close_tab
+  // uses live, so pane folding/focus-repair stays consistent with a normal
+  // tab close rather than a naive tabIds filter.
+  const knownIds = new Set(ws.tabs.map((t) => t.id));
+  for (const tabId of allTabIds(layout)) {
+    if (!knownIds.has(tabId)) {
+      layout = workspaceReducer(layout, { type: 'close_tab', tabId });
+    }
+  }
+
+  return { tabs, layout, builderStates };
+}
+
+/**
+ * Map every id in `tabIds` that contains `oldPrefix` (a `profile:<id>`
+ * connection prefix) to its rebound form under `newConnectionId` — the pairs
+ * the App applies exactly like `handleDatabaseRenamed`: a `tabs` rewrite plus
+ * one `rename_tab` dispatch per pair. Ids without the prefix are left out of
+ * the result entirely (nothing to rebind).
+ */
+export function rebindConnection(
+  oldPrefix: string,
+  newConnectionId: string,
+  tabIds: string[]
+): Array<{ oldId: string; newId: string }> {
+  return tabIds
+    .filter((id) => id.includes(oldPrefix))
+    .map((oldId) => ({ oldId, newId: oldId.replace(oldPrefix, newConnectionId) }));
+}

--- a/src/workspace/persistence.ts
+++ b/src/workspace/persistence.ts
@@ -3,6 +3,26 @@
 // see workspaceStore.ts for the IO side. Keeping this pure makes it trivial
 // to unit test the profile-prefix id substitution and snapshot shaping
 // without mocking Tauri or React.
+//
+// Global Constraint: the backend workspace store (ws.tabs + every window's
+// splitTree) must live ENTIRELY in `profile:<profileId>` id space, never in
+// live `connectionId` space. Live connection ids are minted per `connect_db`
+// call and are worthless after a restart; `profile:<profileId>` ids are
+// stable across reconnects and restarts. Two things follow:
+//  1. `toPersistedTab` rewrites a tab's id at save time (this file).
+//  2. Every OTHER id-bearing field that reaches `workspace_apply` — not just
+//     `open_tab`'s nested tab payload, but every op's own top-level tab-id
+//     field(s) (`tab_id`, `tab_ids[]`, `old_id`/`new_id`, `move_tab_id`,
+//     etc.) — must be translated too, at the single mirror choke point
+//     (`dispatchWorkspace` in App.tsx, via `actionToOp`'s `connections`
+//     param in workspaceStore.ts). Missing (2) is exactly the bug this
+//     comment exists to prevent recurring: a live id can slip into the
+//     backend's layout tree while `ws.tabs` holds the profile-space id for
+//     the same tab, splitting the tree and the tab list into two id spaces
+//     that never resolve to each other again.
+// Pane/split ids are NOT part of this constraint — both the TS and Rust
+// reducers mint them deterministically from the same op stream, so they're
+// already identical across the two sides without any translation.
 
 import {
   workspaceReducer,
@@ -102,6 +122,24 @@ const NON_PERSISTED_TYPES = new Set<QueryTabType>(['export', 'import']);
 const CONNECTIONLESS_TYPES = new Set<QueryTabType>(['settings', 'quickstart', 'tasks']);
 
 /**
+ * Rewrite `id`'s live `<connectionId>` segment (if any) to
+ * `profile:<profileId>`, by scanning `connections` for one whose `id`
+ * appears in `id` as a substring — the same substitution `toPersistedTab`
+ * needs for a single already-known tab, generalized to scan a whole list so
+ * the App-level mirror choke point can translate ANY id-bearing op field
+ * (which may reference any of several live connections, e.g. a `close_many`
+ * batch) without knowing in advance which connection it belongs to. Ids with
+ * no matching live-connection segment pass through unchanged — this
+ * correctly no-ops for ids already in `profile:` form (nothing in
+ * `connections` has a live id that looks like `profile:...`) and for
+ * connectionless ids (`settings`/`quickstart`/`tasks`, or a pane/split id).
+ */
+export function toProfileSpaceId(id: string, connections: PersistableConnection[]): string {
+  const conn = connections.find((c) => id.includes(c.id));
+  return conn ? id.replace(conn.id, `profile:${conn.profileId}`) : id;
+}
+
+/**
  * Build the persisted (wire) form of a live tab, or `null` if this tab kind
  * never survives a restart (export/import). Connection-scoped tab ids are
  * rewritten at save time: the live id's leading `<connectionId>` segment
@@ -133,7 +171,7 @@ export function toPersistedTab(
 
   const profileId = conn?.profileId ?? '';
   const profileName = conn?.name ?? '';
-  const id = conn ? tab.id.replace(conn.id, `profile:${profileId}`) : tab.id;
+  const id = conn ? toProfileSpaceId(tab.id, [conn]) : tab.id;
   return {
     id,
     type: tab.type,

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -6,7 +6,7 @@
 
 import { invoke } from '@tauri-apps/api/core';
 import type { WorkspaceAction } from './model';
-import type { PersistedTab, PersistedWorkspace } from './persistence';
+import { toProfileSpaceId, type PersistableConnection, type PersistedTab, type PersistedWorkspace } from './persistence';
 
 /** `GET workspace.json` (backend-cached after first call). */
 export async function workspaceGet(): Promise<PersistedWorkspace | null> {
@@ -31,27 +31,41 @@ export function workspaceApply(op: Record<string, unknown>): void {
  * only meaningful for `open_tab` — pass the already-persisted form (or
  * `null`/omit to move/focus an existing backend tab without touching its
  * stored model).
+ *
+ * `connections`, when supplied, translates every TAB-id-bearing field
+ * (`tab_id`, `tab_ids[]`, `old_id`/`new_id`, `move_tab_id`) from the live
+ * `<connectionId>` space the frontend action was built in into the
+ * `profile:<profileId>` space the backend store must stay in — see
+ * persistence.ts's "Global Constraint" note. PANE/split ids (`pane_id`,
+ * `target_pane_id`, `split_id`) are deliberately left untouched: both the TS
+ * and Rust reducers mint those deterministically from the same op stream, so
+ * they already agree without translation. Omitting `connections` (or passing
+ * an empty list) is a no-op passthrough — used by tests that want the raw,
+ * untranslated op shape.
  */
 export function actionToOp(
   action: WorkspaceAction,
-  tab?: PersistedTab | null
+  tab?: PersistedTab | null,
+  connections: PersistableConnection[] = []
 ): Record<string, unknown> {
+  const id = (raw: string): string => toProfileSpaceId(raw, connections);
+
   switch (action.type) {
     case 'open_tab': {
-      const op: Record<string, unknown> = { type: 'open_tab', tab_id: action.tabId };
+      const op: Record<string, unknown> = { type: 'open_tab', tab_id: id(action.tabId) };
       if (action.paneId !== undefined) op.pane_id = action.paneId;
       if (tab) op.tab = tab;
       return op;
     }
     case 'close_tab':
-      return { type: 'close_tab', tab_id: action.tabId };
+      return { type: 'close_tab', tab_id: id(action.tabId) };
     case 'close_many':
-      return { type: 'close_many', tab_ids: action.tabIds };
+      return { type: 'close_many', tab_ids: action.tabIds.map(id) };
     case 'move_tab': {
       const op: Record<string, unknown> = {
         type: 'move_tab',
-        tab_id: action.tabId,
-        target_pane_id: action.targetPaneId,
+        tab_id: id(action.tabId),
+        target_pane_id: action.targetPaneId, // pane id — not translated
       };
       if (action.index !== undefined) op.index = action.index;
       return op;
@@ -59,21 +73,24 @@ export function actionToOp(
     case 'split_pane': {
       const op: Record<string, unknown> = {
         type: 'split_pane',
-        pane_id: action.paneId,
+        pane_id: action.paneId, // pane id — not translated
         dir: action.dir,
         side: action.side,
       };
-      if (action.moveTabId !== undefined) op.move_tab_id = action.moveTabId;
+      // moveTabId is a TAB id (the tab being carried into the new pane) —
+      // same translation requirement as move_tab.tabId, even though it
+      // isn't itself a top-level op field.
+      if (action.moveTabId !== undefined) op.move_tab_id = id(action.moveTabId);
       return op;
     }
     case 'resize_split':
-      return { type: 'resize_split', split_id: action.splitId, ratio: action.ratio };
+      return { type: 'resize_split', split_id: action.splitId, ratio: action.ratio }; // split id — not translated
     case 'set_active':
-      return { type: 'set_active', pane_id: action.paneId, tab_id: action.tabId };
+      return { type: 'set_active', pane_id: action.paneId, tab_id: id(action.tabId) }; // pane_id not translated
     case 'focus_pane':
-      return { type: 'focus_pane', pane_id: action.paneId };
+      return { type: 'focus_pane', pane_id: action.paneId }; // pane id — not translated
     case 'rename_tab':
-      return { type: 'rename_tab', old_id: action.oldId, new_id: action.newId };
+      return { type: 'rename_tab', old_id: id(action.oldId), new_id: id(action.newId) };
     case 'hydrate':
       // Frontend-only (Phase 2 Task 6 restore-on-boot) — App.tsx dispatches
       // it via raw `dispatchLayout`, never through the mirrored

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -1,0 +1,128 @@
+// Thin invoke wrappers for the backend workspace store (see
+// src-tauri/src/workspace.rs) — mirrors the queryStore.ts idiom: async
+// wrappers for reads, fire-and-forget for writes the caller doesn't need to
+// await. Pure translation logic (id substitution, snapshot shaping) lives in
+// persistence.ts; this module is the only one that touches `invoke`.
+
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceAction } from './model';
+import type { PersistedTab, PersistedWorkspace } from './persistence';
+
+/** `GET workspace.json` (backend-cached after first call). */
+export async function workspaceGet(): Promise<PersistedWorkspace | null> {
+  return invoke<PersistedWorkspace | null>('workspace_get');
+}
+
+/**
+ * Fire-and-forget apply of one op to the backend store. Never throws — the
+ * mirror must never block or fail the UI action it shadows; failures are
+ * logged and dropped.
+ */
+export function workspaceApply(op: Record<string, unknown>): void {
+  invoke('workspace_apply', { op }).catch((err) => {
+    console.warn('workspace_apply failed', err);
+  });
+}
+
+/**
+ * Translate one frontend `WorkspaceAction` (camelCase keys) into the wire-
+ * shaped op `workspace_apply` expects (snake_case keys; a nested `tab`
+ * payload, when present, keeps TabModel's camelCase fields as-is). `tab` is
+ * only meaningful for `open_tab` — pass the already-persisted form (or
+ * `null`/omit to move/focus an existing backend tab without touching its
+ * stored model).
+ */
+export function actionToOp(
+  action: WorkspaceAction,
+  tab?: PersistedTab | null
+): Record<string, unknown> {
+  switch (action.type) {
+    case 'open_tab': {
+      const op: Record<string, unknown> = { type: 'open_tab', tab_id: action.tabId };
+      if (action.paneId !== undefined) op.pane_id = action.paneId;
+      if (tab) op.tab = tab;
+      return op;
+    }
+    case 'close_tab':
+      return { type: 'close_tab', tab_id: action.tabId };
+    case 'close_many':
+      return { type: 'close_many', tab_ids: action.tabIds };
+    case 'move_tab': {
+      const op: Record<string, unknown> = {
+        type: 'move_tab',
+        tab_id: action.tabId,
+        target_pane_id: action.targetPaneId,
+      };
+      if (action.index !== undefined) op.index = action.index;
+      return op;
+    }
+    case 'split_pane': {
+      const op: Record<string, unknown> = {
+        type: 'split_pane',
+        pane_id: action.paneId,
+        dir: action.dir,
+        side: action.side,
+      };
+      if (action.moveTabId !== undefined) op.move_tab_id = action.moveTabId;
+      return op;
+    }
+    case 'resize_split':
+      return { type: 'resize_split', split_id: action.splitId, ratio: action.ratio };
+    case 'set_active':
+      return { type: 'set_active', pane_id: action.paneId, tab_id: action.tabId };
+    case 'focus_pane':
+      return { type: 'focus_pane', pane_id: action.paneId };
+    case 'rename_tab':
+      return { type: 'rename_tab', old_id: action.oldId, new_id: action.newId };
+  }
+}
+
+export interface UpdateTabStatePatch {
+  lastQuery?: unknown;
+  lastAggregate?: unknown;
+  builderState?: unknown;
+}
+
+const DEBOUNCE_MS = 500;
+const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const pendingPatches = new Map<string, UpdateTabStatePatch>();
+
+function flushUpdateTabState(tabId: string): void {
+  debounceTimers.delete(tabId);
+  const patch = pendingPatches.get(tabId);
+  pendingPatches.delete(tabId);
+  if (!patch) return;
+
+  const op: Record<string, unknown> = { type: 'update_tab_state', tab_id: tabId };
+  if ('lastQuery' in patch) op.last_query = patch.lastQuery;
+  if ('lastAggregate' in patch) op.last_aggregate = patch.lastAggregate;
+  if ('builderState' in patch) op.builder_state = patch.builderState;
+  workspaceApply(op);
+}
+
+/**
+ * Queue an `update_tab_state` mirror for `tabId`, debounced 500ms per tab.
+ * Repeated calls for the same tab within the window merge their patches
+ * (later fields win) and reset the timer, so a burst of keystrokes/builder
+ * edits collapses into a single backend write. Pass `null` (not omit) for a
+ * field to explicitly clear it server-side — omitting a key leaves the
+ * backend's current value untouched.
+ */
+export function updateTabState(tabId: string, patch: UpdateTabStatePatch): void {
+  const merged = { ...(pendingPatches.get(tabId) ?? {}), ...patch };
+  pendingPatches.set(tabId, merged);
+
+  const existing = debounceTimers.get(tabId);
+  if (existing !== undefined) clearTimeout(existing);
+  debounceTimers.set(
+    tabId,
+    setTimeout(() => flushUpdateTabState(tabId), DEBOUNCE_MS)
+  );
+}
+
+/** Test-only: flush and clear all pending debounced updateTabState timers. */
+export function resetUpdateTabStateDebounce(): void {
+  for (const timer of debounceTimers.values()) clearTimeout(timer);
+  debounceTimers.clear();
+  pendingPatches.clear();
+}

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -74,6 +74,11 @@ export function actionToOp(
       return { type: 'focus_pane', pane_id: action.paneId };
     case 'rename_tab':
       return { type: 'rename_tab', old_id: action.oldId, new_id: action.newId };
+    case 'hydrate':
+      // Frontend-only (Phase 2 Task 6 restore-on-boot) — App.tsx dispatches
+      // it via raw `dispatchLayout`, never through the mirrored
+      // `dispatchWorkspace` path, so this must never actually be reached.
+      throw new Error('hydrate is frontend-only and must never be mirrored to workspace_apply');
   }
 }
 


### PR DESCRIPTION
## Summary
Phase 2 of the multi-panel workspace (#97): the workspace survives restarts.

- **Rust-owned workspace store** (`src-tauri/src/workspace.rs`): a 1:1 port of the frontend layout reducer, persisted to `workspace.json` (app config dir) with debounced single-flight atomic writes. Parity between the two reducers is locked by **22 golden vectors executed by both vitest and cargo** — either reducer changing alone fails a test.
- **Profile-keyed persistence**: session connection ids are ephemeral UUIDs, so the store lives entirely in `profile:<id>` space; every mirrored op id is translated at the single dispatch choke point.
- **Restore on boot**: layout + tabs + per-tab query/editor state come back exactly; tabs wake **disconnected** with a per-connection Reconnect banner — one click revives every tab of that connection (never auto-connects). Reconnecting reuses an already-live connection for the profile, and connecting normally via sidebar/manager also clears banners.
- Malformed/corrupt `workspace.json` (including valid-JSON-broken-shape) degrades to a clean fresh boot; export/import tabs deliberately don't persist.

## Review trail
Subagent-driven with per-task adversarial reviews + two whole-branch review rounds. Notable catches fixed en route: serde double-`Option` null-clear semantics; a live-vs-profile id-space split that would have emptied every real restore; reconnect-while-connected duplicating backend connections; the no-op mirror gate's trial run advancing id counters (caught by the reviewer in its own recommended remedy, fixed with counter snapshot/restore + a RED-verified DOM parity test).

## Verification
vitest **882/882** (with coverage), cargo **303/303**, clippy at baseline, `tsc --noEmit` clean, production build clean. Realistic profile-space session stream round-trips through disk (Rust integration test).

**Outstanding (user environment)**: GUI checklist — quit with splits across two profiles → relaunch → layout + banners restore; reconnect one profile revives only its tabs; hand-corrupt `workspace.json` → clean quickstart boot.

## Follow-ups (non-blocking)
**#197 (P0 before Phase 3)**: StrictMode dev-build pane-id skew. Also: debounce max-latency flush; per-tick resize mirrors; users-tab db-rescope re-mirror; `toProfileSpaceId` substring-match note; Phase-3 `windows[1..]` tabs restore as invisible orphans; two pre-existing mongotools parallel-thread cargo flakes.

Squash-merge recommended (single `feat:` line for release notes).