### PR TITLE
feat: detachable windows — multi-window workspace phase 3 (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ queries actually do — from a single cross-platform desktop app.
   derivation).
 - **Split panes** — drag a tab to any pane edge to split the workspace; compare
   collections side by side, keep a shell under your results.
+- **Detachable windows** — pop a tab out into its own window and spread your
+  workspace across monitors.
 - **Session restore** — your splits and tabs come back after a restart;
   reconnect per connection with one click.
 

--- a/fixtures/workspace-golden.json
+++ b/fixtures/workspace-golden.json
@@ -307,6 +307,102 @@
         { "id": "t1", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
           "db": "mydb", "collection": "mycoll",
           "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] }
+    },
+    {
+      "name": "move_tab_to_window_moves_and_activates_in_target",
+      "tsSkip": true,
+      "_comment": "multi-window: backend-authoritative (Task 4 wires the frontend to apply these via events, not this reducer)",
+      "initial": { "revision": 0, "windows": [
+        { "id": "main", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a", "b"], "activeTabId": "a" } },
+        { "id": "win-1", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["c"], "activeTabId": "c" } }
+      ], "tabs": [] },
+      "ops": [
+        { "type": "move_tab_to_window", "tab_id": "b", "target_window_id": "win-1" }
+      ],
+      "expected": { "revision": 1, "windows": [
+        { "id": "main", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } },
+        { "id": "win-1", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["c", "b"], "activeTabId": "b" } }
+      ], "tabs": [] }
+    },
+    {
+      "name": "detach_tab_creates_new_window_and_folds_source",
+      "tsSkip": true,
+      "_comment": "multi-window: backend-authoritative (Task 4 wires the frontend to apply these via events, not this reducer)",
+      "initial": { "revision": 0, "windows": [ { "id": "main", "focusedPaneId": "pane-2",
+        "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+          { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" },
+          { "kind": "pane", "id": "pane-2", "tabIds": ["b"], "activeTabId": "b" } ] } } ], "tabs": [] },
+      "ops": [
+        { "type": "detach_tab", "tab_id": "b" }
+      ],
+      "expected": { "revision": 1, "windows": [
+        { "id": "main", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } },
+        { "id": "win-1", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["b"], "activeTabId": "b" } }
+      ], "tabs": [] }
+    },
+    {
+      "name": "window_closed_removes_window_and_its_tabs",
+      "tsSkip": true,
+      "_comment": "multi-window: backend-authoritative (Task 4 wires the frontend to apply these via events, not this reducer)",
+      "initial": { "revision": 0, "windows": [
+        { "id": "main", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } },
+        { "id": "win-1", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["b", "c"], "activeTabId": "b" } }
+      ], "tabs": [
+        { "id": "a", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null },
+        { "id": "b", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null },
+        { "id": "c", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] },
+      "ops": [
+        { "type": "window_closed", "window_id": "win-1" }
+      ],
+      "expected": { "revision": 1, "windows": [
+        { "id": "main", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "pane", "id": "pane-1", "tabIds": ["a"], "activeTabId": "a" } }
+      ], "tabs": [
+        { "id": "a", "type": "documents", "profileId": "p1", "profileName": "Profile 1",
+          "db": "mydb", "collection": "mycoll",
+          "indexName": null, "lastQuery": null, "lastAggregate": null, "builderState": null } ] }
+    },
+    {
+      "name": "window_id_targeting_is_window_local",
+      "tsSkip": true,
+      "_comment": "multi-window: proves op.window_id resolution never cross-talks into another window's same-named pane-2 (backend-authoritative, see Task 4)",
+      "initial": { "revision": 0, "windows": [
+        { "id": "main", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+            { "kind": "pane", "id": "pane-1", "tabIds": ["m1"], "activeTabId": "m1" },
+            { "kind": "pane", "id": "pane-2", "tabIds": ["m2", "m3"], "activeTabId": "m2" } ] } },
+        { "id": "win-1", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+            { "kind": "pane", "id": "pane-1", "tabIds": ["x1"], "activeTabId": "x1" },
+            { "kind": "pane", "id": "pane-2", "tabIds": ["x2", "x3"], "activeTabId": "x2" } ] } }
+      ], "tabs": [] },
+      "ops": [
+        { "type": "set_active", "window_id": "win-1", "pane_id": "pane-2", "tab_id": "x3" }
+      ],
+      "expected": { "revision": 1, "windows": [
+        { "id": "main", "focusedPaneId": "pane-1",
+          "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+            { "kind": "pane", "id": "pane-1", "tabIds": ["m1"], "activeTabId": "m1" },
+            { "kind": "pane", "id": "pane-2", "tabIds": ["m2", "m3"], "activeTabId": "m2" } ] } },
+        { "id": "win-1", "focusedPaneId": "pane-2",
+          "splitTree": { "kind": "split", "id": "split-1", "dir": "row", "ratio": 0.5, "children": [
+            { "kind": "pane", "id": "pane-1", "tabIds": ["x1"], "activeTabId": "x1" },
+            { "kind": "pane", "id": "pane-2", "tabIds": ["x2", "x3"], "activeTabId": "x3" } ] } }
+      ], "tabs": [] }
     }
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub mod toolsetup;
 pub mod updater;
 mod vault;
 mod window;
+mod windows;
 mod workspace;
 pub mod biometric;
 pub use db::aggregate::{execute_aggregate_impl, explain_aggregate_query_impl};
@@ -2018,6 +2019,10 @@ pub fn run() {
             queries::list_all_saved_queries,
             workspace::workspace_get,
             workspace::workspace_apply,
+            windows::workspace_detach_tab,
+            windows::spawn_saved_windows,
+            windows::focus_window,
+            windows::close_workspace_window,
             server_status,
             current_ops,
             repl_set_status,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -954,6 +954,18 @@ async fn disconnect_db(
     Ok(())
 }
 
+/// `connection_list` command: thin wrapper over `connection_list_impl`
+/// (final whole-branch review, Fix 2). Unlike `disconnect_db`/
+/// `set_connection_meta`, this never broadcasts — it's a plain read, called
+/// once by App.tsx's boot effect (after `workspace_get` resolves) so a
+/// freshly spawned window sees every connection already live in the session
+/// immediately, instead of rendering a `ReconnectBanner` for a
+/// restored-but-actually-live profile and inviting a duplicate `connect_db`.
+#[tauri::command]
+async fn connection_list(state: tauri::State<'_, AppState>) -> Result<Vec<ConnectionEntry>, String> {
+    connection_list_impl(&state)
+}
+
 #[tauri::command]
 async fn set_connection_meta(
     app_handle: tauri::AppHandle,
@@ -1927,6 +1939,12 @@ pub fn run() {
                     }
                 }
             }
+            // Final whole-branch review, Fix 1 (CRITICAL): closing "main"
+            // must quit the app even with a secondary `win-*` window open —
+            // see `windows::wire_main_window_exit`'s doc comment for why the
+            // runtime's default `ExitRequested`-on-last-window-close
+            // behavior is no longer sufficient once multi-window exists.
+            windows::wire_main_window_exit(app.handle());
             Ok(())
         })
         .manage(AppState::new())
@@ -1950,6 +1968,7 @@ pub fn run() {
             stop_mongosh_session,
             disconnect_db,
             set_connection_meta,
+            connection_list,
             list_databases,
             list_collections,
             list_indexes,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,7 +63,7 @@ pub use db::users::{
 pub use db::version::get_mongodb_version_impl;
 pub use db::copy::{preflight_copy_impl, start_collection_copy_impl, start_database_copy_impl, CopyTargetRef};
 pub use biometric::{decode_and_verify_key, encode_key, BiometricStatus};
-pub use state::{AppState, LockExt};
+pub use state::{AppState, ConnectionEntry, ConnectionMeta, ConnectionsChangedPayload, LockExt};
 pub use window::target_window_size;
 #[cfg(test)]
 mod tests;
@@ -531,8 +531,43 @@ pub async fn disconnect_db_impl(state: &AppState, id: &str) -> Result<(), String
             tunnel.close();
         }
     }
+    {
+        let mut meta = state.connection_meta.lock_safe()?;
+        meta.remove(id);
+    }
 
     Ok(())
+}
+
+/// Insert/replace `id`'s connection metadata (the profile it came from plus
+/// a display name) — called by the frontend once a connection succeeds.
+/// `AppHandle`-free like `connect_db_impl`/`disconnect_db_impl`: the
+/// `connections-changed` broadcast is the `set_connection_meta` command
+/// wrapper's job, mirroring `workspace::apply_impl`/`workspace_apply`'s
+/// pure-mutation/emit split.
+pub fn set_connection_meta_impl(
+    state: &AppState,
+    id: &str,
+    profile_id: &str,
+    name: &str,
+) -> Result<(), String> {
+    let mut meta = state.connection_meta.lock_safe()?;
+    meta.insert(id.to_string(), ConnectionMeta { profile_id: profile_id.to_string(), name: name.to_string() });
+    Ok(())
+}
+
+/// The full current connection list for a `connections-changed` broadcast,
+/// sorted by connection id — a `HashMap`'s iteration order is otherwise
+/// unspecified, which would make every emitted payload's element order
+/// nondeterministic between calls.
+pub fn connection_list_impl(state: &AppState) -> Result<Vec<ConnectionEntry>, String> {
+    let meta = state.connection_meta.lock_safe()?;
+    let mut list: Vec<ConnectionEntry> = meta
+        .iter()
+        .map(|(id, m)| ConnectionEntry { id: id.clone(), profile_id: m.profile_id.clone(), name: m.name.clone() })
+        .collect();
+    list.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(list)
 }
 
 pub async fn start_mongosh_session_impl(
@@ -903,8 +938,37 @@ async fn stop_mongosh_session(
 }
 
 #[tauri::command]
-async fn disconnect_db(state: tauri::State<'_, AppState>, id: String) -> Result<(), String> {
-    disconnect_db_impl(&state, &id).await
+async fn disconnect_db(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    id: String,
+) -> Result<(), String> {
+    use tauri::Emitter;
+    disconnect_db_impl(&state, &id).await?;
+    let connections = connection_list_impl(&state)?;
+    // Broadcast is best-effort: a window that misses this event picks up
+    // current connection metadata the next time it connects or calls
+    // `set_connection_meta` itself.
+    let _ = app_handle.emit("connections-changed", ConnectionsChangedPayload { connections });
+    Ok(())
+}
+
+#[tauri::command]
+async fn set_connection_meta(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    id: String,
+    profile_id: String,
+    name: String,
+) -> Result<(), String> {
+    use tauri::Emitter;
+    set_connection_meta_impl(&state, &id, &profile_id, &name)?;
+    let connections = connection_list_impl(&state)?;
+    // Broadcast is best-effort: a window that misses this event picks up
+    // current connection metadata the next time it connects or calls
+    // `set_connection_meta` itself.
+    let _ = app_handle.emit("connections-changed", ConnectionsChangedPayload { connections });
+    Ok(())
 }
 
 #[tauri::command]
@@ -1884,6 +1948,7 @@ pub fn run() {
             run_mongosh_command,
             stop_mongosh_session,
             disconnect_db,
+            set_connection_meta,
             list_databases,
             list_collections,
             list_indexes,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2,10 +2,45 @@
 
 use crate::{ssh_tunnel, workspace, IndexInfo, MongoshSession, TaskInfo};
 use mongodb::Client;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+
+/// Metadata kept per live connection id for the `connections-changed`
+/// broadcast (Phase 3 Task 3) — enough for another window to label a
+/// connection in its own UI (profile it came from, display name).
+/// Deliberately excludes the connection URI: event payloads go out via
+/// `app_handle.emit`, and a connection string must never ride on that.
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionMeta {
+    pub profile_id: String,
+    pub name: String,
+}
+
+/// One entry of the `connections-changed` payload's `connections` list —
+/// `ConnectionMeta` plus the id it's keyed by in `AppState.connection_meta`
+/// (the id itself isn't part of `ConnectionMeta` since it's the map key,
+/// but listeners need it to tell entries apart).
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionEntry {
+    pub id: String,
+    pub profile_id: String,
+    pub name: String,
+}
+
+/// The `connections-changed` broadcast payload: the full current connection
+/// list (not a diff) — simplest for a listener to reconcile against, and
+/// matches `workspace-changed` carrying the full `Workspace` rather than a
+/// delta.
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionsChangedPayload {
+    pub connections: Vec<ConnectionEntry>,
+}
 
 /// Lock a std mutex, mapping a poisoned lock to an error instead of panicking.
 pub trait LockExt<T> {
@@ -47,6 +82,12 @@ pub struct AppState {
     /// spawned save only writes if its captured generation is still current,
     /// collapsing bursts of changes into a single-flight write.
     pub workspace_write_gen: Arc<AtomicU64>,
+    /// Metadata for currently-live connections, keyed by connection id —
+    /// broadcast to every window via `connections-changed` whenever it
+    /// changes (`set_connection_meta` on connect, removed on
+    /// `disconnect_db`). See `ConnectionMeta`'s doc comment for why this
+    /// deliberately never holds a URI.
+    pub connection_meta: Mutex<HashMap<String, ConnectionMeta>>,
 }
 
 impl AppState {
@@ -66,6 +107,7 @@ impl AppState {
             conn_uris: Mutex::new(HashMap::new()),
             workspace: Mutex::new(None),
             workspace_write_gen: Arc::new(AtomicU64::new(0)),
+            connection_meta: Mutex::new(HashMap::new()),
         }
     }
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3,7 +3,8 @@ mod tests {
     use crate::db::documents::CsvImportOptions;
     use crate::AppState;
     use crate::{
-        connect_db_impl, count_documents_impl, create_collection_impl, create_index_impl,
+        connect_db_impl, connection_list_impl, count_documents_impl, create_collection_impl,
+        create_index_impl,
         delete_document_impl, delete_gridfs_file_impl, disconnect_db_impl,
         download_gridfs_file_impl, drop_collection_impl,
         drop_database_impl, execute_aggregate_impl, execute_mql_query_impl, explain_mql_query_impl,
@@ -12,6 +13,7 @@ mod tests {
         json_to_bson_document, list_collections_impl, list_databases_impl, list_gridfs_files_impl,
         list_indexes_impl, parse_json_array_docs,
         preview_export_impl, rename_collection_impl, rename_database_impl, sample_export_fields_impl,
+        set_connection_meta_impl,
         start_collection_export_impl, start_filtered_export_impl, update_document_impl,
         upload_gridfs_file_impl, get_collection_options_impl, set_validator_impl,
     };
@@ -3682,5 +3684,104 @@ mod tests {
         assert!(state.cancels.lock().unwrap().get(&task2.id).is_none(), "cancel flag cleaned up");
 
         let _ = std::fs::remove_dir_all(&app_data);
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 3 Task 3: connection-meta registry — CRUD, list determinism,
+    // and removal on disconnect. Impl-level (no `AppHandle`), matching
+    // `workspace::apply_impl`'s testing precedent: the `connections-changed`
+    // emit itself lives only in the `set_connection_meta`/`disconnect_db`
+    // command wrappers, which need a real Tauri app to exercise.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn set_connection_meta_inserts_and_overwrites() {
+        let state = AppState::new();
+        set_connection_meta_impl(&state, "conn-1", "profile-a", "Prod Cluster").unwrap();
+        {
+            let meta = state.connection_meta.lock().unwrap();
+            let m = meta.get("conn-1").expect("meta inserted");
+            assert_eq!(m.profile_id, "profile-a");
+            assert_eq!(m.name, "Prod Cluster");
+        }
+
+        // Re-registering the same id (e.g. a reconnect) overwrites in place
+        // rather than accumulating a second entry.
+        set_connection_meta_impl(&state, "conn-1", "profile-b", "Renamed").unwrap();
+        let meta = state.connection_meta.lock().unwrap();
+        assert_eq!(meta.len(), 1, "same id must overwrite, not duplicate");
+        let m = meta.get("conn-1").unwrap();
+        assert_eq!(m.profile_id, "profile-b");
+        assert_eq!(m.name, "Renamed");
+    }
+
+    #[test]
+    fn connection_meta_never_carries_a_uri() {
+        // Regression guard for the explicit constraint: event payloads must
+        // never carry a connection string. `ConnectionMeta`/`ConnectionEntry`
+        // only ever expose `profileId`/`name` — this test would fail to
+        // compile (not just fail at runtime) the moment a `uri` field is
+        // added, since the struct literal below is exhaustive.
+        let meta = crate::ConnectionMeta { profile_id: "p".into(), name: "n".into() };
+        let entry = crate::ConnectionEntry { id: "c".into(), profile_id: meta.profile_id.clone(), name: meta.name.clone() };
+        assert_eq!(entry.id, "c");
+    }
+
+    #[test]
+    fn connection_list_is_sorted_by_id_regardless_of_insertion_order() {
+        let state = AppState::new();
+        set_connection_meta_impl(&state, "conn-c", "p3", "Third").unwrap();
+        set_connection_meta_impl(&state, "conn-a", "p1", "First").unwrap();
+        set_connection_meta_impl(&state, "conn-b", "p2", "Second").unwrap();
+
+        let list = connection_list_impl(&state).unwrap();
+        let ids: Vec<&str> = list.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, ["conn-a", "conn-b", "conn-c"], "list must be sorted by id, not insertion order");
+
+        // Same map contents, re-listed: must produce the exact same order
+        // every time (determinism, not just "happens to sort now").
+        let list2 = connection_list_impl(&state).unwrap();
+        assert_eq!(list, list2);
+    }
+
+    #[test]
+    fn connection_list_is_empty_when_no_meta_registered() {
+        let state = AppState::new();
+        assert!(connection_list_impl(&state).unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn disconnect_removes_connection_meta() {
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+        set_connection_meta_impl(&state, &conn_id, "profile-a", "Mock Conn").unwrap();
+        assert!(state.connection_meta.lock().unwrap().contains_key(&conn_id));
+
+        disconnect_db_impl(&state, &conn_id)
+            .await
+            .expect("disconnect should succeed");
+
+        assert!(
+            !state.connection_meta.lock().unwrap().contains_key(&conn_id),
+            "disconnect_db_impl must remove the connection's meta entry"
+        );
+        assert!(connection_list_impl(&state).unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn disconnect_of_unregistered_meta_is_a_noop() {
+        // A connection that was never announced via `set_connection_meta`
+        // (e.g. one connected before this feature existed, or a mock in a
+        // test) must disconnect cleanly rather than erroring on a missing
+        // meta entry.
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("mock connect");
+        disconnect_db_impl(&state, &conn_id)
+            .await
+            .expect("disconnect must succeed even with no registered meta");
     }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -26,12 +26,23 @@
 //!   `CloseRequested` handler to every `win-*` window it creates, which
 //!   applies `WindowClosed` (origin `"backend"`) and broadcasts
 //!   `workspace-changed`, then lets the close proceed via the runtime's
-//!   default behavior (verified below). The **main** window never gets this
-//!   handler — its close is untouched, default `ExitRequested` behavior
-//!   (app exit), exactly as before this task.
+//!   default behavior (verified below). The **main** window never goes
+//!   through THIS handler — it gets its own, [`wire_main_window_exit`] (see
+//!   above and that function's doc comment): Tauri v2 only synthesizes
+//!   `RunEvent::ExitRequested`/app-exit once the LAST OS window closes, so
+//!   with a secondary `win-*` window still open, closing main can no longer
+//!   be left as "untouched, default `ExitRequested` behavior" the way it
+//!   was before multi-window existed — it must force the exit itself.
 //! - **App boot**: [`spawn_saved_windows`] recreates every non-main window
 //!   the store remembers that isn't already open (used by `App.tsx`'s
 //!   restore effect, main window only).
+//! - **The user closes the main window** (final whole-branch review, Fix
+//!   1 — CRITICAL): [`wire_main_window_exit`] attaches a `CloseRequested`
+//!   handler to `"main"` (called once from `lib.rs`'s `.setup()`) that
+//!   calls `AppHandle::exit(0)` unconditionally. See that function's doc
+//!   comment for why this can no longer be "untouched, default
+//!   `ExitRequested` behavior" once a secondary `win-*` window can be
+//!   open at the same time.
 //!
 //! ## `WebviewWindowBuilder` / `CloseRequested` API, verified against the
 //! pinned `tauri` 2.11.2 source (`~/.cargo/registry/src/.../tauri-2.11.2`),
@@ -91,6 +102,17 @@ pub(crate) fn windows_to_spawn(ws: &Workspace, open_labels: &[String]) -> Vec<St
         .collect()
 }
 
+/// Whether the workspace store still lists `label` among its windows — the
+/// pure decision [`focus_window`]'s widened contract (Fix 4(b)) is built on:
+/// an OS window that isn't currently open is worth SPAWNING (self-healing a
+/// dead "Move to <label>" target) only if the store still remembers it, not
+/// for an arbitrary/typo'd label. Pure and order-independent, so it's
+/// unit-testable without a live `AppHandle`, same rationale as
+/// `windows_to_spawn` above.
+pub(crate) fn window_is_known(ws: &Workspace, label: &str) -> bool {
+    ws.windows.iter().any(|w| w.id == label)
+}
+
 /// Applies `WorkspaceOp::WindowClosed { window_id: label }` and, if that
 /// actually changed the store, broadcasts `workspace-changed` — the shared
 /// core of the `CloseRequested` handler (X button, origin `"backend"`) and
@@ -110,6 +132,51 @@ fn apply_window_closed_and_broadcast(app: &AppHandle, label: &str, origin: Strin
         Ok(None) => {} // already gone from the store, or unknown/"main" — nothing to broadcast
         Err(e) => eprintln!("close_workspace_window: failed to apply window_closed for {label}: {e}"),
     }
+}
+
+/// Wires the **main** window's `CloseRequested` to `AppHandle::exit(0)`
+/// (final whole-branch review, Fix 1 — CRITICAL). Called once from
+/// `lib.rs`'s `.setup()`, main-only — every `win-*` window gets the
+/// different handler in [`spawn_workspace_window`] instead.
+///
+/// Why this can't be left as "do nothing, let the runtime's default
+/// `ExitRequested` handling take over" (which is exactly what happens for a
+/// single-window session, and was correct before this app had a second
+/// window): Tauri v2 only synthesizes `RunEvent::ExitRequested` once the
+/// LAST OS window closes (traced the same `tauri-runtime-wry-2.11.3`
+/// `on_close_requested`/window-count bookkeeping this module's own doc
+/// comment already cites for the `win-*` `CloseRequested` wiring). With a
+/// secondary `win-*` window open, closing main would otherwise just destroy
+/// that one window and leave the app running headless — the workspace
+/// store still lists `"main"` as a live window (a "Move to main" menu entry
+/// pointing at a dead window), and closing the lingering `win-*` afterward
+/// runs the normal `WindowClosed` path, which DELETES its tabs from the
+/// store — turning "close windows to quit" into "destroy the session
+/// instead of quitting".
+///
+/// `AppHandle::exit(exit_code)` (`tauri-2.11.2/src/app.rs`, doc comment on
+/// `exit()`) "exits the app by triggering `RunEvent::ExitRequested` and
+/// `RunEvent::Exit`" — the SAME event sequence a normal single-window quit
+/// already goes through, not an abrupt `std::process::exit` bypassing it
+/// (that fallback only fires if the runtime handle's `request_exit` itself
+/// errors). So the debounced-save loss window here — an in-flight
+/// `update_tab_state`/workspace-save debounce timer that hasn't fired yet
+/// gets cut off — is no worse than an ordinary quit already accepts; this
+/// fix doesn't introduce a new data-loss window, it just makes the
+/// multi-window case reach the same one a single-window quit already has.
+/// Deliberately never touches `signal_tx` either (same reasoning as the
+/// `win-*` handler below) — `exit()` tears the whole app down on its own,
+/// so there's nothing to "let proceed" on this specific window close.
+pub fn wire_main_window_exit(app: &AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        return; // headless/test environment with no "main" window — nothing to wire.
+    };
+    let app_for_exit = app.clone();
+    window.on_window_event(move |event| {
+        if let WindowEvent::CloseRequested { .. } = event {
+            app_for_exit.exit(0);
+        }
+    });
 }
 
 /// Create (or, if already open, focus) the `WebviewWindow` labeled `label`.
@@ -179,6 +246,17 @@ pub async fn workspace_detach_tab(
 /// `spawn_saved_windows` command: recreates every non-main OS window the
 /// store remembers that isn't already open. Called once, main-window-only,
 /// by `App.tsx`'s boot/restore effect after `workspace_get` resolves.
+///
+/// Final whole-branch review, Fix 4(a): a single window that fails to spawn
+/// (e.g. a transient OS/windowing error) no longer aborts the loop via `?` —
+/// every OTHER healthy window in `windows_to_spawn`'s list still gets
+/// spawned. Errors are collected and joined into one `Err` so the caller
+/// still learns something failed (App.tsx's `.catch(console.warn)` treats
+/// it as non-fatal either way, same as before), instead of silently
+/// stopping at the first failure and leaving every window after it in the
+/// store but never recreated as an OS window (exactly the "dead move
+/// target" state Fix 4(b)'s widened `focus_window` now self-heals, but
+/// spawning everything that CAN spawn up front is strictly better).
 #[tauri::command]
 pub async fn spawn_saved_windows(app: AppHandle, state: tauri::State<'_, AppState>) -> Result<(), String> {
     let path = workspace::workspace_path(&app);
@@ -186,21 +264,47 @@ pub async fn spawn_saved_windows(app: AppHandle, state: tauri::State<'_, AppStat
         return Ok(()); // no persisted workspace yet: nothing to recreate
     };
     let open_labels: Vec<String> = app.webview_windows().keys().cloned().collect();
+    let mut errors: Vec<String> = Vec::new();
     for label in windows_to_spawn(&ws, &open_labels) {
-        spawn_workspace_window(&app, &label)?;
+        if let Err(e) = spawn_workspace_window(&app, &label) {
+            eprintln!("spawn_saved_windows: failed to spawn {label}: {e}");
+            errors.push(format!("{label}: {e}"));
+        }
     }
-    Ok(())
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
 }
 
 /// `focus_window` command: brings an existing OS window to the front.
-/// No-op (`Ok`) if `label` names a window that isn't currently open — the
-/// caller (the cross-window open dedupe in `App.tsx`) can't know in advance
-/// whether the window it's about to focus is still alive, and losing that
+///
+/// Final whole-branch review, Fix 4(b): widened beyond "focus-only" — if
+/// `label` names no currently-open OS window but the workspace store still
+/// lists it (a "Move to <label>" menu entry can go stale if that window's
+/// process died, or `spawn_saved_windows` above failed for just that one
+/// label), this now SPAWNS it via [`spawn_workspace_window`] instead of
+/// silently no-opping, so a move/focus into a dead-looking target self-heals
+/// instead of leaving the tab stranded. `spawn_workspace_window` is already
+/// focus-if-exists idempotent, so the open-and-known branch below is just a
+/// focus in practice — the widened contract only changes behavior for the
+/// known-but-not-open case. Still a true no-op (`Ok`) if `label` names
+/// neither an open OS window NOR a window the store remembers at all — the
+/// caller (the cross-window open dedupe / move-to-window flow in App.tsx)
+/// can't know in advance whether its target is still alive, and losing that
 /// race must never surface as an error.
 #[tauri::command]
-pub async fn focus_window(app: AppHandle, label: String) -> Result<(), String> {
-    if let Some(window) = app.get_webview_window(&label) {
-        window.set_focus().map_err(|e| e.to_string())?;
+pub async fn focus_window(app: AppHandle, state: tauri::State<'_, AppState>, label: String) -> Result<(), String> {
+    if app.get_webview_window(&label).is_some() {
+        return spawn_workspace_window(&app, &label);
+    }
+    let path = workspace::workspace_path(&app);
+    let known = workspace::get_impl(&state, &path)?
+        .map(|ws| window_is_known(&ws, &label))
+        .unwrap_or(false);
+    if known {
+        return spawn_workspace_window(&app, &label);
     }
     Ok(())
 }
@@ -283,5 +387,19 @@ mod tests {
         let ws = ws_with_windows(&["main", "win-1"]);
         let open: Vec<String> = vec!["main".into(), "win-1".into()];
         assert!(windows_to_spawn(&ws, &open).is_empty());
+    }
+
+    // Fix 4(b) — `focus_window`'s widened "spawn if the store still knows
+    // about it" decision, in isolation from any real `AppHandle`/`State`.
+    #[test]
+    fn window_is_known_true_for_a_window_the_store_still_lists() {
+        let ws = ws_with_windows(&["main", "win-1"]);
+        assert!(window_is_known(&ws, "win-1"));
+    }
+
+    #[test]
+    fn window_is_known_false_for_a_label_the_store_never_had() {
+        let ws = ws_with_windows(&["main", "win-1"]);
+        assert!(!window_is_known(&ws, "win-99"));
     }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -1,0 +1,287 @@
+//! Window lifecycle: spawning/focusing secondary `WebviewWindow`s, and the
+//! commands the frontend's Task 5 detach/move UX calls to drive the backend
+//! workspace store's window-lifecycle ops (`DetachTab`/`WindowClosed`) in
+//! lockstep with the real OS windows they describe.
+//!
+//! ## Design: who applies what, and who owns OS-window teardown
+//!
+//! - **User drags/clicks "Detach to New Window"**: frontend calls
+//!   [`workspace_detach_tab`], which applies `DetachTab` (mutating the store
+//!   and broadcasting `workspace-changed` exactly like `workspace_apply`
+//!   does), then spawns the `win-N` the reducer just minted for the detached
+//!   tab.
+//! - **User clicks "Move to Window"**: this is a plain `workspace_apply`
+//!   call with a `MoveTabToWindow` op — no OS window is created or
+//!   destroyed, so it needs nothing from this module. (Handled entirely by
+//!   `workspace.rs` + the existing `workspace_apply` command.)
+//! - **A secondary window empties out (its last tab closes/moves away) and
+//!   the frontend proactively wants to close itself**, or **another
+//!   window's op silently removed this window from the document and its
+//!   frontend notices its own entry is gone**: both call
+//!   [`close_workspace_window`], which applies `WindowClosed` (a no-op if
+//!   the window is already gone from the store — see
+//!   `workspace::apply_window_closed`) and then destroys the real OS window.
+//! - **The user clicks a secondary window's OS close (X) button**: no
+//!   frontend code runs at all — [`spawn_workspace_window`] attaches a
+//!   `CloseRequested` handler to every `win-*` window it creates, which
+//!   applies `WindowClosed` (origin `"backend"`) and broadcasts
+//!   `workspace-changed`, then lets the close proceed via the runtime's
+//!   default behavior (verified below). The **main** window never gets this
+//!   handler — its close is untouched, default `ExitRequested` behavior
+//!   (app exit), exactly as before this task.
+//! - **App boot**: [`spawn_saved_windows`] recreates every non-main window
+//!   the store remembers that isn't already open (used by `App.tsx`'s
+//!   restore effect, main window only).
+//!
+//! ## `WebviewWindowBuilder` / `CloseRequested` API, verified against the
+//! pinned `tauri` 2.11.2 source (`~/.cargo/registry/src/.../tauri-2.11.2`),
+//! matching this repo's established precedent of reading the vendored crate
+//! rather than assuming API shape:
+//! - `WebviewWindowBuilder::new(&app_handle, label, WebviewUrl::App(...))`
+//!   (`src/webview/webview_window.rs`) — the builder's own doc comment warns
+//!   it can deadlock "when used in a synchronous command"; every caller here
+//!   is an `async fn` Tauri command (or runs off one), matching the doc's
+//!   own recommended fix.
+//! - `WebviewWindow::on_window_event(&self, f: Fn(&WindowEvent) + Send +
+//!   'static)` is an INSTANCE method (registered after `.build()`), not a
+//!   builder method — there is no `.on_window_event(...)` step in the
+//!   builder chain itself.
+//! - `WindowEvent::CloseRequested { signal_tx: Sender<bool> }`
+//!   (`tauri-runtime-2.11.2/src/window.rs`): sending `true` on `signal_tx`
+//!   prevents the close. Tracing `tauri-runtime-wry-2.11.3/src/lib.rs`'s
+//!   `on_close_requested`, every registered handler is invoked with the same
+//!   `signal_tx`, then `rx.try_recv()` is checked ONCE after all handlers
+//!   run: only an explicit `Ok(true)` prevents the close; leaving the
+//!   channel untouched (an `Err` on `try_recv`) falls through to
+//!   `on_window_close`, closing the window normally. So a handler that
+//!   simply never touches `signal_tx` — exactly what this module's
+//!   `CloseRequested` handler does — is the correct way to "observe but let
+//!   the close proceed".
+//! - `WebviewWindow::destroy()` "does not emit any events and force close[s]
+//!   the window instead" (vs. `.close()`, which re-emits `CloseRequested`).
+//!   `close_workspace_window` already applied `WindowClosed` itself before
+//!   reaching the OS window, so it uses `.destroy()` — using `.close()`
+//!   instead would loop back through the very `CloseRequested` handler this
+//!   module attaches to every `win-*` window, redundantly (harmlessly,
+//!   since a second `WindowClosed` apply for an already-removed window
+//!   no-ops — but wasteful and not the simplest correct wiring).
+
+use crate::workspace::{self, Workspace, WorkspaceOp};
+use crate::AppState;
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent};
+
+const WINDOW_TITLE: &str = "MQLens";
+const DEFAULT_WIDTH: f64 = 1000.0;
+const DEFAULT_HEIGHT: f64 = 700.0;
+const MIN_WIDTH: f64 = 700.0;
+const MIN_HEIGHT: f64 = 500.0;
+
+/// Every non-`"main"` window id in `ws.windows` that isn't already present in
+/// `open_labels` — the set of OS windows [`spawn_saved_windows`] still needs
+/// to create. Pure and order-preserving (matches `ws.windows`'s own order)
+/// so it's unit-testable without a live `AppHandle`/real `WebviewWindow`s;
+/// `spawn_saved_windows` itself is a thin wrapper that gathers
+/// `open_labels` from `app.webview_windows()` and calls this.
+pub(crate) fn windows_to_spawn(ws: &Workspace, open_labels: &[String]) -> Vec<String> {
+    ws.windows
+        .iter()
+        .map(|w| w.id.as_str())
+        .filter(|id| *id != "main" && !open_labels.iter().any(|l| l == id))
+        .map(|id| id.to_string())
+        .collect()
+}
+
+/// Applies `WorkspaceOp::WindowClosed { window_id: label }` and, if that
+/// actually changed the store, broadcasts `workspace-changed` — the shared
+/// core of the `CloseRequested` handler (X button, origin `"backend"`) and
+/// the [`close_workspace_window`] command (frontend-initiated, any origin).
+/// Errors are swallowed (logged) rather than propagated: a `CloseRequested`
+/// handler has no `Result` return, and `close_workspace_window` treats a
+/// failure to record the close as non-fatal to actually closing the OS
+/// window — matching every other best-effort broadcast in this codebase
+/// (`workspace_apply`'s own emit, `connections-changed`, etc.).
+fn apply_window_closed_and_broadcast(app: &AppHandle, label: &str, origin: String) {
+    let state = app.state::<AppState>();
+    let path = workspace::workspace_path(app);
+    match workspace::apply_impl(&state, &path, WorkspaceOp::WindowClosed { window_id: label.to_string() }, origin) {
+        Ok(Some(payload)) => {
+            let _ = app.emit("workspace-changed", payload);
+        }
+        Ok(None) => {} // already gone from the store, or unknown/"main" — nothing to broadcast
+        Err(e) => eprintln!("close_workspace_window: failed to apply window_closed for {label}: {e}"),
+    }
+}
+
+/// Create (or, if already open, focus) the `WebviewWindow` labeled `label`.
+/// Every window this app spawns beyond the config-defined `"main"` goes
+/// through here — `workspace_detach_tab`, `spawn_saved_windows`, and manual
+/// testing/future call sites all get the same size/title and (for `win-*`
+/// labels) the same `CloseRequested` -> `WindowClosed` wiring for free.
+pub fn spawn_workspace_window(app: &AppHandle, label: &str) -> Result<(), String> {
+    if let Some(existing) = app.get_webview_window(label) {
+        return existing.set_focus().map_err(|e| e.to_string());
+    }
+
+    let window = WebviewWindowBuilder::new(app, label, WebviewUrl::App("index.html".into()))
+        .title(WINDOW_TITLE)
+        .inner_size(DEFAULT_WIDTH, DEFAULT_HEIGHT)
+        .min_inner_size(MIN_WIDTH, MIN_HEIGHT)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    // Main is created from `tauri.conf.json`, never through this function —
+    // this check is what keeps main's close behavior untouched (default
+    // `ExitRequested`/app-exit) even if a future caller ever passed "main"
+    // here by mistake.
+    if label.starts_with("win-") {
+        let app_for_close = app.clone();
+        let label_owned = label.to_string();
+        window.on_window_event(move |event| {
+            if let WindowEvent::CloseRequested { .. } = event {
+                // Deliberately never touches `signal_tx` — see this module's
+                // doc comment for why that's what lets the close proceed.
+                apply_window_closed_and_broadcast(&app_for_close, &label_owned, "backend".to_string());
+            }
+        });
+    }
+
+    Ok(())
+}
+
+/// `workspace_detach_tab` command: applies `DetachTab` for `tab_id` (via the
+/// same `apply_impl` path `workspace_apply` uses, so the broadcast/debounced-
+/// save machinery is identical), finds the fresh `win-N` the reducer minted
+/// for it, spawns that window, and returns its label. Errors if the op
+/// no-opped (unknown `tab_id`, or it was already the sole tab of its own
+/// non-main window — see `workspace::apply_detach_tab`'s doc comment) since
+/// there is then no new window to report.
+#[tauri::command]
+pub async fn workspace_detach_tab(
+    app: AppHandle,
+    state: tauri::State<'_, AppState>,
+    tab_id: String,
+    origin: Option<String>,
+) -> Result<String, String> {
+    let origin = origin.unwrap_or_else(workspace::default_origin);
+    let path = workspace::workspace_path(&app);
+    let payload = workspace::apply_impl(&state, &path, WorkspaceOp::DetachTab { tab_id: tab_id.clone() }, origin)?
+        .ok_or_else(|| "detach_tab: nothing to detach (unknown tab, or already alone)".to_string())?;
+
+    let new_label = workspace::window_containing_tab(&payload.workspace, &tab_id)
+        .ok_or_else(|| "detach_tab: detached tab not found in the post-apply workspace".to_string())?
+        .to_string();
+
+    let _ = app.emit("workspace-changed", payload);
+    spawn_workspace_window(&app, &new_label)?;
+    Ok(new_label)
+}
+
+/// `spawn_saved_windows` command: recreates every non-main OS window the
+/// store remembers that isn't already open. Called once, main-window-only,
+/// by `App.tsx`'s boot/restore effect after `workspace_get` resolves.
+#[tauri::command]
+pub async fn spawn_saved_windows(app: AppHandle, state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let path = workspace::workspace_path(&app);
+    let Some(ws) = workspace::get_impl(&state, &path)? else {
+        return Ok(()); // no persisted workspace yet: nothing to recreate
+    };
+    let open_labels: Vec<String> = app.webview_windows().keys().cloned().collect();
+    for label in windows_to_spawn(&ws, &open_labels) {
+        spawn_workspace_window(&app, &label)?;
+    }
+    Ok(())
+}
+
+/// `focus_window` command: brings an existing OS window to the front.
+/// No-op (`Ok`) if `label` names a window that isn't currently open — the
+/// caller (the cross-window open dedupe in `App.tsx`) can't know in advance
+/// whether the window it's about to focus is still alive, and losing that
+/// race must never surface as an error.
+#[tauri::command]
+pub async fn focus_window(app: AppHandle, label: String) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window(&label) {
+        window.set_focus().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// `close_workspace_window` command: applies `WorkspaceOp::WindowClosed` for
+/// `label` (broadcasting `workspace-changed` if that actually changed the
+/// store — a no-op if `label` is already gone, e.g. this is the "remote
+/// close" path reacting to another window's op that already removed it), then
+/// destroys the real OS window if one is still open. Two call sites in
+/// `App.tsx`: a secondary window proactively closing itself once its last tab
+/// closes/moves away, and a window discovering its own entry vanished from a
+/// `crossWindow` broadcast it didn't cause.
+#[tauri::command]
+pub async fn close_workspace_window(
+    app: AppHandle,
+    state: tauri::State<'_, AppState>,
+    label: String,
+    origin: Option<String>,
+) -> Result<(), String> {
+    let origin = origin.unwrap_or_else(workspace::default_origin);
+    let path = workspace::workspace_path(&app);
+    let payload = workspace::apply_impl(&state, &path, WorkspaceOp::WindowClosed { window_id: label.clone() }, origin)?;
+    if let Some(payload) = payload {
+        let _ = app.emit("workspace-changed", payload);
+    }
+    // `.destroy()`, not `.close()` — see this module's doc comment: the
+    // WindowClosed op above is already applied, so re-emitting
+    // CloseRequested (what `.close()` does) would be redundant.
+    if let Some(window) = app.get_webview_window(&label) {
+        window.destroy().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace::{LayoutNode, WindowModel};
+
+    fn ws_with_windows(ids: &[&str]) -> Workspace {
+        Workspace {
+            revision: 0,
+            windows: ids
+                .iter()
+                .map(|id| WindowModel {
+                    id: id.to_string(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane {
+                        id: "pane-1".into(),
+                        tab_ids: if *id == "main" { vec![] } else { vec![format!("{id}-tab")] },
+                        active_tab_id: None,
+                    },
+                })
+                .collect(),
+            tabs: vec![],
+        }
+    }
+
+    #[test]
+    fn windows_to_spawn_skips_main_and_already_open_windows() {
+        let ws = ws_with_windows(&["main", "win-1", "win-2"]);
+        let open: Vec<String> = vec!["main".into(), "win-1".into()];
+        assert_eq!(windows_to_spawn(&ws, &open), vec!["win-2".to_string()]);
+    }
+
+    #[test]
+    fn windows_to_spawn_returns_everything_non_main_when_nothing_is_open() {
+        let ws = ws_with_windows(&["main", "win-1", "win-2"]);
+        assert_eq!(windows_to_spawn(&ws, &[]), vec!["win-1".to_string(), "win-2".to_string()]);
+    }
+
+    #[test]
+    fn windows_to_spawn_is_empty_when_only_main_exists() {
+        let ws = ws_with_windows(&["main"]);
+        assert!(windows_to_spawn(&ws, &[]).is_empty());
+    }
+
+    #[test]
+    fn windows_to_spawn_is_empty_when_everything_is_already_open() {
+        let ws = ws_with_windows(&["main", "win-1"]);
+        let open: Vec<String> = vec!["main".into(), "win-1".into()];
+        assert!(windows_to_spawn(&ws, &open).is_empty());
+    }
+}

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1029,6 +1029,23 @@ fn apply_window_closed(ws: &mut Workspace, window_id: &str) {
     ws.revision += 1; // removing a found, non-main window always changes something
 }
 
+/// The id of the window whose layout tree currently references `tab_id`, or
+/// `None` if it isn't open anywhere. Pure and `pub(crate)` (Phase 3 Task 5):
+/// `windows.rs`'s `workspace_detach_tab` command calls `apply_impl` with a
+/// `DetachTab` op (which always mints a brand-new `win-N` for the detached
+/// tab — see `apply_detach_tab`), then needs to learn that fresh window's id
+/// from the post-apply `Workspace` snapshot the payload carries in order to
+/// spawn its OS window. Scanning for the window that now contains `tab_id` is
+/// simpler and more robust than re-deriving `next_window_id`'s numbering a
+/// second time on the Rust-command side (which would silently desync if
+/// `apply_detach_tab`'s minting logic ever changed).
+pub(crate) fn window_containing_tab<'a>(ws: &'a Workspace, tab_id: &str) -> Option<&'a str> {
+    ws.windows
+        .iter()
+        .find(|w| pane_of_tab(&w.split_tree, tab_id).is_some())
+        .map(|w| w.id.as_str())
+}
+
 /// Port of TS's tab-id collection helpers (`allTabIds`), used only by
 /// `validate` below — flattens every `tabIds` entry across an entire
 /// `LayoutNode` tree, panes and splits alike.
@@ -1160,8 +1177,12 @@ pub fn save_to_file(path: &Path, ws: &Workspace) -> Result<(), String> {
 }
 
 /// Where workspace.json lives, mirroring `queries::get_queries_path`
-/// (queries.rs:72-81).
-fn workspace_path(app_handle: &tauri::AppHandle) -> PathBuf {
+/// (queries.rs:72-81). `pub(crate)` (Phase 3 Task 5): `windows.rs`'s
+/// `workspace_detach_tab`/`spawn_saved_windows`/`close_workspace_window`
+/// commands, and the `CloseRequested` handler `spawn_workspace_window`
+/// attaches to every `win-*` window, all need to resolve the same path this
+/// module's own `workspace_get`/`workspace_apply` commands use.
+pub(crate) fn workspace_path(app_handle: &tauri::AppHandle) -> PathBuf {
     use tauri::Manager;
     match app_handle.path().app_config_dir() {
         Ok(mut path) => {
@@ -1291,7 +1312,10 @@ pub async fn workspace_get(
 /// parameter is `Option<String>`, defaulted here — existing callers that
 /// don't yet send `origin` (Task 4 wires the frontend) keep working exactly
 /// as `#[serde(default = "default_window_id")]` does for `WorkspaceOp`.
-fn default_origin() -> String {
+/// `pub(crate)` (Phase 3 Task 5): `windows.rs`'s `workspace_detach_tab` /
+/// `close_workspace_window` commands take the exact same `Option<String>`
+/// `origin` parameter and need the same fallback.
+pub(crate) fn default_origin() -> String {
     "main".to_string()
 }
 
@@ -2492,6 +2516,24 @@ mod tests {
         apply(&mut ws, WorkspaceOp::DetachTab { tab_id: "b".into() });
         let ids: Vec<&str> = ws.windows.iter().map(|w| w.id.as_str()).collect();
         assert!(ids.contains(&"win-4"), "expected win-4 past existing win-3, got {ids:?}");
+    }
+
+    #[test]
+    fn window_containing_tab_finds_the_freshly_detached_window() {
+        // Phase 3 Task 5: `workspace_detach_tab`'s exact use case — after
+        // `DetachTab` runs, the command needs to learn which `win-N` the
+        // reducer just minted for the detached tab so it can spawn that OS
+        // window.
+        let mut ws = ws_with(&["a", "b"]);
+        apply(&mut ws, WorkspaceOp::DetachTab { tab_id: "b".into() });
+        assert_eq!(window_containing_tab(&ws, "b"), Some("win-1"));
+        assert_eq!(window_containing_tab(&ws, "a"), Some("main"));
+    }
+
+    #[test]
+    fn window_containing_tab_is_none_for_an_unknown_tab() {
+        let ws = ws_with(&["a"]);
+        assert_eq!(window_containing_tab(&ws, "nope"), None);
     }
 
     #[test]

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -117,6 +117,31 @@ fn default_window_id() -> String {
     "main".to_string()
 }
 
+/// The `workspace-changed` broadcast payload — emitted to every window
+/// (Phase 3 Task 3) whenever `workspace_apply` actually changes state.
+/// `origin` is the calling window's label (so a window can ignore its own
+/// echo); `cross_window` flags the three ops whose effect spans more than
+/// one window (`MoveTabToWindow`, `DetachTab`, `WindowClosed`) so a listener
+/// can decide whether a narrower, single-window repaint suffices.
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceChangedPayload {
+    pub revision: u64,
+    pub origin: String,
+    pub cross_window: bool,
+    pub workspace: Workspace,
+}
+
+/// True for the three window-lifecycle ops (see the module DESIGN RULE and
+/// `apply`'s doc comment) — the only ops whose effect can be visible in more
+/// than one window's layout tree at once.
+fn op_is_cross_window(op: &WorkspaceOp) -> bool {
+    matches!(
+        op,
+        WorkspaceOp::MoveTabToWindow { .. } | WorkspaceOp::DetachTab { .. } | WorkspaceOp::WindowClosed { .. }
+    )
+}
+
 /// A single workspace mutation. The `type` discriminator is snake_case to
 /// match the frontend reducer's action `type` strings exactly (e.g.
 /// `split_pane`, `update_tab_state`).
@@ -1179,9 +1204,26 @@ fn should_write(current_gen: u64, own_gen: u64) -> bool {
     current_gen == own_gen
 }
 
+/// Apply one op to `ws` and describe the result — `Some(payload)` iff the op
+/// actually changed state, `None` for a no-op. Pure (no `AppState`, no
+/// `AppHandle`, no IO): this is what makes the `workspace-changed` emit
+/// decision unit-testable on its own, independent of the store's
+/// lock/debounced-save plumbing in `apply_impl` and the `AppHandle`-only
+/// `.emit()` call in the `workspace_apply` command wrapper.
+fn apply_and_describe(ws: &mut Workspace, op: WorkspaceOp, origin: String) -> Option<WorkspaceChangedPayload> {
+    let cross_window = op_is_cross_window(&op);
+    let before_revision = ws.revision;
+    apply(ws, op);
+    if ws.revision == before_revision {
+        return None;
+    }
+    Some(WorkspaceChangedPayload { revision: ws.revision, origin, cross_window, workspace: ws.clone() })
+}
+
 /// Apply one op to the in-memory workspace — initializing it (and its
 /// default `main` window) on first use — and, if anything actually changed,
-/// schedule a debounced save.
+/// schedule a debounced save and return a `workspace-changed` payload for
+/// the caller (the `workspace_apply` command) to broadcast.
 ///
 /// Single-flight, last-writer-wins: every real change mints a new
 /// generation via `state.workspace_write_gen.fetch_add`, *inside* the same
@@ -1201,18 +1243,21 @@ fn should_write(current_gen: u64, own_gen: u64) -> bool {
 /// The `std::sync::MutexGuard` above is dropped before this function ever
 /// spawns or awaits anything — required for correctness, since a std guard
 /// is `!Send` and cannot cross an `.await` point.
-pub fn apply_impl(state: &AppState, path: &Path, op: WorkspaceOp) -> Result<(), String> {
-    let scheduled: Option<(Workspace, u64)> = {
+pub fn apply_impl(
+    state: &AppState,
+    path: &Path,
+    op: WorkspaceOp,
+    origin: String,
+) -> Result<Option<WorkspaceChangedPayload>, String> {
+    let (payload, scheduled): (Option<WorkspaceChangedPayload>, Option<(Workspace, u64)>) = {
         let mut guard = state.workspace.lock_safe()?;
         let ws = guard.get_or_insert_with(Workspace::default);
-        let before_revision = ws.revision;
-        apply(ws, op);
-        if ws.revision != before_revision {
+        let payload = apply_and_describe(ws, op, origin);
+        let scheduled = payload.as_ref().map(|p| {
             let gen = state.workspace_write_gen.fetch_add(1, Ordering::SeqCst) + 1;
-            Some((ws.clone(), gen))
-        } else {
-            None
-        }
+            (p.workspace.clone(), gen)
+        });
+        (payload, scheduled)
     }; // guard dropped here, before any spawn/await.
 
     if let Some((snapshot, gen)) = scheduled {
@@ -1226,7 +1271,7 @@ pub fn apply_impl(state: &AppState, path: &Path, op: WorkspaceOp) -> Result<(), 
         });
     }
 
-    Ok(())
+    Ok(payload)
 }
 
 #[tauri::command]
@@ -1237,13 +1282,36 @@ pub async fn workspace_get(
     get_impl(&state, &workspace_path(&app_handle))
 }
 
+/// Origin defaults to `"main"` when the frontend caller omits it. `origin`
+/// can't be a plain `String` command parameter with a `#[serde(default)]`
+/// fallback the way `WorkspaceOp`'s struct fields are — Tauri's `CommandArg`
+/// deserializer errors on a genuinely missing key unless the parameter type
+/// is `Option<T>` (a missing key deserializes to `None`; see
+/// `tauri::ipc::command::CommandItem::deserialize_option`). So the wire
+/// parameter is `Option<String>`, defaulted here — existing callers that
+/// don't yet send `origin` (Task 4 wires the frontend) keep working exactly
+/// as `#[serde(default = "default_window_id")]` does for `WorkspaceOp`.
+fn default_origin() -> String {
+    "main".to_string()
+}
+
 #[tauri::command]
 pub async fn workspace_apply(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     op: WorkspaceOp,
+    origin: Option<String>,
 ) -> Result<(), String> {
-    apply_impl(&state, &workspace_path(&app_handle), op)
+    use tauri::Emitter;
+    let origin = origin.unwrap_or_else(default_origin);
+    let payload = apply_impl(&state, &workspace_path(&app_handle), op, origin)?;
+    if let Some(payload) = payload {
+        // Broadcast is best-effort: a window that misses this event
+        // re-syncs its workspace via `workspace_get` on its next boot, so a
+        // dropped emit (e.g. no windows currently listening) is never fatal.
+        let _ = app_handle.emit("workspace-changed", payload);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -2737,7 +2805,7 @@ mod store {
         let path = tmp_path("apply-init.json");
         assert!(state.workspace.lock_safe().unwrap().is_none(), "precondition: no workspace loaded yet");
 
-        apply_impl(&state, &path, WorkspaceOp::FocusPane { pane_id: "pane-1".into(), window_id: "main".into() }).unwrap();
+        apply_impl(&state, &path, WorkspaceOp::FocusPane { pane_id: "pane-1".into(), window_id: "main".into() }, "main".into()).unwrap();
 
         let ws = state.workspace.lock_safe().unwrap().clone().unwrap();
         assert_eq!(ws.windows.len(), 1);
@@ -2759,7 +2827,7 @@ mod store {
         // reducer returns the same layout and the tabs[] retain is a no-op,
         // so `apply`'s revision never bumps (see
         // `unknown_ids_are_noops_without_revision_bump` in `mod tests`).
-        apply_impl(&state, &path, WorkspaceOp::CloseTab { tab_id: "nope".into(), window_id: "main".into() }).unwrap();
+        apply_impl(&state, &path, WorkspaceOp::CloseTab { tab_id: "nope".into(), window_id: "main".into() }, "main".into()).unwrap();
 
         assert_eq!(
             state.workspace_write_gen.load(Ordering::SeqCst),
@@ -2795,6 +2863,7 @@ mod store {
                 &state,
                 &path,
                 WorkspaceOp::OpenTab { tab_id: format!("t{i}"), pane_id: None, tab: None, window_id: "main".into() },
+                "main".into(),
             )
             .unwrap();
         }
@@ -2820,5 +2889,155 @@ mod store {
             panic!("expected a pane, got a split");
         };
         assert_eq!(tab_ids.len(), 10);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `workspace-changed` broadcast tests (Phase 3 Task 3) — pure, no AppState
+// and no AppHandle: `apply_and_describe` is exercised directly, matching the
+// module's precedent (`mod golden`, `mod store`) of a sibling module per
+// concern so `cargo test workspace::broadcast` targets just these.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod broadcast {
+    use super::*;
+
+    fn single_window_ws(tab_ids: &[&str]) -> Workspace {
+        let ids: Vec<String> = tab_ids.iter().map(|s| s.to_string()).collect();
+        let active = ids.first().cloned();
+        Workspace {
+            revision: 0,
+            windows: vec![WindowModel {
+                id: "main".into(),
+                focused_pane_id: "pane-1".into(),
+                split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: ids, active_tab_id: active },
+            }],
+            tabs: vec![],
+        }
+    }
+
+    /// A `"main"` window holding tab `"a"` plus a secondary `"win-1"`
+    /// window holding tab `"b"` — the minimal shape every cross-window op
+    /// test below needs a source and target window for.
+    fn two_window_ws() -> Workspace {
+        Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                },
+                WindowModel {
+                    id: "win-1".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["b".into()], active_tab_id: Some("b".into()) },
+                },
+            ],
+            tabs: vec![],
+        }
+    }
+
+    #[test]
+    fn changing_op_returns_some_with_correct_revision_and_origin() {
+        let mut ws = single_window_ws(&["a"]);
+        let payload = apply_and_describe(
+            &mut ws,
+            WorkspaceOp::OpenTab { tab_id: "b".into(), pane_id: None, tab: None, window_id: "main".into() },
+            "win-2".into(),
+        )
+        .expect("opening a new tab changes state");
+
+        assert_eq!(payload.revision, 1);
+        assert_eq!(payload.revision, ws.revision, "payload revision must match the mutated workspace");
+        assert_eq!(payload.origin, "win-2");
+        assert!(!payload.cross_window, "OpenTab is not a window-lifecycle op");
+        assert_eq!(payload.workspace, ws, "payload must carry the fully-applied workspace, not a stale snapshot");
+    }
+
+    #[test]
+    fn noop_returns_none() {
+        let mut ws = single_window_ws(&["a"]);
+        let before = ws.clone();
+        let payload = apply_and_describe(
+            &mut ws,
+            WorkspaceOp::CloseTab { tab_id: "does-not-exist".into(), window_id: "main".into() },
+            "main".into(),
+        );
+        assert_eq!(payload, None);
+        assert_eq!(ws, before, "a no-op must never mutate the workspace");
+    }
+
+    #[test]
+    fn cross_window_is_true_for_move_tab_to_window() {
+        let mut ws = two_window_ws();
+        let payload = apply_and_describe(
+            &mut ws,
+            WorkspaceOp::MoveTabToWindow { tab_id: "a".into(), target_window_id: "win-1".into(), target_pane_id: None },
+            "main".into(),
+        )
+        .expect("moving an existing tab into another window changes state");
+        assert!(payload.cross_window);
+    }
+
+    #[test]
+    fn cross_window_is_true_for_detach_tab() {
+        let mut ws = two_window_ws();
+        let payload = apply_and_describe(&mut ws, WorkspaceOp::DetachTab { tab_id: "a".into() }, "main".into())
+            .expect("detaching a tab out of a multi-tab window changes state");
+        assert!(payload.cross_window);
+    }
+
+    #[test]
+    fn cross_window_is_true_for_window_closed() {
+        let mut ws = two_window_ws();
+        let payload = apply_and_describe(&mut ws, WorkspaceOp::WindowClosed { window_id: "win-1".into() }, "main".into())
+            .expect("closing a known non-main window changes state");
+        assert!(payload.cross_window);
+    }
+
+    #[test]
+    fn cross_window_is_false_for_every_non_lifecycle_op() {
+        // A representative spread of the non-cross-window `WorkspaceOp`
+        // shapes (layout ops and the tabs-only `UpdateTabState`), each set
+        // up to actually change state so `apply_and_describe` returns
+        // `Some` — every one of them must come back `cross_window: false`.
+        let cases: Vec<(&str, WorkspaceOp)> = vec![
+            ("open_tab", WorkspaceOp::OpenTab { tab_id: "b".into(), pane_id: None, tab: None, window_id: "main".into() }),
+            ("close_tab", WorkspaceOp::CloseTab { tab_id: "a".into(), window_id: "main".into() }),
+            ("close_many", WorkspaceOp::CloseMany { tab_ids: vec!["a".into()], window_id: "main".into() }),
+            (
+                "split_pane",
+                WorkspaceOp::SplitPane { pane_id: "pane-1".into(), dir: "row".into(), side: "end".into(), move_tab_id: None, window_id: "main".into() },
+            ),
+            ("rename_tab", WorkspaceOp::RenameTab { old_id: "a".into(), new_id: "z".into(), window_id: "main".into() }),
+            (
+                "update_tab_state",
+                WorkspaceOp::UpdateTabState {
+                    tab_id: "a".into(),
+                    last_query: Some(Some(serde_json::json!({"x": 1}))),
+                    last_aggregate: None,
+                    builder_state: None,
+                },
+            ),
+        ];
+        for (name, op) in cases {
+            let mut ws = single_window_ws(&["a"]);
+            ws.tabs.push(TabModel {
+                id: "a".into(),
+                tab_type: "collection".into(),
+                profile_id: "p1".into(),
+                profile_name: "p1".into(),
+                db: "db".into(),
+                collection: "coll".into(),
+                index_name: None,
+                last_query: None,
+                last_aggregate: None,
+                builder_state: None,
+            });
+            let payload = apply_and_describe(&mut ws, op, "main".into());
+            let payload = payload.unwrap_or_else(|| panic!("`{name}` was expected to change state"));
+            assert!(!payload.cross_window, "`{name}` must not be flagged cross-window");
+        }
     }
 }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1,6 +1,22 @@
 //! Multi-panel workspace store: layout tree, tabs, and the workspace.json
 //! document. This module owns the data model and best-effort file IO only —
 //! the reducer (`apply`) and Tauri commands land in later tasks.
+//!
+//! ## DESIGN RULE: pane/split ids are WINDOW-LOCAL (Phase 3 Task 2)
+//!
+//! Two different windows may both contain a pane literally named `pane-2` —
+//! ids are only unique *within* the window that minted them, never across
+//! `ws.windows` as a whole. Every op that resolves a pane/split id (`apply`
+//! dispatching through `workspace_reducer`, `find_pane`, `pane_of_tab`,
+//! `next_pane_id`/`next_split_id`) MUST do so strictly within the one
+//! `WindowModel.split_tree` it was resolved to — never by scanning across
+//! windows. This matches Phase 3 Task 1's frontend semantics, where each
+//! window owns an independent `WorkspaceLayout` and mints/resolves its own
+//! pane/split ids purely from its own tree.
+//!
+//! Window ids, by contrast, ARE global (`"main"` plus `"win-N"`): `WindowClosed`/
+//! `DetachTab`/`MoveTabToWindow` resolve/mint them by scanning `ws.windows`
+//! as a whole, not any single tree.
 
 use crate::state::{AppState, LockExt};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -94,9 +110,33 @@ pub struct Workspace {
     pub tabs: Vec<TabModel>, // flat, mirrors frontend tabs[]
 }
 
+/// `"main"` — the id of the always-present primary window, and the fallback
+/// every pane-referencing op's `window_id` decodes to when absent from the
+/// wire payload (older callers/fixtures that predate multi-window).
+fn default_window_id() -> String {
+    "main".to_string()
+}
+
 /// A single workspace mutation. The `type` discriminator is snake_case to
 /// match the frontend reducer's action `type` strings exactly (e.g.
 /// `split_pane`, `update_tab_state`).
+///
+/// Every variant that resolves a pane/split id also carries `window_id`
+/// (`#[serde(default = "default_window_id")]`, so existing single-window
+/// payloads keep decoding unchanged): `apply` resolves that op's target
+/// window first, then every pane/split lookup happens strictly inside that
+/// one window's tree — see the module DESIGN RULE above. `UpdateTabState`
+/// is the one exception: it never touches a layout tree (it patches
+/// `ws.tabs` only), so it carries no `window_id`. `MoveTabToWindow`,
+/// `DetachTab`, and `WindowClosed` are window-lifecycle ops in their own
+/// right (they name a source/target *window*, not a single resolved one) —
+/// see their doc comments in `apply`'s helpers below.
+// One WorkspaceOp is deserialized per user action (not a hot path), so the
+// size gap between OpenTab (carries an optional inline TabModel) and the
+// smaller variants (e.g. DetachTab's single String) is irrelevant — same
+// rationale as db/import.rs's ImportReader / db/export/mod.rs's analogous
+// allow.
+#[allow(clippy::large_enum_variant)]
 #[derive(Deserialize, Clone, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WorkspaceOp {
@@ -106,18 +146,26 @@ pub enum WorkspaceOp {
         pane_id: Option<String>,
         #[serde(default)]
         tab: Option<TabModel>,
+        #[serde(default = "default_window_id")]
+        window_id: String,
     },
     CloseTab {
         tab_id: String,
+        #[serde(default = "default_window_id")]
+        window_id: String,
     },
     CloseMany {
         tab_ids: Vec<String>,
+        #[serde(default = "default_window_id")]
+        window_id: String,
     },
     MoveTab {
         tab_id: String,
         target_pane_id: String,
         #[serde(default)]
         index: Option<usize>,
+        #[serde(default = "default_window_id")]
+        window_id: String,
     },
     SplitPane {
         pane_id: String,
@@ -125,21 +173,31 @@ pub enum WorkspaceOp {
         side: String,
         #[serde(default)]
         move_tab_id: Option<String>,
+        #[serde(default = "default_window_id")]
+        window_id: String,
     },
     ResizeSplit {
         split_id: String,
         ratio: f64,
+        #[serde(default = "default_window_id")]
+        window_id: String,
     },
     SetActive {
         pane_id: String,
         tab_id: String,
+        #[serde(default = "default_window_id")]
+        window_id: String,
     },
     FocusPane {
         pane_id: String,
+        #[serde(default = "default_window_id")]
+        window_id: String,
     },
     RenameTab {
         old_id: String,
         new_id: String,
+        #[serde(default = "default_window_id")]
+        window_id: String,
     },
     UpdateTabState {
         tab_id: String,
@@ -152,6 +210,54 @@ pub enum WorkspaceOp {
         #[serde(default, deserialize_with = "deserialize_some")]
         builder_state: Option<Option<serde_json::Value>>,
     },
+    /// Moves an already-open tab from wherever it currently lives (found by
+    /// scanning ALL windows — the op itself doesn't name a source) into
+    /// `target_window_id`'s `target_pane_id` (or that window's focused pane
+    /// if omitted), activating and focusing it there. `tabs[]` is untouched
+    /// — the tab model already exists; this only moves its layout-tree
+    /// placement. No-op if `tab_id` isn't open anywhere, or if
+    /// `target_window_id` doesn't exist.
+    MoveTabToWindow {
+        tab_id: String,
+        target_window_id: String,
+        #[serde(default)]
+        target_pane_id: Option<String>,
+    },
+    /// Pulls `tab_id` out of its current window into a brand-new window of
+    /// its own (`win-N`, minted by scanning ALL window ids — window ids are
+    /// global, unlike pane/split ids). No-op if `tab_id` is unknown, or if
+    /// it's already the only tab in the only pane of a non-main window
+    /// (already alone — detaching would just destroy and recreate an
+    /// equivalent window).
+    DetachTab { tab_id: String },
+    /// A frontend window was closed. No-op for `"main"` (the primary window
+    /// can't be closed this way) or an unknown id. Otherwise removes the
+    /// window AND every tab id its layout tree referenced from `tabs[]` —
+    /// closing a secondary window closes its tabs.
+    WindowClosed { window_id: String },
+}
+
+/// The `window_id` a pane-referencing `WorkspaceOp` variant targets, or
+/// `None` for the variants that don't resolve a pane inside one specific
+/// window (`UpdateTabState` touches only `ws.tabs`; `MoveTabToWindow` /
+/// `DetachTab` / `WindowClosed` are window-lifecycle ops with their own
+/// source/target window resolution, handled outside `apply_layout_op`).
+fn op_window_id(op: &WorkspaceOp) -> Option<&str> {
+    match op {
+        WorkspaceOp::OpenTab { window_id, .. }
+        | WorkspaceOp::CloseTab { window_id, .. }
+        | WorkspaceOp::CloseMany { window_id, .. }
+        | WorkspaceOp::MoveTab { window_id, .. }
+        | WorkspaceOp::SplitPane { window_id, .. }
+        | WorkspaceOp::ResizeSplit { window_id, .. }
+        | WorkspaceOp::SetActive { window_id, .. }
+        | WorkspaceOp::FocusPane { window_id, .. }
+        | WorkspaceOp::RenameTab { window_id, .. } => Some(window_id.as_str()),
+        WorkspaceOp::UpdateTabState { .. }
+        | WorkspaceOp::MoveTabToWindow { .. }
+        | WorkspaceOp::DetachTab { .. }
+        | WorkspaceOp::WindowClosed { .. } => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -378,9 +484,9 @@ fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp)
             (new_root, target_id)
         }
 
-        WorkspaceOp::CloseTab { tab_id } => close_tab(root, focused_pane_id, tab_id),
+        WorkspaceOp::CloseTab { tab_id, .. } => close_tab(root, focused_pane_id, tab_id),
 
-        WorkspaceOp::CloseMany { tab_ids } => {
+        WorkspaceOp::CloseMany { tab_ids, .. } => {
             let mut r = root.clone();
             let mut f = focused_pane_id.to_string();
             for t in tab_ids {
@@ -391,7 +497,7 @@ fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp)
             (r, f)
         }
 
-        WorkspaceOp::MoveTab { tab_id, target_pane_id, index } => {
+        WorkspaceOp::MoveTab { tab_id, target_pane_id, index, .. } => {
             let (Some(source), Some(target)) = (pane_of_tab(root, tab_id), find_pane(root, target_pane_id)) else {
                 return (root.clone(), focused_pane_id.to_string());
             };
@@ -428,7 +534,7 @@ fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp)
             (new_root, new_focused)
         }
 
-        WorkspaceOp::SplitPane { pane_id, dir, side, move_tab_id } => {
+        WorkspaceOp::SplitPane { pane_id, dir, side, move_tab_id, .. } => {
             let Some(pane) = find_pane(root, pane_id) else {
                 return (root.clone(), focused_pane_id.to_string());
             };
@@ -465,7 +571,7 @@ fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp)
             (new_root, fresh_id)
         }
 
-        WorkspaceOp::ResizeSplit { split_id, ratio } => {
+        WorkspaceOp::ResizeSplit { split_id, ratio, .. } => {
             let clamped = ratio.clamp(MIN_RATIO, MAX_RATIO);
             let mut found = false;
             fn visit(node: &LayoutNode, split_id: &str, clamped: f64, found: &mut bool) -> LayoutNode {
@@ -494,7 +600,7 @@ fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp)
             }
         }
 
-        WorkspaceOp::SetActive { pane_id, tab_id } => {
+        WorkspaceOp::SetActive { pane_id, tab_id, .. } => {
             let ok = matches!(find_pane(root, pane_id), Some(LayoutNode::Pane { tab_ids, .. }) if tab_ids.contains(tab_id));
             if !ok {
                 return (root.clone(), focused_pane_id.to_string());
@@ -507,7 +613,7 @@ fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp)
             (new_root, pane_id.clone())
         }
 
-        WorkspaceOp::FocusPane { pane_id } => {
+        WorkspaceOp::FocusPane { pane_id, .. } => {
             if find_pane(root, pane_id).is_some() {
                 (root.clone(), pane_id.clone())
             } else {
@@ -515,7 +621,7 @@ fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp)
             }
         }
 
-        WorkspaceOp::RenameTab { old_id, new_id } => {
+        WorkspaceOp::RenameTab { old_id, new_id, .. } => {
             let Some(pane) = pane_of_tab(root, old_id) else {
                 return (root.clone(), focused_pane_id.to_string());
             };
@@ -537,6 +643,14 @@ fn workspace_reducer(root: &LayoutNode, focused_pane_id: &str, op: &WorkspaceOp)
 
         // Tabs-only op — no layout-tree effect. Handled by `apply`.
         WorkspaceOp::UpdateTabState { .. } => (root.clone(), focused_pane_id.to_string()),
+
+        // Window-lifecycle ops never reach `workspace_reducer` — `apply`
+        // dispatches them to their own appliers (`apply_move_tab_to_window`
+        // / `apply_detach_tab` / `apply_window_closed`) before
+        // `apply_layout_op` (this function's only caller) ever runs.
+        WorkspaceOp::MoveTabToWindow { .. } | WorkspaceOp::DetachTab { .. } | WorkspaceOp::WindowClosed { .. } => {
+            unreachable!("window-lifecycle ops are dispatched by `apply` before reaching workspace_reducer")
+        }
     }
 }
 
@@ -582,34 +696,104 @@ fn default_window() -> WindowModel {
     }
 }
 
-/// Apply one op to the workspace, mutating `windows[0]` (Phase 2: exactly
-/// one window; seeded with `default_window()` on first use) and `tabs`.
-/// `revision` bumps only when something actually changed — TS returns the
-/// same object reference for a no-op action; Rust mutates in place, so we
-/// mirror that by comparing old vs. new values (both `LayoutNode` and
-/// `WindowModel` derive `PartialEq`) rather than tracking reference
-/// identity. See the Task 2 report for the semantic-choice writeup of edge
-/// cases (e.g. `open_tab` re-activating an already-active+focused tab) where
-/// this differs from "TS would have returned a new object".
+/// Mints `win-N` by scanning ALL window ids in `ws.windows` for the current
+/// max numeric suffix among ids prefixed `win-` — window ids are global
+/// (unlike pane/split ids, which are window-local; see the module DESIGN
+/// RULE), so this scan deliberately covers every window, not just one
+/// tree. `"main"` never matches the `win-` prefix, so it's naturally
+/// excluded. Stateless for the same reason `next_pane_id`/`next_split_id`
+/// are: a `Workspace` restored from disk may already contain `win-3`, and a
+/// process-local counter seeded at 0 would collide with it immediately.
+fn next_window_id(ws: &Workspace) -> String {
+    let best = ws
+        .windows
+        .iter()
+        .filter_map(|w| w.id.strip_prefix("win-").and_then(|rest| rest.parse::<u64>().ok()))
+        .max()
+        .unwrap_or(0);
+    format!("win-{}", best + 1)
+}
+
+/// Apply one op to the workspace. Window-lifecycle ops (`MoveTabToWindow`,
+/// `DetachTab`, `WindowClosed`) name a source/target *window* themselves and
+/// are dispatched to their own appliers below; every other op carries a
+/// `window_id` (default `"main"`) naming the single window whose tree it
+/// resolves against — see `apply_layout_op`. `ws.windows` is seeded with
+/// `default_window()` on first use, same as Phase 2.
 pub fn apply(ws: &mut Workspace, op: WorkspaceOp) {
     if ws.windows.is_empty() {
         ws.windows.push(default_window());
     }
 
+    match op {
+        WorkspaceOp::MoveTabToWindow { tab_id, target_window_id, target_pane_id } => {
+            apply_move_tab_to_window(ws, &tab_id, &target_window_id, target_pane_id.as_deref());
+        }
+        WorkspaceOp::DetachTab { tab_id } => apply_detach_tab(ws, &tab_id),
+        WorkspaceOp::WindowClosed { window_id } => apply_window_closed(ws, &window_id),
+        other => apply_layout_op(ws, other),
+    }
+}
+
+/// Applies every `WorkspaceOp` variant except the three window-lifecycle
+/// ops (see `apply`). `revision` bumps only when something actually
+/// changed — TS returns the same object reference for a no-op action; Rust
+/// mutates in place, so we mirror that by comparing old vs. new values
+/// (both `LayoutNode` and `WindowModel` derive `PartialEq`) rather than
+/// tracking reference identity. See the Task 2 report (Phase 2) for the
+/// semantic-choice writeup of edge cases (e.g. `open_tab` re-activating an
+/// already-active+focused tab) where this differs from "TS would have
+/// returned a new object".
+///
+/// An op naming an unknown `window_id` no-ops entirely — tree AND `tabs[]`
+/// bookkeeping both skip, since there's no window to have resolved a pane
+/// inside. This is what makes the window-local DESIGN RULE hold even for
+/// the tabs[] side effects below: `CloseTab`/`RenameTab`'s bookkeeping is
+/// gated on `tree_changed`, which (for these single-tab-id ops) is `true`
+/// if and only if the tab was actually found inside the *resolved* window's
+/// tree — so a tab id that happens to also exist in a different window is
+/// never touched by an op that didn't target that window. `CloseMany` needs
+/// finer-than-one-bool granularity (only some of its many ids may belong to
+/// this window), so it precomputes a per-id membership set before the tree
+/// mutates.
+fn apply_layout_op(ws: &mut Workspace, op: WorkspaceOp) {
     let mut changed = false;
 
-    if !matches!(op, WorkspaceOp::UpdateTabState { .. }) {
-        let win = &mut ws.windows[0];
+    // Precompute, before the tree mutates, exactly which of CloseMany's
+    // requested ids actually live in the window this op resolves to. A tab
+    // id absent there must never be deleted from the flat, cross-window
+    // `tabs[]` here even if that same id happens to live in a *different*
+    // window — pane/tab placement is window-local; ids are not required to
+    // be, so a collision (unlikely, but not ruled out) must not leak.
+    let close_many_scope: Option<std::collections::HashSet<String>> = match &op {
+        WorkspaceOp::CloseMany { tab_ids, window_id } => ws
+            .windows
+            .iter()
+            .find(|w| &w.id == window_id)
+            .map(|w| tab_ids.iter().filter(|t| pane_of_tab(&w.split_tree, t).is_some()).cloned().collect()),
+        _ => None,
+    };
+
+    let tree_changed = if matches!(op, WorkspaceOp::UpdateTabState { .. }) {
+        false // tabs-only op — no window to resolve, no layout-tree effect.
+    } else {
+        let win_id = op_window_id(&op).expect("every non-UpdateTabState WorkspaceOp variant here carries window_id");
+        let Some(win) = ws.windows.iter_mut().find(|w| w.id == win_id) else {
+            return; // unknown window_id: the whole op no-ops, tabs[] included.
+        };
         let (new_root, new_focused) = workspace_reducer(&win.split_tree, &win.focused_pane_id, &op);
-        if new_root != win.split_tree || new_focused != win.focused_pane_id {
+        let tc = new_root != win.split_tree || new_focused != win.focused_pane_id;
+        if tc {
             win.split_tree = new_root;
             win.focused_pane_id = new_focused;
-            changed = true;
         }
-    }
+        tc
+    };
+    changed |= tree_changed;
 
     // Rust-only tabs[] bookkeeping — TS has no `tabs` array (the frontend
-    // keeps QueryTab[] in App); these mirror the tree op above.
+    // keeps QueryTab[] in App); these mirror the tree op above, gated to
+    // the window this op resolved to (see the doc comment above).
     match &op {
         WorkspaceOp::OpenTab { tab: Some(model), .. } => match ws.tabs.iter_mut().find(|t| t.id == model.id) {
             Some(existing) if existing != model => {
@@ -622,20 +806,32 @@ pub fn apply(ws: &mut Workspace, op: WorkspaceOp) {
                 changed = true;
             }
         },
-        WorkspaceOp::CloseTab { tab_id } => {
-            let before = ws.tabs.len();
-            ws.tabs.retain(|t| &t.id != tab_id);
-            changed |= ws.tabs.len() != before;
+        WorkspaceOp::CloseTab { tab_id, .. } => {
+            // `tree_changed` here is true iff `tab_id` was actually found in
+            // the resolved window's tree (removing a present tab always
+            // alters that pane's `tab_ids`; a not-found tab leaves the tree
+            // byte-for-byte equal) — exactly the membership check we need.
+            if tree_changed {
+                let before = ws.tabs.len();
+                ws.tabs.retain(|t| &t.id != tab_id);
+                changed |= ws.tabs.len() != before;
+            }
         }
-        WorkspaceOp::CloseMany { tab_ids } => {
-            let before = ws.tabs.len();
-            ws.tabs.retain(|t| !tab_ids.contains(&t.id));
-            changed |= ws.tabs.len() != before;
+        WorkspaceOp::CloseMany { .. } => {
+            if let Some(scope) = &close_many_scope {
+                let before = ws.tabs.len();
+                ws.tabs.retain(|t| !scope.contains(&t.id));
+                changed |= ws.tabs.len() != before;
+            }
         }
-        WorkspaceOp::RenameTab { old_id, new_id } => {
-            if let Some(t) = ws.tabs.iter_mut().find(|t| &t.id == old_id) {
-                t.id = new_id.clone();
-                changed = true;
+        WorkspaceOp::RenameTab { old_id, new_id, .. } => {
+            // Same reasoning as CloseTab: `tree_changed` <=> `old_id` was
+            // present in the resolved window's tree.
+            if tree_changed {
+                if let Some(t) = ws.tabs.iter_mut().find(|t| &t.id == old_id) {
+                    t.id = new_id.clone();
+                    changed = true;
+                }
             }
         }
         WorkspaceOp::UpdateTabState { tab_id, last_query, last_aggregate, builder_state } => {
@@ -669,6 +865,143 @@ pub fn apply(ws: &mut Workspace, op: WorkspaceOp) {
     if changed {
         ws.revision += 1;
     }
+}
+
+/// `MoveTabToWindow`: relocates `tab_id` from wherever it currently lives
+/// (found by scanning ALL windows — the op names no source, only a target)
+/// into `target_window_id`'s `target_pane_id` (or that window's focused
+/// pane if omitted), activating and focusing it there. `tabs[]` is
+/// untouched — the tab model already exists; only its layout-tree placement
+/// moves. No-op if `tab_id` isn't open anywhere, or `target_window_id`
+/// doesn't exist.
+///
+/// Source-side removal reuses `close_tab`'s fold semantics (a pane that's
+/// emptied by the move folds into its sibling, exactly like `CloseTab`). If
+/// that leaves the source window's entire tree as a single empty pane (i.e.
+/// the source window is now fully empty) and that window isn't `"main"`,
+/// the window itself is removed — UNLESS it's also the target window
+/// (moving a tab "to" the same window it's already the sole occupant of
+/// must never delete the window it's about to be reinserted into).
+fn apply_move_tab_to_window(ws: &mut Workspace, tab_id: &str, target_window_id: &str, target_pane_id: Option<&str>) {
+    if !ws.windows.iter().any(|w| w.id == target_window_id) {
+        return; // unknown target window: no-op
+    }
+    let Some(source_idx) = ws.windows.iter().position(|w| pane_of_tab(&w.split_tree, tab_id).is_some()) else {
+        return; // tab not open anywhere: no-op
+    };
+
+    let before = ws.windows.clone();
+    let source_window_id = ws.windows[source_idx].id.clone();
+
+    {
+        let src = &mut ws.windows[source_idx];
+        let (new_root, new_focused) = close_tab(&src.split_tree, &src.focused_pane_id, tab_id);
+        src.split_tree = new_root;
+        src.focused_pane_id = new_focused;
+    }
+
+    let source_is_now_empty =
+        matches!(&ws.windows[source_idx].split_tree, LayoutNode::Pane { tab_ids, .. } if tab_ids.is_empty());
+    if source_is_now_empty && source_window_id != "main" && source_window_id != target_window_id {
+        ws.windows.remove(source_idx);
+    }
+
+    let target_win = ws
+        .windows
+        .iter_mut()
+        .find(|w| w.id == target_window_id)
+        .expect("target_window_id was checked to exist above and is never the window just removed");
+    let resolved_pane = target_pane_id
+        .and_then(|pid| find_pane(&target_win.split_tree, pid))
+        .map(|p| node_id(p).to_string())
+        .unwrap_or_else(|| target_win.focused_pane_id.clone());
+    let tab_id_owned = tab_id.to_string();
+    target_win.split_tree = map_pane(&target_win.split_tree, &resolved_pane, &mut |p| {
+        let LayoutNode::Pane { id, tab_ids, .. } = p else { return None };
+        let mut new_tab_ids = tab_ids.clone();
+        new_tab_ids.push(tab_id_owned.clone());
+        Some(LayoutNode::Pane { id: id.clone(), tab_ids: new_tab_ids, active_tab_id: Some(tab_id_owned.clone()) })
+    });
+    target_win.focused_pane_id = resolved_pane;
+
+    if ws.windows != before {
+        ws.revision += 1;
+    }
+}
+
+/// `DetachTab`: pulls `tab_id` out of its current window into a brand-new
+/// window of its own. No-op if `tab_id` is unknown, or if it's already the
+/// only tab in the only pane of a non-`"main"` window — it's already alone,
+/// so detaching would just destroy that window and recreate an equivalent
+/// one.
+///
+/// Otherwise: source-side removal reuses the same fold-and-maybe-remove-the-
+/// window logic as `apply_move_tab_to_window` (source pane folds; if the
+/// source window empties entirely and isn't `"main"`, it's removed — no
+/// self-target special case is needed here since the *new* window always
+/// gets a fresh `win-N` id, never the source's). Then a new `WindowModel`
+/// is pushed: `id` is the next `win-N` (scanning ALL window ids — see
+/// `next_window_id`), `split_tree` a single `"pane-1"` holding just this
+/// tab, `focused_pane_id: "pane-1"`.
+fn apply_detach_tab(ws: &mut Workspace, tab_id: &str) {
+    let Some(source_idx) = ws.windows.iter().position(|w| pane_of_tab(&w.split_tree, tab_id).is_some()) else {
+        return; // unknown tab: no-op
+    };
+
+    let already_alone = {
+        let src = &ws.windows[source_idx];
+        src.id != "main"
+            && matches!(&src.split_tree, LayoutNode::Pane { tab_ids, .. } if tab_ids.len() == 1 && tab_ids[0] == tab_id)
+    };
+    if already_alone {
+        return;
+    }
+
+    let before = ws.windows.clone();
+
+    let source_window_id = ws.windows[source_idx].id.clone();
+    {
+        let src = &mut ws.windows[source_idx];
+        let (new_root, new_focused) = close_tab(&src.split_tree, &src.focused_pane_id, tab_id);
+        src.split_tree = new_root;
+        src.focused_pane_id = new_focused;
+    }
+    let source_is_now_empty =
+        matches!(&ws.windows[source_idx].split_tree, LayoutNode::Pane { tab_ids, .. } if tab_ids.is_empty());
+    if source_is_now_empty && source_window_id != "main" {
+        ws.windows.remove(source_idx);
+    }
+
+    let new_window_id = next_window_id(ws);
+    ws.windows.push(WindowModel {
+        id: new_window_id,
+        split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec![tab_id.to_string()], active_tab_id: Some(tab_id.to_string()) },
+        focused_pane_id: "pane-1".into(),
+    });
+
+    if ws.windows != before {
+        ws.revision += 1;
+    }
+}
+
+/// `WindowClosed`: a frontend window was closed. No-op for `"main"` (the
+/// primary window can't be closed this way) or an unknown id. Otherwise
+/// removes the window from `ws.windows` AND removes every tab id its layout
+/// tree referenced from `ws.tabs` — per spec, closing a secondary window
+/// closes its tabs (unlike `MoveTabToWindow`/`DetachTab`, which relocate a
+/// tab's layout placement but never touch `tabs[]`).
+fn apply_window_closed(ws: &mut Workspace, window_id: &str) {
+    if window_id == "main" {
+        return;
+    }
+    let Some(idx) = ws.windows.iter().position(|w| w.id == window_id) else {
+        return; // unknown window: no-op
+    };
+    let removed = ws.windows.remove(idx);
+    let mut removed_tab_ids = Vec::new();
+    collect_tab_ids(&removed.split_tree, &mut removed_tab_ids);
+    ws.tabs.retain(|t| !removed_tab_ids.contains(&t.id));
+    ws.revision += 1; // removing a found, non-main window always changes something
 }
 
 /// Port of TS's tab-id collection helpers (`allTabIds`), used only by
@@ -705,6 +1038,16 @@ fn collect_tab_ids(node: &LayoutNode, out: &mut Vec<String>) {
 /// already-placed id just re-focuses it — so a duplicate can only mean a
 /// corrupt file).
 ///
+/// Window-level checks (Phase 3 Task 2): every `WindowModel.id` is unique;
+/// a `"main"` window must exist (every op that omits `window_id` targets it,
+/// and `WindowClosed`/`DetachTab`'s "non-main" special-casing assumes it's
+/// always there); every non-`"main"` window holds at least one tab
+/// (`WindowClosed` and the fold-empties-non-main-window paths in
+/// `apply_move_tab_to_window`/`apply_detach_tab` remove a secondary window
+/// the instant it empties, so a persisted empty secondary window can only
+/// mean a corrupt file — `"main"` is exempt, since an empty root pane is
+/// exactly Phase 2's initial state).
+///
 /// A dangling `focused_pane_id` is treated as invalid here rather than
 /// silently repaired to the tree's first pane: `validate` takes `&Workspace`
 /// and only ever reports a yes/no, so "repair" would mean a second, mutable
@@ -724,8 +1067,16 @@ fn validate(ws: &Workspace) -> bool {
         }
     }
 
+    if !ws.windows.iter().any(|w| w.id == "main") {
+        return false;
+    }
+
+    let mut seen_window_ids = std::collections::HashSet::new();
     let mut seen_tab_ids = std::collections::HashSet::new();
     for win in &ws.windows {
+        if !seen_window_ids.insert(win.id.as_str()) {
+            return false; // duplicate window id
+        }
         match shape(&win.split_tree) {
             Some(n) if n >= 1 => {}
             _ => return false,
@@ -735,6 +1086,9 @@ fn validate(ws: &Workspace) -> bool {
         }
         let mut ids = Vec::new();
         collect_tab_ids(&win.split_tree, &mut ids);
+        if win.id != "main" && ids.is_empty() {
+            return false; // a non-main window must hold at least one tab
+        }
         for id in ids {
             if !seen_tab_ids.insert(id) {
                 return false;
@@ -953,7 +1307,7 @@ mod tests {
         // lazy default-window initialization, exercised here via a no-op-ish
         // op on an empty `Workspace`.
         let mut ws = Workspace::default();
-        apply(&mut ws, WorkspaceOp::FocusPane { pane_id: "pane-1".into() });
+        apply(&mut ws, WorkspaceOp::FocusPane { pane_id: "pane-1".into(), window_id: "main".into() });
         assert_eq!(ws.windows.len(), 1);
         assert_eq!(ws.windows[0].id, "main");
         let (id, tab_ids, active_tab_id) = pane_fields(root(&ws));
@@ -966,7 +1320,7 @@ mod tests {
     #[test]
     fn open_tab_appends_new_tab_and_activates_it() {
         let mut ws = ws_with(&["a"]);
-        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "b".into(), pane_id: None, tab: None });
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "b".into(), pane_id: None, tab: None, window_id: "main".into() });
         let (_, tab_ids, active_tab_id) = pane_fields(root(&ws));
         assert_eq!(tab_ids, ["a", "b"]);
         assert_eq!(active_tab_id, Some("b"));
@@ -979,11 +1333,11 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()), window_id: "main".into() },
         );
         let pane_a = node_id(pane_of_tab(root(&ws), "a").unwrap()).to_string();
-        apply(&mut ws, WorkspaceOp::FocusPane { pane_id: pane_a });
-        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "b".into(), pane_id: None, tab: None });
+        apply(&mut ws, WorkspaceOp::FocusPane { pane_id: pane_a, window_id: "main".into() });
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "b".into(), pane_id: None, tab: None, window_id: "main".into() });
         let pane_b_id = node_id(pane_of_tab(root(&ws), "b").unwrap()).to_string();
         let (_, tab_ids, _) = pane_fields(find_pane(root(&ws), &pane_b_id).unwrap());
         assert_eq!(tab_ids, ["b"]); // still exactly one 'b' in that pane
@@ -1000,7 +1354,7 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()), window_id: "main".into() },
         );
         let (id, dir, ratio, children) = split_fields(root(&ws));
         assert_eq!(id, "split-1");
@@ -1020,7 +1374,7 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "col".into(), side: "start".into(), move_tab_id: Some("b".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "col".into(), side: "start".into(), move_tab_id: Some("b".into()), window_id: "main".into() },
         );
         let (_, _, _, children) = split_fields(root(&ws));
         let (_, first_tabs, _) = pane_fields(&children[0]);
@@ -1034,7 +1388,7 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("a".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("a".into()), window_id: "main".into() },
         );
         assert_eq!(ws, before);
         assert_eq!(ws.revision, 0);
@@ -1044,7 +1398,7 @@ mod tests {
     fn split_pane_without_moving_tab_creates_empty_pane() {
         let mut ws = ws_with(&["a"]);
         let root_id = node_id(root(&ws)).to_string();
-        apply(&mut ws, WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: None });
+        apply(&mut ws, WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: None, window_id: "main".into() });
         let (_, _, _, children) = split_fields(root(&ws));
         let (_, right_tabs, right_active) = pane_fields(&children[1]);
         assert!(right_tabs.is_empty());
@@ -1055,8 +1409,8 @@ mod tests {
     fn close_tab_activates_last_remaining_tab() {
         let mut ws = ws_with(&["a", "b", "c"]);
         let root_id = node_id(root(&ws)).to_string();
-        apply(&mut ws, WorkspaceOp::SetActive { pane_id: root_id, tab_id: "c".into() });
-        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "c".into() });
+        apply(&mut ws, WorkspaceOp::SetActive { pane_id: root_id, tab_id: "c".into(), window_id: "main".into() });
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "c".into(), window_id: "main".into() });
         let (_, tab_ids, active) = pane_fields(root(&ws));
         assert_eq!(tab_ids, ["a", "b"]);
         assert_eq!(active, Some("b"));
@@ -1068,9 +1422,9 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()), window_id: "main".into() },
         );
-        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "b".into() });
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "b".into(), window_id: "main".into() });
         let (id, tab_ids, _) = pane_fields(root(&ws));
         assert_eq!(tab_ids, ["a"]);
         assert_eq!(ws.windows[0].focused_pane_id, id);
@@ -1079,7 +1433,7 @@ mod tests {
     #[test]
     fn close_tab_leaves_empty_root_pane_in_place() {
         let mut ws = ws_with(&["a"]);
-        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "a".into() });
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "a".into(), window_id: "main".into() });
         let (_, tab_ids, active) = pane_fields(root(&ws));
         assert!(tab_ids.is_empty());
         assert_eq!(active, None);
@@ -1091,19 +1445,19 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()), window_id: "main".into() },
         );
         let pane_b = node_id(pane_of_tab(root(&ws), "b").unwrap()).to_string();
         // 'c' must belong to pane_b before it can be split off from it.
-        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "c".into(), target_pane_id: pane_b.clone(), index: None });
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "c".into(), target_pane_id: pane_b.clone(), index: None, window_id: "main".into() });
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: pane_b, dir: "col".into(), side: "end".into(), move_tab_id: Some("c".into()) },
+            WorkspaceOp::SplitPane { pane_id: pane_b, dir: "col".into(), side: "end".into(), move_tab_id: Some("c".into()), window_id: "main".into() },
         );
         let mut all = Vec::new();
         all_panes(root(&ws), &mut all);
         assert_eq!(all.len(), 3);
-        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "c".into() }); // pane empties -> depth-2 fold
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "c".into(), window_id: "main".into() }); // pane empties -> depth-2 fold
         let mut all2 = Vec::new();
         all_panes(root(&ws), &mut all2);
         assert_eq!(all2.len(), 2);
@@ -1117,12 +1471,12 @@ mod tests {
         // (no move_tab_id) must NOT be swept away by an unrelated close_tab.
         let mut ws = ws_with(&["a", "b"]);
         let root_id = node_id(root(&ws)).to_string();
-        apply(&mut ws, WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: None });
+        apply(&mut ws, WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: None, window_id: "main".into() });
         let mut all = Vec::new();
         all_panes(root(&ws), &mut all);
         assert_eq!(all.len(), 2);
         let empty_pane_id = all.iter().find(|p| pane_fields(p).1.is_empty()).map(|p| node_id(p).to_string()).unwrap();
-        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "b".into() });
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "b".into(), window_id: "main".into() });
         let mut all2 = Vec::new();
         all_panes(root(&ws), &mut all2);
         assert_eq!(all2.len(), 2);
@@ -1133,8 +1487,8 @@ mod tests {
     fn close_tab_activates_right_hand_neighbor() {
         let mut ws = ws_with(&["a", "b", "c"]);
         let root_id = node_id(root(&ws)).to_string();
-        apply(&mut ws, WorkspaceOp::SetActive { pane_id: root_id, tab_id: "b".into() });
-        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "b".into() });
+        apply(&mut ws, WorkspaceOp::SetActive { pane_id: root_id, tab_id: "b".into(), window_id: "main".into() });
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "b".into(), window_id: "main".into() });
         let (_, tab_ids, active) = pane_fields(root(&ws));
         assert_eq!(tab_ids, ["a", "c"]);
         assert_eq!(active, Some("c"));
@@ -1146,9 +1500,9 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("c".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("c".into()), window_id: "main".into() },
         );
-        apply(&mut ws, WorkspaceOp::CloseMany { tab_ids: vec!["b".into(), "c".into()] });
+        apply(&mut ws, WorkspaceOp::CloseMany { tab_ids: vec!["b".into(), "c".into()], window_id: "main".into() });
         let mut all = Vec::new();
         all_panes(root(&ws), &mut all);
         assert_eq!(all.len(), 1);
@@ -1162,10 +1516,10 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("c".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("c".into()), window_id: "main".into() },
         );
         let target = node_id(pane_of_tab(root(&ws), "c").unwrap()).to_string();
-        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "b".into(), target_pane_id: target.clone(), index: None });
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "b".into(), target_pane_id: target.clone(), index: None, window_id: "main".into() });
         assert_eq!(node_id(pane_of_tab(root(&ws), "b").unwrap()), target);
         let (_, tab_ids, active) = pane_fields(find_pane(root(&ws), &target).unwrap());
         assert_eq!(tab_ids, ["c", "b"]);
@@ -1179,11 +1533,11 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()), window_id: "main".into() },
         );
         let source_b = node_id(pane_of_tab(root(&ws), "b").unwrap()).to_string();
         let target_a = node_id(pane_of_tab(root(&ws), "a").unwrap()).to_string();
-        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "b".into(), target_pane_id: target_a, index: None });
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "b".into(), target_pane_id: target_a, index: None, window_id: "main".into() });
         let (_, tab_ids, _) = pane_fields(root(&ws));
         assert_eq!(tab_ids, ["a", "b"]);
         assert!(find_pane(root(&ws), &source_b).is_none());
@@ -1193,7 +1547,7 @@ mod tests {
     fn move_tab_reorders_within_same_pane_using_index() {
         let mut ws = ws_with(&["a", "b", "c"]);
         let root_id = node_id(root(&ws)).to_string();
-        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "c".into(), target_pane_id: root_id, index: Some(0) });
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "c".into(), target_pane_id: root_id, index: Some(0), window_id: "main".into() });
         let (_, tab_ids, _) = pane_fields(root(&ws));
         assert_eq!(tab_ids, ["c", "a", "b"]);
     }
@@ -1204,27 +1558,27 @@ mod tests {
         let root_id = node_id(root(&ws)).to_string();
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()) },
+            WorkspaceOp::SplitPane { pane_id: root_id, dir: "row".into(), side: "end".into(), move_tab_id: Some("b".into()), window_id: "main".into() },
         );
         let split_id = node_id(root(&ws)).to_string();
 
         let mut a = ws.clone();
-        apply(&mut a, WorkspaceOp::ResizeSplit { split_id: split_id.clone(), ratio: 0.3 });
+        apply(&mut a, WorkspaceOp::ResizeSplit { split_id: split_id.clone(), ratio: 0.3, window_id: "main".into() });
         assert_eq!(split_fields(root(&a)).2, 0.3);
 
         let mut b = ws.clone();
-        apply(&mut b, WorkspaceOp::ResizeSplit { split_id: split_id.clone(), ratio: 0.01 });
+        apply(&mut b, WorkspaceOp::ResizeSplit { split_id: split_id.clone(), ratio: 0.01, window_id: "main".into() });
         assert_eq!(split_fields(root(&b)).2, 0.15);
 
         let mut c = ws.clone();
-        apply(&mut c, WorkspaceOp::ResizeSplit { split_id, ratio: 0.99 });
+        apply(&mut c, WorkspaceOp::ResizeSplit { split_id, ratio: 0.99, window_id: "main".into() });
         assert_eq!(split_fields(root(&c)).2, 0.85);
     }
 
     #[test]
     fn rename_tab_rewrites_id_everywhere_including_active() {
         let mut ws = ws_with(&["conn.db.old"]);
-        apply(&mut ws, WorkspaceOp::RenameTab { old_id: "conn.db.old".into(), new_id: "conn.db.new".into() });
+        apply(&mut ws, WorkspaceOp::RenameTab { old_id: "conn.db.old".into(), new_id: "conn.db.new".into(), window_id: "main".into() });
         let (_, tab_ids, active) = pane_fields(root(&ws));
         assert_eq!(tab_ids, ["conn.db.new"]);
         assert_eq!(active, Some("conn.db.new"));
@@ -1234,13 +1588,13 @@ mod tests {
     fn unknown_ids_are_noops_without_revision_bump() {
         let mut ws = ws_with(&["a"]);
         let before = ws.clone();
-        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "nope".into() });
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: "nope".into(), window_id: "main".into() });
         assert_eq!(ws, before);
-        apply(&mut ws, WorkspaceOp::SetActive { pane_id: "nope".into(), tab_id: "a".into() });
+        apply(&mut ws, WorkspaceOp::SetActive { pane_id: "nope".into(), tab_id: "a".into(), window_id: "main".into() });
         assert_eq!(ws, before);
-        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "a".into(), target_pane_id: "nope".into(), index: None });
+        apply(&mut ws, WorkspaceOp::MoveTab { tab_id: "a".into(), target_pane_id: "nope".into(), index: None, window_id: "main".into() });
         assert_eq!(ws, before);
-        apply(&mut ws, WorkspaceOp::ResizeSplit { split_id: "nope".into(), ratio: 0.5 });
+        apply(&mut ws, WorkspaceOp::ResizeSplit { split_id: "nope".into(), ratio: 0.5, window_id: "main".into() });
         assert_eq!(ws, before);
         assert_eq!(ws.revision, 0);
     }
@@ -1266,19 +1620,19 @@ mod tests {
     fn open_tab_upserts_tab_model_into_tabs() {
         let mut ws = ws_with(&[]);
         let tab = sample_tab("t1");
-        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "t1".into(), pane_id: None, tab: Some(tab.clone()) });
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "t1".into(), pane_id: None, tab: Some(tab.clone()), window_id: "main".into() });
         assert_eq!(ws.tabs, vec![tab.clone()]);
         assert_eq!(ws.revision, 1);
 
         // Re-opening with an identical model is a true no-op: no revision bump.
         let rev_before = ws.revision;
-        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "t1".into(), pane_id: None, tab: Some(tab.clone()) });
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "t1".into(), pane_id: None, tab: Some(tab.clone()), window_id: "main".into() });
         assert_eq!(ws.revision, rev_before);
 
         // A changed model (e.g. renamed profile) upserts in place, replacing not duplicating.
         let mut renamed = tab.clone();
         renamed.profile_name = "Renamed".into();
-        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "t1".into(), pane_id: None, tab: Some(renamed.clone()) });
+        apply(&mut ws, WorkspaceOp::OpenTab { tab_id: "t1".into(), pane_id: None, tab: Some(renamed.clone()), window_id: "main".into() });
         assert_eq!(ws.tabs, vec![renamed]);
         assert_eq!(ws.revision, rev_before + 1);
     }
@@ -1409,7 +1763,7 @@ mod tests {
         };
         apply(
             &mut ws,
-            WorkspaceOp::SplitPane { pane_id: "pane-3".into(), dir: "row".into(), side: "end".into(), move_tab_id: Some("x".into()) },
+            WorkspaceOp::SplitPane { pane_id: "pane-3".into(), dir: "row".into(), side: "end".into(), move_tab_id: Some("x".into()), window_id: "main".into() },
         );
         let mut ids = Vec::new();
         collect_ids(root(&ws), &mut ids);
@@ -1676,6 +2030,7 @@ mod tests {
                 tab_id: tab1_id.clone(),
                 pane_id: None,
                 tab: Some(tab(&tab1_id, "p1", "Prod Cluster", "mydb", "customers")),
+                window_id: "main".into(),
             },
         );
         apply(
@@ -1684,6 +2039,7 @@ mod tests {
                 tab_id: tab2_id.clone(),
                 pane_id: None,
                 tab: Some(tab(&tab2_id, "p1", "Prod Cluster", "mydb", "orders")),
+                window_id: "main".into(),
             },
         );
         apply(
@@ -1692,6 +2048,7 @@ mod tests {
                 tab_id: tab3_id.clone(),
                 pane_id: None,
                 tab: Some(tab(&tab3_id, "p2", "Analytics", "otherdb", "items")),
+                window_id: "main".into(),
             },
         );
 
@@ -1704,12 +2061,13 @@ mod tests {
                 dir: "row".into(),
                 side: "end".into(),
                 move_tab_id: Some(tab3_id.clone()),
+                window_id: "main".into(),
             },
         );
 
         // set_active on the pane that still holds tab1/tab2.
         let left_pane_id = node_id(pane_of_tab(root(&ws), &tab1_id).unwrap()).to_string();
-        apply(&mut ws, WorkspaceOp::SetActive { pane_id: left_pane_id, tab_id: tab2_id.clone() });
+        apply(&mut ws, WorkspaceOp::SetActive { pane_id: left_pane_id, tab_id: tab2_id.clone(), window_id: "main".into() });
 
         // update_tab_state patches tab1's lastQuery.
         let patched_query = serde_json::json!({ "filter": { "active": true } });
@@ -1724,7 +2082,7 @@ mod tests {
         );
 
         // close_tab drops tab2.
-        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: tab2_id.clone() });
+        apply(&mut ws, WorkspaceOp::CloseTab { tab_id: tab2_id.clone(), window_id: "main".into() });
 
         // Save to a temp-dir file and load it back.
         let dir = std::env::temp_dir().join("mqlens-ws-realistic-roundtrip-test");
@@ -1773,6 +2131,477 @@ mod tests {
                 "id `{id}` is neither profile-space nor a connectionless structural id"
             );
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 3 Task 2: window-scoped ops — MoveTabToWindow, DetachTab,
+    // WindowClosed, window_id resolution, and validate()'s window rules.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn move_tab_to_window_moves_and_activates_in_target() {
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane {
+                        id: "pane-1".into(),
+                        tab_ids: vec!["a".into(), "b".into()],
+                        active_tab_id: Some("a".into()),
+                    },
+                },
+                WindowModel {
+                    id: "win-1".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["c".into()], active_tab_id: Some("c".into()) },
+                },
+            ],
+            tabs: vec![],
+        };
+        apply(
+            &mut ws,
+            WorkspaceOp::MoveTabToWindow { tab_id: "b".into(), target_window_id: "win-1".into(), target_pane_id: None },
+        );
+
+        let (_, main_tabs, main_active) = pane_fields(&ws.windows[0].split_tree);
+        assert_eq!(main_tabs, ["a"], "source pane loses the moved tab");
+        assert_eq!(main_active, Some("a"));
+
+        let (_, win1_tabs, win1_active) = pane_fields(&ws.windows[1].split_tree);
+        assert_eq!(win1_tabs, ["c", "b"], "target pane gains the moved tab, appended");
+        assert_eq!(win1_active, Some("b"), "moved tab activates in the target pane");
+        assert_eq!(ws.windows[1].focused_pane_id, "pane-1", "target window focuses the pane the tab landed in");
+        assert_eq!(ws.revision, 1);
+        assert!(ws.tabs.is_empty(), "tabs[] is untouched — the tab model already existed");
+    }
+
+    #[test]
+    fn move_tab_to_window_folds_source_pane_when_emptied() {
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-2".into(),
+                    split_tree: LayoutNode::Split {
+                        id: "split-1".into(),
+                        dir: "row".into(),
+                        ratio: 0.5,
+                        children: vec![
+                            LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                            LayoutNode::Pane { id: "pane-2".into(), tab_ids: vec!["b".into()], active_tab_id: Some("b".into()) },
+                        ],
+                    },
+                },
+                WindowModel {
+                    id: "win-1".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["c".into()], active_tab_id: Some("c".into()) },
+                },
+            ],
+            tabs: vec![],
+        };
+        apply(
+            &mut ws,
+            WorkspaceOp::MoveTabToWindow { tab_id: "b".into(), target_window_id: "win-1".into(), target_pane_id: None },
+        );
+
+        // pane-2 emptied and folded away; main's tree collapses to pane-1 alone.
+        let (id, tab_ids, _) = pane_fields(&ws.windows[0].split_tree);
+        assert_eq!(id, "pane-1");
+        assert_eq!(tab_ids, ["a"]);
+        assert_eq!(ws.windows[0].focused_pane_id, "pane-1", "focus repairs off the folded-away pane-2");
+        assert_eq!(ws.windows.len(), 2, "main itself is never removed, only the folded pane inside it");
+
+        let (_, win1_tabs, _) = pane_fields(&ws.windows[1].split_tree);
+        assert_eq!(win1_tabs, ["c", "b"]);
+    }
+
+    #[test]
+    fn move_tab_to_window_removes_emptied_non_main_source_window() {
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                },
+                WindowModel {
+                    id: "win-2".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["x".into()], active_tab_id: Some("x".into()) },
+                },
+            ],
+            tabs: vec![],
+        };
+        apply(
+            &mut ws,
+            WorkspaceOp::MoveTabToWindow { tab_id: "x".into(), target_window_id: "main".into(), target_pane_id: None },
+        );
+
+        assert_eq!(ws.windows.len(), 1, "the emptied non-main source window must be removed");
+        assert_eq!(ws.windows[0].id, "main");
+        let (_, tab_ids, active) = pane_fields(&ws.windows[0].split_tree);
+        assert_eq!(tab_ids, ["a", "x"]);
+        assert_eq!(active, Some("x"));
+        assert_eq!(ws.revision, 1);
+    }
+
+    #[test]
+    fn move_tab_to_window_honors_explicit_target_pane_id() {
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                },
+                WindowModel {
+                    id: "win-1".into(),
+                    focused_pane_id: "pane-1".into(), // NOT the explicit target below
+                    split_tree: LayoutNode::Split {
+                        id: "split-1".into(),
+                        dir: "row".into(),
+                        ratio: 0.5,
+                        children: vec![
+                            LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["c".into()], active_tab_id: Some("c".into()) },
+                            LayoutNode::Pane { id: "pane-2".into(), tab_ids: vec!["d".into()], active_tab_id: Some("d".into()) },
+                        ],
+                    },
+                },
+            ],
+            tabs: vec![],
+        };
+        apply(
+            &mut ws,
+            WorkspaceOp::MoveTabToWindow {
+                tab_id: "a".into(),
+                target_window_id: "win-1".into(),
+                target_pane_id: Some("pane-2".into()),
+            },
+        );
+
+        let win1 = &ws.windows[1];
+        assert_eq!(win1.focused_pane_id, "pane-2", "explicit target_pane_id wins over the target window's prior focus");
+        let LayoutNode::Split { children, .. } = &win1.split_tree else { panic!("expected a split") };
+        let (_, pane1_tabs, _) = pane_fields(&children[0]);
+        let (_, pane2_tabs, pane2_active) = pane_fields(&children[1]);
+        assert_eq!(pane1_tabs, ["c"], "the target window's other pane is untouched");
+        assert_eq!(pane2_tabs, ["d", "a"]);
+        assert_eq!(pane2_active, Some("a"));
+    }
+
+    #[test]
+    fn move_tab_to_window_unknown_tab_or_window_is_noop() {
+        let mut ws = ws_with(&["a"]);
+        let before = ws.clone();
+        apply(
+            &mut ws,
+            WorkspaceOp::MoveTabToWindow { tab_id: "nope".into(), target_window_id: "main".into(), target_pane_id: None },
+        );
+        assert_eq!(ws, before);
+        apply(
+            &mut ws,
+            WorkspaceOp::MoveTabToWindow { tab_id: "a".into(), target_window_id: "nope".into(), target_pane_id: None },
+        );
+        assert_eq!(ws, before);
+        assert_eq!(ws.revision, 0);
+    }
+
+    #[test]
+    fn detach_tab_creates_new_window_and_folds_source() {
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![WindowModel {
+                id: "main".into(),
+                focused_pane_id: "pane-2".into(),
+                split_tree: LayoutNode::Split {
+                    id: "split-1".into(),
+                    dir: "row".into(),
+                    ratio: 0.5,
+                    children: vec![
+                        LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                        LayoutNode::Pane { id: "pane-2".into(), tab_ids: vec!["b".into()], active_tab_id: Some("b".into()) },
+                    ],
+                },
+            }],
+            tabs: vec![],
+        };
+        apply(&mut ws, WorkspaceOp::DetachTab { tab_id: "b".into() });
+
+        assert_eq!(ws.windows.len(), 2);
+        let (id, tab_ids, _) = pane_fields(&ws.windows[0].split_tree);
+        assert_eq!(id, "pane-1");
+        assert_eq!(tab_ids, ["a"], "source pane-2 emptied and folded away");
+        assert_eq!(ws.windows[0].focused_pane_id, "pane-1");
+
+        let new_win = &ws.windows[1];
+        assert_eq!(new_win.id, "win-1");
+        assert_eq!(new_win.focused_pane_id, "pane-1");
+        let (_, new_tabs, new_active) = pane_fields(&new_win.split_tree);
+        assert_eq!(new_tabs, ["b"]);
+        assert_eq!(new_active, Some("b"));
+        assert_eq!(ws.revision, 1);
+    }
+
+    #[test]
+    fn detach_tab_noop_when_already_alone_in_non_main_window() {
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                },
+                WindowModel {
+                    id: "win-1".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["b".into()], active_tab_id: Some("b".into()) },
+                },
+            ],
+            tabs: vec![],
+        };
+        let before = ws.clone();
+        apply(&mut ws, WorkspaceOp::DetachTab { tab_id: "b".into() });
+        assert_eq!(ws, before, "b is already the sole tab in the sole pane of its own non-main window");
+        assert_eq!(ws.revision, 0);
+    }
+
+    #[test]
+    fn detach_tab_always_detaches_a_main_window_singleton() {
+        // The "already alone" no-op exemption is explicitly non-main only —
+        // detaching main's last tab must still create a new window (main
+        // stays behind, empty, exactly like Phase 2's initial state).
+        let mut ws = ws_with(&["a"]);
+        apply(&mut ws, WorkspaceOp::DetachTab { tab_id: "a".into() });
+        assert_eq!(ws.windows.len(), 2);
+        let (_, main_tabs, _) = pane_fields(root(&ws));
+        assert!(main_tabs.is_empty());
+        assert_eq!(ws.windows[1].id, "win-1");
+        let (_, new_tabs, _) = pane_fields(&ws.windows[1].split_tree);
+        assert_eq!(new_tabs, ["a"]);
+    }
+
+    #[test]
+    fn detach_tab_unknown_tab_is_noop() {
+        let mut ws = ws_with(&["a"]);
+        let before = ws.clone();
+        apply(&mut ws, WorkspaceOp::DetachTab { tab_id: "nope".into() });
+        assert_eq!(ws, before);
+        assert_eq!(ws.revision, 0);
+    }
+
+    #[test]
+    fn detach_tab_mints_next_window_id_by_scanning_all_window_ids() {
+        // win-3 already exists (unrelated to the window being detached
+        // from) — the next id must be win-4, proving the scan covers ALL
+        // window ids, not just a per-tree counter.
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane {
+                        id: "pane-1".into(),
+                        tab_ids: vec!["a".into(), "b".into()],
+                        active_tab_id: Some("a".into()),
+                    },
+                },
+                WindowModel {
+                    id: "win-3".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["z".into()], active_tab_id: Some("z".into()) },
+                },
+            ],
+            tabs: vec![],
+        };
+        apply(&mut ws, WorkspaceOp::DetachTab { tab_id: "b".into() });
+        let ids: Vec<&str> = ws.windows.iter().map(|w| w.id.as_str()).collect();
+        assert!(ids.contains(&"win-4"), "expected win-4 past existing win-3, got {ids:?}");
+    }
+
+    #[test]
+    fn window_closed_removes_window_and_its_tabs() {
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                },
+                WindowModel {
+                    id: "win-1".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane {
+                        id: "pane-1".into(),
+                        tab_ids: vec!["b".into(), "c".into()],
+                        active_tab_id: Some("b".into()),
+                    },
+                },
+            ],
+            tabs: vec![sample_tab("a"), sample_tab("b"), sample_tab("c")],
+        };
+        apply(&mut ws, WorkspaceOp::WindowClosed { window_id: "win-1".into() });
+
+        assert_eq!(ws.windows.len(), 1);
+        assert_eq!(ws.windows[0].id, "main");
+        let remaining_tab_ids: Vec<&str> = ws.tabs.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(remaining_tab_ids, ["a"], "win-1's layout tab ids (b, c) leave tabs[] too");
+        assert_eq!(ws.revision, 1);
+    }
+
+    #[test]
+    fn window_closed_noop_for_main_or_unknown() {
+        let mut ws = ws_with(&["a"]);
+        let before = ws.clone();
+        apply(&mut ws, WorkspaceOp::WindowClosed { window_id: "main".into() });
+        assert_eq!(ws, before, "main can't be closed via window_closed");
+        apply(&mut ws, WorkspaceOp::WindowClosed { window_id: "nope".into() });
+        assert_eq!(ws, before);
+        assert_eq!(ws.revision, 0);
+    }
+
+    #[test]
+    fn window_scoped_op_resolves_panes_strictly_within_target_window() {
+        // Two windows, each with a pane-2 — proves op.window_id resolution
+        // never lets a window-local id cross-talk into the wrong window.
+        let mut ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Split {
+                        id: "split-1".into(),
+                        dir: "row".into(),
+                        ratio: 0.5,
+                        children: vec![
+                            LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["m1".into()], active_tab_id: Some("m1".into()) },
+                            LayoutNode::Pane {
+                                id: "pane-2".into(),
+                                tab_ids: vec!["m2".into(), "m3".into()],
+                                active_tab_id: Some("m2".into()),
+                            },
+                        ],
+                    },
+                },
+                WindowModel {
+                    id: "win-1".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Split {
+                        id: "split-1".into(),
+                        dir: "row".into(),
+                        ratio: 0.5,
+                        children: vec![
+                            LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["x1".into()], active_tab_id: Some("x1".into()) },
+                            LayoutNode::Pane {
+                                id: "pane-2".into(),
+                                tab_ids: vec!["x2".into(), "x3".into()],
+                                active_tab_id: Some("x2".into()),
+                            },
+                        ],
+                    },
+                },
+            ],
+            tabs: vec![],
+        };
+        let main_before = ws.windows[0].clone();
+
+        apply(
+            &mut ws,
+            WorkspaceOp::SetActive { window_id: "win-1".into(), pane_id: "pane-2".into(), tab_id: "x3".into() },
+        );
+
+        assert_eq!(ws.windows[0], main_before, "main's pane-2 (same id, different window) must be untouched");
+        let LayoutNode::Split { children, .. } = &ws.windows[1].split_tree else { panic!("expected a split") };
+        let (_, _, active) = pane_fields(&children[1]);
+        assert_eq!(active, Some("x3"));
+        assert_eq!(ws.windows[1].focused_pane_id, "pane-2");
+        assert_eq!(ws.revision, 1);
+    }
+
+    #[test]
+    fn validate_rejects_missing_main_window() {
+        let ws = Workspace {
+            revision: 0,
+            windows: vec![WindowModel {
+                id: "win-1".into(),
+                focused_pane_id: "pane-1".into(),
+                split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+            }],
+            tabs: vec![],
+        };
+        assert!(!validate(&ws));
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_window_ids() {
+        let ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec![], active_tab_id: None },
+                },
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                },
+            ],
+            tabs: vec![],
+        };
+        assert!(!validate(&ws));
+    }
+
+    #[test]
+    fn validate_rejects_non_main_window_with_no_tabs() {
+        let ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                },
+                WindowModel {
+                    id: "win-1".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec![], active_tab_id: None },
+                },
+            ],
+            tabs: vec![],
+        };
+        assert!(!validate(&ws));
+    }
+
+    #[test]
+    fn validate_accepts_a_well_formed_multi_window_document() {
+        let ws = Workspace {
+            revision: 0,
+            windows: vec![
+                WindowModel {
+                    id: "main".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec![], active_tab_id: None },
+                },
+                WindowModel {
+                    id: "win-1".into(),
+                    focused_pane_id: "pane-1".into(),
+                    split_tree: LayoutNode::Pane { id: "pane-1".into(), tab_ids: vec!["a".into()], active_tab_id: Some("a".into()) },
+                },
+            ],
+            tabs: vec![],
+        };
+        assert!(validate(&ws));
     }
 }
 
@@ -1908,7 +2737,7 @@ mod store {
         let path = tmp_path("apply-init.json");
         assert!(state.workspace.lock_safe().unwrap().is_none(), "precondition: no workspace loaded yet");
 
-        apply_impl(&state, &path, WorkspaceOp::FocusPane { pane_id: "pane-1".into() }).unwrap();
+        apply_impl(&state, &path, WorkspaceOp::FocusPane { pane_id: "pane-1".into(), window_id: "main".into() }).unwrap();
 
         let ws = state.workspace.lock_safe().unwrap().clone().unwrap();
         assert_eq!(ws.windows.len(), 1);
@@ -1930,7 +2759,7 @@ mod store {
         // reducer returns the same layout and the tabs[] retain is a no-op,
         // so `apply`'s revision never bumps (see
         // `unknown_ids_are_noops_without_revision_bump` in `mod tests`).
-        apply_impl(&state, &path, WorkspaceOp::CloseTab { tab_id: "nope".into() }).unwrap();
+        apply_impl(&state, &path, WorkspaceOp::CloseTab { tab_id: "nope".into(), window_id: "main".into() }).unwrap();
 
         assert_eq!(
             state.workspace_write_gen.load(Ordering::SeqCst),
@@ -1962,8 +2791,12 @@ mod store {
         let path = tmp_path("debounce-burst.json");
 
         for i in 0..10 {
-            apply_impl(&state, &path, WorkspaceOp::OpenTab { tab_id: format!("t{i}"), pane_id: None, tab: None })
-                .unwrap();
+            apply_impl(
+                &state,
+                &path,
+                WorkspaceOp::OpenTab { tab_id: format!("t{i}"), pane_id: None, tab: None, window_id: "main".into() },
+            )
+            .unwrap();
         }
 
         // 10 distinct real changes mint 10 generations; only the last

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -556,16 +556,15 @@ fn max_numeric_suffix(node: &LayoutNode, prefix: &str) -> u64 {
 /// Mints `pane-N` / `split-N` ids by scanning the live tree for the current
 /// max suffix at call time, rather than keeping a counter on `Workspace`.
 ///
-/// Deliberate divergence from TS: `model.ts` keeps module-level
-/// `paneCounter`/`splitCounter` mutable statics (reset per-test via
-/// `resetLayoutIds`) with no file-load case — a fresh page load starts both
-/// counters at 0 because the in-memory layout is always freshly built from
-/// `tabIds`. The Rust store, by contrast, *restores* a tree from
-/// `workspace.json` that may already contain `pane-7`/`split-3`; a
-/// process-local counter seeded at 0 would immediately collide with ids
-/// already in the restored tree. Scanning the tree at mint time is
-/// stateless (nothing to seed on load, nothing to serialize, nothing to get
-/// out of sync with the actual tree) and cheap at these tree sizes.
+/// `model.ts`'s `nextPaneId`/`nextSplitId` (TS #197 fix) mirror this exactly
+/// — both sides mint by scanning the tree being reduced rather than a
+/// standalone counter. That statelessness matters most here: the Rust store
+/// *restores* a tree from `workspace.json` that may already contain
+/// `pane-7`/`split-3`, so a process-local counter seeded at 0 would
+/// immediately collide with ids already in the restored tree. Scanning the
+/// tree at mint time needs nothing to seed on load, nothing to serialize,
+/// and nothing that can get out of sync with the actual tree — and is cheap
+/// at these tree sizes.
 fn next_pane_id(root: &LayoutNode) -> String {
     format!("pane-{}", max_numeric_suffix(root, "pane-") + 1)
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1907,6 +1907,10 @@ function Workspace() {
   const [tabContextMenu, setTabContextMenu] = useState<{ tabId: string; x: number; y: number } | null>(null);
 
   const handleTabContextMenu = (tabId: string, e: React.MouseEvent) => {
+    // Sole tab in this window, no other windows to move to: buildTabContextMenuItems
+    // returns [] and an empty ContextMenu would render as an empty floating box.
+    // Skip opening the menu entirely in that case.
+    if (buildTabContextMenuItems(tabId).length === 0) return;
     setTabContextMenu({ tabId, x: e.clientX, y: e.clientY });
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ import {
 } from './components/RestoreView';
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
-import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, mapLayoutTabIds, type WorkspaceAction, type WorkspaceLayout } from './workspace/model';
+import { workspaceReducer, createInitialLayout, findPane, paneOfTab, allPanes, allTabIds, mapLayoutTabIds, type WorkspaceAction, type WorkspaceLayout } from './workspace/model';
 import { WorkspaceRoot } from './workspace/WorkspaceRoot';
 import {
   workspaceApply,
@@ -2131,25 +2131,38 @@ function Workspace() {
   };
 
   // Foreign-event reconciliation (Phase 3 Task 4). Two independent
-  // subscriptions, set up once — `reconciliationSubscribedRef` guards
-  // against React 18 StrictMode's double-invoke of effects in dev exactly
-  // like `restoredRef` above, so a second invocation of this same effect
-  // never attaches a second pair of listeners (which would double-apply
-  // every foreign hydrate/reconcile). Both listener callbacks are captured
-  // ONCE at mount and never refreshed on later renders, so — like
-  // `handleBuilderStateChange` above — they must read live component state
-  // exclusively through refs (`activeConnectionsRef`, `tabsRef`,
-  // `lastWorkspaceRef`) or through a setter's functional-update form
-  // (`setTabs(prev => ...)`), never through a state variable captured
-  // directly in the closure.
-  const reconciliationSubscribedRef = useRef(false);
+  // subscriptions, symmetric setup/cleanup on every mount (the
+  // `resUsage`-poll `let active = true` pattern above) — NOT a persist-
+  // across-remount ref guard: React 18 StrictMode's dev double-invoke runs
+  // setup→cleanup→setup, and a ref guard set permanently `true` by the
+  // FIRST setup makes the SECOND setup's early-return skip subscribing
+  // entirely, leaving this component with zero listeners for the rest of
+  // its life (a real bug caught in review — the ref-guard idiom is only
+  // safe for effects that must run their body's side effect at most once
+  // ever, like `restoredRef`'s single `workspace_get`; it actively breaks
+  // effects, like this one, whose job is to stay subscribed for the
+  // component's lifetime). `listen`'s subscribe call is itself async
+  // (`Promise<UnlistenFn>`) — `cancelled` covers the case where cleanup
+  // runs before that promise resolves (StrictMode's rapid setup/cleanup),
+  // unlistening immediately once it does rather than leaking a listener
+  // registered after this instance was already torn down. Both listener
+  // callbacks are captured ONCE per mount and never refreshed on later
+  // renders of that same mount, so — like `handleBuilderStateChange`
+  // above — they must read live component state exclusively through refs
+  // (`activeConnectionsRef`, `tabsRef`, `layoutRef`, `lastWorkspaceRef`) or
+  // through a setter's functional-update form (`setTabs(prev => ...)`),
+  // never through a state variable captured directly in the closure.
   useEffect(() => {
-    if (reconciliationSubscribedRef.current) return;
-    reconciliationSubscribedRef.current = true;
+    let cancelled = false;
+    const unlistenFns: Array<() => void> = [];
+    const own = (p: Promise<() => void>) => {
+      p.then((unlisten) => {
+        if (cancelled) unlisten();
+        else unlistenFns.push(unlisten);
+      }).catch(() => {});
+    };
 
-    const unlistenPromises: Promise<() => void>[] = [];
-
-    unlistenPromises.push(
+    own(
       subscribeWorkspaceChanged((payload: WorkspaceChangedPayload) => {
         // Drop a replayed/out-of-order event — revisions only ever
         // increase, so anything at or below what's already applied adds
@@ -2159,15 +2172,32 @@ function Workspace() {
         lastSeenRevisionRef.current = payload.revision;
         lastWorkspaceRef.current = payload.workspace;
 
-        // Self-origin, single-window ops are our own optimistic dispatch
-        // echoing back — already applied locally by `dispatchWorkspace`,
-        // nothing to reconcile. Cross-window ops
-        // (move_tab_to_window/detach_tab/window_closed) are the one
-        // exception: they never go through the local layout reducer at all
-        // (there is no frontend action for them — Task 5 fires them
-        // straight at `workspace_apply`), so even the origin window
-        // depends entirely on this event to update its own tree.
-        if (payload.origin === windowLabel() && !payload.crossWindow) return;
+        // Bystander semantics (CRITICAL fix, review round 1): the backend
+        // guarantees `crossWindow: false` for an op iff it changed ONLY
+        // the origin window's own tree (see workspace.rs's
+        // `op_is_cross_window`). That means, for every non-crossWindow
+        // event regardless of origin:
+        //  - if origin IS this window: it's our own optimistic dispatch
+        //    echoing back — already applied locally, nothing to do.
+        //  - if origin is ANOTHER window: that op provably did not touch
+        //    THIS window's tree, so this window's entry in `payload` is
+        //    just whatever it already was — reconciling against it is a
+        //    no-op AT BEST. At worst it's actively wrong: if this window
+        //    has a local optimistic change in flight whose mirror hasn't
+        //    landed yet, the payload's snapshot of "this window" predates
+        //    that change, and hydrating from it would silently roll the
+        //    local change back — with no way to recover, since the
+        //    self-origin echo that will eventually confirm the mirror is
+        //    exactly the kind of event this same branch would (correctly)
+        //    ignore too.
+        // Only cross-window ops (move_tab_to_window/detach_tab/
+        // window_closed) can touch more than one window's tree, including
+        // this one's, and are the only ones ever worth reconciling against
+        // — regardless of origin, since none of them ever run through this
+        // window's own layout reducer even when THIS window caused them
+        // (there is no frontend action for them; Task 5 fires them
+        // straight at `workspace_apply`).
+        if (!payload.crossWindow) return;
 
         const connections = activeConnectionsRef.current;
         const winEntry = payload.workspace.windows.find((w) => w.id === windowLabel());
@@ -2183,6 +2213,18 @@ function Workspace() {
           return;
         }
 
+        // IMPORTANT fix (review round 1): unmirrored tabs (export/import —
+        // `toPersistedTab` returns null for them, so they're NEVER sent to
+        // the backend and can never appear in ANY snapshot) must survive a
+        // hydrate. Captured from `layoutRef.current` (the last-committed
+        // local layout — refs stay fresh across this frozen listener,
+        // renders keep it current) BEFORE hydrating, so each can be grafted
+        // back into the pane it occupied.
+        const unmirroredPlacements = tabsRef.current
+          .filter((t) => unmirroredTabIdsRef.current.has(t.id))
+          .map((t) => ({ tabId: t.id, paneId: paneOfTab(layoutRef.current.root, t.id)?.id }))
+          .filter((p): p is { tabId: string; paneId: string } => !!p.paneId);
+
         // The backend stays in profile-space always (persistence.ts's
         // Global Constraint); translate every id in the incoming tree to
         // THIS window's live space wherever it already has that
@@ -2195,17 +2237,39 @@ function Workspace() {
         // backend, which is where this tree just came from.
         dispatchLayout({ type: 'hydrate', layout: liveLayout });
 
+        // Graft local unmirrored tabs back in: the pane they occupied
+        // before, if it still exists in the just-hydrated tree (checked
+        // against the plain `liveLayout` value, not React state — a
+        // second `dispatchLayout` in this same synchronous callback is
+        // applied by the reducer strictly AFTER the hydrate above, same as
+        // any other same-tick multi-dispatch burst in this file), else the
+        // window's newly-focused pane. Raw `open_tab` (never mirrored —
+        // these tabs were never mirrored to begin with); `existing` inside
+        // the reducer is guaranteed null since the hydrated tree can never
+        // reference an id that was never sent to the backend.
+        for (const { tabId, paneId } of unmirroredPlacements) {
+          const targetPaneId = findPane(liveLayout.root, paneId) ? paneId : liveLayout.focusedPaneId;
+          dispatchLayout({ type: 'open_tab', tabId, paneId: targetPaneId });
+        }
+
         const foreignProfileIds = allTabIds(foreignLayout);
         const foreignLiveIds = new Set(foreignProfileIds.map((id) => toLiveSpaceId(id, connections)));
         const localIds = new Set(tabsRef.current.map((t) => t.id));
 
         // Leaving: local tabs this window's foreign tree no longer
-        // references (moved/detached elsewhere). `hydrate` above already
-        // replaced the whole tree, so there's nothing left to fold in the
-        // layout — just drop the now-orphaned entries from `tabs[]` and the
-        // builder cache. Never mirrored: this window didn't cause the
-        // change, the window that DID already mirrored it.
-        const leaving = tabsRef.current.filter((t) => !foreignLiveIds.has(t.id));
+        // references (moved/detached elsewhere) — EXCLUDING unmirrored
+        // tabs (IMPORTANT fix above: they never appear in ANY snapshot, so
+        // without this exclusion every export/import tab would look
+        // "leaving" on every single crossWindow event). `hydrate` above
+        // already replaced the whole tree (grafting unmirrored tabs back
+        // in), so there's nothing left to fold in the layout for the
+        // REST of this set — just drop their now-orphaned entries from
+        // `tabs[]` and the builder cache. Never mirrored: this window
+        // didn't cause the change, the window that DID already mirrored
+        // it.
+        const leaving = tabsRef.current.filter(
+          (t) => !foreignLiveIds.has(t.id) && !unmirroredTabIdsRef.current.has(t.id)
+        );
         if (leaving.length > 0) {
           const leavingIds = new Set(leaving.map((t) => t.id));
           leavingIds.forEach((id) => {
@@ -2250,7 +2314,7 @@ function Workspace() {
       })
     );
 
-    unlistenPromises.push(
+    own(
       subscribeConnectionsChanged((payload: ConnectionsChangedPayload) => {
         const liveProfileIds = new Set(payload.connections.map((c) => c.profileId));
         const localByProfile = new Map(activeConnectionsRef.current.map((c) => [c.profileId, c]));
@@ -2294,9 +2358,8 @@ function Workspace() {
     );
 
     return () => {
-      unlistenPromises.forEach((p) => {
-        p.then((unlisten) => unlisten()).catch(() => {});
-      });
+      cancelled = true;
+      unlistenFns.forEach((unlisten) => unlisten());
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ import {
 } from './components/RestoreView';
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
-import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, snapshotLayoutIds, restoreLayoutIds, type WorkspaceAction } from './workspace/model';
+import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, type WorkspaceAction } from './workspace/model';
 import { WorkspaceRoot } from './workspace/WorkspaceRoot';
 import { workspaceApply, updateTabState, actionToOp, workspaceGet } from './workspace/workspaceStore';
 import { toPersistedTab, toDisconnectedSnapshot, rebindConnection, toProfileSpaceId } from './workspace/persistence';
@@ -1641,29 +1641,25 @@ function Workspace() {
     // land in one synchronous handler (rename storms) — see layoutRef's
     // declaration above for why the closure value would be stale for the
     // second and later calls in that case.
-    // The trial reducer call below must not itself mint pane/split ids that
-    // never actually get used (amended after a closing-review regression):
-    // `workspaceReducer` mints them via `newPaneId`/`newSplitId`'s
-    // module-level counters (model.ts), and this trial's return value is
-    // discarded except for reference-identity comparison. Left unchecked, a
-    // real `split_pane` mints TWICE per dispatch — once here, once more when
-    // React actually applies the action during render — so the id React
-    // commits ends up one generation ahead of what the mirrored op causes
-    // the backend to mint from its own, separately-counted id space,
-    // silently desyncing every later op that addresses that pane/split by
-    // id. `snapshotLayoutIds`/`restoreLayoutIds` bracket the trial so it's
-    // side-effect-free; the one real, render-time reducer application is the
-    // only one that actually advances the counters, and it starts from the
-    // exact same (restored) counter state the trial did — so it mints the
-    // SAME ids the trial minted and discarded. `nextLayout` below is a
-    // different object than what React eventually commits, but its
-    // pane/split ids are identical, so using it for the optimistic
-    // `layoutRef.current` advance (compared against by later same-tick
-    // dispatches) stays accurate.
+    // This trial reducer call used to need a snapshot/restore bracket
+    // (`snapshotLayoutIds`/`restoreLayoutIds`) around it: `workspaceReducer`
+    // minted fresh pane/split ids via module-level counters, and this
+    // trial's return value is discarded except for reference-identity
+    // comparison — left unchecked, a real `split_pane` minted TWICE per
+    // dispatch (once here, once more when React actually applies the action
+    // during render), so the id React committed ended up one generation
+    // ahead of what the mirrored op caused the backend to mint from its own,
+    // separately-counted id space. Minting is now a stateless scan of the
+    // layout being reduced (model.ts's `nextPaneId`/`nextSplitId`, #197) —
+    // the same (layout, action) pair always mints the same id no matter how
+    // many times it's evaluated, so this trial call and the later real
+    // render-time application naturally mint identical ids with no
+    // bracketing required. `nextLayout` below is a different object than
+    // what React eventually commits, but its pane/split ids are identical,
+    // so using it for the optimistic `layoutRef.current` advance (compared
+    // against by later same-tick dispatches) stays accurate.
     const currentLayout = layoutRef.current;
-    const idSnapshot = snapshotLayoutIds();
     const nextLayout = workspaceReducer(currentLayout, action);
-    restoreLayoutIds(idSnapshot);
     layoutRef.current = nextLayout;
     const isNoOp = nextLayout === currentLayout;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,9 @@ import {
   windowLabel,
   subscribeWorkspaceChanged,
   subscribeConnectionsChanged,
+  detachTabToNewWindow,
+  closeWorkspaceWindow,
+  moveTabToWindow,
   type WorkspaceChangedPayload,
   type ConnectionsChangedPayload,
 } from './workspace/workspaceStore';
@@ -58,8 +61,11 @@ import {
   toLiveSpaceId,
   materializeArrivingTab,
   type PersistedWorkspace,
+  type PersistedWindow,
+  type PersistedTab,
 } from './workspace/persistence';
 import { ReconnectBanner } from './workspace/ReconnectBanner';
+import { ContextMenu, type ContextMenuItem } from './components/ContextMenu';
 import { CreateViewView } from './components/CreateViewView';
 import { ValidationRulesView } from './components/ValidationRulesView';
 import { GridFsView } from './components/GridFsView';
@@ -81,7 +87,7 @@ import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
-import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck } from 'lucide-react';
+import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck, ExternalLink, MoveRight } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 interface QueryTab {
@@ -283,6 +289,25 @@ const tabLabelFor = (
   }
 };
 
+/**
+ * A short human hint for a FOREIGN window's tab-context-menu entry (Phase 3
+ * Task 5's "Move to Window" list) — the collection/kind of that window's
+ * currently active tab, resolved from the same `PersistedWorkspace` snapshot
+ * `lastWorkspaceRef` already carries (no extra IPC round trip). `null` when
+ * unresolvable (window has no focused pane's active tab, or that tab id
+ * isn't in the flat `tabs[]` list — e.g. a not-yet-mirrored write race);
+ * callers fall back to the bare window id in that case.
+ */
+function activeTabHintFor(win: PersistedWindow, allTabs: PersistedTab[]): string | null {
+  const pane = findPane(win.splitTree, win.focusedPaneId);
+  const activeId = pane?.activeTabId;
+  if (!activeId) return null;
+  const tab = allTabs.find((t) => t.id === activeId);
+  if (!tab) return null;
+  if (tab.type === 'quickstart') return 'Quick Start';
+  return tab.collection || tab.type;
+}
+
 function Workspace() {
   const { toast, confirm, prompt } = useDialogs();
   const { config, resolvedMode, setMode, setSpacingDensity, resetZoom } = useTheme();
@@ -350,6 +375,14 @@ function Workspace() {
   // close_tab/close_many/move_tab/rename_tab consult this so they never
   // reference a tab id the backend has no record of.
   const unmirroredTabIdsRef = useRef(new Set<string>());
+  // Guards `closeWorkspaceWindow()` (Phase 3 Task 5) against firing twice
+  // for the same close: the remote-close reconciliation branch's own
+  // `setTabs([])` flips `tabs.length` to 0, which would otherwise
+  // independently re-trigger the tabs-empty effect's `closeWorkspaceWindow()`
+  // call too. The backend command is idempotent either way (a second
+  // `WindowClosed` apply for an already-removed window no-ops), but there is
+  // no reason to fire the IPC call twice for one logical close.
+  const windowClosingRef = useRef(false);
   // The most recent full backend `Workspace` document (Phase 3 Task 4) —
   // seeded from `workspace_get` at boot, kept current by every accepted
   // `workspace-changed` event thereafter (self-origin or not; see the
@@ -613,17 +646,13 @@ function Workspace() {
       } finally {
         mirroringEnabledRef.current = true;
         if (isMainWindow) {
-          // Task 5 registers `spawn_saved_windows` (spawns a real OS window
-          // per `windows[1..]` the snapshot above just proved exist). It
-          // doesn't exist yet — `invoke` is an `async function`, so calling
-          // an unregistered command REJECTS the returned promise rather
-          // than throwing synchronously (verified against
-          // @tauri-apps/api/core's `invoke`, itself declared `async`, plus
-          // Tauri's IPC dispatch, which reports "command not found" as an
-          // error reply, never a sync panic) — `.catch` alone is sufficient
-          // here, exactly like every other fire-and-forget invoke in this
-          // file.
-          invoke('spawn_saved_windows').catch(() => {});
+          // Recreates a real OS window per `windows[1..]` the snapshot above
+          // just proved exist (main-window-only — a secondary window has no
+          // business recreating siblings). Fire-and-forget: this window has
+          // nothing further to do once the spawn requests are sent, and a
+          // failure here (e.g. a window that can't be created) is not fatal
+          // to this window's own boot.
+          invoke('spawn_saved_windows').catch(console.warn);
         }
       }
     })();
@@ -892,11 +921,11 @@ function Workspace() {
   // Never sit on a blank canvas — if every tab is closed, bring back Quick
   // Start. Main-window-only (Phase 3 Task 4): a secondary window has no
   // quickstart concept — the spec says an emptied secondary window closes
-  // itself instead. It dispatches `window_closed` (a raw op — there is no
-  // frontend layout action for it, same as `move_tab_to_window`/`detach_tab`)
-  // so every other window's next `workspace-changed` sees this window is
-  // gone, then falls through to a TODO Task 5 will fill in: actually closing
-  // the OS window (today it just sits empty).
+  // itself instead. `closeWorkspaceWindow()` (Phase 3 Task 5) applies
+  // `WindowClosed` for THIS window's own label itself (broadcasting
+  // `workspace-changed` so every other window sees it's gone) and then
+  // destroys the real OS window — no separate `workspaceApply` call needed
+  // here, and there is nothing else useful to render once it fires.
   useEffect(() => {
     if (tabs.length !== 0) return;
     if (isMainWindow) {
@@ -905,9 +934,9 @@ function Workspace() {
       dispatchWorkspace({ type: 'open_tab', tabId: QUICK_START_TAB_ID }, { tab: qs });
       return;
     }
-    workspaceApply({ type: 'window_closed', window_id: windowLabel() });
-    // TODO(Task 5): close this OS window (a `close_window`-style command);
-    // there is nothing else useful to render here once it dispatches.
+    if (windowClosingRef.current) return; // already closing via the remote-close path below
+    windowClosingRef.current = true;
+    closeWorkspaceWindow();
   }, [tabs.length, isMainWindow]);
 
   // savedQuery (palette "jump to saved query") runs instead of the pinned
@@ -1747,9 +1776,11 @@ function Workspace() {
     // `setTabs`/local-state update BEFORE calling `dispatchWorkspace` (it
     // has no way to know about a foreign duplicate ahead of time) — the
     // filter below undoes that speculative insert so the tab never lingers
-    // in `tabs[]` unreferenced by any pane. `focus_window` is a Task 5
-    // command that doesn't exist yet; same fire-and-forget/`.catch`
-    // reasoning as `spawn_saved_windows` above.
+    // in `tabs[]` unreferenced by any pane. `focus_window` (Phase 3 Task 5)
+    // brings that foreign window to the front; fire-and-forget, same as
+    // `spawn_saved_windows` above — losing this race (the window closed in
+    // the meantime) is a no-op on the backend side, never an error worth
+    // surfacing.
     if (action.type === 'open_tab') {
       const profileSpaceId = toProfileSpaceId(action.tabId, activeConnections);
       const foreignWindow = lastWorkspaceRef.current?.windows.find(
@@ -1759,7 +1790,7 @@ function Workspace() {
       );
       if (foreignWindow) {
         setTabs((prev) => prev.filter((t) => t.id !== action.tabId));
-        invoke('focus_window', { label: foreignWindow.id }).catch(() => {});
+        invoke('focus_window', { label: foreignWindow.id }).catch(console.warn);
         return;
       }
     }
@@ -1861,6 +1892,73 @@ function Workspace() {
       default:
         workspaceApply(actionToOp(action, undefined, activeConnections));
     }
+  };
+
+  // Tab strip right-click menu (Phase 3 Task 5): detach the tab into a new
+  // window, or move it straight into an already-open one. Both cross-window
+  // ops are backend-authoritative (see `moveTabToWindow`'s doc comment in
+  // workspaceStore.ts) — neither handler below touches `dispatchLayout`
+  // directly; the eventual `workspace-changed` broadcast reconciles this
+  // window (and the target window) via the existing crossWindow echo path.
+  const [tabContextMenu, setTabContextMenu] = useState<{ tabId: string; x: number; y: number } | null>(null);
+
+  const handleTabContextMenu = (tabId: string, e: React.MouseEvent) => {
+    setTabContextMenu({ tabId, x: e.clientX, y: e.clientY });
+  };
+
+  const handleDetachTab = (tabId: string) => {
+    detachTabToNewWindow(toProfileSpaceId(tabId, activeConnections));
+  };
+
+  const handleMoveTab = (tabId: string, targetWindowId: string) => {
+    moveTabToWindow(toProfileSpaceId(tabId, activeConnections), targetWindowId);
+  };
+
+  // Simplest correct rule (documented, per the task brief): "Detach to New
+  // Window" is hidden unless THIS window currently holds more than one tab
+  // across ALL its panes (`allTabIds(layout).length > 1`) — the same single
+  // condition covers both cases the spec calls out: detaching the sole tab
+  // of a secondary window is a backend no-op (`apply_detach_tab`'s
+  // "already alone" guard), and detaching a main window's only tab is
+  // pointless churn (destroy-and-recreate an equivalent window). "Move to
+  // Window" has no such restriction — moving a window's sole tab elsewhere
+  // is meaningful (it empties this window, which then closes itself via the
+  // tabs-empty effect above) — it's gated only on other windows existing.
+  // Unmirrored (export/import) tabs can't participate in either — the
+  // backend has no record of them — so both are hidden for them, replaced
+  // by a single disabled, explanatory entry.
+  const buildTabContextMenuItems = (tabId: string): ContextMenuItem[] => {
+    if (unmirroredTabIdsRef.current.has(tabId)) {
+      const explanation = 'Export/import tabs stay in their window';
+      return [{ label: explanation, onClick: () => {}, disabled: true, title: explanation }];
+    }
+
+    const items: ContextMenuItem[] = [];
+    if (allTabIds(layout).length > 1) {
+      items.push({
+        label: 'Detach to New Window',
+        icon: <ExternalLink />,
+        onClick: () => handleDetachTab(tabId),
+      });
+    }
+
+    const otherWindows = (lastWorkspaceRef.current?.windows ?? []).filter((w) => w.id !== windowLabel());
+    const allTabs = lastWorkspaceRef.current?.tabs ?? [];
+    // Separator only when there's something above to separate from (i.e. a
+    // "Detach to New Window" item was actually pushed) — otherwise the
+    // first "Move to" entry would render an orphan divider line at the very
+    // top of the menu.
+    otherWindows.forEach((w, i) => {
+      const hint = activeTabHintFor(w, allTabs);
+      items.push({
+        label: `Move to ${hint ? `${w.id} (${hint})` : w.id}`,
+        icon: <MoveRight />,
+        separatorBefore: i === 0 && items.length > 0,
+        onClick: () => handleMoveTab(tabId, w.id),
+      });
+    });
+
+    return items;
   };
 
   const cycleTab = (dir: 1 | -1) => {
@@ -2204,9 +2302,18 @@ function Workspace() {
         if (!winEntry) {
           // Another window's op (a fold-on-close, a detach, a
           // move-to-window) removed THIS window from the document — there
-          // is no tree left to reconcile against. Render empty rather than
-          // leave a stale, now-orphaned layout on screen.
-          // TODO(Task 5): invoke the close-self command once it exists.
+          // is no tree left to reconcile against. Render empty and destroy
+          // the real OS window (Phase 3 Task 5): `closeWorkspaceWindow()`'s
+          // `WindowClosed` apply no-ops here (the backend already removed
+          // this window from the store — that's WHY `winEntry` is missing),
+          // but it still destroys the OS window, which is otherwise never
+          // told to close in this "closed by someone else" path.
+          // `windowClosingRef` guard: `setTabs([])` right below will also
+          // flip `tabs.length` to 0, which would otherwise independently
+          // re-trigger the tabs-empty effect's own `closeWorkspaceWindow()`
+          // call for this same close (see that effect's comment).
+          windowClosingRef.current = true;
+          closeWorkspaceWindow();
           setTabs([]);
           tabBuilderStateCache.current.clear();
           dispatchLayout({ type: 'hydrate', layout: createInitialLayout([], null) });
@@ -3418,7 +3525,16 @@ function Workspace() {
         }
         renderTabContent={renderTabContent}
         renderEmptyPane={renderEmptyPane}
+        onTabContextMenu={handleTabContextMenu}
       />
+      {tabContextMenu && (
+        <ContextMenu
+          x={tabContextMenu.x}
+          y={tabContextMenu.y}
+          items={buildTabContextMenuItems(tabContextMenu.tabId)}
+          onClose={() => setTabContextMenu(null)}
+        />
+      )}
     </AppShell>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import {
   windowLabel,
   subscribeWorkspaceChanged,
   subscribeConnectionsChanged,
+  setConnectionMeta,
   detachTabToNewWindow,
   closeWorkspaceWindow,
   moveTabToWindow,
@@ -667,6 +668,9 @@ function Workspace() {
     try {
       const id = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
       addActiveConnection(id, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined);
+      // Announce this fresh id to every other window (Phase 3 Task 6) — see
+      // `setConnectionMeta`'s doc comment for why every connect path calls it.
+      setConnectionMeta(id, profile.id, profile.name);
       // Clear any ReconnectBanner this profile still has showing (#97 phase
       // 2 final review Fix 1) — see `rebindProfileTabs`'s doc comment.
       rebindProfileTabs(profile.id, id);
@@ -2441,6 +2445,39 @@ function Workspace() {
           rebindProfileTabs(entry.profileId, entry.id);
         }
 
+        // Phase 3 Task 6 (LEDGER MANDATE) considered — and deliberately does
+        // NOT implement — a self-healing cleanup for "stale" backend
+        // `connection_meta` entries: an id present in `payload.connections`
+        // that is NOT this window's local id for that profile, while THIS
+        // window already has a DIFFERENT, live id for the same profileId
+        // (`localByProfile.has(entry.profileId) && localByProfile.get(entry.profileId)!.id !== entry.id`).
+        // The backend never prunes `connection_meta` on anything but an
+        // explicit `disconnect_db` (see `set_connection_meta_impl`/
+        // `connection_list_impl`), so a truly-orphaned id (this window's own
+        // past reconnect that never disconnected its predecessor) really
+        // would sit there forever without one.
+        //
+        // The blocker: that same shape is indistinguishable from a genuine
+        // race where ANOTHER window is fresh-connecting the same profile
+        // concurrently. `handleReconnectProfile`'s fresh-connect branch runs
+        // whenever a window's OWN `activeConnections` lacks the profile —
+        // nothing stops two windows from independently reconnecting the same
+        // profile before either's `connections-changed` broadcast reaches
+        // the other (the addition loop above only reconciles a profile ONCE
+        // a window has learned about it; until then, both windows call
+        // `connect_db` and mint their own id). If that race lands here, BOTH
+        // windows would see "an id for my profile that isn't mine" and BOTH
+        // would call `disconnect_db` on what is, from the other window's
+        // point of view, its own live connection — tearing down a
+        // still-in-use connection instead of an orphan. There is no signal
+        // in the payload (no origin/window id) to tell the two cases apart.
+        // Per the task's own safety rule — "a lingering meta entry is
+        // cosmetic; killing a live connection is not" — this cleanup is
+        // skipped entirely. The cost is a harmless extra row in another
+        // window's `connections-changed` payload for an id nothing
+        // references anymore, invisible in the UI (no local `activeConnections`
+        // entry ever points at it) until that window reconnects/restarts.
+
         // Removals: a profile we thought was live is gone from the
         // broadcast — another window disconnected it. Mirrors Sidebar's
         // `onDisconnect` teardown (activeConnections + tabs[] + layout)
@@ -2508,6 +2545,11 @@ function Workspace() {
 
         newId = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
         addActiveConnection(newId, profileName, profile.uri, profile.id, profile.color_tag ?? undefined);
+        // Announce this fresh id to every other window (Phase 3 Task 6) —
+        // see `setConnectionMeta`'s doc comment. Deliberately NOT called on
+        // the `existing` (reuse) branch above: that id's meta was already
+        // set the first time it connected.
+        setConnectionMeta(newId, profile.id, profileName);
       }
 
       // Captured before any state updates below — `tabs`/`layout` in this
@@ -3410,6 +3452,9 @@ function Workspace() {
             onClose={() => { setIsConnectionModalOpen(false); setProfilesRefreshKey((k) => k + 1); }}
             onConnect={(id, name, uri, profileId, colorTag) => {
               addActiveConnection(id, name, uri, profileId, colorTag ?? undefined);
+              // Announce this fresh id to every other window (Phase 3 Task 6)
+              // — see `setConnectionMeta`'s doc comment.
+              setConnectionMeta(id, profileId, name);
               // Clear any ReconnectBanner this profile still has showing
               // (#97 phase 2 final review Fix 1) — see `rebindProfileTabs`'s
               // doc comment.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,10 +37,28 @@ import {
 } from './components/RestoreView';
 import { CopyToDialog } from './components/CopyToDialog';
 import { SchemaView } from './components/SchemaView';
-import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, type WorkspaceAction } from './workspace/model';
+import { workspaceReducer, createInitialLayout, findPane, allPanes, allTabIds, mapLayoutTabIds, type WorkspaceAction, type WorkspaceLayout } from './workspace/model';
 import { WorkspaceRoot } from './workspace/WorkspaceRoot';
-import { workspaceApply, updateTabState, actionToOp, workspaceGet } from './workspace/workspaceStore';
-import { toPersistedTab, toDisconnectedSnapshot, rebindConnection, toProfileSpaceId } from './workspace/persistence';
+import {
+  workspaceApply,
+  updateTabState,
+  actionToOp,
+  workspaceGet,
+  windowLabel,
+  subscribeWorkspaceChanged,
+  subscribeConnectionsChanged,
+  type WorkspaceChangedPayload,
+  type ConnectionsChangedPayload,
+} from './workspace/workspaceStore';
+import {
+  toPersistedTab,
+  toDisconnectedSnapshot,
+  rebindConnection,
+  toProfileSpaceId,
+  toLiveSpaceId,
+  materializeArrivingTab,
+  type PersistedWorkspace,
+} from './workspace/persistence';
 import { ReconnectBanner } from './workspace/ReconnectBanner';
 import { CreateViewView } from './components/CreateViewView';
 import { ValidationRulesView } from './components/ValidationRulesView';
@@ -269,8 +287,22 @@ function Workspace() {
   const { toast, confirm, prompt } = useDialogs();
   const { config, resolvedMode, setMode, setSpacingDensity, resetZoom } = useTheme();
   const density = config.spacingDensity;
+  // Phase 3 Task 4: every window runs this same component — `isMainWindow`
+  // gates the behaviors that only make sense for the primary window
+  // (quickstart resurrection, restore-driven secondary-window spawning).
+  // `windowLabel()` is memoized process-wide (see workspaceStore.ts), so
+  // this is stable for the component's whole lifetime.
+  const isMainWindow = windowLabel() === 'main';
   // Open the Quick Start tab by default so the app never starts on a blank canvas.
   const [tabs, setTabs] = useState<QueryTab[]>([createQuickStartTab()]);
+  // Foreign-event reconciliation (below) runs inside a `listen` callback
+  // captured once at mount — it can never see a fresh `tabs` STATE value
+  // from that closure, same staleness problem `activeConnectionsRef` exists
+  // to solve for `handleBuilderStateChange`. Mirrors `tabs` on every change.
+  const tabsRef = useRef<QueryTab[]>(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
   const [layout, dispatchLayout] = useReducer(
     workspaceReducer,
     undefined,
@@ -318,6 +350,17 @@ function Workspace() {
   // close_tab/close_many/move_tab/rename_tab consult this so they never
   // reference a tab id the backend has no record of.
   const unmirroredTabIdsRef = useRef(new Set<string>());
+  // The most recent full backend `Workspace` document (Phase 3 Task 4) —
+  // seeded from `workspace_get` at boot, kept current by every accepted
+  // `workspace-changed` event thereafter (self-origin or not; see the
+  // reconciliation effect below). Two consumers: the foreign-event
+  // reconciliation itself, and `dispatchWorkspace`'s cross-window open
+  // dedupe (a tab already open in ANOTHER window's tree must not be opened
+  // here too — see its own comment). `lastSeenRevisionRef` guards against
+  // applying an out-of-order/replayed event (revision <= what's already
+  // been applied is dropped).
+  const lastWorkspaceRef = useRef<PersistedWorkspace | null>(null);
+  const lastSeenRevisionRef = useRef(-1);
   const [activeConnections, setActiveConnections] = useState<ActiveConnection[]>([]);
   // `handleBuilderStateChange` below is a `useCallback` with an empty deps
   // array (a stable identity for DocumentViewer), so it can never see a
@@ -390,12 +433,21 @@ function Workspace() {
   // never land in `activeConnections` — every tab rebound to it becomes
   // unreachable, and every later mirror for those tabs ships a live id the
   // backend can't translate back to profile-space).
+  //
+  // Reads `layoutRef.current`, not the `layout` render-scope closure
+  // (Phase 3 Task 4): the `connections-changed` reconciliation effect below
+  // calls this from a `listen` callback captured once at mount, where
+  // `layout` would be frozen at its mount-time value forever. `layoutRef`
+  // is the same mutable ref object across every render, so reading
+  // `.current` always sees whatever the component most recently committed,
+  // regardless of which render's closure is doing the reading — identical
+  // behavior to before for every existing (render-fresh) call site.
   const rebindProfileTabs = (
     profileId: string,
     liveId: string
   ): { pairs: Array<{ oldId: string; newId: string }>; idMap: Map<string, string> } => {
     const oldPrefix = `profile:${profileId}`;
-    const pairs = rebindConnection(oldPrefix, liveId, allTabIds(layout));
+    const pairs = rebindConnection(oldPrefix, liveId, allTabIds(layoutRef.current));
     if (pairs.length === 0) return { pairs, idMap: new Map() };
 
     const idMap = new Map(pairs.map((p) => [p.oldId, p.newId]));
@@ -483,6 +535,12 @@ function Workspace() {
   // this narrow — losing a few clicks from before the very first paint has
   // settled is an acceptable trade for a wholesale, easy-to-reason-about
   // restore.
+  // Phase 3 Task 4: every window boots from the SAME `workspace_get` call
+  // but hydrates only ITS OWN slice — `toDisconnectedSnapshot(ws,
+  // windowLabel())` selects the window entry matching this label (default
+  // `"main"`) instead of always reading `windows[0]`, and filters
+  // `ws.tabs` (a flat list shared across every window) down to the ids
+  // this window's tree actually references.
   const restoredRef = useRef(false);
   useEffect(() => {
     if (restoredRef.current) return;
@@ -490,42 +548,83 @@ function Workspace() {
     (async () => {
       try {
         const ws = await workspaceGet();
-        if (ws && Array.isArray(ws.tabs) && ws.tabs.length > 0) {
-          const snapshot = toDisconnectedSnapshot(ws);
-          setTabs(snapshot.tabs as QueryTab[]);
-          // Clear first: `hydrate` wholesale-replaces `tabs` (see the
-          // "hydrate wins" note above), but the builder-state cache is a
-          // ref keyed by tab id — if the user opened a builder on any
-          // pre-restore tab (e.g. the default Quick Start render) before
-          // this settled, that stale entry would otherwise survive under an
-          // id that may now belong to a completely different restored tab.
-          tabBuilderStateCache.current.clear();
-          for (const [tabId, state] of snapshot.builderStates) {
-            tabBuilderStateCache.current.set(tabId, state as BuilderState);
-          }
-          const profileNames = new Map<string, string>();
-          for (const t of ws.tabs) {
-            if (t.profileId) profileNames.set(t.profileId, t.profileName || t.profileId);
-          }
-          setRestoredProfileNames(profileNames);
-          // `hydrate` is a frontend-only reducer action — there is no backend
-          // op for "replace my whole layout". Dispatched via raw
-          // `dispatchLayout`, bypassing `dispatchWorkspace`'s mirror-to-
-          // backend choke point entirely, so this restore is never echoed
-          // back to workspace_apply as a stream of synthetic ops (mirroring
-          // is still disabled here regardless — see mirroringEnabledRef's
-          // init above — but the direct dispatch documents the exception
-          // even once mirroring flips on below).
-          dispatchLayout({ type: 'hydrate', layout: snapshot.layout });
+        // Guards against more than a bare `null`/absent snapshot — a
+        // malformed or unexpectedly-shaped response (e.g. a test harness's
+        // untyped default mock) must not seed `lastWorkspaceRef` with
+        // something whose `.windows` isn't actually an array, which the
+        // dedupe check and reconciliation effect both assume.
+        const wsValid = !!ws && Array.isArray(ws.tabs) && Array.isArray(ws.windows);
+        if (wsValid) {
+          // Seed the cross-window view (dedupe's `lastWorkspaceRef`,
+          // reconciliation's `lastSeenRevisionRef`) from the FULL document,
+          // regardless of whether THIS window ends up with any tabs of its
+          // own — both need to see every window, not just this one.
+          lastWorkspaceRef.current = ws;
+          lastSeenRevisionRef.current = typeof ws.revision === 'number' ? ws.revision : -1;
         }
-        // No snapshot (or an empty one): the default Quick Start state from
-        // this component's initializers stands as-is.
+        if (wsValid) {
+          const snapshot = toDisconnectedSnapshot(ws, windowLabel());
+          if (snapshot.tabs.length > 0) {
+            setTabs(snapshot.tabs as QueryTab[]);
+            // Clear first: `hydrate` wholesale-replaces `tabs` (see the
+            // "hydrate wins" note above), but the builder-state cache is a
+            // ref keyed by tab id — if the user opened a builder on any
+            // pre-restore tab (e.g. the default Quick Start render) before
+            // this settled, that stale entry would otherwise survive under an
+            // id that may now belong to a completely different restored tab.
+            tabBuilderStateCache.current.clear();
+            for (const [tabId, state] of snapshot.builderStates) {
+              tabBuilderStateCache.current.set(tabId, state as BuilderState);
+            }
+            const windowTabIds = new Set(snapshot.tabs.map((t) => t.id));
+            const profileNames = new Map<string, string>();
+            for (const t of ws.tabs) {
+              if (windowTabIds.has(t.id) && t.profileId) profileNames.set(t.profileId, t.profileName || t.profileId);
+            }
+            setRestoredProfileNames(profileNames);
+            // `hydrate` is a frontend-only reducer action — there is no backend
+            // op for "replace my whole layout". Dispatched via raw
+            // `dispatchLayout`, bypassing `dispatchWorkspace`'s mirror-to-
+            // backend choke point entirely, so this restore is never echoed
+            // back to workspace_apply as a stream of synthetic ops (mirroring
+            // is still disabled here regardless — see mirroringEnabledRef's
+            // init above — but the direct dispatch documents the exception
+            // even once mirroring flips on below).
+            dispatchLayout({ type: 'hydrate', layout: snapshot.layout });
+          } else if (!isMainWindow) {
+            // No tabs for THIS window and it's a secondary one: the
+            // component's initializers default to a Quick Start tab
+            // regardless of window kind (shared across `Workspace()`
+            // instances), which would otherwise sit there forever — a
+            // secondary window never resurrects Quick Start, so nothing
+            // would ever make `tabs.length` actually hit 0 to trigger the
+            // tabs-empty effect's `window_closed` dispatch below. Clear it
+            // explicitly so that effect fires.
+            setTabs([]);
+            dispatchLayout({ type: 'hydrate', layout: createInitialLayout([], null) });
+          }
+          // Main window with nothing of its own: the default Quick Start
+          // state from this component's initializers stands as-is.
+        }
       } catch {
         // workspace_get failing (corrupt file, IO error) is not fatal —
         // fall back to the default Quick Start state exactly as if there
         // were no snapshot at all.
       } finally {
         mirroringEnabledRef.current = true;
+        if (isMainWindow) {
+          // Task 5 registers `spawn_saved_windows` (spawns a real OS window
+          // per `windows[1..]` the snapshot above just proved exist). It
+          // doesn't exist yet — `invoke` is an `async function`, so calling
+          // an unregistered command REJECTS the returned promise rather
+          // than throwing synchronously (verified against
+          // @tauri-apps/api/core's `invoke`, itself declared `async`, plus
+          // Tauri's IPC dispatch, which reports "command not found" as an
+          // error reply, never a sync panic) — `.catch` alone is sufficient
+          // here, exactly like every other fire-and-forget invoke in this
+          // file.
+          invoke('spawn_saved_windows').catch(() => {});
+        }
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -790,14 +889,26 @@ function Workspace() {
   const connectionNameFor = (connectionId: string): string =>
     activeConnections.find((c) => c.id === connectionId)?.name || connectionId;
 
-  // Never sit on a blank canvas — if every tab is closed, bring back Quick Start.
+  // Never sit on a blank canvas — if every tab is closed, bring back Quick
+  // Start. Main-window-only (Phase 3 Task 4): a secondary window has no
+  // quickstart concept — the spec says an emptied secondary window closes
+  // itself instead. It dispatches `window_closed` (a raw op — there is no
+  // frontend layout action for it, same as `move_tab_to_window`/`detach_tab`)
+  // so every other window's next `workspace-changed` sees this window is
+  // gone, then falls through to a TODO Task 5 will fill in: actually closing
+  // the OS window (today it just sits empty).
   useEffect(() => {
-    if (tabs.length === 0) {
+    if (tabs.length !== 0) return;
+    if (isMainWindow) {
       const qs = createQuickStartTab();
       setTabs([qs]);
       dispatchWorkspace({ type: 'open_tab', tabId: QUICK_START_TAB_ID }, { tab: qs });
+      return;
     }
-  }, [tabs.length]);
+    workspaceApply({ type: 'window_closed', window_id: windowLabel() });
+    // TODO(Task 5): close this OS window (a `close_window`-style command);
+    // there is nothing else useful to render here once it dispatches.
+  }, [tabs.length, isMainWindow]);
 
   // savedQuery (palette "jump to saved query") runs instead of the pinned
   // default — for existing tabs it re-runs in place.
@@ -1623,6 +1734,35 @@ function Workspace() {
     action: WorkspaceAction,
     options?: { tab?: QueryTab }
   ) => {
+    // Cross-window open dedupe (Phase 3 Task 4 — MANDATE from Task 2
+    // review): the backend's own OpenTab dedupe only applies WITHIN one
+    // window's tree, so it would happily accept a tab id that's already
+    // open in a DIFFERENT window — the next `workspace_get`/`validate()`
+    // would then choke on the same tab id living in two trees at once.
+    // `lastWorkspaceRef` (seeded at boot, kept current by every accepted
+    // `workspace-changed` event) is the full cross-window view; compare in
+    // PROFILE-space (the backend's own space) since a live id is only
+    // meaningful within the window that minted/owns the connection.
+    // Every `open_tab` caller in this file does its own optimistic
+    // `setTabs`/local-state update BEFORE calling `dispatchWorkspace` (it
+    // has no way to know about a foreign duplicate ahead of time) — the
+    // filter below undoes that speculative insert so the tab never lingers
+    // in `tabs[]` unreferenced by any pane. `focus_window` is a Task 5
+    // command that doesn't exist yet; same fire-and-forget/`.catch`
+    // reasoning as `spawn_saved_windows` above.
+    if (action.type === 'open_tab') {
+      const profileSpaceId = toProfileSpaceId(action.tabId, activeConnections);
+      const foreignWindow = lastWorkspaceRef.current?.windows.find(
+        (w) =>
+          w.id !== windowLabel() &&
+          allTabIds({ root: w.splitTree, focusedPaneId: w.focusedPaneId }).includes(profileSpaceId)
+      );
+      if (foreignWindow) {
+        setTabs((prev) => prev.filter((t) => t.id !== action.tabId));
+        invoke('focus_window', { label: foreignWindow.id }).catch(() => {});
+        return;
+      }
+    }
     if (action.type === 'close_tab') {
       tabBuilderStateCache.current.delete(action.tabId);
       setTabs(prev => prev.filter(t => t.id !== action.tabId));
@@ -1989,6 +2129,177 @@ function Workspace() {
       setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, error: String(err) } : t));
     }
   };
+
+  // Foreign-event reconciliation (Phase 3 Task 4). Two independent
+  // subscriptions, set up once — `reconciliationSubscribedRef` guards
+  // against React 18 StrictMode's double-invoke of effects in dev exactly
+  // like `restoredRef` above, so a second invocation of this same effect
+  // never attaches a second pair of listeners (which would double-apply
+  // every foreign hydrate/reconcile). Both listener callbacks are captured
+  // ONCE at mount and never refreshed on later renders, so — like
+  // `handleBuilderStateChange` above — they must read live component state
+  // exclusively through refs (`activeConnectionsRef`, `tabsRef`,
+  // `lastWorkspaceRef`) or through a setter's functional-update form
+  // (`setTabs(prev => ...)`), never through a state variable captured
+  // directly in the closure.
+  const reconciliationSubscribedRef = useRef(false);
+  useEffect(() => {
+    if (reconciliationSubscribedRef.current) return;
+    reconciliationSubscribedRef.current = true;
+
+    const unlistenPromises: Promise<() => void>[] = [];
+
+    unlistenPromises.push(
+      subscribeWorkspaceChanged((payload: WorkspaceChangedPayload) => {
+        // Drop a replayed/out-of-order event — revisions only ever
+        // increase, so anything at or below what's already applied adds
+        // nothing (and applying it would risk clobbering newer local state
+        // with older backend state).
+        if (payload.revision <= lastSeenRevisionRef.current) return;
+        lastSeenRevisionRef.current = payload.revision;
+        lastWorkspaceRef.current = payload.workspace;
+
+        // Self-origin, single-window ops are our own optimistic dispatch
+        // echoing back — already applied locally by `dispatchWorkspace`,
+        // nothing to reconcile. Cross-window ops
+        // (move_tab_to_window/detach_tab/window_closed) are the one
+        // exception: they never go through the local layout reducer at all
+        // (there is no frontend action for them — Task 5 fires them
+        // straight at `workspace_apply`), so even the origin window
+        // depends entirely on this event to update its own tree.
+        if (payload.origin === windowLabel() && !payload.crossWindow) return;
+
+        const connections = activeConnectionsRef.current;
+        const winEntry = payload.workspace.windows.find((w) => w.id === windowLabel());
+        if (!winEntry) {
+          // Another window's op (a fold-on-close, a detach, a
+          // move-to-window) removed THIS window from the document — there
+          // is no tree left to reconcile against. Render empty rather than
+          // leave a stale, now-orphaned layout on screen.
+          // TODO(Task 5): invoke the close-self command once it exists.
+          setTabs([]);
+          tabBuilderStateCache.current.clear();
+          dispatchLayout({ type: 'hydrate', layout: createInitialLayout([], null) });
+          return;
+        }
+
+        // The backend stays in profile-space always (persistence.ts's
+        // Global Constraint); translate every id in the incoming tree to
+        // THIS window's live space wherever it already has that
+        // connection, so a foreign tab whose profile is already connected
+        // here renders live immediately instead of as a `profile:` banner.
+        const foreignLayout: WorkspaceLayout = { root: winEntry.splitTree, focusedPaneId: winEntry.focusedPaneId };
+        const liveLayout = mapLayoutTabIds(foreignLayout, (id) => toLiveSpaceId(id, connections));
+        // `{mirror:false}`-equivalent: a raw hydrate, exactly like the
+        // restore effect's own dispatch — never mirrored back to the
+        // backend, which is where this tree just came from.
+        dispatchLayout({ type: 'hydrate', layout: liveLayout });
+
+        const foreignProfileIds = allTabIds(foreignLayout);
+        const foreignLiveIds = new Set(foreignProfileIds.map((id) => toLiveSpaceId(id, connections)));
+        const localIds = new Set(tabsRef.current.map((t) => t.id));
+
+        // Leaving: local tabs this window's foreign tree no longer
+        // references (moved/detached elsewhere). `hydrate` above already
+        // replaced the whole tree, so there's nothing left to fold in the
+        // layout — just drop the now-orphaned entries from `tabs[]` and the
+        // builder cache. Never mirrored: this window didn't cause the
+        // change, the window that DID already mirrored it.
+        const leaving = tabsRef.current.filter((t) => !foreignLiveIds.has(t.id));
+        if (leaving.length > 0) {
+          const leavingIds = new Set(leaving.map((t) => t.id));
+          leavingIds.forEach((id) => {
+            tabBuilderStateCache.current.delete(id);
+            unmirroredTabIdsRef.current.delete(id);
+          });
+          setTabs((prev) => prev.filter((t) => !leavingIds.has(t.id)));
+        }
+
+        // Arriving: tabs newly referenced by this window's foreign tree.
+        // Looked up in `payload.workspace.tabs` (the flat, profile-space
+        // backend tab list) by the RAW (pre-translation) id, since that's
+        // the space wire `TabModel`s are keyed in.
+        const toRefresh: QueryTab[] = [];
+        for (const profileId of foreignProfileIds) {
+          const liveId = toLiveSpaceId(profileId, connections);
+          if (localIds.has(liveId)) continue; // already open here
+          const tabModel = payload.workspace.tabs.find((t) => t.id === profileId);
+          if (!tabModel) continue; // defensive: tree referenced an unknown tab
+          const { tab: arrivingTab, isLive } = materializeArrivingTab(tabModel, connections);
+          setTabs((prev) => (prev.some((t) => t.id === arrivingTab.id) ? prev : [...prev, arrivingTab as QueryTab]));
+          if (tabModel.builderState != null) {
+            tabBuilderStateCache.current.set(arrivingTab.id, tabModel.builderState as BuilderState);
+          }
+          if (tabModel.profileId) {
+            const label = tabModel.profileName || tabModel.profileId;
+            setRestoredProfileNames((prev) =>
+              prev.get(tabModel.profileId) === label ? prev : new Map(prev).set(tabModel.profileId, label)
+            );
+          }
+          if (isLive && arrivingTab.type === 'collection') toRefresh.push(arrivingTab as QueryTab);
+        }
+        // Sequential — reuses `refreshTabResults`, the same revive path
+        // `handleReconnectProfile` uses below, and for the same reason:
+        // don't burst concurrent queries at a connection that may just
+        // have finished dialing.
+        (async () => {
+          for (const tab of toRefresh) {
+            await refreshTabResults(tab);
+          }
+        })();
+      })
+    );
+
+    unlistenPromises.push(
+      subscribeConnectionsChanged((payload: ConnectionsChangedPayload) => {
+        const liveProfileIds = new Set(payload.connections.map((c) => c.profileId));
+        const localByProfile = new Map(activeConnectionsRef.current.map((c) => [c.profileId, c]));
+
+        // Additions: a profile now has a live id we didn't know about —
+        // another window connected it. `addActiveConnection`/
+        // `rebindProfileTabs` are the same two calls
+        // `handleQuickConnect`/`handleReconnectProfile` make after their
+        // own `connect_db`; the payload carries no `uri` by design (Task 3
+        // — connection strings never ride an event), so any UI reading
+        // `activeConnections[].uri` (the status bar's username display)
+        // degrades to '' for a connection registered this way rather than
+        // crash.
+        for (const entry of payload.connections) {
+          if (localByProfile.has(entry.profileId)) continue;
+          addActiveConnection(entry.id, entry.name, '', entry.profileId);
+          rebindProfileTabs(entry.profileId, entry.id);
+        }
+
+        // Removals: a profile we thought was live is gone from the
+        // broadcast — another window disconnected it. Mirrors Sidebar's
+        // `onDisconnect` teardown (activeConnections + tabs[] + layout)
+        // MINUS the two things that window already did: calling
+        // `disconnect_db` itself, and mirroring the `close_many` (mirroring
+        // it again here would double-apply the same close backend-side —
+        // see the who-mirrors-what note in the task report).
+        for (const local of activeConnectionsRef.current) {
+          if (liveProfileIds.has(local.profileId)) continue;
+          setActiveConnections((prev) => prev.filter((c) => c.id !== local.id));
+          const removed = tabsRef.current.filter((t) => t.connectionId === local.id).map((t) => t.id);
+          if (removed.length === 0) continue;
+          const removedIds = new Set(removed);
+          removedIds.forEach((id) => {
+            tabBuilderStateCache.current.delete(id);
+            unmirroredTabIdsRef.current.delete(id);
+          });
+          setTabs((prev) => prev.filter((t) => !removedIds.has(t.id)));
+          dispatchLayout({ type: 'close_many', tabIds: removed });
+        }
+      })
+    );
+
+    return () => {
+      unlistenPromises.forEach((p) => {
+        p.then((unlisten) => unlisten()).catch(() => {});
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Reconnect flow for a ReconnectBanner (Phase 2 Task 6). One click revives
   // EVERY restored tab for this profile — not just the tab whose banner was

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,11 +48,13 @@ import {
   subscribeWorkspaceChanged,
   subscribeConnectionsChanged,
   setConnectionMeta,
+  connectionList,
   detachTabToNewWindow,
   closeWorkspaceWindow,
   moveTabToWindow,
   type WorkspaceChangedPayload,
   type ConnectionsChangedPayload,
+  type ConnectionEntry,
 } from './workspace/workspaceStore';
 import {
   toPersistedTab,
@@ -405,6 +407,19 @@ function Workspace() {
   useEffect(() => {
     activeConnectionsRef.current = activeConnections;
   }, [activeConnections]);
+  // Every profileId this window has ever learned about from a
+  // `connections-changed` broadcast OR the boot-time `connection_list` seed
+  // (final whole-branch review, Fix 3) — NOT from this window's own local
+  // connects, which never touch it. Gates the removal branch of the
+  // `connections-changed` listener below: a profile absent from a broadcast
+  // is only ever torn down if it was previously SEEN live in some earlier
+  // broadcast. Without this, a profile THIS window just connected itself
+  // (added to `activeConnections` synchronously, but whose `set_connection_meta`
+  // hasn't landed backend-side yet) looks identical to a genuinely-removed
+  // one the moment an unrelated broadcast arrives — e.g. some other window
+  // connecting/disconnecting something else — and would otherwise have its
+  // tabs killed by a broadcast that has nothing to do with it.
+  const seenProfilesRef = useRef<Set<string>>(new Set());
   // Shared by every `update_tab_state` emission site (handleBuilderStateChange
   // here, plus handleExecuteQuery/handleExecuteAggregate below): skips
   // unmirrored tabs and translates the live id to profile-space before
@@ -518,6 +533,27 @@ function Workspace() {
     return { pairs, idMap };
   };
 
+  // Shared "a live connection this window doesn't have locally yet" path
+  // (final whole-branch review, Fix 2) — the connections-changed listener's
+  // addition loop below AND the boot-time `connection_list` seed both funnel
+  // through here, so a spawned window's very first paint and every later
+  // broadcast add/rebind identically: `addActiveConnection` (dedupes by
+  // profileId) plus `rebindProfileTabs` (rebinds any restored `profile:<id>`
+  // tab onto the live id, same as `handleQuickConnect`/`handleReconnectProfile`
+  // do after their own `connect_db`). Also updates `seenProfilesRef` (Fix 3)
+  // for every entry, regardless of whether it was new — a boot seed or
+  // broadcast that mentions a profile is evidence that profile is being
+  // actively tracked, whether or not this window happens to already have it.
+  const applyConnectionsAdditions = (connections: ConnectionEntry[]) => {
+    for (const entry of connections) seenProfilesRef.current.add(entry.profileId);
+    const localByProfile = new Map(activeConnectionsRef.current.map((c) => [c.profileId, c]));
+    for (const entry of connections) {
+      if (localByProfile.has(entry.profileId)) continue;
+      addActiveConnection(entry.id, entry.name, '', entry.profileId);
+      rebindProfileTabs(entry.profileId, entry.id);
+    }
+  };
+
   // profileId -> profileName for every restored-but-not-yet-reconnected tab,
   // captured from the persisted snapshot at restore time. RestoredTab (what
   // toDisconnectedSnapshot hands back) deliberately drops profileName — it's
@@ -625,6 +661,15 @@ function Workspace() {
             // init above — but the direct dispatch documents the exception
             // even once mirroring flips on below).
             dispatchLayout({ type: 'hydrate', layout: snapshot.layout });
+            // `dispatchLayout` (React's reducer dispatch) doesn't commit
+            // synchronously — `layoutRef.current` (line ~350) only catches up
+            // on the next render. The connection_list seed below (Fix 2) runs
+            // later in this SAME tick and needs `rebindProfileTabs` (which
+            // reads `layoutRef.current`, not React state) to already see this
+            // hydrated layout's restored tab ids, so advance the ref by hand
+            // here — same technique `dispatchWorkspace`'s own `nextLayout`
+            // optimistic-advance uses below, for the same reason.
+            layoutRef.current = snapshot.layout;
           } else if (!isMainWindow) {
             // No tabs for THIS window and it's a secondary one: the
             // component's initializers default to a Quick Start tab
@@ -645,6 +690,27 @@ function Workspace() {
         // fall back to the default Quick Start state exactly as if there
         // were no snapshot at all.
       } finally {
+        // Final whole-branch review, Fix 2: seed every connection already
+        // live in this session BEFORE mirroring flips on below, same
+        // "restore settles first" ordering as the hydrate above. Every
+        // window does this (not just spawned secondaries) — main boots
+        // first in the common case and simply seeds nothing, but a window
+        // spawned later (or re-launched into an already-running session)
+        // needs this to avoid a spurious ReconnectBanner + duplicate
+        // connect_db for a profile another window already connected.
+        // `applyConnectionsAdditions` (Fix 3) also seeds `seenProfilesRef`
+        // for every entry here, exactly like a `connections-changed`
+        // broadcast would.
+        try {
+          const connections = await connectionList();
+          if (Array.isArray(connections) && connections.length > 0) {
+            applyConnectionsAdditions(connections);
+          }
+        } catch {
+          // connection_list failing at boot is not fatal — this window
+          // just starts with nothing pre-seeded, same as before this fix;
+          // the next connections-changed broadcast still catches it up.
+        }
         mirroringEnabledRef.current = true;
         if (isMainWindow) {
           // Recreates a real OS window per `windows[1..]` the snapshot above
@@ -1920,6 +1986,15 @@ function Workspace() {
 
   const handleMoveTab = (tabId: string, targetWindowId: string) => {
     moveTabToWindow(toProfileSpaceId(tabId, activeConnections), targetWindowId);
+    // Final whole-branch review, Fix 4(b): the "Move to <window>" list is
+    // built from `lastWorkspaceRef` (the last-known cross-window document),
+    // which can list a window whose OS window died without a clean
+    // `WindowClosed` record — a dead move target. `focus_window`'s widened
+    // backend contract (windows.rs) spawns `targetWindowId` if the store
+    // still remembers it but no OS window is currently open, and just
+    // focuses it otherwise — fire-and-forget, same as the cross-window open
+    // dedupe's own `focus_window` call above.
+    invoke('focus_window', { label: targetWindowId }).catch(console.warn);
   };
 
   // Simplest correct rule (documented, per the task brief): "Detach to New
@@ -2432,22 +2507,18 @@ function Workspace() {
     own(
       subscribeConnectionsChanged((payload: ConnectionsChangedPayload) => {
         const liveProfileIds = new Set(payload.connections.map((c) => c.profileId));
-        const localByProfile = new Map(activeConnectionsRef.current.map((c) => [c.profileId, c]));
 
         // Additions: a profile now has a live id we didn't know about —
-        // another window connected it. `addActiveConnection`/
-        // `rebindProfileTabs` are the same two calls
+        // another window connected it. `applyConnectionsAdditions`
+        // (`addActiveConnection`/`rebindProfileTabs`, same two calls
         // `handleQuickConnect`/`handleReconnectProfile` make after their
-        // own `connect_db`; the payload carries no `uri` by design (Task 3
-        // — connection strings never ride an event), so any UI reading
-        // `activeConnections[].uri` (the status bar's username display)
-        // degrades to '' for a connection registered this way rather than
-        // crash.
-        for (const entry of payload.connections) {
-          if (localByProfile.has(entry.profileId)) continue;
-          addActiveConnection(entry.id, entry.name, '', entry.profileId);
-          rebindProfileTabs(entry.profileId, entry.id);
-        }
+        // own `connect_db`) also marks every entry here as SEEN
+        // (`seenProfilesRef` — Fix 3, read by the removal loop below); the
+        // payload carries no `uri` by design (Task 3 — connection strings
+        // never ride an event), so any UI reading `activeConnections[].uri`
+        // (the status bar's username display) degrades to '' for a
+        // connection registered this way rather than crash.
+        applyConnectionsAdditions(payload.connections);
 
         // Phase 3 Task 6 (LEDGER MANDATE) considered — and deliberately does
         // NOT implement — a self-healing cleanup for "stale" backend
@@ -2489,8 +2560,27 @@ function Workspace() {
         // `disconnect_db` itself, and mirroring the `close_many` (mirroring
         // it again here would double-apply the same close backend-side —
         // see the who-mirrors-what note in the task report).
+        //
+        // Final whole-branch review, Fix 3: gated on `seenProfilesRef` —
+        // absence from THIS broadcast alone is not enough to tear down. A
+        // profile THIS window just connected can legitimately be missing
+        // from an UNRELATED broadcast that races ahead of its own
+        // `set_connection_meta` landing backend-side (e.g. some other
+        // window connecting/disconnecting something else in between); that
+        // shape is indistinguishable from a real removal by `liveProfileIds`
+        // alone. Only tear down a profile that was previously SEEN live in
+        // some earlier broadcast (or the boot `connection_list` seed) and
+        // is NOW absent — see `seenProfilesRef`'s own doc comment. A local
+        // connection that was NEVER seen is instead self-healed by
+        // re-announcing it via `setConnectionMeta`, so the backend's
+        // `connection_meta` map (and hence the next broadcast) catches up
+        // instead of this window silently killing its own live tabs.
         for (const local of activeConnectionsRef.current) {
           if (liveProfileIds.has(local.profileId)) continue;
+          if (!seenProfilesRef.current.has(local.profileId)) {
+            setConnectionMeta(local.id, local.profileId, local.name);
+            continue;
+          }
           setActiveConnections((prev) => prev.filter((c) => c.id !== local.id));
           const removed = tabsRef.current.filter((t) => t.connectionId === local.id).map((t) => t.id);
           if (removed.length === 0) continue;

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -9,6 +9,9 @@ export interface ContextMenuItem {
   danger?: boolean;
   separatorBefore?: boolean;
   disabled?: boolean;
+  /** Native HTML `title` attribute (hover tooltip) — e.g. explaining why a
+   *  disabled item is disabled (Phase 3 Task 5's unmirrored-tab menu entry). */
+  title?: string;
 }
 
 interface ContextMenuProps {
@@ -79,6 +82,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, items, onClose }
               it.danger && 'is-danger text-destructive hover:text-destructive',
             )}
             disabled={it.disabled}
+            title={it.title}
             onClick={() => {
               it.onClick();
               onClose();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,11 +7,14 @@ import { type CollectionSelection, emptySelection, toggleCollection, selectionSc
 import {
   type FolderNode,
   FOLDERS_CHANGED_EVENT,
+  FOLDERS_STORAGE_KEY,
+  PROFILE_FOLDERS_STORAGE_KEY,
   loadConnectionFolders,
 } from '../lib/connectionFolders';
 import {
   type PinnedItem,
   PINNED_CHANGED_EVENT,
+  PINNED_STORAGE_KEY,
   loadPinnedCollections,
   isItemPinned,
   togglePinItem,
@@ -23,6 +26,7 @@ import {
 import {
   type FavoriteItem,
   FAVORITES_CHANGED_EVENT,
+  FAVORITES_STORAGE_KEY,
   loadFavoriteItems,
   isItemFavorited,
   toggleFavoriteItem,
@@ -528,15 +532,42 @@ export const Sidebar: React.FC<SidebarProps> = ({
   useEffect(() => {
     reloadPinned();
     const onPinned = () => reloadPinned();
+    // Phase 3 Task 6: pins live in localStorage, shared same-origin across
+    // every Tauri window — but each window only reads it once (on mount) and
+    // otherwise relies on the in-window `PINNED_CHANGED_EVENT` above, which
+    // never crosses windows (it's a plain `window.dispatchEvent`, scoped to
+    // this window's own `window` object). The browser-native `storage` event
+    // is the cross-window signal: it fires on every OTHER window's `window`
+    // when localStorage changes (never on the window that made the change —
+    // that's what `PINNED_CHANGED_EVENT` already covers), so the two
+    // listeners together keep pins in sync everywhere. Filtered by key so an
+    // unrelated localStorage write (folders, favorites, anything else) in
+    // another window doesn't force a redundant reload here.
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === PINNED_STORAGE_KEY) reloadPinned();
+    };
     window.addEventListener(PINNED_CHANGED_EVENT, onPinned);
-    return () => window.removeEventListener(PINNED_CHANGED_EVENT, onPinned);
+    window.addEventListener('storage', onStorage);
+    return () => {
+      window.removeEventListener(PINNED_CHANGED_EVENT, onPinned);
+      window.removeEventListener('storage', onStorage);
+    };
   }, []);
 
   useEffect(() => {
     reloadFavoritesStorage();
     const onFavorites = () => reloadFavoritesStorage();
+    // Cross-window sync via the native `storage` event — see the pins effect
+    // above for why this is needed alongside `FAVORITES_CHANGED_EVENT`.
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === FAVORITES_STORAGE_KEY) reloadFavoritesStorage();
+    };
     window.addEventListener(FAVORITES_CHANGED_EVENT, onFavorites);
-    return () => window.removeEventListener(FAVORITES_CHANGED_EVENT, onFavorites);
+    window.addEventListener('storage', onStorage);
+    return () => {
+      window.removeEventListener(FAVORITES_CHANGED_EVENT, onFavorites);
+      window.removeEventListener('storage', onStorage);
+    };
   }, []);
 
   useEffect(() => {
@@ -557,8 +588,18 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
   useEffect(() => {
     const onFolders = () => reloadFolders();
+    // Cross-window sync via the native `storage` event — see the pins
+    // effect above. Folders persist across two keys (the node list and the
+    // profile->folder map), so either one changing triggers a reload.
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === FOLDERS_STORAGE_KEY || e.key === PROFILE_FOLDERS_STORAGE_KEY) reloadFolders();
+    };
     window.addEventListener(FOLDERS_CHANGED_EVENT, onFolders);
-    return () => window.removeEventListener(FOLDERS_CHANGED_EVENT, onFolders);
+    window.addEventListener('storage', onStorage);
+    return () => {
+      window.removeEventListener(FOLDERS_CHANGED_EVENT, onFolders);
+      window.removeEventListener('storage', onStorage);
+    };
   }, []);
 
   const ensureConnectionExpanded = (connId: string) => {

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -36,6 +36,29 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: any[]) => mockInvoke(...args),
 }));
 
+// Phase 3 Task 4: `listen` mocked to capture registered callbacks per event
+// name so tests can fire a `workspace-changed`/`connections-changed` payload
+// manually (Tauri has no real event channel under jsdom). `windowLabel()`
+// itself is left unmocked — `@tauri-apps/api/webviewWindow`'s real
+// `getCurrentWebviewWindow()` throws under jsdom (no `__TAURI_INTERNALS__`),
+// which is exactly the fallback-to-`"main"` path every test below relies on
+// ("running as main").
+const eventListeners = new Map<string, Array<(event: { payload: unknown }) => void>>();
+function fireMockEvent(eventName: string, payload: unknown) {
+  for (const cb of eventListeners.get(eventName) ?? []) cb({ payload });
+}
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (eventName: string, cb: (event: { payload: unknown }) => void) => {
+    const arr = eventListeners.get(eventName) ?? [];
+    arr.push(cb);
+    eventListeners.set(eventName, arr);
+    return Promise.resolve(() => {
+      const idx = arr.indexOf(cb);
+      if (idx >= 0) arr.splice(idx, 1);
+    });
+  },
+}));
+
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: () => Promise.resolve('0.3.1'),
 }));
@@ -104,6 +127,7 @@ vi.mock('../Sidebar', () => ({
 describe('App Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    eventListeners.clear();
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === 'load_app_settings') {
         return Promise.resolve({});
@@ -2133,6 +2157,342 @@ describe('App Component', () => {
       // single reducer application (matching the backend) would produce.
       expect(screen.getByTestId('pane-pane-2')).toBeInTheDocument();
       expect(screen.queryByTestId('pane-pane-3')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('foreign-event reconciliation (Phase 3 Task 4)', () => {
+    it('(a) a foreign workspace-changed event re-hydrates this window\'s layout', async () => {
+      const { fireEvent, waitFor, act, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // pane-1 now holds two already-known tabs: Quick Start + customers.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await within(screen.getByTestId('workspace-tab-strip')).findByText('customers');
+      expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
+
+      // A DIFFERENT window (win-1) split main's tree in two — the broadcast
+      // carries the FULL workspace, main's entry now shows a split with the
+      // two tabs this window already knows about (no arriving/leaving).
+      await act(async () => {
+        fireMockEvent('workspace-changed', {
+          revision: 1,
+          origin: 'win-1',
+          crossWindow: false,
+          workspace: {
+            revision: 1,
+            windows: [
+              {
+                id: 'main',
+                focusedPaneId: 'pane-1',
+                splitTree: {
+                  kind: 'split',
+                  id: 'split-1',
+                  dir: 'row',
+                  ratio: 0.5,
+                  children: [
+                    { kind: 'pane', id: 'pane-1', tabIds: ['quickstart'], activeTabId: 'quickstart' },
+                    {
+                      kind: 'pane',
+                      id: 'pane-2',
+                      tabIds: ['conn-1.sales_db.customers'],
+                      activeTabId: 'conn-1.sales_db.customers',
+                    },
+                  ],
+                },
+              },
+              { id: 'win-1', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null } },
+            ],
+            tabs: [
+              { id: 'quickstart', type: 'quickstart', profileId: '', profileName: '', db: '', collection: '' },
+              { id: 'conn-1.sales_db.customers', type: 'collection', profileId: '', profileName: '', db: 'sales_db', collection: 'customers' },
+            ],
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(2);
+      });
+    });
+
+    it('(b) an arriving tab materializes and refreshes when its connection is already live locally', async () => {
+      const workspaceSnapshot = {
+        revision: 1,
+        windows: [
+          { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.sales_db.customers'], activeTabId: 'profile:p1.sales_db.customers' } },
+        ],
+        tabs: [
+          { id: 'profile:p1.sales_db.customers', type: 'collection', profileId: 'p1', profileName: 'Prod Cluster', db: 'sales_db', collection: 'customers' },
+        ],
+      };
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('new-conn-1');
+        if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor, act, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      // Reconnect p1 — establishes activeConnections=[{id:'new-conn-1',profileId:'p1',...}]
+      // and rebinds the existing customers tab onto the live id.
+      const [firstBtn] = await screen.findAllByRole('button', { name: /Reconnect Prod Cluster/ });
+      fireEvent.click(firstBtn);
+      await waitFor(() => {
+        expect(screen.queryAllByTestId('reconnect-banner')).toHaveLength(0);
+      });
+
+      calls.length = 0; // only care about what the arriving event triggers below
+
+      // A foreign event: main's tree now ALSO holds an `orders` tab for the
+      // same profile p1 — arriving, and live (p1 is already connected here).
+      await act(async () => {
+        fireMockEvent('workspace-changed', {
+          revision: 2,
+          origin: 'win-1',
+          crossWindow: false,
+          workspace: {
+            revision: 2,
+            windows: [
+              {
+                id: 'main',
+                focusedPaneId: 'pane-1',
+                splitTree: {
+                  kind: 'pane',
+                  id: 'pane-1',
+                  tabIds: ['profile:p1.sales_db.customers', 'profile:p1.sales_db.orders'],
+                  activeTabId: 'profile:p1.sales_db.orders',
+                },
+              },
+            ],
+            tabs: [
+              { id: 'profile:p1.sales_db.customers', type: 'collection', profileId: 'p1', profileName: 'Prod Cluster', db: 'sales_db', collection: 'customers' },
+              { id: 'profile:p1.sales_db.orders', type: 'collection', profileId: 'p1', profileName: 'Prod Cluster', db: 'sales_db', collection: 'orders' },
+            ],
+          },
+        });
+      });
+
+      // Materialized: shows up in the tab strip.
+      expect(await within(screen.getByTestId('workspace-tab-strip')).findByText('orders')).toBeInTheDocument();
+      // Live: refreshed automatically (re-ran the default query against the
+      // now-live connection) without any user interaction.
+      await waitFor(() => {
+        const orderCalls = calls.filter((c) => c.cmd === 'execute_mql_query' && c.args?.collection === 'orders');
+        expect(orderCalls.length).toBeGreaterThan(0);
+        expect(orderCalls[0].args.id).toBe('new-conn-1');
+      });
+    });
+
+    it('(c) a leaving tab is removed locally without mirroring a close', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor, act, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findAllByText(/"Ada"/)).toBeTruthy();
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      expect(within(tabStrip).getByText('customers')).toBeInTheDocument();
+
+      calls.length = 0; // only care about what firing the event below does
+
+      // A foreign event: main's tree now holds ONLY Quick Start — customers
+      // left (moved/closed elsewhere).
+      await act(async () => {
+        fireMockEvent('workspace-changed', {
+          revision: 1,
+          origin: 'win-1',
+          crossWindow: true,
+          workspace: {
+            revision: 1,
+            windows: [
+              { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['quickstart'], activeTabId: 'quickstart' } },
+            ],
+            tabs: [{ id: 'quickstart', type: 'quickstart', profileId: '', profileName: '', db: '', collection: '' }],
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(within(tabStrip).queryByText('customers')).not.toBeInTheDocument();
+      });
+      // Never mirrored — the window that moved/closed it already did.
+      const mirrored = calls.filter((c) => c.cmd === 'workspace_apply');
+      expect(mirrored).toHaveLength(0);
+    });
+
+    it('(d) a self-origin, non-cross-window event is ignored entirely', async () => {
+      const { waitFor, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('quickstart-tab');
+      expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
+
+      await act(async () => {
+        fireMockEvent('workspace-changed', {
+          revision: 1,
+          origin: 'main', // this window's own label
+          crossWindow: false,
+          workspace: {
+            revision: 1,
+            windows: [
+              {
+                id: 'main',
+                focusedPaneId: 'pane-1',
+                splitTree: {
+                  kind: 'split',
+                  id: 'split-1',
+                  dir: 'row',
+                  ratio: 0.5,
+                  children: [
+                    { kind: 'pane', id: 'pane-1', tabIds: ['quickstart'], activeTabId: 'quickstart' },
+                    { kind: 'pane', id: 'pane-2', tabIds: [], activeTabId: null },
+                  ],
+                },
+              },
+            ],
+            tabs: [{ id: 'quickstart', type: 'quickstart', profileId: '', profileName: '', db: '', collection: '' }],
+          },
+        });
+      });
+
+      // Give any (incorrect) reconciliation a chance to run, then assert
+      // nothing changed — still exactly one pane.
+      await waitFor(() => {
+        expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
+      });
+    });
+
+    it('(e) an out-of-order/replayed event (revision <= last seen) is dropped', async () => {
+      const { act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      const eventAt = (revision: number) => ({
+        revision,
+        origin: 'win-1',
+        crossWindow: false,
+        workspace: {
+          revision,
+          windows: [
+            { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.sales_db.customers'], activeTabId: 'profile:p1.sales_db.customers' } },
+          ],
+          tabs: [
+            { id: 'profile:p1.sales_db.customers', type: 'collection', profileId: 'p1', profileName: 'Prod Cluster', db: 'sales_db', collection: 'customers' },
+          ],
+        },
+      });
+
+      // revision 2 lands first — customers arrives.
+      await act(async () => {
+        fireMockEvent('workspace-changed', eventAt(2));
+      });
+      expect(await screen.findByText('customers')).toBeInTheDocument();
+
+      // A STALE revision 1 replay tries to wipe main's tree back to empty —
+      // it must be dropped entirely, leaving revision 2's state intact.
+      const staleEmpty = {
+        revision: 1,
+        origin: 'win-1',
+        crossWindow: false,
+        workspace: {
+          revision: 1,
+          windows: [{ id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null } }],
+          tabs: [],
+        },
+      };
+      await act(async () => {
+        fireMockEvent('workspace-changed', staleEmpty);
+      });
+
+      // Still there — the stale event never applied.
+      expect(screen.getByText('customers')).toBeInTheDocument();
+    });
+
+    it('(f) opening a tab already present in another window\'s tree does not add it locally (MANDATE)', async () => {
+      const quickConnectWorkspace = {
+        revision: 1,
+        windows: [
+          { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['quickstart'], activeTabId: 'quickstart' } },
+          { id: 'win-1', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['conn-1.sales_db.customers'], activeTabId: 'conn-1.sales_db.customers' } },
+        ],
+        tabs: [
+          { id: 'quickstart', type: 'quickstart', profileId: '', profileName: '', db: '', collection: '' },
+          { id: 'conn-1.sales_db.customers', type: 'collection', profileId: '', profileName: '', db: 'sales_db', collection: 'customers' },
+        ],
+      };
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(quickConnectWorkspace);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('quickstart-tab');
+
+      // 'customers' (conn-1.sales_db.customers) is already open in win-1's
+      // tree per the boot snapshot above (lastWorkspaceRef is seeded at
+      // boot). Selecting it here (running as main) must not add it locally.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+
+      await waitFor(() => {
+        const focusCalls = calls.filter((c) => c.cmd === 'focus_window');
+        expect(focusCalls).toHaveLength(1);
+        expect(focusCalls[0].args).toEqual({ label: 'win-1' });
+      });
+      // Never added to this window's tab strip/pane.
+      expect(screen.queryByText('customers')).not.toBeInTheDocument();
+      expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
+    });
+
+    it('(g) a connections-changed addition rebinds a restored profile\'s banner tabs without this window ever connecting itself', async () => {
+      const workspaceSnapshot = {
+        revision: 1,
+        windows: [
+          { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.sales_db.customers'], activeTabId: 'profile:p1.sales_db.customers' } },
+        ],
+        tabs: [
+          { id: 'profile:p1.sales_db.customers', type: 'collection', profileId: 'p1', profileName: 'Prod Cluster', db: 'sales_db', collection: 'customers' },
+        ],
+      };
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        return Promise.resolve([]);
+      });
+
+      const { waitFor, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      expect(await screen.findByTestId('reconnect-banner')).toBeInTheDocument();
+
+      // Another window connected p1 — this window never called connect_db.
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [{ id: 'live-99', profileId: 'p1', name: 'Prod Cluster' }],
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('reconnect-banner')).not.toBeInTheDocument();
+      });
+      expect(calls.some((c) => c.cmd === 'connect_db')).toBe(false);
     });
   });
 });

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -3088,5 +3088,20 @@ describe('App Component', () => {
       expect(placeholder.closest('button')).toBeDisabled();
       expect(placeholder.closest('button')).toHaveAttribute('title', 'Export/import tabs stay in their window');
     });
+
+    it('does not open an empty context menu for the sole tab when no other windows exist', async () => {
+      const { fireEvent, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // Only Quick Start is open, and no other windows were seeded — both
+      // "Detach to New Window" and any "Move to" entries are absent, so
+      // buildTabContextMenuItems returns [] and the menu must not open.
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      const quickstartTab = await within(tabStrip).findByText('Quick Start');
+      fireEvent.contextMenu(quickstartTab.closest('div')!);
+
+      expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -82,8 +82,17 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 
 // Mock Sidebar component
 vi.mock('../Sidebar', () => ({
-  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings, onOpenDump, onOpenRestore, onEditValidation, onDatabaseRenamed }: any) => (
+  Sidebar: ({ onSelectCollection, onSelectIndex, onCreateIndex, onDeleteIndex, onOpenSettings, onOpenDump, onOpenRestore, onEditValidation, onDatabaseRenamed, activeConnections }: any) => (
     <div data-testid="mock-sidebar">
+      {/* Phase 3 Task 6 (b): mirrors the real Sidebar's dependence on the
+          `activeConnections` prop for its "Connections" tree — lets tests
+          assert a connection landed in this window's sidebar without
+          rendering the (heavy) real component. */}
+      <ul data-testid="mock-sidebar-connections">
+        {(activeConnections ?? []).map((c: any) => (
+          <li key={c.id} data-testid={`sidebar-conn-${c.id}`}>{c.name}</li>
+        ))}
+      </ul>
       <button data-testid="select-collection-btn" onClick={() => onSelectCollection('conn-1', 'sales_db', 'customers')}>
         Select Collection
       </button>
@@ -122,6 +131,25 @@ vi.mock('../Sidebar', () => ({
       </button>
     </div>
   ),
+}));
+
+// Mock ConnectionManager: the real component's full add/edit/test/connect
+// form is exercised by its own dedicated test suite (ConnectionManager.test.tsx).
+// Here only the `onConnect` callback's WIRING through App.tsx matters (Phase
+// 3 Task 6's set_connection_meta call) — a single button that fires it with
+// fixed args, gated on `isOpen` like the real modal.
+vi.mock('../ConnectionManager', () => ({
+  ConnectionManager: ({ isOpen, onConnect }: any) =>
+    isOpen ? (
+      <div data-testid="mock-connection-manager">
+        <button
+          data-testid="mock-cm-connect-btn"
+          onClick={() => onConnect('cm-live-1', 'Staging Cluster', 'mongodb://staging', 'p-cm', '#fff')}
+        >
+          Connect
+        </button>
+      </div>
+    ) : null,
 }));
 
 describe('App Component', () => {
@@ -2690,6 +2718,220 @@ describe('App Component', () => {
         expect(screen.queryByTestId('reconnect-banner')).not.toBeInTheDocument();
       });
       expect(calls.some((c) => c.cmd === 'connect_db')).toBe(false);
+    });
+  });
+
+  describe('cross-window connection + pref coherence (Phase 3 Task 6)', () => {
+    it('(a1) a quick-connect from the Quick Start pane calls set_connection_meta for the fresh id', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('live-1');
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      const connectCard = await screen.findByTestId('conn-card-p1');
+      fireEvent.click(connectCard);
+
+      await waitFor(() => {
+        expect(
+          calls.some(
+            (c) =>
+              c.cmd === 'set_connection_meta' &&
+              c.args?.id === 'live-1' &&
+              c.args?.profileId === 'p1' &&
+              c.args?.name === 'Prod Cluster',
+          ),
+        ).toBe(true);
+      });
+    });
+
+    it('(a2) connecting via the ConnectionManager dialog calls set_connection_meta for the fresh id', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('quickstart-tab');
+
+      fireEvent.click(screen.getAllByText('New connection')[0]);
+      const connectBtn = await screen.findByTestId('mock-cm-connect-btn');
+      fireEvent.click(connectBtn);
+
+      await waitFor(() => {
+        expect(
+          calls.some(
+            (c) =>
+              c.cmd === 'set_connection_meta' &&
+              c.args?.id === 'cm-live-1' &&
+              c.args?.profileId === 'p-cm' &&
+              c.args?.name === 'Staging Cluster',
+          ),
+        ).toBe(true);
+      });
+    });
+
+    it('(a3) the fresh-connect branch of a ReconnectBanner click calls set_connection_meta for the new id', async () => {
+      const workspaceSnapshot = {
+        revision: 1,
+        windows: [
+          { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.sales_db.customers'], activeTabId: 'profile:p1.sales_db.customers' } },
+        ],
+        tabs: [
+          { id: 'profile:p1.sales_db.customers', type: 'collection', profileId: 'p1', profileName: 'Prod Cluster', db: 'sales_db', collection: 'customers' },
+        ],
+      };
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('live-1');
+        if (cmd === 'execute_mql_query') return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      expect(await screen.findByTestId('reconnect-banner')).toBeInTheDocument();
+      fireEvent.click(screen.getByText(/Reconnect Prod Cluster/));
+
+      await waitFor(() => {
+        expect(
+          calls.some(
+            (c) =>
+              c.cmd === 'set_connection_meta' &&
+              c.args?.id === 'live-1' &&
+              c.args?.profileId === 'p1' &&
+              c.args?.name === 'Prod Cluster',
+          ),
+        ).toBe(true);
+      });
+      // The reuse branch (an id already in `activeConnections`) never calls
+      // `connect_db`/`set_connection_meta` a second time — see App.tsx's
+      // `handleReconnectProfile` comment. Nothing else exercises that branch
+      // here, so this just confirms `set_connection_meta` fired exactly once.
+      expect(calls.filter((c) => c.cmd === 'set_connection_meta')).toHaveLength(1);
+    });
+
+    it('(b) a connections-changed addition renders in this window\'s sidebar even though it never connected anything itself', async () => {
+      const { act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      expect(screen.queryByTestId('sidebar-conn-live-99')).not.toBeInTheDocument();
+
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [{ id: 'live-99', profileId: 'p1', name: 'Prod Cluster' }],
+        });
+      });
+
+      expect(await screen.findByTestId('sidebar-conn-live-99')).toHaveTextContent('Prod Cluster');
+    });
+
+    it('(d) a stale connection_meta entry for a profile already live locally under a different id is left alone (no disconnect_db)', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('live-1');
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      const connectCard = await screen.findByTestId('conn-card-p1');
+      fireEvent.click(connectCard);
+      await waitFor(() => expect(calls.some((c) => c.cmd === 'connect_db')).toBe(true));
+
+      calls.length = 0; // only the event handler's own reaction matters below
+
+      // The backend broadcast still carries an id for p1 this window did NOT
+      // mint (`live-old`) alongside the one it did (`live-1`) — the shape a
+      // genuinely-orphaned meta entry AND a same-profile race with another
+      // window are both indistinguishable in. Per App.tsx's comment, this is
+      // deliberately left alone rather than risk killing a live connection.
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [
+            { id: 'live-1', profileId: 'p1', name: 'Prod Cluster' },
+            { id: 'live-old', profileId: 'p1', name: 'Prod Cluster' },
+          ],
+        });
+      });
+
+      expect(calls.some((c) => c.cmd === 'disconnect_db')).toBe(false);
+    });
+
+    it('(e) a connections-changed removal tears down local tabs without double-mirroring the close', async () => {
+      const workspaceSnapshot = {
+        revision: 1,
+        windows: [
+          { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.sales_db.customers'], activeTabId: 'profile:p1.sales_db.customers' } },
+        ],
+        tabs: [
+          { id: 'profile:p1.sales_db.customers', type: 'collection', profileId: 'p1', profileName: 'Prod Cluster', db: 'sales_db', collection: 'customers' },
+        ],
+      };
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        if (cmd === 'execute_mql_query') return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      const { waitFor, act, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      expect(await screen.findByTestId('reconnect-banner')).toBeInTheDocument();
+
+      // Another window connected p1 first — rebinds this window's banner tab.
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [{ id: 'live-99', profileId: 'p1', name: 'Prod Cluster' }],
+        });
+      });
+      await waitFor(() => expect(screen.queryByTestId('reconnect-banner')).not.toBeInTheDocument());
+      expect(within(screen.getByTestId('workspace-tab-strip')).getByText('customers')).toBeInTheDocument();
+
+      calls.length = 0; // only what the REMOVAL itself triggers matters below
+
+      // That connection is now gone from the broadcast — another window
+      // disconnected it (or this one would have via Sidebar's onDisconnect,
+      // which calls disconnect_db itself and is not exercised here).
+      await act(async () => {
+        fireMockEvent('connections-changed', { connections: [] });
+      });
+
+      await waitFor(() => {
+        expect(within(screen.getByTestId('workspace-tab-strip')).queryByText('customers')).not.toBeInTheDocument();
+      });
+      // The close is a raw local `dispatchLayout`, never re-mirrored to the
+      // backend workspace store — mirroring it again would double-apply the
+      // same close backend-side (see App.tsx's "Removals" comment). The
+      // tabs-empty effect firing afterward (main window resurrects Quick
+      // Start) DOES call workspace_apply for an `open_tab` — this only
+      // asserts no `close_many` op was ever mirrored.
+      const closeManyMirrors = calls.filter((c) => c.cmd === 'workspace_apply' && c.args?.op?.type === 'close_many');
+      expect(closeManyMirrors).toHaveLength(0);
+      expect(calls.some((c) => c.cmd === 'disconnect_db')).toBe(false);
     });
   });
 

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -2161,7 +2161,7 @@ describe('App Component', () => {
   });
 
   describe('foreign-event reconciliation (Phase 3 Task 4)', () => {
-    it('(a) a foreign workspace-changed event re-hydrates this window\'s layout', async () => {
+    it('(a) a foreign NON-crossWindow event is bystander-only: lastWorkspaceRef updates, layout/tabs untouched', async () => {
       const { fireEvent, waitFor, act, within } = await import('@testing-library/react');
       renderWithProviders(<App />);
       await screen.findByTestId('mock-sidebar');
@@ -2171,14 +2171,96 @@ describe('App Component', () => {
       await within(screen.getByTestId('workspace-tab-strip')).findByText('customers');
       expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
 
-      // A DIFFERENT window (win-1) split main's tree in two — the broadcast
-      // carries the FULL workspace, main's entry now shows a split with the
-      // two tabs this window already knows about (no arriving/leaving).
+      // A DIFFERENT window's (win-1) LOCAL, non-crossWindow op — per the
+      // backend's own guarantee (op_is_cross_window), this could only have
+      // touched win-1's own tree, never main's. main's entry below is
+      // deliberately a DIFFERENT shape (a 2-pane split) than what's
+      // actually committed here, standing in for a stale/pre-mirror
+      // snapshot — reconciling against it would be wrong, so it must be
+      // ignored outright (CRITICAL fix, review round 1). win-1's own entry
+      // claims 'conn-1.sales_db.orders' — reachable via the mock sidebar's
+      // "select orders" button, used below to prove the ref DID update.
       await act(async () => {
         fireMockEvent('workspace-changed', {
           revision: 1,
           origin: 'win-1',
           crossWindow: false,
+          workspace: {
+            revision: 1,
+            windows: [
+              {
+                id: 'main',
+                focusedPaneId: 'pane-1',
+                splitTree: {
+                  kind: 'split',
+                  id: 'split-1',
+                  dir: 'row',
+                  ratio: 0.5,
+                  children: [
+                    { kind: 'pane', id: 'pane-1', tabIds: ['quickstart'], activeTabId: 'quickstart' },
+                    { kind: 'pane', id: 'pane-2', tabIds: [], activeTabId: null },
+                  ],
+                },
+              },
+              {
+                id: 'win-1',
+                focusedPaneId: 'pane-1',
+                splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['conn-1.sales_db.orders'], activeTabId: 'conn-1.sales_db.orders' },
+              },
+            ],
+            tabs: [
+              { id: 'quickstart', type: 'quickstart', profileId: '', profileName: '', db: '', collection: '' },
+              { id: 'conn-1.sales_db.orders', type: 'collection', profileId: '', profileName: '', db: 'sales_db', collection: 'orders' },
+            ],
+          },
+        });
+      });
+
+      // Layout/tabs untouched — still exactly one pane, still "customers".
+      await waitFor(() => {
+        expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
+      });
+      expect(within(screen.getByTestId('workspace-tab-strip')).getByText('customers')).toBeInTheDocument();
+
+      // lastWorkspaceRef DID update, though (proven indirectly via the
+      // cross-window open dedupe, the other consumer of that ref): opening
+      // the tab this event said win-1 holds must be deduped/focus-routed,
+      // not added locally — which is only possible if the bystander path
+      // still updated lastWorkspaceRef even though it skipped hydrate/diff.
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        return Promise.resolve([]);
+      });
+      fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
+      await waitFor(() => {
+        const focusCalls = calls.filter((c) => c.cmd === 'focus_window');
+        expect(focusCalls).toHaveLength(1);
+        expect(focusCalls[0].args).toEqual({ label: 'win-1' });
+      });
+      expect(within(screen.getByTestId('workspace-tab-strip')).queryByText('orders')).not.toBeInTheDocument();
+    });
+
+    it('(a2) a crossWindow event re-hydrates this window\'s layout', async () => {
+      const { fireEvent, waitFor, act, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // pane-1 now holds two already-known tabs: Quick Start + customers.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await within(screen.getByTestId('workspace-tab-strip')).findByText('customers');
+      expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
+
+      // A crossWindow op (move_tab_to_window/detach_tab/window_closed) —
+      // the one class of event that CAN touch this window's tree even when
+      // it didn't originate here. The broadcast carries the FULL workspace;
+      // main's entry now shows a split with the two tabs this window
+      // already knows about (no arriving/leaving).
+      await act(async () => {
+        fireMockEvent('workspace-changed', {
+          revision: 1,
+          origin: 'win-1',
+          crossWindow: true,
           workspace: {
             revision: 1,
             windows: [
@@ -2216,6 +2298,114 @@ describe('App Component', () => {
       });
     });
 
+    it('(i) an unmirrored (export/import) tab survives a crossWindow reconcile — never in any snapshot, must not be dropped', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        return Promise.resolve([]);
+      });
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { fireEvent, act, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findAllByText(/"Ada"/)).toBeTruthy();
+
+      fireEvent.keyDown(window, { key: 'k', metaKey: true });
+      fireEvent.change(await screen.findByTestId('command-palette-input'), { target: { value: 'Export Collection' } });
+      fireEvent.click(await screen.findByText('Export Collection…'));
+
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      await within(tabStrip).findByText('Export: customers');
+
+      calls.length = 0;
+
+      // A crossWindow event affecting THIS window — main's backend tree
+      // only ever lists quickstart + the collection tab (export tabs are
+      // NEVER mirrored, toPersistedTab returns null for them), regardless
+      // of what unrelated activity elsewhere triggered this event.
+      await act(async () => {
+        fireMockEvent('workspace-changed', {
+          revision: 1,
+          origin: 'win-1',
+          crossWindow: true,
+          workspace: {
+            revision: 1,
+            windows: [
+              {
+                id: 'main',
+                focusedPaneId: 'pane-1',
+                splitTree: {
+                  kind: 'pane',
+                  id: 'pane-1',
+                  tabIds: ['quickstart', 'conn-1.sales_db.customers'],
+                  activeTabId: 'conn-1.sales_db.customers',
+                },
+              },
+            ],
+            tabs: [
+              { id: 'quickstart', type: 'quickstart', profileId: '', profileName: '', db: '', collection: '' },
+              { id: 'conn-1.sales_db.customers', type: 'collection', profileId: '', profileName: '', db: 'sales_db', collection: 'customers' },
+            ],
+          },
+        });
+      });
+
+      // Still there — never treated as "leaving" (IMPORTANT fix, review
+      // round 1: the leaving-set now excludes unmirroredTabIdsRef ids).
+      expect(within(tabStrip).getByText('Export: customers')).toBeInTheDocument();
+      // Grafted back into the LAYOUT tree too, not just left dangling in
+      // tabs[] — no dev-mode layout/tabs[] desync warning.
+      const desyncWarnings = consoleErrorSpy.mock.calls.filter(
+        (c) =>
+          typeof c[0] === 'string' &&
+          (c[0].includes('workspace layout references unknown tab') || c[0].includes('tabs[] contains ids missing'))
+      );
+      expect(desyncWarnings).toHaveLength(0);
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('(ii) an optimistic local open survives a foreign non-crossWindow event carrying an older (pre-mirror) snapshot', async () => {
+      const { fireEvent, act, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // Local optimistic open — in a real app its mirror (workspace_apply)
+      // is still in flight; nothing here waits for it.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      await within(tabStrip).findByText('customers');
+
+      // A foreign, non-crossWindow event from another window's UNRELATED
+      // activity — its snapshot of main's tree predates this window's
+      // local open (the backend hasn't processed that mirror yet), so it
+      // still shows only Quick Start. Pre-fix, this would have hydrated
+      // and wiped the just-opened tab (CRITICAL — review round 1). Post-fix:
+      // bystander semantics mean this window is untouched by definition —
+      // the race is trivially safe.
+      await act(async () => {
+        fireMockEvent('workspace-changed', {
+          revision: 1,
+          origin: 'win-1',
+          crossWindow: false,
+          workspace: {
+            revision: 1,
+            windows: [
+              { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['quickstart'], activeTabId: 'quickstart' } },
+              { id: 'win-1', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null } },
+            ],
+            tabs: [{ id: 'quickstart', type: 'quickstart', profileId: '', profileName: '', db: '', collection: '' }],
+          },
+        });
+      });
+
+      // Survives — this window was never touched by that event.
+      expect(within(tabStrip).getByText('customers')).toBeInTheDocument();
+    });
+
     it('(b) an arriving tab materializes and refreshes when its connection is already live locally', async () => {
       const workspaceSnapshot = {
         revision: 1,
@@ -2251,13 +2441,16 @@ describe('App Component', () => {
 
       calls.length = 0; // only care about what the arriving event triggers below
 
-      // A foreign event: main's tree now ALSO holds an `orders` tab for the
-      // same profile p1 — arriving, and live (p1 is already connected here).
+      // A crossWindow event: main's tree now ALSO holds an `orders` tab for
+      // the same profile p1 — arriving, and live (p1 is already connected
+      // here). Reconciliation only ever runs for crossWindow events now
+      // (bystander fix, review round 1) — a non-crossWindow event wouldn't
+      // reach this diff at all.
       await act(async () => {
         fireMockEvent('workspace-changed', {
           revision: 2,
           origin: 'win-1',
-          crossWindow: false,
+          crossWindow: true,
           workspace: {
             revision: 2,
             windows: [
@@ -2381,10 +2574,13 @@ describe('App Component', () => {
       renderWithProviders(<App />);
       await screen.findByTestId('mock-sidebar');
 
+      // crossWindow: true throughout — reconciliation (and therefore this
+      // revision-replay guard) is only ever reached for crossWindow events
+      // now (bystander fix, review round 1).
       const eventAt = (revision: number) => ({
         revision,
         origin: 'win-1',
-        crossWindow: false,
+        crossWindow: true,
         workspace: {
           revision,
           windows: [
@@ -2403,11 +2599,12 @@ describe('App Component', () => {
       expect(await screen.findByText('customers')).toBeInTheDocument();
 
       // A STALE revision 1 replay tries to wipe main's tree back to empty —
-      // it must be dropped entirely, leaving revision 2's state intact.
+      // it must be dropped entirely (by the revision check, before the
+      // crossWindow gate is even reached), leaving revision 2's state intact.
       const staleEmpty = {
         revision: 1,
         origin: 'win-1',
-        crossWindow: false,
+        crossWindow: true,
         workspace: {
           revision: 1,
           windows: [{ id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null } }],

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -2097,13 +2097,12 @@ describe('App Component', () => {
     it('a real split_pane commits pane-pane-2, not pane-pane-3 — the no-op mirror gate\'s trial reducer call must not itself consume a pane id', async () => {
       // The gate's trial run (see the previous describe block) calls
       // `workspaceReducer` purely for reference-identity comparison and
-      // discards its result — but `workspaceReducer` mints pane/split ids
-      // via model.ts's module-level counters as a SIDE EFFECT. Reset here so
-      // this test's own split is the first mint since module load,
-      // regardless of what earlier tests in this file minted.
-      const { resetLayoutIds } = await import('../../workspace/model');
-      resetLayoutIds();
-
+      // discards its result. Minting is a stateless scan of the layout being
+      // reduced (model.ts's `nextPaneId`/`nextSplitId`, #197), so this test
+      // needs no reset between runs: every App render starts from the same
+      // fresh `pane-1` root regardless of what earlier tests in this file
+      // minted, and the trial call above cannot leave any residue behind for
+      // this test to inherit.
       mockInvoke.mockImplementation((cmd: string) => {
         if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
         return Promise.resolve([]);

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -2719,6 +2719,40 @@ describe('App Component', () => {
       });
       expect(calls.some((c) => c.cmd === 'connect_db')).toBe(false);
     });
+
+    it('(h) the boot-time connection_list seed rebinds a restored profile\'s banner tab without any connect_db call (final whole-branch review Fix 2)', async () => {
+      const workspaceSnapshot = {
+        revision: 1,
+        windows: [
+          { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.sales_db.customers'], activeTabId: 'profile:p1.sales_db.customers' } },
+        ],
+        tabs: [
+          { id: 'profile:p1.sales_db.customers', type: 'collection', profileId: 'p1', profileName: 'Prod Cluster', db: 'sales_db', collection: 'customers' },
+        ],
+      };
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        // Simulates a window spawned into an already-live session — another
+        // window connected p1 before this one ever booted.
+        if (cmd === 'connection_list') {
+          return Promise.resolve([{ id: 'live-99', profileId: 'p1', name: 'Prod Cluster' }]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const { waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      // Never even flashes a ReconnectBanner — the seed lands before the
+      // hydrated tab renders as "disconnected".
+      await waitFor(() => {
+        expect(screen.queryByTestId('reconnect-banner')).not.toBeInTheDocument();
+      });
+      expect(await screen.findByTestId('sidebar-conn-live-99')).toHaveTextContent('Prod Cluster');
+      expect(calls.some((c) => c.cmd === 'connect_db')).toBe(false);
+    });
   });
 
   describe('cross-window connection + pref coherence (Phase 3 Task 6)', () => {
@@ -2933,6 +2967,53 @@ describe('App Component', () => {
       expect(closeManyMirrors).toHaveLength(0);
       expect(calls.some((c) => c.cmd === 'disconnect_db')).toBe(false);
     });
+
+    it('(f) a fresh local connect survives an unrelated connections-changed broadcast that never mentions it, and re-fires set_connection_meta (final whole-branch review Fix 3)', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('live-1');
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      const connectCard = await screen.findByTestId('conn-card-p1');
+      fireEvent.click(connectCard);
+      await waitFor(() => expect(screen.getByTestId('sidebar-conn-live-1')).toBeInTheDocument());
+
+      calls.length = 0; // only the broadcast handler's own reaction matters below
+
+      // An unrelated broadcast lands — this window's own `set_connection_meta`
+      // for p1 hasn't registered backend-side yet (a race), so the very
+      // first connections-changed payload it ever sees doesn't mention p1
+      // at all. p1 was never SEEN in any prior broadcast (seenProfilesRef is
+      // empty for it), so this must NOT be treated as a removal.
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [{ id: 'live-other', profileId: 'p-other', name: 'Other Cluster' }],
+        });
+      });
+
+      // Still there — not torn down by a broadcast that has nothing to do
+      // with it.
+      expect(screen.getByTestId('sidebar-conn-live-1')).toBeInTheDocument();
+      expect(calls.some((c) => c.cmd === 'disconnect_db')).toBe(false);
+      // Self-healing re-registration: re-announces this window's own live
+      // connection so the backend's connection_meta map (and hence the next
+      // broadcast) catches up.
+      await waitFor(() => {
+        expect(
+          calls.some(
+            (c) => c.cmd === 'set_connection_meta' && c.args?.id === 'live-1' && c.args?.profileId === 'p1',
+          ),
+        ).toBe(true);
+      });
+    });
   });
 
   describe('tab context menu — detach/move (Phase 3 Task 5)', () => {
@@ -3053,6 +3134,15 @@ describe('App Component', () => {
           op: { type: 'move_tab_to_window', tab_id: 'conn-1.sales_db.customers', target_window_id: 'win-1' },
           origin: 'main',
         });
+      });
+      // Final whole-branch review, Fix 4(b): also fires `focus_window` for
+      // the target — the backend widens its contract to spawn `win-1` if
+      // the store still lists it but no OS window is currently open (a
+      // dead move target), so this self-heals instead of stranding the tab.
+      await waitFor(() => {
+        const focusCalls = calls.filter((c) => c.cmd === 'focus_window');
+        expect(focusCalls).toHaveLength(1);
+        expect(focusCalls[0].args).toEqual({ label: 'win-1' });
       });
       // CRITICAL: this window's own tab strip/pane is untouched by the
       // click itself — dispatchLayout was never called for this op, only

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -2692,4 +2692,159 @@ describe('App Component', () => {
       expect(calls.some((c) => c.cmd === 'connect_db')).toBe(false);
     });
   });
+
+  describe('tab context menu — detach/move (Phase 3 Task 5)', () => {
+    // Seeds lastWorkspaceRef with a second open window (win-1, active tab
+    // "orders") via a workspace-changed event — the same seeding technique
+    // Task 4's reconciliation tests use. `crossWindow: false` is deliberate:
+    // per the bystander fix, a non-crossWindow event still updates
+    // lastWorkspaceRef (only the hydrate/diff is skipped), and updating the
+    // ref is all this describe block's context-menu items read from.
+    async function seedForeignWindow() {
+      const { act } = await import('@testing-library/react');
+      await act(async () => {
+        fireMockEvent('workspace-changed', {
+          revision: 1,
+          origin: 'win-1',
+          crossWindow: false,
+          workspace: {
+            revision: 1,
+            windows: [
+              { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['quickstart'], activeTabId: 'quickstart' } },
+              { id: 'win-1', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['conn-1.sales_db.orders'], activeTabId: 'conn-1.sales_db.orders' } },
+            ],
+            tabs: [
+              { id: 'quickstart', type: 'quickstart', profileId: '', profileName: '', db: '', collection: '' },
+              { id: 'conn-1.sales_db.orders', type: 'collection', profileId: '', profileName: '', db: 'sales_db', collection: 'orders' },
+            ],
+          },
+        });
+      });
+    }
+
+    it('shows "Detach to New Window" and "Move to <window>" for a tab once this window has more than one tab open', async () => {
+      const { fireEvent, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+      await seedForeignWindow();
+
+      // pane-1 now holds two tabs: Quick Start + customers.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      const customersTab = await within(tabStrip).findByText('customers');
+
+      fireEvent.contextMenu(customersTab.closest('div')!);
+
+      expect(await screen.findByTestId('context-menu')).toBeInTheDocument();
+      expect(screen.getByText('Detach to New Window')).toBeInTheDocument();
+      expect(screen.getByText('Move to win-1 (orders)')).toBeInTheDocument();
+    });
+
+    it('hides "Detach to New Window" when this window holds only one tab, but still offers "Move to <window>"', async () => {
+      const { fireEvent, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+      await seedForeignWindow();
+
+      // Only the default Quick Start tab is open in this window.
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      const quickstartTab = await within(tabStrip).findByText('Quick Start');
+      fireEvent.contextMenu(quickstartTab.closest('div')!);
+
+      expect(await screen.findByTestId('context-menu')).toBeInTheDocument();
+      expect(screen.queryByText('Detach to New Window')).not.toBeInTheDocument();
+      expect(screen.getByText('Move to win-1 (orders)')).toBeInTheDocument();
+    });
+
+    it('detaching calls workspace_detach_tab with this tab\'s id', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        return Promise.resolve([]);
+      });
+      const { fireEvent, within, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      const customersTab = await within(tabStrip).findByText('customers');
+      calls.length = 0; // drop the open_tab mirror from selecting the collection above
+      fireEvent.contextMenu(customersTab.closest('div')!);
+
+      fireEvent.click(await screen.findByText('Detach to New Window'));
+
+      await waitFor(() => {
+        const detachCalls = calls.filter((c) => c.cmd === 'workspace_detach_tab');
+        expect(detachCalls).toHaveLength(1);
+        expect(detachCalls[0].args).toEqual({ tabId: 'conn-1.sales_db.customers', origin: 'main' });
+      });
+      // Never applied through the local layout reducer/dispatchWorkspace —
+      // this window's own tree is untouched by the detach click itself,
+      // only the crossWindow echo (not fired in this test) ever would be.
+      expect(calls.some((c) => c.cmd === 'workspace_apply')).toBe(false);
+    });
+
+    it('moving to another window calls workspace_apply with move_tab_to_window and never touches this window\'s local layout', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        return Promise.resolve([]);
+      });
+      const { fireEvent, within, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+      await seedForeignWindow();
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      const customersTab = await within(tabStrip).findByText('customers');
+      calls.length = 0;
+      fireEvent.contextMenu(customersTab.closest('div')!);
+
+      fireEvent.click(await screen.findByText('Move to win-1 (orders)'));
+
+      await waitFor(() => {
+        const moveCalls = calls.filter((c) => c.cmd === 'workspace_apply' && (c.args?.op as any)?.type === 'move_tab_to_window');
+        expect(moveCalls).toHaveLength(1);
+        expect(moveCalls[0].args).toEqual({
+          op: { type: 'move_tab_to_window', tab_id: 'conn-1.sales_db.customers', target_window_id: 'win-1' },
+          origin: 'main',
+        });
+      });
+      // CRITICAL: this window's own tab strip/pane is untouched by the
+      // click itself — dispatchLayout was never called for this op, only
+      // the crossWindow echo (not fired in this test) would ever remove it.
+      expect(within(tabStrip).getByText('customers')).toBeInTheDocument();
+      expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
+    });
+
+    it('hides both cross-window items for an unmirrored (export/import) tab, showing a disabled explanatory entry instead', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        return Promise.resolve([]);
+      });
+      const { fireEvent, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+      await seedForeignWindow();
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findAllByText(/"Ada"/)).toBeTruthy();
+      fireEvent.keyDown(window, { key: 'k', metaKey: true });
+      fireEvent.change(await screen.findByTestId('command-palette-input'), { target: { value: 'Export Collection' } });
+      fireEvent.click(await screen.findByText('Export Collection…'));
+
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      const exportTab = await within(tabStrip).findByText('Export: customers');
+      fireEvent.contextMenu(exportTab.closest('div')!);
+
+      expect(await screen.findByTestId('context-menu')).toBeInTheDocument();
+      expect(screen.queryByText('Detach to New Window')).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Move to /)).not.toBeInTheDocument();
+      const placeholder = screen.getByText('Export/import tabs stay in their window');
+      expect(placeholder.closest('button')).toBeDisabled();
+      expect(placeholder.closest('button')).toHaveAttribute('title', 'Export/import tabs stay in their window');
+    });
+  });
 });

--- a/src/components/__tests__/AppSecondaryWindow.test.tsx
+++ b/src/components/__tests__/AppSecondaryWindow.test.tsx
@@ -1,0 +1,171 @@
+// Phase 3 Task 5: the emptied-secondary-window close path (`App.tsx`'s
+// tabs-empty effect, `!isMainWindow` branch) and the remote-close detection
+// path (the reconciliation listener's `!winEntry` branch) only run when
+// `windowLabel()` resolves to something other than `"main"`. Every OTHER
+// test in this suite (App.test.tsx) runs as main — jsdom has no real Tauri
+// runtime, so `getCurrentWebviewWindow()` throws and `windowLabel()` falls
+// back to `"main"` (see workspaceStore.ts's doc comment) — and that fallback
+// is cached process-wide for the lifetime of the module. This file exists
+// SOLELY to get a different, non-throwing `getCurrentWebviewWindow()` mock
+// registered before `workspaceStore.ts` is ever imported, in a separate
+// vitest module registry (each test FILE gets its own), so `windowLabel()`
+// resolves to `"win-2"` for every test below — proving Task 5's
+// secondary-window-only behaviors without touching App.test.tsx's "always
+// main" assumption relied on by ~everything else in that much larger file.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-with-providers';
+import App from '../../App';
+
+vi.mock('../../lib/vault', () => ({
+  getVaultStatus: vi.fn().mockResolvedValue('unlocked'),
+  initializeVault: vi.fn(),
+  unlockVault: vi.fn(),
+  lockVault: vi.fn(),
+  changeVaultPassword: vi.fn(),
+  resetVault: vi.fn(),
+  biometricStatus: vi.fn().mockResolvedValue({ available: false, biometryType: 0, enrolled: false }),
+  biometricEnable: vi.fn(),
+  biometricDisable: vi.fn(),
+  notifyVaultUnlocked: vi.fn(),
+}));
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: any[]) => mockInvoke(...args),
+}));
+
+// The one mock this file adds beyond App.test.tsx's baseline set: a
+// non-throwing `getCurrentWebviewWindow()` claiming THIS window is a
+// secondary one, `"win-2"` — see the file-level comment above.
+vi.mock('@tauri-apps/api/webviewWindow', () => ({
+  getCurrentWebviewWindow: () => ({ label: 'win-2' }),
+}));
+
+const eventListeners = new Map<string, Array<(event: { payload: unknown }) => void>>();
+function fireMockEvent(eventName: string, payload: unknown) {
+  for (const cb of eventListeners.get(eventName) ?? []) cb({ payload });
+}
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (eventName: string, cb: (event: { payload: unknown }) => void) => {
+    const arr = eventListeners.get(eventName) ?? [];
+    arr.push(cb);
+    eventListeners.set(eventName, arr);
+    return Promise.resolve(() => {
+      const idx = arr.indexOf(cb);
+      if (idx >= 0) arr.splice(idx, 1);
+    });
+  },
+}));
+
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: () => Promise.resolve('0.3.1'),
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+  appConfigDir: () => Promise.resolve('/tmp/MQLens'),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  save: vi.fn(),
+  open: vi.fn(),
+}));
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  writeTextFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock('../Sidebar', () => ({
+  Sidebar: () => <div data-testid="mock-sidebar" />,
+}));
+
+describe('App as a secondary window (windowLabel() === "win-2") — Phase 3 Task 5', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventListeners.clear();
+  });
+
+  it('an emptied secondary window (no tabs restored for it) closes itself via close_workspace_window', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'load_app_settings') return Promise.resolve({});
+      if (cmd === 'workspace_get') {
+        // A valid document with no "win-2" entry — `toDisconnectedSnapshot`
+        // falls back to an empty layout for this window, `tabs.length`
+        // hits 0, and (since this is NOT main) the tabs-empty effect fires
+        // `closeWorkspaceWindow()` instead of resurrecting Quick Start.
+        return Promise.resolve({
+          revision: 1,
+          windows: [{ id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null } }],
+          tabs: [],
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+
+    await vi.waitFor(() => {
+      const closeCalls = calls.filter((c) => c.cmd === 'close_workspace_window');
+      expect(closeCalls).toHaveLength(1);
+      expect(closeCalls[0].args).toEqual({ label: 'win-2', origin: 'win-2' });
+    });
+    // Never the main-window resurrection path.
+    expect(calls.some((c) => c.cmd === 'open_tab')).toBe(false);
+    expect(screen.queryByTestId('quickstart-tab')).not.toBeInTheDocument();
+  });
+
+  it('discovering its own entry missing from a crossWindow broadcast also closes itself via close_workspace_window', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'load_app_settings') return Promise.resolve({});
+      if (cmd === 'workspace_get') {
+        // This window DOES start with a tab of its own, so the tabs-empty
+        // effect does not fire on boot — the close below must come from the
+        // reconciliation listener's remote-close detection instead.
+        return Promise.resolve({
+          revision: 1,
+          windows: [
+            { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null } },
+            { id: 'win-2', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['conn-1.sales_db.customers'], activeTabId: 'conn-1.sales_db.customers' } },
+          ],
+          tabs: [
+            { id: 'conn-1.sales_db.customers', type: 'collection', profileId: '', profileName: '', db: 'sales_db', collection: 'customers' },
+          ],
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const { act, within } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+    await within(screen.getByTestId('workspace-tab-strip')).findByText('customers');
+
+    calls.length = 0;
+
+    // Another window's op (e.g. a MoveTabToWindow of win-2's last tab
+    // elsewhere) removed win-2 from the document entirely.
+    await act(async () => {
+      fireMockEvent('workspace-changed', {
+        revision: 2,
+        origin: 'win-1',
+        crossWindow: true,
+        workspace: {
+          revision: 2,
+          windows: [{ id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null } }],
+          tabs: [],
+        },
+      });
+    });
+
+    await vi.waitFor(() => {
+      const closeCalls = calls.filter((c) => c.cmd === 'close_workspace_window');
+      expect(closeCalls).toHaveLength(1);
+      expect(closeCalls[0].args).toEqual({ label: 'win-2', origin: 'win-2' });
+    });
+  });
+});

--- a/src/components/__tests__/ContextMenu.test.tsx
+++ b/src/components/__tests__/ContextMenu.test.tsx
@@ -31,4 +31,18 @@ describe('ContextMenu', () => {
     render(<ContextMenu x={0} y={0} items={[{ label: 'Delete', onClick: () => {}, danger: true }]} onClose={() => {}} />);
     expect(screen.getByText('Delete').closest('button')).toHaveClass('is-danger');
   });
+
+  it('renders an item\'s title as the native HTML tooltip attribute (Phase 3 Task 5)', () => {
+    render(
+      <ContextMenu
+        x={0}
+        y={0}
+        items={[{ label: 'Can\'t move', onClick: () => {}, disabled: true, title: 'Explanation text' }]}
+        onClose={() => {}}
+      />,
+    );
+    const button = screen.getByText('Can\'t move').closest('button');
+    expect(button).toHaveAttribute('title', 'Explanation text');
+    expect(button).toBeDisabled();
+  });
 });

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -1284,6 +1284,43 @@ describe('Sidebar Component', () => {
     expect(screen.getByText('sales_db')).toBeInTheDocument();
   });
 
+  it('(Phase 3 Task 6c) a storage event for the pins key refreshes pinned items from another window; an unrelated key is ignored', async () => {
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Local', uri: 'mongodb://localhost' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /pinned/i }));
+    expect(screen.queryByText('orders')).not.toBeInTheDocument();
+
+    // A DIFFERENT window wrote to an UNRELATED localStorage key — jsdom only
+    // fires `storage` via a manual dispatch (real browsers fire it natively
+    // on every OTHER window; never on the window that made the write, which
+    // is what the in-window PINNED_CHANGED_EVENT already covers). Must not
+    // force a reload.
+    localStorage.setItem('some_other_key', 'x');
+    window.dispatchEvent(new StorageEvent('storage', { key: 'some_other_key', newValue: 'x' }));
+    expect(screen.queryByText('orders')).not.toBeInTheDocument();
+
+    // Another window pinned something and wrote the pins key.
+    localStorage.setItem(
+      'mqlens_pinned_collections',
+      JSON.stringify([
+        { kind: 'collection', connectionName: 'Local', db: 'sales_db', collection: 'orders' },
+      ]),
+    );
+    window.dispatchEvent(new StorageEvent('storage', { key: 'mqlens_pinned_collections' }));
+
+    expect(await screen.findByText('orders')).toBeInTheDocument();
+  });
+
   it('pins a connection from the context menu and shows a toast', async () => {
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === 'list_databases') return Promise.resolve(['sales_db']);

--- a/src/components/layout/WorkspaceTabBar.tsx
+++ b/src/components/layout/WorkspaceTabBar.tsx
@@ -29,6 +29,10 @@ interface WorkspaceTabBarProps {
   onTabDragStart?: (id: string, e: React.DragEvent) => void;
   /** Drop on the tab strip itself = move-to-end of this pane. */
   onTabStripDrop?: (e: React.DragEvent) => void;
+  /** Right-click on a tab (Phase 3 Task 5's detach/move context menu).
+   *  Additive/optional — omitting it leaves right-click as a no-op, same as
+   *  before this prop existed. */
+  onTabContextMenu?: (id: string, e: React.MouseEvent) => void;
 }
 
 export function WorkspaceTabBar({
@@ -39,6 +43,7 @@ export function WorkspaceTabBar({
   draggable,
   onTabDragStart,
   onTabStripDrop,
+  onTabContextMenu,
 }: WorkspaceTabBarProps) {
   return (
     <TooltipProvider delayDuration={400}>
@@ -74,6 +79,11 @@ export function WorkspaceTabBar({
                   onClick={() => onSelectTab(tab.id)}
                   draggable={draggable}
                   onDragStart={(e) => onTabDragStart?.(tab.id, e)}
+                  onContextMenu={(e) => {
+                    if (!onTabContextMenu) return;
+                    e.preventDefault();
+                    onTabContextMenu(tab.id, e);
+                  }}
                 >
                   <span className="shrink-0">{tab.icon}</span>
                   <span className="truncate font-medium">{tab.label}</span>

--- a/src/lib/favoriteItems.ts
+++ b/src/lib/favoriteItems.ts
@@ -11,6 +11,8 @@ export interface FavoriteItem {
 }
 
 const STORAGE_KEY = 'mqlens_favorites';
+/** Exported so cross-window `storage` listeners (Sidebar.tsx) can filter events by key. */
+export const FAVORITES_STORAGE_KEY = STORAGE_KEY;
 export const FAVORITES_CHANGED_EVENT = 'mqlens-favorites-changed';
 
 export function favoriteItemKey(item: FavoriteItem): string {

--- a/src/lib/pinnedCollections.ts
+++ b/src/lib/pinnedCollections.ts
@@ -15,6 +15,8 @@ export interface PinnedItem {
 }
 
 const STORAGE_KEY = 'mqlens_pinned_collections';
+/** Exported so cross-window `storage` listeners (Sidebar.tsx) can filter events by key. */
+export const PINNED_STORAGE_KEY = STORAGE_KEY;
 export const PINNED_CHANGED_EVENT = 'mqlens-pinned-changed';
 
 function normalizeItem(raw: unknown): PinnedItem | null {

--- a/src/workspace/PaneView.tsx
+++ b/src/workspace/PaneView.tsx
@@ -36,10 +36,13 @@ export interface PaneViewProps {
   dispatch: (action: WorkspaceAction) => void;
   renderTabContent: (tabId: string) => React.ReactNode;
   renderEmptyPane: () => React.ReactNode;
+  /** Right-click on a tab (Phase 3 Task 5) — forwarded straight to
+   *  WorkspaceTabBar. Additive/optional, same as there. */
+  onTabContextMenu?: (tabId: string, e: React.MouseEvent) => void;
 }
 
 export function PaneView({
-  pane, focused, multiPane, tabs, dispatch, renderTabContent, renderEmptyPane,
+  pane, focused, multiPane, tabs, dispatch, renderTabContent, renderEmptyPane, onTabContextMenu,
 }: PaneViewProps) {
   const [zone, setZone] = useState<DropZone | null>(null);
 
@@ -80,6 +83,7 @@ export function PaneView({
           onCloseTab={id => dispatch({ type: 'close_tab', tabId: id })}
           draggable
           onTabDragStart={(id, e) => { e.dataTransfer.setData(TAB_DRAG_MIME, id); e.dataTransfer.effectAllowed = 'move'; }}
+          onTabContextMenu={onTabContextMenu}
           onTabStripDrop={e => {
             const tabId = e.dataTransfer.getData(TAB_DRAG_MIME);
             if (tabId) {

--- a/src/workspace/WorkspaceRoot.tsx
+++ b/src/workspace/WorkspaceRoot.tsx
@@ -11,10 +11,13 @@ export interface WorkspaceRootProps {
   tabsFor: (pane: PaneNode) => WorkspaceTab[];
   renderTabContent: (tabId: string) => React.ReactNode;
   renderEmptyPane: () => React.ReactNode;
+  /** Right-click on a tab (Phase 3 Task 5) — forwarded straight to
+   *  PaneView/WorkspaceTabBar. Additive/optional, same as there. */
+  onTabContextMenu?: (tabId: string, e: React.MouseEvent) => void;
 }
 
 function NodeView({ node, props }: { node: LayoutNode; props: WorkspaceRootProps }) {
-  const { layout, dispatch, tabsFor, renderTabContent, renderEmptyPane } = props;
+  const { layout, dispatch, tabsFor, renderTabContent, renderEmptyPane, onTabContextMenu } = props;
   if (node.kind === 'pane') {
     return (
       <PaneView
@@ -25,6 +28,7 @@ function NodeView({ node, props }: { node: LayoutNode; props: WorkspaceRootProps
         dispatch={dispatch}
         renderTabContent={renderTabContent}
         renderEmptyPane={renderEmptyPane}
+        onTabContextMenu={onTabContextMenu}
       />
     );
   }

--- a/src/workspace/__tests__/WorkspaceRoot.test.tsx
+++ b/src/workspace/__tests__/WorkspaceRoot.test.tsx
@@ -137,4 +137,28 @@ describe('WorkspaceRoot', () => {
     fireEvent.drop(strip, { dataTransfer: dt, clientX: 500, clientY: 10 });
     expect(dispatch).not.toHaveBeenCalled();
   });
+
+  it('forwards onTabContextMenu through PaneView/WorkspaceTabBar on right-click, preventing the native menu (Phase 3 Task 5)', () => {
+    const l = createInitialLayout(['a', 'b'], 'a');
+    const onTabContextMenu = vi.fn();
+    render(
+      <WorkspaceRoot
+        layout={l}
+        dispatch={vi.fn()}
+        tabsFor={tabsFor}
+        renderTabContent={tabId => <div data-testid={`content-${tabId}`} />}
+        renderEmptyPane={() => <div data-testid="empty-pane" />}
+        onTabContextMenu={onTabContextMenu}
+      />,
+    );
+    const notPrevented = fireEvent.contextMenu(screen.getByText('B'));
+    expect(onTabContextMenu).toHaveBeenCalledWith('b', expect.anything());
+    expect(notPrevented).toBe(false); // preventDefault() called — the native browser menu never shows
+  });
+
+  it('omitting onTabContextMenu leaves right-click a no-op (additive/optional prop, backward compatible)', () => {
+    renderLayout(createInitialLayout(['a'], 'a'));
+    const notPrevented = fireEvent.contextMenu(screen.getByText('A'));
+    expect(notPrevented).toBe(true); // never prevented — nothing wired up to handle it
+  });
 });

--- a/src/workspace/__tests__/WorkspaceRoot.test.tsx
+++ b/src/workspace/__tests__/WorkspaceRoot.test.tsx
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { WorkspaceRoot } from '../WorkspaceRoot';
 import { TAB_DRAG_MIME } from '../PaneView';
 import {
-  createInitialLayout, workspaceReducer, resetLayoutIds,
+  createInitialLayout, workspaceReducer,
   type WorkspaceLayout, type PaneNode,
 } from '../model';
 
@@ -22,8 +22,6 @@ function renderLayout(layout: WorkspaceLayout, dispatch = vi.fn()) {
   );
   return dispatch;
 }
-
-beforeEach(() => resetLayoutIds());
 
 describe('WorkspaceRoot', () => {
   it('renders a single pane with its active tab content', () => {

--- a/src/workspace/__tests__/golden.test.ts
+++ b/src/workspace/__tests__/golden.test.ts
@@ -52,6 +52,16 @@ interface Vector {
   initial: FixtureDoc;
   ops: RawOp[];
   expected: FixtureDoc;
+  // Multi-window vectors (move_tab_to_window / detach_tab / window_closed,
+  // or an op targeting a non-"main" window_id) are backend-authoritative:
+  // the Rust reducer (src-tauri/src/workspace.rs) owns window-scoped
+  // resolution end to end, and the frontend only ever applies their effects
+  // via events pushed from the backend (Task 4), never through this
+  // single-window TS reducer. This runner only ever hydrates
+  // `doc.windows[0]`, so it structurally cannot exercise those vectors —
+  // skip them here; the Rust `golden_vectors_match_fixture` test asserts
+  // them (and everything else) in full.
+  tsSkip?: boolean;
 }
 
 const { vectors } = goldenFixture as unknown as { vectors: Vector[] };
@@ -98,7 +108,11 @@ describe('workspace golden parity vectors (layout half)', () => {
   });
 
   for (const vector of vectors) {
-    it(vector.name, () => {
+    // tsSkip vectors are multi-window — see the `tsSkip` doc comment on
+    // `Vector` above. `it.skip` still registers the test (visible, greyed
+    // out) rather than silently omitting it.
+    const test = vector.tsSkip ? it.skip : it;
+    test(vector.name, () => {
       let layout = layoutOf(vector.initial);
       for (const op of vector.ops) {
         const action = opToAction(op);

--- a/src/workspace/__tests__/golden.test.ts
+++ b/src/workspace/__tests__/golden.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect } from 'vitest';
 import goldenFixture from '../../../fixtures/workspace-golden.json';
 import {
   workspaceReducer,
-  resetLayoutIds,
-  seedLayoutIds,
   type WorkspaceLayout,
   type WorkspaceAction,
   type LayoutNode,
@@ -101,9 +99,7 @@ describe('workspace golden parity vectors (layout half)', () => {
 
   for (const vector of vectors) {
     it(vector.name, () => {
-      resetLayoutIds();
       let layout = layoutOf(vector.initial);
-      seedLayoutIds(layout);
       for (const op of vector.ops) {
         const action = opToAction(op);
         if (action) layout = workspaceReducer(layout, action);

--- a/src/workspace/__tests__/model.test.ts
+++ b/src/workspace/__tests__/model.test.ts
@@ -1,14 +1,12 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   createInitialLayout, workspaceReducer, findPane, paneOfTab, allPanes,
-  allTabIds, resetLayoutIds, seedLayoutIds, snapshotLayoutIds, restoreLayoutIds,
+  allTabIds,
   type WorkspaceLayout, type SplitNode, type PaneNode,
 } from '../model';
 
 const layoutWith = (...tabIds: string[]): WorkspaceLayout =>
   createInitialLayout(tabIds, tabIds[0] ?? null);
-
-beforeEach(() => resetLayoutIds());
 
 describe('createInitialLayout', () => {
   it('creates a single root pane holding the tabs', () => {
@@ -186,9 +184,12 @@ describe('rename_tab', () => {
   });
 });
 
-describe('seedLayoutIds', () => {
-  it('seeds counters past the max numeric suffix already present in the tree', () => {
+describe('stateless id minting (#197)', () => {
+  it('mints ids by scanning the tree, not filling gaps: closing pane-3 in a tree that still has pane-7 mints pane-8', () => {
     // A tree "loaded" from a fixture already containing pane-7 / split-2.
+    // pane-3 (a leaf under split-2) gets closed down to nothing and folds
+    // away, leaving a gap at 3 — the next mint must still skip past the
+    // highest surviving suffix (7), not reuse the gap.
     const layout: WorkspaceLayout = {
       focusedPaneId: 'pane-3',
       root: {
@@ -197,47 +198,53 @@ describe('seedLayoutIds', () => {
         dir: 'row',
         ratio: 0.5,
         children: [
-          { kind: 'pane', id: 'pane-3', tabIds: ['a', 'x'], activeTabId: 'a' },
-          { kind: 'pane', id: 'pane-7', tabIds: ['b'], activeTabId: 'b' },
+          { kind: 'pane', id: 'pane-3', tabIds: ['x'], activeTabId: 'x' },
+          { kind: 'pane', id: 'pane-7', tabIds: ['a', 'b'], activeTabId: 'b' },
         ],
       },
     };
-    seedLayoutIds(layout);
-    const l = workspaceReducer(layout, {
-      type: 'split_pane', paneId: 'pane-3', dir: 'row', side: 'end', moveTabId: 'x',
+    const closed = workspaceReducer(layout, { type: 'close_tab', tabId: 'x' });
+    // pane-3 emptied and folded into its sibling: only pane-7 remains.
+    expect(closed.root).toEqual({ kind: 'pane', id: 'pane-7', tabIds: ['a', 'b'], activeTabId: 'b' });
+    const l = workspaceReducer(closed, {
+      type: 'split_pane', paneId: 'pane-7', dir: 'row', side: 'end', moveTabId: 'b',
     });
     const paneIds = allPanes(l.root).map(p => p.id);
-    expect(paneIds).toContain('pane-8'); // past existing pane-7, not colliding with pane-1
-    const nestedSplit = (l.root as SplitNode).children[0] as SplitNode;
-    expect(nestedSplit.id).toBe('split-3'); // past existing split-2
+    expect(paneIds).toContain('pane-8'); // max-scan past pane-7, NOT a reused pane-3/pane-4 gap
+    // split-2 folded away along with pane-3 — the tree holds no split node at
+    // all once pane-3 empties, so this new split starts a fresh sequence.
+    expect((l.root as SplitNode).id).toBe('split-1');
   });
-});
 
-describe('snapshotLayoutIds / restoreLayoutIds', () => {
-  it('a restored snapshot makes the next mint reuse the same id as a discarded trial run', () => {
-    // Simulates App.tsx's dispatchWorkspace no-op mirror gate: a "trial"
-    // reducer call whose minted ids must never actually be consumed.
+  it('a single split on a fresh tree mints pane-2 AND split-1 from one scan, without the two mints colliding', () => {
+    // Edge case: split_pane mints a pane id AND a split id within the same
+    // reducer call. Both must be computed from the SAME pristine tree — if
+    // the split-id scan ran against a tree that already contained the
+    // freshly-minted pane, or ignored the id-kind prefix, it could
+    // misfire (e.g. minting split-2/split-3 instead of split-1).
+    const layout = layoutWith('a', 'b'); // root is pane-1
+    const l = workspaceReducer(layout, {
+      type: 'split_pane', paneId: layout.root.id, dir: 'row', side: 'end', moveTabId: 'b',
+    });
+    const root = l.root as SplitNode;
+    expect(root.id).toBe('split-1');
+    const paneIds = allPanes(root).map(p => p.id);
+    expect(paneIds).toEqual(['pane-1', 'pane-2']);
+  });
+
+  it('reducing the same (layout, action) twice from the same input yields deep-equal results, including minted ids', () => {
+    // Shape of React 18 StrictMode's double-invoke of a reducer, and of
+    // App.tsx's dispatchWorkspace no-op mirror gate running a discardable
+    // "trial" reducer call ahead of the real render-time one — both call
+    // the reducer more than once against the identical starting layout and
+    // must get back identical results each time, ids included.
     const layout = layoutWith('a', 'b');
-    const snap = snapshotLayoutIds();
-
-    // Trial run: mints pane-2/split-1 for the new pane, then is discarded.
-    const trial = workspaceReducer(layout, {
-      type: 'split_pane', paneId: layout.root.id, dir: 'row', side: 'end', moveTabId: 'b',
-    });
-    const trialPaneIds = allPanes(trial.root).map(p => p.id);
-    expect(trialPaneIds).toContain('pane-2');
-
-    restoreLayoutIds(snap);
-
-    // The real (render-time) application starts from the restored counters
-    // and must mint the EXACT SAME ids the trial did, not the next ones up.
-    const real = workspaceReducer(layout, {
-      type: 'split_pane', paneId: layout.root.id, dir: 'row', side: 'end', moveTabId: 'b',
-    });
-    const realPaneIds = allPanes(real.root).map(p => p.id);
-    expect(realPaneIds).toEqual(trialPaneIds);
-    expect(realPaneIds).toContain('pane-2');
-    expect(realPaneIds).not.toContain('pane-3');
+    const action = {
+      type: 'split_pane' as const, paneId: layout.root.id, dir: 'row' as const, side: 'end' as const, moveTabId: 'b',
+    };
+    const first = workspaceReducer(layout, action);
+    const second = workspaceReducer(layout, action);
+    expect(second).toEqual(first);
   });
 });
 
@@ -251,7 +258,7 @@ describe('hydrate', () => {
     expect(l).toEqual(incoming);
   });
 
-  it('seeds id counters from the incoming layout so a later split does not collide', () => {
+  it('a later split after hydrate mints past the incoming layout, never colliding with it', () => {
     const incoming: WorkspaceLayout = {
       focusedPaneId: 'pane-7',
       root: { kind: 'pane', id: 'pane-7', tabIds: ['a', 'b'], activeTabId: 'a' },
@@ -259,8 +266,8 @@ describe('hydrate', () => {
     let l = workspaceReducer(layoutWith('placeholder'), { type: 'hydrate', layout: incoming });
     l = workspaceReducer(l, { type: 'split_pane', paneId: 'pane-7', dir: 'row', side: 'end', moveTabId: 'b' });
     const paneIds = allPanes(l.root).map(p => p.id);
-    expect(paneIds).toContain('pane-8'); // seeded past the incoming pane-7
-    expect(paneIds).not.toContain('pane-1'); // would collide with the pre-hydrate counter state
+    expect(paneIds).toContain('pane-8'); // scanned past the incoming pane-7
+    expect(paneIds).not.toContain('pane-1'); // would collide if minting had reset to a fresh counter
   });
 });
 

--- a/src/workspace/__tests__/model.test.ts
+++ b/src/workspace/__tests__/model.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   createInitialLayout, workspaceReducer, findPane, paneOfTab, allPanes,
-  allTabIds,
+  allTabIds, mapLayoutTabIds,
   type WorkspaceLayout, type SplitNode, type PaneNode,
 } from '../model';
 
@@ -278,5 +278,47 @@ describe('robustness', () => {
     expect(workspaceReducer(l, { type: 'set_active', paneId: 'nope', tabId: 'a' })).toBe(l);
     expect(workspaceReducer(l, { type: 'move_tab', tabId: 'a', targetPaneId: 'nope' })).toBe(l);
     expect(workspaceReducer(l, { type: 'resize_split', splitId: 'nope', ratio: 0.5 })).toBe(l);
+  });
+});
+
+// Phase 3 Task 4: used to translate a FOREIGN window's tree (received
+// profile-space over `workspace-changed`) into this window's live id space
+// before hydrating it locally.
+describe('mapLayoutTabIds', () => {
+  const upper = (id: string) => id.toUpperCase();
+
+  it('rewrites every tab id in a single pane, leaving the pane id untouched', () => {
+    const l = layoutWith('a', 'b');
+    const mapped = mapLayoutTabIds(l, upper);
+    expect((mapped.root as PaneNode).tabIds).toEqual(['A', 'B']);
+    expect((mapped.root as PaneNode).activeTabId).toBe('A');
+    expect(mapped.root.id).toBe(l.root.id); // pane id untouched
+    expect(mapped.focusedPaneId).toBe(l.focusedPaneId);
+  });
+
+  it('rewrites tab ids in both children of a split, leaving split/pane ids and structure untouched', () => {
+    let l = layoutWith('a', 'b');
+    l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });
+    const mapped = mapLayoutTabIds(l, upper);
+    const [left, right] = (mapped.root as SplitNode).children as [PaneNode, PaneNode];
+    expect(left.tabIds).toEqual(['A']);
+    expect(right.tabIds).toEqual(['B']);
+    expect(right.activeTabId).toBe('B');
+    expect(mapped.root.id).toBe(l.root.id);
+    expect((left as PaneNode).id).toBe(((l.root as SplitNode).children[0] as PaneNode).id);
+  });
+
+  it('a null activeTabId (empty pane) stays null, never passed through fn', () => {
+    const empty: WorkspaceLayout = { root: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null }, focusedPaneId: 'pane-1' };
+    const mapped = mapLayoutTabIds(empty, upper);
+    expect((mapped.root as PaneNode).activeTabId).toBeNull();
+    expect((mapped.root as PaneNode).tabIds).toEqual([]);
+  });
+
+  it('an identity fn produces a structurally-equal (but not reference-equal) layout', () => {
+    const l = layoutWith('a', 'b');
+    const mapped = mapLayoutTabIds(l, (id) => id);
+    expect(mapped).toEqual(l);
+    expect(mapped).not.toBe(l);
   });
 });

--- a/src/workspace/__tests__/persistence.test.ts
+++ b/src/workspace/__tests__/persistence.test.ts
@@ -4,6 +4,8 @@ import {
   toDisconnectedSnapshot,
   rebindConnection,
   toProfileSpaceId,
+  toLiveSpaceId,
+  materializeArrivingTab,
   type PersistableTab,
   type PersistableConnection,
   type PersistedTab,
@@ -170,6 +172,51 @@ describe('toDisconnectedSnapshot', () => {
     expect(snapshot.tabs).toEqual([]);
     expect(snapshot.layout.root).toEqual({ kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null });
   });
+
+  it('defaults to "main" when windowId is omitted', () => {
+    const snapshot = toDisconnectedSnapshot(ws);
+    expect(snapshot.tabs.map((t) => t.id)).toEqual(['profile:p1.mydb.mycoll']);
+  });
+
+  // Phase 3 Task 4: ws.tabs is now a FLAT list shared by every window's
+  // splitTree, not one window's own list — a boot must materialize ONLY the
+  // requested window's tabs, never another window's, even though they all
+  // live in the same ws.tabs array.
+  it('windowId selects which window to hydrate, filtering ws.tabs down to ONLY that window\'s tabs', () => {
+    const multiWindow: PersistedWorkspace = {
+      revision: 5,
+      windows: [
+        {
+          id: 'main',
+          focusedPaneId: 'pane-1',
+          splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.mydb.a'], activeTabId: 'profile:p1.mydb.a' },
+        },
+        {
+          id: 'win-1',
+          focusedPaneId: 'pane-1',
+          splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.mydb.b'], activeTabId: 'profile:p1.mydb.b' },
+        },
+      ],
+      tabs: [
+        { id: 'profile:p1.mydb.a', type: 'collection', profileId: 'p1', profileName: 'Profile 1', db: 'mydb', collection: 'a' },
+        { id: 'profile:p1.mydb.b', type: 'collection', profileId: 'p1', profileName: 'Profile 1', db: 'mydb', collection: 'b' },
+      ],
+    };
+
+    const mainSnapshot = toDisconnectedSnapshot(multiWindow, 'main');
+    expect(mainSnapshot.tabs.map((t) => t.id)).toEqual(['profile:p1.mydb.a']);
+    expect(mainSnapshot.layout.root).toEqual({ kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.mydb.a'], activeTabId: 'profile:p1.mydb.a' });
+
+    const win1Snapshot = toDisconnectedSnapshot(multiWindow, 'win-1');
+    expect(win1Snapshot.tabs.map((t) => t.id)).toEqual(['profile:p1.mydb.b']);
+    expect(win1Snapshot.layout.root).toEqual({ kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.mydb.b'], activeTabId: 'profile:p1.mydb.b' });
+  });
+
+  it('an unknown windowId produces the same empty fallback as no windows at all — never another window\'s tree', () => {
+    const snapshot = toDisconnectedSnapshot(ws, 'win-does-not-exist');
+    expect(snapshot.tabs).toEqual([]);
+    expect(snapshot.layout.root).toEqual({ kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null });
+  });
 });
 
 describe('toProfileSpaceId', () => {
@@ -201,6 +248,86 @@ describe('toProfileSpaceId', () => {
 
   it('an empty connections list is a no-op passthrough', () => {
     expect(toProfileSpaceId('live-conn-1.mydb.mycoll', [])).toBe('live-conn-1.mydb.mycoll');
+  });
+});
+
+// Phase 3 Task 4: the exact inverse of toProfileSpaceId, used to translate a
+// FOREIGN window's tree (always profile-space over the wire) into this
+// window's live id space wherever it already has that connection.
+describe('toLiveSpaceId', () => {
+  const connections: PersistableConnection[] = [
+    { id: 'live-conn-1', profileId: 'p1', name: 'Profile 1' },
+    { id: 'live-conn-2', profileId: 'p2', name: 'Profile 2' },
+  ];
+
+  it('rewrites profile:<profileId> to the matching live connection id', () => {
+    expect(toLiveSpaceId('profile:p1.mydb.mycoll', connections)).toBe('live-conn-1.mydb.mycoll');
+  });
+
+  it('finds the right connection out of several', () => {
+    expect(toLiveSpaceId('shell.profile:p2.mydb.x', connections)).toBe('shell.live-conn-2.mydb.x');
+  });
+
+  it('passes through a profile prefix with no matching live connection unchanged (still disconnected)', () => {
+    expect(toLiveSpaceId('profile:p9.mydb.mycoll', connections)).toBe('profile:p9.mydb.mycoll');
+  });
+
+  it('passes through an id already in live-space unchanged (no profile: prefix to match)', () => {
+    expect(toLiveSpaceId('live-conn-1.mydb.mycoll', connections)).toBe('live-conn-1.mydb.mycoll');
+  });
+
+  it('passes through connectionless/pane ids unchanged', () => {
+    expect(toLiveSpaceId('settings', connections)).toBe('settings');
+    expect(toLiveSpaceId('pane-1', connections)).toBe('pane-1');
+  });
+
+  it('an empty connections list is a no-op passthrough', () => {
+    expect(toLiveSpaceId('profile:p1.mydb.mycoll', [])).toBe('profile:p1.mydb.mycoll');
+  });
+
+  it('round-trips with toProfileSpaceId', () => {
+    const live = 'live-conn-1.mydb.mycoll';
+    const profileSpace = toProfileSpaceId(live, connections);
+    expect(toLiveSpaceId(profileSpace, connections)).toBe(live);
+  });
+});
+
+describe('materializeArrivingTab', () => {
+  const connections: PersistableConnection[] = [{ id: 'live-conn-1', profileId: 'p1', name: 'Profile 1' }];
+
+  const wireTab: PersistedTab = {
+    id: 'profile:p1.mydb.mycoll',
+    type: 'collection',
+    profileId: 'p1',
+    profileName: 'Profile 1',
+    db: 'mydb',
+    collection: 'mycoll',
+    lastQuery: { filter: '{}' },
+  };
+
+  it('rebinds onto the live connection id and reports isLive when the profile is already connected here', () => {
+    const { tab, isLive } = materializeArrivingTab(wireTab, connections);
+    expect(isLive).toBe(true);
+    expect(tab.id).toBe('live-conn-1.mydb.mycoll');
+    expect(tab.connectionId).toBe('live-conn-1');
+    expect(tab.results).toEqual([]);
+    expect(tab.loading).toBe(false);
+    expect(tab.lastQuery).toEqual({ filter: '{}' });
+  });
+
+  it('leaves the tab in profile-space and reports isLive: false when the profile has no live connection', () => {
+    const { tab, isLive } = materializeArrivingTab(wireTab, []);
+    expect(isLive).toBe(false);
+    expect(tab.id).toBe('profile:p1.mydb.mycoll');
+    expect(tab.connectionId).toBe('profile:p1');
+  });
+
+  it('passes a connectionless tab (settings/quickstart/tasks) through unchanged', () => {
+    const connectionless: PersistedTab = { id: 'tasks', type: 'tasks', profileId: '', profileName: '', db: '', collection: '' };
+    const { tab, isLive } = materializeArrivingTab(connectionless, connections);
+    expect(isLive).toBe(false);
+    expect(tab.id).toBe('tasks');
+    expect(tab.connectionId).toBe('');
   });
 });
 
@@ -307,7 +434,12 @@ describe('rebindConnection', () => {
 describe('actionToOp', () => {
   // Ground truth: reuse a handful of ops from the golden parity fixture
   // (fixtures/workspace-golden.json) that the Rust backend's WorkspaceOp
-  // deserializer was built and tested against.
+  // deserializer was built and tested against. The fixture predates Phase 3
+  // Task 2's `window_id` field (which the Rust side defaults to `"main"`
+  // when absent), so every comparison below adds it explicitly — `actionToOp`
+  // now always stamps `window_id: windowLabel()`, which resolves to `"main"`
+  // under jsdom (no real Tauri runtime — see workspaceStore.ts's
+  // `windowLabel` doc comment).
   const opsByType = new Map<string, Record<string, unknown>>();
   for (const vector of goldenFixture.vectors) {
     for (const op of vector.ops) {
@@ -318,12 +450,12 @@ describe('actionToOp', () => {
   it('open_tab without a pane_id or tab payload', () => {
     const expected = opsByType.get('open_tab'); // { type: 'open_tab', tab_id: 'b' }
     const action: WorkspaceAction = { type: 'open_tab', tabId: 'b' };
-    expect(actionToOp(action)).toEqual(expected);
+    expect(actionToOp(action)).toEqual({ ...expected, window_id: 'main' });
   });
 
   it('open_tab with an explicit pane_id', () => {
     const action: WorkspaceAction = { type: 'open_tab', tabId: 'c', paneId: 'pane-2' };
-    expect(actionToOp(action)).toEqual({ type: 'open_tab', tab_id: 'c', pane_id: 'pane-2' });
+    expect(actionToOp(action)).toEqual({ type: 'open_tab', tab_id: 'c', pane_id: 'pane-2', window_id: 'main' });
   });
 
   it('open_tab enriched with a persisted tab payload keeps TabModel camelCase fields', () => {
@@ -331,18 +463,18 @@ describe('actionToOp', () => {
     const expected = vector.ops[0] as Record<string, unknown>; // { type: 'open_tab', tab_id: 'b', tab: {...camelCase...} }
     const persisted = expected.tab as Record<string, unknown>;
     const action: WorkspaceAction = { type: 'open_tab', tabId: expected.tab_id as string };
-    expect(actionToOp(action, persisted as any)).toEqual(expected);
+    expect(actionToOp(action, persisted as any)).toEqual({ ...expected, window_id: 'main' });
   });
 
   it('close_tab', () => {
     const action: WorkspaceAction = { type: 'close_tab', tabId: 'nope' };
-    expect(actionToOp(action)).toEqual({ type: 'close_tab', tab_id: 'nope' });
+    expect(actionToOp(action)).toEqual({ type: 'close_tab', tab_id: 'nope', window_id: 'main' });
   });
 
   it('close_many', () => {
     const expected = opsByType.get('close_many'); // { type: 'close_many', tab_ids: [...] }
     const action: WorkspaceAction = { type: 'close_many', tabIds: expected!.tab_ids as string[] };
-    expect(actionToOp(action)).toEqual(expected);
+    expect(actionToOp(action)).toEqual({ ...expected, window_id: 'main' });
   });
 
   it('move_tab with an explicit index', () => {
@@ -360,7 +492,7 @@ describe('actionToOp', () => {
       index: expected.index as number,
     };
     const op = actionToOp(action);
-    expect(op).toEqual(expected);
+    expect(op).toEqual({ ...expected, window_id: 'main' });
     expect('index' in op).toBe(true);
     expect(op.index).toBe(expected.index);
   });
@@ -368,7 +500,7 @@ describe('actionToOp', () => {
   it('move_tab without an index omits the key rather than sending undefined', () => {
     const action: WorkspaceAction = { type: 'move_tab', tabId: 'a', targetPaneId: 'nope' };
     const op = actionToOp(action);
-    expect(op).toEqual({ type: 'move_tab', tab_id: 'a', target_pane_id: 'nope' });
+    expect(op).toEqual({ type: 'move_tab', tab_id: 'a', target_pane_id: 'nope', window_id: 'main' });
     expect('index' in op).toBe(false);
   });
 
@@ -381,37 +513,37 @@ describe('actionToOp', () => {
       side: expected!.side as 'start' | 'end',
       moveTabId: expected!.move_tab_id as string,
     };
-    expect(actionToOp(action)).toEqual(expected);
+    expect(actionToOp(action)).toEqual({ ...expected, window_id: 'main' });
   });
 
   it('split_pane without a move_tab_id', () => {
     const action: WorkspaceAction = { type: 'split_pane', paneId: 'pane-1', dir: 'row', side: 'end' };
     const op = actionToOp(action);
-    expect(op).toEqual({ type: 'split_pane', pane_id: 'pane-1', dir: 'row', side: 'end' });
+    expect(op).toEqual({ type: 'split_pane', pane_id: 'pane-1', dir: 'row', side: 'end', window_id: 'main' });
     expect('move_tab_id' in op).toBe(false);
   });
 
   it('resize_split', () => {
     const expected = opsByType.get('resize_split'); // { type, split_id, ratio }
     const action: WorkspaceAction = { type: 'resize_split', splitId: expected!.split_id as string, ratio: expected!.ratio as number };
-    expect(actionToOp(action)).toEqual(expected);
+    expect(actionToOp(action)).toEqual({ ...expected, window_id: 'main' });
   });
 
   it('set_active', () => {
     const expected = opsByType.get('set_active'); // { type, pane_id, tab_id }
     const action: WorkspaceAction = { type: 'set_active', paneId: expected!.pane_id as string, tabId: expected!.tab_id as string };
-    expect(actionToOp(action)).toEqual(expected);
+    expect(actionToOp(action)).toEqual({ ...expected, window_id: 'main' });
   });
 
   it('focus_pane', () => {
     const expected = opsByType.get('focus_pane'); // { type, pane_id }
     const action: WorkspaceAction = { type: 'focus_pane', paneId: expected!.pane_id as string };
-    expect(actionToOp(action)).toEqual(expected);
+    expect(actionToOp(action)).toEqual({ ...expected, window_id: 'main' });
   });
 
   it('rename_tab', () => {
     const expected = opsByType.get('rename_tab'); // { type, old_id, new_id }
     const action: WorkspaceAction = { type: 'rename_tab', oldId: expected!.old_id as string, newId: expected!.new_id as string };
-    expect(actionToOp(action)).toEqual(expected);
+    expect(actionToOp(action)).toEqual({ ...expected, window_id: 'main' });
   });
 });

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -26,9 +26,14 @@ describe('workspaceStore', () => {
     expect(result).toBeNull();
   });
 
-  it('workspaceApply fire-and-forgets workspace_apply with the op wrapped', () => {
+  it('workspaceApply fire-and-forgets workspace_apply with the op wrapped and this window\'s label as origin', () => {
     workspaceApply({ type: 'focus_pane', pane_id: 'pane-1' });
-    expect(invokeMock).toHaveBeenCalledWith('workspace_apply', { op: { type: 'focus_pane', pane_id: 'pane-1' } });
+    // 'main' — jsdom has no real Tauri runtime, so `windowLabel()` falls
+    // back to it (see workspaceStore.ts's doc comment).
+    expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
+      op: { type: 'focus_pane', pane_id: 'pane-1' },
+      origin: 'main',
+    });
   });
 
   it('workspaceApply swallows a rejected invoke rather than throwing', async () => {
@@ -45,6 +50,7 @@ describe('workspaceStore', () => {
     vi.advanceTimersByTime(500);
     expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
       op: { type: 'update_tab_state', tab_id: 't1', last_query: { filter: '{}' } },
+      origin: 'main',
     });
   });
 
@@ -93,11 +99,13 @@ describe('workspaceStore', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
       op: { type: 'update_tab_state', tab_id: 't1', last_query: { a: 1 } },
+      origin: 'main',
     });
     vi.advanceTimersByTime(250);
     expect(invokeMock).toHaveBeenCalledTimes(2);
     expect(invokeMock).toHaveBeenLastCalledWith('workspace_apply', {
       op: { type: 'update_tab_state', tab_id: 't2', last_query: { b: 2 } },
+      origin: 'main',
     });
   });
 
@@ -115,6 +123,7 @@ describe('workspaceStore', () => {
 
     expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
       op: { type: 'update_tab_state', tab_id: restoredTabId, last_query: { filter: '{}' } },
+      origin: 'main',
     });
   });
 });
@@ -191,7 +200,7 @@ describe('actionToOp id translation (CRITICAL fix)', () => {
       undefined,
       connections
     );
-    expect(op).toEqual({ type: 'rename_tab', old_id: 'profile:p1.db.old', new_id: 'profile:p1.db.new' });
+    expect(op).toEqual({ type: 'rename_tab', old_id: 'profile:p1.db.old', new_id: 'profile:p1.db.new', window_id: 'main' });
   });
 
   it('omitting connections is a passthrough — the raw (untranslated) op shape', () => {

--- a/src/workspace/model.ts
+++ b/src/workspace/model.ts
@@ -47,87 +47,54 @@ export type WorkspaceAction =
 const MIN_RATIO = 0.15;
 const MAX_RATIO = 0.85;
 
-let paneCounter = 0;
-let splitCounter = 0;
-
-/** Test-only: make generated ids deterministic per test. */
-export function resetLayoutIds(): void {
-  paneCounter = 0;
-  splitCounter = 0;
+/** Port of Rust's `max_numeric_suffix` (workspace.rs): the highest numeric
+ *  suffix among ids sharing `prefix` (e.g. `"pane-"` or `"split-"`) anywhere
+ *  in the tree, regardless of node kind — ids of the other kind never share
+ *  a prefix so they simply don't match. */
+function maxNumericSuffix(node: LayoutNode, prefix: string): number {
+  const suffix = node.id.startsWith(prefix) ? node.id.slice(prefix.length) : '';
+  const parsed = /^\d+$/.test(suffix) ? Number(suffix) : NaN;
+  let best = Number.isNaN(parsed) ? 0 : parsed;
+  if (node.kind === 'split') {
+    for (const child of node.children) best = Math.max(best, maxNumericSuffix(child, prefix));
+  }
+  return best;
 }
 
 /**
- * Snapshot the two id counters — for App.tsx's `dispatchWorkspace` no-op
- * mirror gate (#97 phase 2 final review Fix 3, amended). That gate runs
- * `workspaceReducer` once as a side-channel "trial" to check whether an
- * action is a no-op, purely for identity comparison — its RETURN VALUE
- * (including any freshly-minted pane/split id) is discarded, but
- * `newPaneId`/`newSplitId` still mutate the module counters as a side
- * effect of that trial call. Left unchecked, every real `split_pane`
- * mints twice — once in the trial, once more when React actually applies
- * the action during render — so the id that ends up committed to state is
- * ONE GENERATION AHEAD of what a single reducer application would have
- * produced. That mismatches the backend, which mints its own pane/split id
- * from the mirrored op exactly once: the frontend's committed id and the
- * backend's stored id diverge, and every later op addressing that pane/
- * split by id (`resize_split`, `set_active`, `focus_pane`, `move_tab`)
- * silently no-ops on the backend side forever after.
+ * Mint `pane-N` / `split-N` ids by scanning the live tree for the current max
+ * suffix at call time, rather than keeping module-level counters. Port of
+ * Rust's `next_pane_id`/`next_split_id` (workspace.rs) — deliberately
+ * stateless, by construction identical to the backend (#197).
  *
- * `snapshotLayoutIds`/`restoreLayoutIds` bracket that trial call so it's
- * side-effect-free: whatever the trial minted and discarded, the counters
- * end up exactly where they'd have been if the trial had never run, and
- * the one real, render-time reducer application is the only one that ever
- * actually advances them — matching the backend's single mint per op.
+ * WHY stateless: a mutable counter mints a *new* id on every call, so
+ * calling the reducer twice with the same input (React 18 StrictMode's
+ * double-invoke of reducers/effects in dev, or App.tsx's `dispatchWorkspace`
+ * no-op mirror gate running a discardable "trial" reducer call before the
+ * real render-time one) used to mint two different ids from one logical
+ * action — the trial's mint got thrown away, but the counter didn't know
+ * that, so the real application minted one generation ahead of what a
+ * single reducer call would have produced, desyncing from the backend's own
+ * single mint per op. Scanning the tree instead makes minting a pure
+ * function of the input layout: the same (layout, action) pair always mints
+ * the same id, no matter how many times or in what order it's evaluated, so
+ * double-invokes and trial runs are naturally idempotent with no bracketing
+ * needed. Nothing to seed on load or reset between tests either, since
+ * there's no state to seed or reset.
  */
-export function snapshotLayoutIds(): { pane: number; split: number } {
-  return { pane: paneCounter, split: splitCounter };
+function nextPaneId(root: LayoutNode): string {
+  return `pane-${maxNumericSuffix(root, 'pane-') + 1}`;
 }
 
-export function restoreLayoutIds(snap: { pane: number; split: number }): void {
-  paneCounter = snap.pane;
-  splitCounter = snap.split;
-}
-
-/** Test-only: seed the id counters past the max numeric suffix already present
- *  in `layout` (e.g. after loading a fixture containing `pane-7`/`split-3`),
- *  so newly minted ids never collide with ones already in the tree. Mirrors
- *  the Rust store's stateless per-call tree scan (see `next_pane_id`/
- *  `next_split_id` in workspace.rs) — TS instead seeds once, up front, since
- *  its counters are already module-level mutable state. */
-export function seedLayoutIds(layout: WorkspaceLayout): void {
-  const visit = (node: LayoutNode): void => {
-    if (node.kind === 'pane') {
-      const m = /^pane-(\d+)$/.exec(node.id);
-      if (m) paneCounter = Math.max(paneCounter, Number(m[1]));
-      return;
-    }
-    const m = /^split-(\d+)$/.exec(node.id);
-    if (m) splitCounter = Math.max(splitCounter, Number(m[1]));
-    node.children.forEach(visit);
-  };
-  visit(layout.root);
-}
-
-// newPaneId/newSplitId mutate module-level counters even though workspaceReducer is
-// otherwise a pure reducer. This is safe for React StrictMode's OWN double-invoke of
-// the reducer: generated ids are only ever referenced within the same returned layout
-// object, so that just skips a number (e.g. pane-3 then pane-5) rather than colliding
-// or leaking across renders. It is NOT safe for a caller that runs the reducer as a
-// side-channel trial and discards the result while React separately, later, applies
-// the same action for real — see snapshotLayoutIds/restoreLayoutIds above, which exist
-// precisely to make such a trial call side-effect-free. Phase 2's backend port
-// (workspace_apply, see the design doc referenced above) will generate ids server-side
-// and remove these counters.
-function newPaneId(): string {
-  return `pane-${++paneCounter}`;
-}
-
-function newSplitId(): string {
-  return `split-${++splitCounter}`;
+function nextSplitId(root: LayoutNode): string {
+  return `split-${maxNumericSuffix(root, 'split-') + 1}`;
 }
 
 export function createInitialLayout(tabIds: string[], activeTabId: string | null): WorkspaceLayout {
-  const pane: PaneNode = { kind: 'pane', id: newPaneId(), tabIds: [...tabIds], activeTabId };
+  // No tree to scan yet — this call builds the very first node. Hardcoded
+  // like Rust's `default_window()`, which likewise hardcodes `"pane-1"`
+  // rather than scanning an empty tree.
+  const pane: PaneNode = { kind: 'pane', id: 'pane-1', tabIds: [...tabIds], activeTabId };
   return { root: pane, focusedPaneId: pane.id };
 }
 
@@ -258,9 +225,20 @@ export function workspaceReducer(layout: WorkspaceLayout, action: WorkspaceActio
         return layout; // would empty the source pane — pointless split
       }
       const moving = action.moveTabId && pane.tabIds.includes(action.moveTabId) ? action.moveTabId : undefined;
+      // Both ids are minted up front from the pristine, pre-split `layout.root`
+      // — not lazily inside the `mapPane` callback below — so the split-id
+      // scan can never observe the pane just minted a line above (or vice
+      // versa). Matches Rust's `apply` (workspace.rs), which computes
+      // `next_pane_id(root)` then `next_split_id(root)` the same way, both
+      // before `map_pane` runs. The two ids can never collide with each
+      // other regardless of order since they scan disjoint prefixes
+      // (`pane-` vs `split-`), but minting from the same untouched tree
+      // keeps this obviously correct rather than incidentally correct.
+      const freshId = nextPaneId(layout.root);
+      const splitId = nextSplitId(layout.root);
       const fresh: PaneNode = {
         kind: 'pane',
-        id: newPaneId(),
+        id: freshId,
         tabIds: moving ? [moving] : [],
         activeTabId: moving ?? null,
       };
@@ -269,7 +247,7 @@ export function workspaceReducer(layout: WorkspaceLayout, action: WorkspaceActio
         const children: [LayoutNode, LayoutNode] =
           action.side === 'start' ? [fresh, remaining] : [remaining, fresh];
         // mapPane expects a PaneNode return; widen through a split wrapper:
-        return { kind: 'split', id: newSplitId(), dir: action.dir, ratio: 0.5, children } as unknown as PaneNode;
+        return { kind: 'split', id: splitId, dir: action.dir, ratio: 0.5, children } as unknown as PaneNode;
       });
       return { root, focusedPaneId: fresh.id };
     }
@@ -311,13 +289,10 @@ export function workspaceReducer(layout: WorkspaceLayout, action: WorkspaceActio
     }
 
     case 'hydrate':
-      // Seed the id counters past whatever the incoming layout already
-      // contains, same as loading a fixture — otherwise the next split_pane/
-      // open_tab after a restore could mint a `pane-1`/`split-1` that
-      // collides with an id already in the restored tree. Safe to call every
-      // time hydrate fires (including a StrictMode double-invoke): the
-      // module counters only ever move forward via Math.max.
-      seedLayoutIds(action.layout);
+      // Nothing to seed: minting scans the live tree at call time (see
+      // nextPaneId/nextSplitId above), so a later split_pane/open_tab after
+      // this restore mints past whatever the incoming layout already
+      // contains with no setup step required here.
       return action.layout;
   }
 }

--- a/src/workspace/model.ts
+++ b/src/workspace/model.ts
@@ -114,6 +114,29 @@ export function allTabIds(layout: WorkspaceLayout): string[] {
   return allPanes(layout.root).flatMap(p => p.tabIds);
 }
 
+function mapNodeTabIds(node: LayoutNode, fn: (id: string) => string): LayoutNode {
+  if (node.kind === 'pane') {
+    return {
+      ...node,
+      tabIds: node.tabIds.map(fn),
+      activeTabId: node.activeTabId ? fn(node.activeTabId) : null,
+    };
+  }
+  return { ...node, children: [mapNodeTabIds(node.children[0], fn), mapNodeTabIds(node.children[1], fn)] };
+}
+
+/**
+ * Rewrite every tab id in `layout` (every pane's `tabIds`/`activeTabId`)
+ * through `fn`, leaving pane/split ids and `focusedPaneId` untouched (Phase
+ * 3 Task 4 — used to translate a FOREIGN window's tree, always received in
+ * profile-space over `workspace-changed`, into this window's live id space
+ * via `persistence.ts`'s `toLiveSpaceId` before hydrating it locally). Pure;
+ * returns a new tree, same shape.
+ */
+export function mapLayoutTabIds(layout: WorkspaceLayout, fn: (id: string) => string): WorkspaceLayout {
+  return { root: mapNodeTabIds(layout.root, fn), focusedPaneId: layout.focusedPaneId };
+}
+
 /** Replace the pane with the given id via fn; fn returning null folds the pane
  *  (its parent split collapses into the sibling). Root panes never fold. */
 function mapPane(node: LayoutNode, paneId: string, fn: (p: PaneNode) => PaneNode | null): LayoutNode {

--- a/src/workspace/persistence.ts
+++ b/src/workspace/persistence.ts
@@ -140,6 +140,23 @@ export function toProfileSpaceId(id: string, connections: PersistableConnection[
 }
 
 /**
+ * Inverse of `toProfileSpaceId` (Phase 3 Task 4): rewrite `id`'s
+ * `profile:<profileId>` segment (if any) to the live `<connectionId>` of a
+ * connection in `connections` matching that profile. Used when reconciling a
+ * FOREIGN window's slice of the backend workspace (always profile-space,
+ * per the Global Constraint above) into this window's local id space, where
+ * a tab whose connection this window already has live should render exactly
+ * like any other locally-reconnected tab, not stuck as a `profile:` banner.
+ * Ids with no matching profile prefix — already live-space, connectionless
+ * (`settings`/`quickstart`/`tasks`), or a pane/split id — pass through
+ * unchanged, mirroring `toProfileSpaceId`'s own no-op cases.
+ */
+export function toLiveSpaceId(id: string, connections: PersistableConnection[]): string {
+  const conn = connections.find((c) => id.includes(`profile:${c.profileId}`));
+  return conn ? id.replace(`profile:${conn.profileId}`, conn.id) : id;
+}
+
+/**
  * Build the persisted (wire) form of a live tab, or `null` if this tab kind
  * never survives a restart (export/import). Connection-scoped tab ids are
  * rewritten at save time: the live id's leading `<connectionId>` segment
@@ -193,13 +210,36 @@ export function toPersistedTab(
  * and any cached builder states. Tab ids are used exactly as stored —
  * `toPersistedTab` already rewrote them into `profile:<profileId>` form at
  * save time, so no further id surgery happens here.
+ *
+ * `windowId` (Phase 3 Task 4, default `"main"`) selects WHICH window's
+ * slice of the document to materialize — `ws.windows` may hold more than
+ * one window now, and `ws.tabs` is a FLAT list shared across all of them
+ * (each window's `splitTree` only references a subset). Every window's
+ * boot must materialize ONLY its own tabs into local state; the returned
+ * `tabs`/`builderStates` are filtered down to the ids this window's layout
+ * tree actually references. A `windowId` with no matching entry in
+ * `ws.windows` (e.g. a not-yet-registered secondary window) produces the
+ * same empty single-pane fallback as an empty/missing `ws.windows` — never
+ * a silent fallback to some OTHER window's tree, which would leak its tabs
+ * into this one.
  */
-export function toDisconnectedSnapshot(ws: PersistedWorkspace): {
+export function toDisconnectedSnapshot(
+  ws: PersistedWorkspace,
+  windowId: string = 'main'
+): {
   tabs: RestoredTab[];
   layout: WorkspaceLayout;
   builderStates: Map<string, unknown>;
 } {
-  const tabs: RestoredTab[] = ws.tabs.map((t) => ({
+  const win = ws.windows.find((w) => w.id === windowId);
+  let layout: WorkspaceLayout = win
+    ? { root: win.splitTree, focusedPaneId: win.focusedPaneId }
+    : { root: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null }, focusedPaneId: 'pane-1' };
+
+  const windowTabIds = new Set(allTabIds(layout));
+  const windowTabs = ws.tabs.filter((t) => windowTabIds.has(t.id));
+
+  const tabs: RestoredTab[] = windowTabs.map((t) => ({
     id: t.id,
     type: t.type,
     connectionId: t.profileId ? `profile:${t.profileId}` : '',
@@ -215,20 +255,15 @@ export function toDisconnectedSnapshot(ws: PersistedWorkspace): {
   }));
 
   const builderStates = new Map<string, unknown>();
-  for (const t of ws.tabs) {
+  for (const t of windowTabs) {
     if (t.builderState != null) builderStates.set(t.id, t.builderState);
   }
-
-  const win = ws.windows[0];
-  let layout: WorkspaceLayout = win
-    ? { root: win.splitTree, focusedPaneId: win.focusedPaneId }
-    : { root: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null }, focusedPaneId: 'pane-1' };
 
   // Defensive: fold out any layout tab id with no matching persisted tab
   // (e.g. legacy/corrupt workspace.json) using the same reducer close_tab
   // uses live, so pane folding/focus-repair stays consistent with a normal
   // tab close rather than a naive tabIds filter.
-  const knownIds = new Set(ws.tabs.map((t) => t.id));
+  const knownIds = new Set(windowTabs.map((t) => t.id));
   for (const tabId of allTabIds(layout)) {
     if (!knownIds.has(tabId)) {
       layout = workspaceReducer(layout, { type: 'close_tab', tabId });
@@ -236,6 +271,45 @@ export function toDisconnectedSnapshot(ws: PersistedWorkspace): {
   }
 
   return { tabs, layout, builderStates };
+}
+
+/**
+ * Materialize one tab id ARRIVING into this window's tree from a foreign
+ * `workspace-changed` event (Phase 3 Task 4) — the wire `TabModel`
+ * (`tab`, always profile-space) plus whether this window already has a live
+ * connection for its profile. Mirrors `toDisconnectedSnapshot`'s per-tab
+ * shape for the disconnected case, but additionally rebinds onto the live
+ * connection id (like a reconnect's `rebindProfileTabs`) when one exists —
+ * an arriving tab whose profile is already connected here should render
+ * live immediately, not as a stale `profile:` banner the user has to click
+ * through. `results` always starts empty regardless of `isLive`; the caller
+ * is responsible for refreshing (re-running `lastQuery`/`lastAggregate`)
+ * live arrivals afterward — this function is pure and does no IO.
+ */
+export function materializeArrivingTab(
+  tab: PersistedTab,
+  connections: PersistableConnection[]
+): { tab: RestoredTab; isLive: boolean } {
+  const conn = connections.find((c) => c.profileId === tab.profileId && tab.profileId !== '');
+  const id = conn ? toLiveSpaceId(tab.id, connections) : tab.id;
+  const connectionId = conn ? conn.id : tab.profileId ? `profile:${tab.profileId}` : '';
+  return {
+    isLive: !!conn,
+    tab: {
+      id,
+      type: tab.type,
+      connectionId,
+      db: tab.db,
+      collection: tab.collection,
+      indexName: tab.indexName,
+      results: [],
+      loading: false,
+      error: null,
+      explainResult: null,
+      lastQuery: tab.lastQuery,
+      lastAggregate: tab.lastAggregate,
+    },
+  };
 }
 
 /**

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -137,6 +137,26 @@ export function subscribeConnectionsChanged(
 }
 
 /**
+ * Fire-and-forget: announce `id`'s profile/name to the backend's
+ * `connection_meta` map (Phase 3 Task 3's `set_connection_meta` command),
+ * which triggers a `connections-changed` broadcast every other window's
+ * reconciliation listener consumes. Phase 3 Task 6: called once per
+ * newly-minted connection id, right after every `connect_db` that produces
+ * one — App.tsx's `handleQuickConnect`, the `ConnectionManager` `onConnect`
+ * handler, and `handleReconnectProfile`'s fresh-connect branch. Never called
+ * for a path that reuses an id already live in `activeConnections` — that
+ * id's meta was already set the first time it connected, and a redundant
+ * call would just re-broadcast unchanged data. Same fire-and-forget contract
+ * as `workspaceApply`: never throws, failures are logged and dropped rather
+ * than blocking the connect flow that shadows it.
+ */
+export function setConnectionMeta(id: string, profileId: string, name: string): void {
+  invoke('set_connection_meta', { id, profileId, name }).catch((err) => {
+    console.warn('set_connection_meta failed', err);
+  });
+}
+
+/**
  * Translate one frontend `WorkspaceAction` (camelCase keys) into the wire-
  * shaped op `workspace_apply` expects (snake_case keys; a nested `tab`
  * payload, when present, keeps TabModel's camelCase fields as-is). `tab` is

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -5,8 +5,31 @@
 // persistence.ts; this module is the only one that touches `invoke`.
 
 import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import type { WorkspaceAction } from './model';
 import { toProfileSpaceId, type PersistableConnection, type PersistedTab, type PersistedWorkspace } from './persistence';
+
+/**
+ * This window's Tauri label (`"main"` or `"win-N"`), memoized after the
+ * first successful read — a webview's label never changes for its
+ * lifetime. `getCurrentWebviewWindow().label` reaches into
+ * `window.__TAURI_INTERNALS__.metadata`, which doesn't exist under jsdom
+ * (vitest has no real Tauri runtime), so it throws synchronously there;
+ * the catch falls back to `"main"`, matching every existing test's implicit
+ * assumption that it's running as the primary window.
+ */
+let cachedWindowLabel: string | undefined;
+export function windowLabel(): string {
+  if (cachedWindowLabel === undefined) {
+    try {
+      cachedWindowLabel = getCurrentWebviewWindow().label;
+    } catch {
+      cachedWindowLabel = 'main';
+    }
+  }
+  return cachedWindowLabel;
+}
 
 /** `GET workspace.json` (backend-cached after first call). */
 export async function workspaceGet(): Promise<PersistedWorkspace | null> {
@@ -16,12 +39,53 @@ export async function workspaceGet(): Promise<PersistedWorkspace | null> {
 /**
  * Fire-and-forget apply of one op to the backend store. Never throws — the
  * mirror must never block or fail the UI action it shadows; failures are
- * logged and dropped.
+ * logged and dropped. `origin` (this window's label) lets every window's
+ * `workspace-changed` listener recognize and ignore its own echo — see
+ * App.tsx's foreign-event reconciliation effect.
  */
 export function workspaceApply(op: Record<string, unknown>): void {
-  invoke('workspace_apply', { op }).catch((err) => {
+  invoke('workspace_apply', { op, origin: windowLabel() }).catch((err) => {
     console.warn('workspace_apply failed', err);
   });
+}
+
+/** Wire shape of the `workspace-changed` broadcast (src-tauri/src/workspace.rs's `WorkspaceChangedPayload`). */
+export interface WorkspaceChangedPayload {
+  revision: number;
+  origin: string;
+  crossWindow: boolean;
+  workspace: PersistedWorkspace;
+}
+
+/**
+ * Subscribe to the backend's `workspace-changed` broadcast (Phase 3 Task 3),
+ * fired after every state-changing `workspace_apply`. Thin wrapper around
+ * `listen` (pattern precedent: UpdatePrompt.tsx's `update://progress`
+ * listener) — returns the same `Promise<UnlistenFn>` `listen` does; the
+ * caller owns StrictMode-safe subscribe-once/cleanup, same as any other
+ * effect-scoped listener.
+ */
+export function subscribeWorkspaceChanged(
+  listener: (payload: WorkspaceChangedPayload) => void
+): Promise<UnlistenFn> {
+  return listen<WorkspaceChangedPayload>('workspace-changed', (event) => listener(event.payload));
+}
+
+/** Wire shape of the `connections-changed` broadcast (src-tauri/src/state.rs's `ConnectionsChangedPayload`). */
+export interface ConnectionEntry {
+  id: string;
+  profileId: string;
+  name: string;
+}
+export interface ConnectionsChangedPayload {
+  connections: ConnectionEntry[];
+}
+
+/** Subscribe to the backend's `connections-changed` broadcast (Phase 3 Task 3). Same shape/contract as `subscribeWorkspaceChanged`. */
+export function subscribeConnectionsChanged(
+  listener: (payload: ConnectionsChangedPayload) => void
+): Promise<UnlistenFn> {
+  return listen<ConnectionsChangedPayload>('connections-changed', (event) => listener(event.payload));
 }
 
 /**
@@ -49,23 +113,31 @@ export function actionToOp(
   connections: PersistableConnection[] = []
 ): Record<string, unknown> {
   const id = (raw: string): string => toProfileSpaceId(raw, connections);
+  // Every pane-referencing WorkspaceOp variant carries `window_id` (Phase 3
+  // Task 2) so the backend resolves this op against THIS window's tree —
+  // `default_window_id` on the Rust side only covers callers that predate
+  // multi-window, not this one. `update_tab_state`/`hydrate` are the two
+  // exceptions (see their own cases below): the former never touches a
+  // layout tree, the latter is never mirrored at all.
+  const window_id = windowLabel();
 
   switch (action.type) {
     case 'open_tab': {
-      const op: Record<string, unknown> = { type: 'open_tab', tab_id: id(action.tabId) };
+      const op: Record<string, unknown> = { type: 'open_tab', tab_id: id(action.tabId), window_id };
       if (action.paneId !== undefined) op.pane_id = action.paneId;
       if (tab) op.tab = tab;
       return op;
     }
     case 'close_tab':
-      return { type: 'close_tab', tab_id: id(action.tabId) };
+      return { type: 'close_tab', tab_id: id(action.tabId), window_id };
     case 'close_many':
-      return { type: 'close_many', tab_ids: action.tabIds.map(id) };
+      return { type: 'close_many', tab_ids: action.tabIds.map(id), window_id };
     case 'move_tab': {
       const op: Record<string, unknown> = {
         type: 'move_tab',
         tab_id: id(action.tabId),
         target_pane_id: action.targetPaneId, // pane id — not translated
+        window_id,
       };
       if (action.index !== undefined) op.index = action.index;
       return op;
@@ -76,6 +148,7 @@ export function actionToOp(
         pane_id: action.paneId, // pane id — not translated
         dir: action.dir,
         side: action.side,
+        window_id,
       };
       // moveTabId is a TAB id (the tab being carried into the new pane) —
       // same translation requirement as move_tab.tabId, even though it
@@ -84,13 +157,13 @@ export function actionToOp(
       return op;
     }
     case 'resize_split':
-      return { type: 'resize_split', split_id: action.splitId, ratio: action.ratio }; // split id — not translated
+      return { type: 'resize_split', split_id: action.splitId, ratio: action.ratio, window_id }; // split id — not translated
     case 'set_active':
-      return { type: 'set_active', pane_id: action.paneId, tab_id: id(action.tabId) }; // pane_id not translated
+      return { type: 'set_active', pane_id: action.paneId, tab_id: id(action.tabId), window_id }; // pane_id not translated
     case 'focus_pane':
-      return { type: 'focus_pane', pane_id: action.paneId }; // pane id — not translated
+      return { type: 'focus_pane', pane_id: action.paneId, window_id }; // pane id — not translated
     case 'rename_tab':
-      return { type: 'rename_tab', old_id: id(action.oldId), new_id: id(action.newId) };
+      return { type: 'rename_tab', old_id: id(action.oldId), new_id: id(action.newId), window_id };
     case 'hydrate':
       // Frontend-only (Phase 2 Task 6 restore-on-boot) — App.tsx dispatches
       // it via raw `dispatchLayout`, never through the mirrored

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -137,6 +137,23 @@ export function subscribeConnectionsChanged(
 }
 
 /**
+ * `GET` the full current connection list (final whole-branch review, Fix
+ * 2). Thin wrapper over the backend's `connection_list` command
+ * (`connection_list_impl`) — same element shape as
+ * `ConnectionsChangedPayload.connections`. Called once by App.tsx's boot
+ * effect, after `workspace_get` resolves: without this, a freshly spawned
+ * window (or a window that just missed the `connections-changed` broadcast
+ * for a connection another window made before this one existed) starts
+ * with no live connections at all — any restored `profile:<id>` tab it
+ * hydrates renders a `ReconnectBanner` for a profile that's actually
+ * already live, inviting a duplicate `connect_db`. Unlike
+ * `subscribeConnectionsChanged`, this never broadcasts — it's a plain read.
+ */
+export async function connectionList(): Promise<ConnectionEntry[]> {
+  return invoke<ConnectionEntry[]>('connection_list');
+}
+
+/**
  * Fire-and-forget: announce `id`'s profile/name to the backend's
  * `connection_meta` map (Phase 3 Task 3's `set_connection_meta` command),
  * which triggers a `connections-changed` broadcast every other window's

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -49,6 +49,54 @@ export function workspaceApply(op: Record<string, unknown>): void {
   });
 }
 
+/**
+ * Fire-and-forget: detach `tabId` (already profile-space — callers translate
+ * via `toProfileSpaceId` before calling, same as every other cross-window op)
+ * into a brand-new window via the backend `workspace_detach_tab` command
+ * (Phase 3 Task 5). That command applies `DetachTab`, broadcasts
+ * `workspace-changed` itself, and spawns the new OS window — nothing further
+ * to do here; this window's own tree updates (if it was the source) via the
+ * crossWindow echo, same as `moveTabToWindow` below.
+ */
+export function detachTabToNewWindow(tabId: string): void {
+  invoke('workspace_detach_tab', { tabId, origin: windowLabel() }).catch((err) => {
+    console.warn('workspace_detach_tab failed', err);
+  });
+}
+
+/**
+ * Fire-and-forget: close the OS window labeled `label` (default: this
+ * window). Backs two `App.tsx` call sites (Phase 3 Task 5): a secondary
+ * window proactively closing itself once its last tab closes/moves away, and
+ * a window reacting to discovering its own entry vanished from a
+ * `crossWindow` broadcast it didn't cause. The backend `close_workspace_window`
+ * command applies `WindowClosed` (a no-op if already gone from the store)
+ * and then destroys the real OS window if one is still open.
+ */
+export function closeWorkspaceWindow(label: string = windowLabel()): void {
+  invoke('close_workspace_window', { label, origin: windowLabel() }).catch((err) => {
+    console.warn('close_workspace_window failed', err);
+  });
+}
+
+/**
+ * Fire-and-forget: mirrors a `MoveTabToWindow` op straight to the backend
+ * store (Phase 3 Task 5's "Move to Window" context menu entry). `tabId` must
+ * already be profile-space (callers translate via `toProfileSpaceId` first,
+ * same as `detachTabToNewWindow`). Deliberately a THIN wrapper around
+ * `workspaceApply`, not a `dispatchWorkspace` action: this op is
+ * backend-authoritative and cross-window by nature (it can empty THIS
+ * window's tree, or fill another window's), so it must never be applied
+ * locally via `dispatchLayout` — the eventual `workspace-changed` broadcast
+ * (`crossWindow: true`) is what reconciles every affected window, including
+ * this one if it was the source.
+ */
+export function moveTabToWindow(tabId: string, targetWindowId: string, targetPaneId?: string): void {
+  const op: Record<string, unknown> = { type: 'move_tab_to_window', tab_id: tabId, target_window_id: targetWindowId };
+  if (targetPaneId !== undefined) op.target_pane_id = targetPaneId;
+  workspaceApply(op);
+}
+
 /** Wire shape of the `workspace-changed` broadcast (src-tauri/src/workspace.rs's `WorkspaceChangedPayload`). */
 export interface WorkspaceChangedPayload {
   revision: number;


### PR DESCRIPTION
## Summary
Phase 3 — the final phase of the multi-panel workspace (#97): real multi-window.

- **Detach a tab into its own OS window** (right-click → Detach to New Window): each window is a full MQLens clone (sidebar included) sharing the Rust backend. **Move to Window →** relocates tabs between open windows.
- **Windows stay in sync through the backend store**: every applied op broadcasts a `workspace-changed` event (revision + origin + crossWindow flag). Bystander protocol: ordinary ops only update refs in other windows; cross-window ops (move/detach/close) reconcile — with local export/import tabs grafted through unharmed.
- **Session restore is multi-window**: quit with several windows → relaunch restores them all (spawned after vault unlock), each with per-connection reconnect banners; reconnecting in one window clears banners in all. New windows boot-seed live connections, so a detached live tab arrives live — no banner, no duplicate connection.
- **Cross-window coherence**: opening a collection that's open in another window focuses that window instead; pins/folders/favorites sync via storage events; closing the main window quits the app (secondaries are torn down without destroying their stored sessions).
- **Fixes #197**: pane/split id minting is now a stateless tree scan (StrictMode-safe, byte-identical to the Rust reducer's).

## Review trail
Subagent-driven: 7 tasks, per-task adversarial reviews, whole-branch final review + fix wave (closing verdict "Ready to merge: Yes"). Notable catches en route: foreign-event resync destroying unmirrored tabs (→ bystander protocol); main-window close no longer quitting once a secondary existed (would have silently destroyed sessions in the close-everything-to-quit flow); detached tabs landing disconnected with a duplicate-connect trap (→ boot connection seeding); teardown racing un-landed connection metadata (→ seen-profiles gate).

## Verification
vitest **930/930** (+4 deliberately skipped multi-window golden vectors on the single-window TS runner), cargo **340/340**, clippy at baseline, tsc + production build clean. Golden-vector parity harness extended to all window-scoped ops (26 vectors).

**Outstanding (user environment): 13-item GUI checklist** in the phase report — the only real verification of the main-close fix (items 11–13: close main with a secondary open → app quits; detach a live tab → arrives live; quit by closing windows → relaunch restores).

## Follow-ups (non-blocking, triaged by the final review)
File as tickets after merge: crossWindow-hydrate vs in-flight-op reconcile race (compounding pane-id divergence variant); `validate()` all-or-nothing rejection turning two narrow shapes (simultaneous-open TOCTOU, crash between close_tab and window-close) into whole-session resets — prefer load-time repair. Cosmetic: graft focus placement, redundant opener fetch on deduped opens, `close_workspace_window` apply+emit dedupe.

Squash-merge recommended (single `feat:` line for release notes).