### PR TITLE
feat: MCP server — drive MQLens from Claude Code and Cursor (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ queries actually do — from a single cross-platform desktop app.
   workspace across monitors.
 - **Session restore** — your splits and tabs come back after a restart;
   reconnect per connection with one click.
+- **MCP server** — expose your connections to Claude Code, Cursor, and other agents as
+  [Model Context Protocol tools](docs/mcp-tools.md); per-connection opt-in, writes gated behind
+  explicit confirmation, off by default.
 
 ## Install
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -50,7 +50,10 @@ driving a connection.
 Locking the vault or toggling the server off immediately stops it — in-flight requests are
 allowed to finish (a short drain window) but new ones are refused, and connected clients see a
 clean connection error rather than a hang. Regenerating the bearer token invalidates the old one
-immediately; existing client configs using it must be updated.
+immediately; existing client configs using it must be updated. Disabling (or the vault locking)
+only stops the MCP server itself — any database connection an agent already opened via `connect`
+stays live afterward, exactly as it does for any other window; it's still visible in the sidebar
+with its "via MCP" badge, and you disconnect it from there like any other connection.
 
 ## The `_confirm` rule
 
@@ -134,7 +137,7 @@ Close a connection previously opened by this MCP session's `connect` call. Canno
 
 ### `explain`
 
-Explain a find filter or an aggregation pipeline (executionStats verbosity). Pass `pipeline` for an aggregate-style explain (real connections only) or `findFilter` for a find-style explain.
+Explain a find filter or an aggregation pipeline (executionStats verbosity). Pass `pipeline` for an aggregate-style explain (real connections only) or `find_filter` for a find-style explain.
 
 | Arg | Type | Required | Description |
 |---|---|---|---|

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,243 @@
+# MCP tool reference
+
+MQLens can run a local [Model Context Protocol](https://modelcontextprotocol.io) server so
+agents like Claude Code and Cursor can query (and, with explicit confirmation, write to) your
+MongoDB connections. It's **off by default**, and only connections you explicitly opt in are
+ever visible to an agent.
+
+This page is a reference for the 16 tools the server exposes. It's generated from
+[`fixtures/mcp-tools-golden.json`](../fixtures/mcp-tools-golden.json), the same golden fixture
+`cargo test`'s `mcp::tests::tools_list_matches_golden_fixture` checks the live `tools/list`
+response against — so the table below is always exactly what a connected agent sees. A test
+(`mcp::tests::mcp_tools_doc_lists_every_tool_from_the_golden_fixture`) fails CI if this file
+drifts out of sync with the fixture.
+
+## Enabling the server
+
+1. Open **Settings → MCP** (vault must be unlocked).
+2. Flip **Enabled**. MQLens starts a local HTTP server (default port `8765`, configurable before
+   enabling) and mints a bearer token.
+3. In the same panel, copy the ready-made snippet for your client:
+
+   **Claude Code** — run in a terminal:
+   ```
+   claude mcp add --transport http mqlens http://127.0.0.1:8765/mcp --header "Authorization: Bearer <token>"
+   ```
+
+   **Cursor** — add to its MCP server configuration:
+   ```json
+   {
+     "mcpServers": {
+       "mqlens": {
+         "url": "http://127.0.0.1:8765/mcp",
+         "headers": { "Authorization": "Bearer <token>" }
+       }
+     }
+   }
+   ```
+
+   Replace `<token>` with the actual bearer token shown (and copyable) in the panel. Other
+   MCP-compatible clients (streamable HTTP transport, bearer auth) work the same way.
+4. Per connection, open **Connection Manager** and check **"Expose to MCP agents"** for each
+   profile you want an agent to be able to see. Nothing is exposed by opt-in default — a
+   connection stays invisible to MCP until you flip that flag on it, even while the server itself
+   is enabled.
+
+Once connected, any connection an agent opens through `connect` shows a **"via MCP"** badge next
+to it in the sidebar, in every open window, so it's always visible when an agent (not you) is
+driving a connection.
+
+Locking the vault or toggling the server off immediately stops it — in-flight requests are
+allowed to finish (a short drain window) but new ones are refused, and connected clients see a
+clean connection error rather than a hang. Regenerating the bearer token invalidates the old one
+immediately; existing client configs using it must be updated.
+
+## The `_confirm` rule
+
+Every tool that mutates data (`insert_one`, `update_many`, `delete_many`, `create_index`) requires
+an explicit `_confirm: true` argument. Calling one of these tools without it is always rejected
+with an error telling the agent to restate exactly what will change (namespace, filter/keys,
+and — for inserts/updates — a summary of the document) and get the user's go-ahead first, then
+call again with `_confirm: true`. There is no way to skip this by omission or default; every
+destructive call fails closed until confirmed.
+
+Aggregation is read-only end to end: any pipeline stage whose sole key is `$out` or `$merge` is
+rejected outright, `_confirm` or not, since those can write data outside the tool's own
+namespace/filter contract.
+
+## Result caps
+
+Read tools cap what comes back so a single call can't flood the agent's context:
+
+- `find` / `aggregate`: capped at 50 documents or 1MB of output, whichever comes first; `find`'s
+  own `limit` argument additionally caps at 200 documents requested from MongoDB. A non-null
+  `truncated` field in the response means the cap was hit — narrow the filter or lower `limit` to
+  see more.
+- `schema_analysis`: sampled at 100 documents by default, hard-capped at 1000 via `sample_size`.
+
+## Tools
+
+<!-- BEGIN GENERATED TOOL TABLE -->
+### `aggregate`
+
+Run a MongoDB aggregation pipeline. Returns {"documents": [...relaxed EJSON...], "truncated"?}. Real connections only (not the demo/mock data). Stages whose sole key is $out or $merge are rejected — MCP is read-only for aggregation.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes |  |
+| `database` | string | yes |  |
+| `collection` | string | yes |  |
+| `pipeline` | array | yes | Aggregation pipeline as an array of stage objects, e.g. `[{"$match": {"status": "active"}}, {"$limit": 10}]`. Stages whose sole key is `$out` or `$merge` are rejected. |
+
+### `connect`
+
+Open a live connection to an MCP-opted-in profile (by id, from `list_profiles`). Returns {"connectionId": "..."} for use with every other data tool. Every window's sidebar shows this connection with a "via MCP" badge.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `profile_id` | string | yes | Id of an MCP-opted-in profile, as returned by `list_profiles`. |
+
+### `create_index`
+
+Create an index. `name` defaults to MongoDB's own naming convention (each key's field_direction joined by `_`, e.g. `email_1`) when omitted. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be created (the namespace and the key spec) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes |  |
+| `database` | string | yes |  |
+| `collection` | string | yes |  |
+| `keys` | any | yes | Index key spec as a JSON object, e.g. `{"email": 1}` or `{"a": 1, "b": -1}`. |
+| `name` | string | no | Index name. Defaults to MongoDB's own naming convention (each key's `field_direction` joined by `_`, e.g. `email_1`) when omitted. |
+| `unique` | boolean | no |  |
+| `sparse` | boolean | no |  |
+| `_confirm` | boolean | yes | Must be `true`; see `insert_one`'s `_confirm` doc. |
+
+### `delete_many`
+
+Delete every document matching `filter`. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be deleted (the namespace and the filter) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes |  |
+| `database` | string | yes |  |
+| `collection` | string | yes |  |
+| `filter` | any | yes | MQL filter selecting documents to delete, as a JSON object. |
+| `_confirm` | boolean | yes | Must be `true`; see `insert_one`'s `_confirm` doc. |
+
+### `disconnect`
+
+Close a connection previously opened by this MCP session's `connect` call. Cannot disconnect a connection a human opened via the app UI, even if its profile is opted in.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes | Id returned by `connect` or `list_connections`. |
+
+### `explain`
+
+Explain a find filter or an aggregation pipeline (executionStats verbosity). Pass `pipeline` for an aggregate-style explain (real connections only) or `findFilter` for a find-style explain.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes |  |
+| `database` | string | yes |  |
+| `collection` | string | yes |  |
+| `find_filter` | string | no | MQL filter as a JSON object string (find-style explain). Ignored if `pipeline` is set. |
+| `pipeline` | array | no | Aggregation pipeline as an array of stage objects (aggregate-style explain). |
+
+### `find`
+
+Run a MongoDB find query. Returns {"documents": [...relaxed EJSON...], "count"?, "truncated"?}. Results are capped (default 50 docs / 1MB; `limit` also caps at 200) — a non-null `truncated` means narrow the filter or lower `limit`.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes | Id returned by `connect` or `list_connections`. |
+| `database` | string | yes |  |
+| `collection` | string | yes |  |
+| `filter` | string | no | MQL filter as a JSON object string, e.g. `{"status":"active"}`. Omit for "match all". |
+| `sort` | string | no | MQL sort as a JSON object string, e.g. `{"createdAt":-1}`. |
+| `projection` | string | no | MQL projection as a JSON object string, e.g. `{"name":1,"_id":0}`. |
+| `limit` | integer | no | Max documents to fetch from MongoDB. Default 50, hard cap 200. The response may be truncated further by the output size cap. |
+| `skip` | integer | no | Documents to skip before returning results. Default 0. |
+| `include_count` | boolean | no | Also return a total matching-document count (costs an extra query). |
+
+### `insert_one`
+
+Insert one document. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be inserted (the namespace and a summary of the document) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes | Id returned by `connect` or `list_connections`. |
+| `database` | string | yes |  |
+| `collection` | string | yes |  |
+| `document` | any | yes | The document to insert, as a JSON object. |
+| `_confirm` | boolean | yes | Must be `true`. Before setting this, restate to the user exactly what will be inserted (the namespace and a summary of the document) and get their go-ahead — the call is rejected until then. |
+
+### `list_collections`
+
+List collections (and their type: collection/view/timeseries) in a database.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes |  |
+| `database` | string | yes |  |
+
+### `list_connections`
+
+List currently live MongoDB connections whose profile is opted in to MCP access. Use a returned id with `find`/`aggregate`/etc, or `connect` a not-yet-connected opted-in profile first.
+
+_No arguments._
+
+### `list_databases`
+
+List database names visible on a connection.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes | Id returned by `connect` or `list_connections`. |
+
+### `list_indexes`
+
+List a collection's indexes merged with usage stats (size, ops since last restart) where available. Mock/demo connections report indexes with no stats.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes |  |
+| `database` | string | yes |  |
+| `collection` | string | yes |  |
+
+### `list_profiles`
+
+List MongoDB connection profiles opted in to MCP access (Settings → Connection Manager → "Expose to MCP agents"). Returns id/name/colorTag only — never a connection string. Call this before `connect`.
+
+_No arguments._
+
+### `ping`
+
+Health check for the MQLens MCP server. Returns "pong <version>" — call this first to confirm the server is reachable and the bearer token is valid.
+
+_No arguments._
+
+### `schema_analysis`
+
+Infer a collection's schema by sampling documents: per-field types, presence/coverage, and low-cardinality enum values. `sampleSize` defaults to 100, hard cap 1000.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes |  |
+| `database` | string | yes |  |
+| `collection` | string | yes |  |
+| `sample_size` | integer | no | Documents to sample. Default 100, hard cap 1000. |
+
+### `update_many`
+
+Update every document matching `filter` using operators (e.g. {"$set": {...}}) — bare replacement documents are rejected. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be modified (the namespace, the filter, and the update) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have.
+
+| Arg | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | string | yes |  |
+| `database` | string | yes |  |
+| `collection` | string | yes |  |
+| `filter` | any | yes | MQL filter selecting documents to update, as a JSON object. |
+| `update` | any | yes | Update document using operators (e.g. `{"$set": {"field": "value"}}`). Bare replacement documents are rejected. |
+| `_confirm` | boolean | yes | Must be `true`; see `insert_one`'s `_confirm` doc. |
+<!-- END GENERATED TOOL TABLE -->

--- a/fixtures/mcp-tools-golden.json
+++ b/fixtures/mcp-tools-golden.json
@@ -47,6 +47,94 @@
     }
   },
   {
+    "name": "create_index",
+    "description": "Create an index. `name` defaults to MongoDB's own naming convention (each key's field_direction joined by `_`, e.g. `email_1`) when omitted. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be created (the namespace and the key spec) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database",
+        "collection",
+        "keys",
+        "_confirm"
+      ],
+      "properties": {
+        "connection_id": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "collection": {
+          "type": "string"
+        },
+        "keys": {
+          "description": "Index key spec as a JSON object, e.g. `{\"email\": 1}` or\n`{\"a\": 1, \"b\": -1}`."
+        },
+        "name": {
+          "description": "Index name. Defaults to MongoDB's own naming convention (each key's\n`field_direction` joined by `_`, e.g. `email_1`) when omitted.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "unique": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "sparse": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "_confirm": {
+          "description": "Must be `true`; see `insert_one`'s `_confirm` doc.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "delete_many",
+    "description": "Delete every document matching `filter`. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be deleted (the namespace and the filter) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database",
+        "collection",
+        "filter",
+        "_confirm"
+      ],
+      "properties": {
+        "connection_id": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "collection": {
+          "type": "string"
+        },
+        "filter": {
+          "description": "MQL filter selecting documents to delete, as a JSON object."
+        },
+        "_confirm": {
+          "description": "Must be `true`; see `insert_one`'s `_confirm` doc.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
     "name": "disconnect",
     "description": "Close a connection previously opened by this MCP session's `connect` call. Cannot disconnect a connection a human opened via the app UI, even if its profile is opted in.",
     "inputSchema": {
@@ -180,6 +268,40 @@
     }
   },
   {
+    "name": "insert_one",
+    "description": "Insert one document. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be inserted (the namespace and a summary of the document) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database",
+        "collection",
+        "document",
+        "_confirm"
+      ],
+      "properties": {
+        "connection_id": {
+          "description": "Id returned by `connect` or `list_connections`.",
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "collection": {
+          "type": "string"
+        },
+        "document": {
+          "description": "The document to insert, as a JSON object."
+        },
+        "_confirm": {
+          "description": "Must be `true`. Before setting this, restate to the user exactly\nwhat will be inserted (the namespace and a summary of the document)\nand get their go-ahead — the call is rejected until then.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
     "name": "list_collections",
     "description": "List collections (and their type: collection/view/timeseries) in a database.",
     "inputSchema": {
@@ -292,6 +414,43 @@
           ],
           "format": "int64",
           "default": null
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "update_many",
+    "description": "Update every document matching `filter` using operators (e.g. {\"$set\": {...}}) — bare replacement documents are rejected. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be modified (the namespace, the filter, and the update) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database",
+        "collection",
+        "filter",
+        "update",
+        "_confirm"
+      ],
+      "properties": {
+        "connection_id": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "collection": {
+          "type": "string"
+        },
+        "filter": {
+          "description": "MQL filter selecting documents to update, as a JSON object."
+        },
+        "update": {
+          "description": "Update document using operators (e.g. `{\"$set\": {\"field\": \"value\"}}`).\nBare replacement documents are rejected."
+        },
+        "_confirm": {
+          "description": "Must be `true`; see `insert_one`'s `_confirm` doc.",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/fixtures/mcp-tools-golden.json
+++ b/fixtures/mcp-tools-golden.json
@@ -1,0 +1,300 @@
+[
+  {
+    "name": "aggregate",
+    "description": "Run a MongoDB aggregation pipeline. Returns {\"documents\": [...relaxed EJSON...], \"truncated\"?}. Real connections only (not the demo/mock data). Stages whose sole key is $out or $merge are rejected — MCP is read-only for aggregation.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database",
+        "collection",
+        "pipeline"
+      ],
+      "properties": {
+        "connection_id": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "collection": {
+          "type": "string"
+        },
+        "pipeline": {
+          "description": "Aggregation pipeline as an array of stage objects, e.g.\n`[{\"$match\": {\"status\": \"active\"}}, {\"$limit\": 10}]`. Stages whose\nsole key is `$out` or `$merge` are rejected.",
+          "type": "array",
+          "items": true
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "connect",
+    "description": "Open a live connection to an MCP-opted-in profile (by id, from `list_profiles`). Returns {\"connectionId\": \"...\"} for use with every other data tool. Every window's sidebar shows this connection with a \"via MCP\" badge.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "profile_id"
+      ],
+      "properties": {
+        "profile_id": {
+          "description": "Id of an MCP-opted-in profile, as returned by `list_profiles`.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "disconnect",
+    "description": "Close a connection previously opened by this MCP session's `connect` call. Cannot disconnect a connection a human opened via the app UI, even if its profile is opted in.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id"
+      ],
+      "properties": {
+        "connection_id": {
+          "description": "Id returned by `connect` or `list_connections`.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "explain",
+    "description": "Explain a find filter or an aggregation pipeline (executionStats verbosity). Pass `pipeline` for an aggregate-style explain (real connections only) or `findFilter` for a find-style explain.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database",
+        "collection"
+      ],
+      "properties": {
+        "connection_id": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "collection": {
+          "type": "string"
+        },
+        "find_filter": {
+          "description": "MQL filter as a JSON object string (find-style explain). Ignored if `pipeline` is set.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "pipeline": {
+          "description": "Aggregation pipeline as an array of stage objects (aggregate-style explain).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": true,
+          "default": null
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "find",
+    "description": "Run a MongoDB find query. Returns {\"documents\": [...relaxed EJSON...], \"count\"?, \"truncated\"?}. Results are capped (default 50 docs / 1MB; `limit` also caps at 200) — a non-null `truncated` means narrow the filter or lower `limit`.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database",
+        "collection"
+      ],
+      "properties": {
+        "connection_id": {
+          "description": "Id returned by `connect` or `list_connections`.",
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "collection": {
+          "type": "string"
+        },
+        "filter": {
+          "description": "MQL filter as a JSON object string, e.g. `{\"status\":\"active\"}`. Omit for \"match all\".",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "sort": {
+          "description": "MQL sort as a JSON object string, e.g. `{\"createdAt\":-1}`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "projection": {
+          "description": "MQL projection as a JSON object string, e.g. `{\"name\":1,\"_id\":0}`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "limit": {
+          "description": "Max documents to fetch from MongoDB. Default 50, hard cap 200. The\nresponse may be truncated further by the output size cap.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "default": null
+        },
+        "skip": {
+          "description": "Documents to skip before returning results. Default 0.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "default": null
+        },
+        "include_count": {
+          "description": "Also return a total matching-document count (costs an extra query).",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "list_collections",
+    "description": "List collections (and their type: collection/view/timeseries) in a database.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database"
+      ],
+      "properties": {
+        "connection_id": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "list_connections",
+    "description": "List currently live MongoDB connections whose profile is opted in to MCP access. Use a returned id with `find`/`aggregate`/etc, or `connect` a not-yet-connected opted-in profile first.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "list_databases",
+    "description": "List database names visible on a connection.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id"
+      ],
+      "properties": {
+        "connection_id": {
+          "description": "Id returned by `connect` or `list_connections`.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "list_indexes",
+    "description": "List a collection's indexes merged with usage stats (size, ops since last restart) where available. Mock/demo connections report indexes with no stats.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database",
+        "collection"
+      ],
+      "properties": {
+        "connection_id": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "collection": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  {
+    "name": "list_profiles",
+    "description": "List MongoDB connection profiles opted in to MCP access (Settings → Connection Manager → \"Expose to MCP agents\"). Returns id/name/colorTag only — never a connection string. Call this before `connect`.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "ping",
+    "description": "Health check for the MQLens MCP server. Returns \"pong <version>\" — call this first to confirm the server is reachable and the bearer token is valid.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "schema_analysis",
+    "description": "Infer a collection's schema by sampling documents: per-field types, presence/coverage, and low-cardinality enum values. `sampleSize` defaults to 100, hard cap 1000.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "connection_id",
+        "database",
+        "collection"
+      ],
+      "properties": {
+        "connection_id": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "collection": {
+          "type": "string"
+        },
+        "sample_size": {
+          "description": "Documents to sample. Default 100, hard cap 1000.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "default": null
+        }
+      },
+      "type": "object"
+    }
+  }
+]

--- a/fixtures/mcp-tools-golden.json
+++ b/fixtures/mcp-tools-golden.json
@@ -153,7 +153,7 @@
   },
   {
     "name": "explain",
-    "description": "Explain a find filter or an aggregation pipeline (executionStats verbosity). Pass `pipeline` for an aggregate-style explain (real connections only) or `findFilter` for a find-style explain.",
+    "description": "Explain a find filter or an aggregation pipeline (executionStats verbosity). Pass `pipeline` for an aggregate-style explain (real connections only) or `find_filter` for a find-style explain.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "required": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -680,6 +680,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,6 +2925,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3573,6 +3620,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -4364,6 +4417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5148,6 +5207,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rsa"
 version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5434,7 +5537,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -5459,8 +5562,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -5470,6 +5575,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5947,6 +6064,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "ssh-cipher"
 version = "0.3.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6303,6 +6433,7 @@ version = "0.12.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",
+ "axum",
  "base64 0.22.1",
  "csv",
  "flate2",
@@ -6310,6 +6441,7 @@ dependencies = [
  "mongodb",
  "rand 0.8.6",
  "reqwest 0.12.28",
+ "rmcp",
  "russh",
  "rust_xlsxwriter",
  "serde",
@@ -6830,6 +6962,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,15 @@ sha2 = "0.11.0"
 zip = "8.6.0"
 tar = "0.4.46"
 flate2 = "1.1.9"
+rmcp = { version = "=2.2.0", features = ["server", "transport-streamable-http-server"] }
+# Serves rmcp's `StreamableHttpService` (a plain `tower_service::Service`) on our
+# already-bound `TcpListener`. Minimal, no-default-features build: "http1" (we only
+# need HTTP/1.1 for a loopback MCP endpoint, no h2) + "tokio" (required to enable
+# `axum::serve`/graceful shutdown at all — see axum's own feature table). This is
+# the exact feature set rmcp's own test suite uses to drive its streamable-HTTP
+# server transport (rmcp-2.2.0/Cargo.toml `[dev-dependencies.axum]`), so it's a
+# proven-compatible pairing rather than a guess.
+axum = { version = "=0.8.9", default-features = false, features = ["http1", "tokio"] }
 
 [dev-dependencies]
 tiny_http = "0.12.0"

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -17,6 +17,10 @@ pub struct ConnectionProfile {
     // connections.json files readable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ssh: Option<crate::ssh_tunnel::SshConfig>,
+    /// Expose this profile to MCP agents (Settings → MCP / #98). Old files
+    /// without the field deserialize as false — never opted in by surprise.
+    #[serde(default)]
+    pub mcp_enabled: bool,
 }
 
 fn default_anthropic_model() -> String {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod limits;
 pub mod ai;
 pub mod connections;
 mod db;
+pub mod mcp;
 pub(crate) mod mock_db;
 pub mod monitoring;
 pub mod path_env;
@@ -1847,6 +1848,10 @@ async fn vault_unlock(
 #[tauri::command]
 async fn vault_lock(state: tauri::State<'_, AppState>) -> Result<(), String> {
     *state.vault_key.lock_safe()? = None;
+    // A locked vault must never leave the embedded MCP server listening —
+    // it reads through `require_key`-gated seams, same precondition as
+    // enabling it in the first place.
+    mcp::stop_if_running(&state).await?;
     Ok(())
 }
 
@@ -1865,6 +1870,8 @@ async fn vault_reset(
         }
     }
     *state.vault_key.lock_safe()? = None;
+    // Same precondition as `vault_lock`: no key means no MCP server.
+    mcp::stop_if_running(&state).await?;
     // A reset invalidates the old key; forget any biometric copy too.
     let _ = biometric::remove_stored_key(&app_handle);
     Ok(())
@@ -1900,6 +1907,29 @@ async fn vault_change_password(
     // Approach A: a password change derives a new key; keep biometrics working transparently.
     biometric::restore_key_if_enrolled(&app_handle, &new_key);
     Ok(())
+}
+
+/// Thin wrappers over `mcp.rs`'s testable impl fns (the established
+/// impl/wrapper split — see `set_connection_meta_impl`'s doc comment above)
+/// so the lifecycle logic itself never touches a `tauri::State` and can be
+/// unit-tested with a plain `AppState`.
+#[tauri::command]
+async fn mcp_get_status(state: tauri::State<'_, AppState>) -> Result<mcp::McpStatusUi, String> {
+    mcp::get_status_impl(&state)
+}
+
+#[tauri::command]
+async fn mcp_set_enabled(
+    state: tauri::State<'_, AppState>,
+    enabled: bool,
+    port: Option<u16>,
+) -> Result<mcp::McpStatusUi, String> {
+    mcp::set_enabled_impl(&state, enabled, port).await
+}
+
+#[tauri::command]
+async fn mcp_regenerate_token(state: tauri::State<'_, AppState>) -> Result<mcp::McpStatusUi, String> {
+    mcp::regenerate_token_impl(&state)
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -2019,6 +2049,9 @@ pub fn run() {
             vault_lock,
             vault_reset,
             vault_change_password,
+            mcp_get_status,
+            mcp_set_enabled,
+            mcp_regenerate_token,
             biometric::biometric_status,
             biometric::biometric_enable,
             biometric::biometric_unlock,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1920,11 +1920,12 @@ async fn mcp_get_status(state: tauri::State<'_, AppState>) -> Result<mcp::McpSta
 
 #[tauri::command]
 async fn mcp_set_enabled(
+    app_handle: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     enabled: bool,
     port: Option<u16>,
 ) -> Result<mcp::McpStatusUi, String> {
-    mcp::set_enabled_impl(&state, enabled, port).await
+    mcp::set_enabled_impl(&state, enabled, port, Some(app_handle)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod ai;
 pub mod connections;
 mod db;
 pub mod mcp;
+pub mod mcp_tools;
 pub(crate) mod mock_db;
 pub mod monitoring;
 pub mod path_env;
@@ -552,9 +553,10 @@ pub fn set_connection_meta_impl(
     id: &str,
     profile_id: &str,
     name: &str,
+    via_mcp: bool,
 ) -> Result<(), String> {
     let mut meta = state.connection_meta.lock_safe()?;
-    meta.insert(id.to_string(), ConnectionMeta { profile_id: profile_id.to_string(), name: name.to_string() });
+    meta.insert(id.to_string(), ConnectionMeta { profile_id: profile_id.to_string(), name: name.to_string(), via_mcp });
     Ok(())
 }
 
@@ -566,7 +568,7 @@ pub fn connection_list_impl(state: &AppState) -> Result<Vec<ConnectionEntry>, St
     let meta = state.connection_meta.lock_safe()?;
     let mut list: Vec<ConnectionEntry> = meta
         .iter()
-        .map(|(id, m)| ConnectionEntry { id: id.clone(), profile_id: m.profile_id.clone(), name: m.name.clone() })
+        .map(|(id, m)| ConnectionEntry { id: id.clone(), profile_id: m.profile_id.clone(), name: m.name.clone(), via_mcp: m.via_mcp })
         .collect();
     list.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(list)
@@ -976,7 +978,10 @@ async fn set_connection_meta(
     name: String,
 ) -> Result<(), String> {
     use tauri::Emitter;
-    set_connection_meta_impl(&state, &id, &profile_id, &name)?;
+    // Frontend-initiated (sidebar/Connection Manager/quick-connect) -- never
+    // an MCP agent connection, which flows through `mcp_tools::connect_impl`
+    // instead and passes `via_mcp: true` directly.
+    set_connection_meta_impl(&state, &id, &profile_id, &name, false)?;
     let connections = connection_list_impl(&state)?;
     // Broadcast is best-effort: a window that misses this event picks up
     // current connection metadata the next time it connects or calls

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -538,6 +538,23 @@ pub async fn disconnect_db_impl(state: &AppState, id: &str) -> Result<(), String
         let mut meta = state.connection_meta.lock_safe()?;
         meta.remove(id);
     }
+    // A human disconnecting (Sidebar's onDisconnect -> this command) an
+    // agent-opened connection must also drop it from the MCP server's own
+    // `session_connections` bookkeeping (final whole-branch review fix
+    // wave) — otherwise a stale id lingers there forever, and a later MCP
+    // `disconnect` call for that id would pass `mcp_tools::disconnect_impl`'s
+    // session-owned check and try to tear down a connection that's already
+    // gone (`crate::disconnect_db_impl` above is idempotent per-map-removal,
+    // so that itself wouldn't error, but the stale bookkeeping is exactly
+    // the kind of drift Task 4's `session_connections` doc comment says this
+    // set should never carry). `mcp_tools::disconnect_impl`'s own path
+    // already prunes this set itself, so this is only reached for a
+    // human-initiated disconnect of an id that happens to also be
+    // session-owned; harmless (and a no-op `remove`) otherwise.
+    {
+        let mut control = state.mcp.lock_safe()?;
+        control.session_connections.remove(id);
+    }
 
     Ok(())
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1150,6 +1150,37 @@ mod tests {
         assert_eq!(names.len(), 16, "unexpected tool count — update this list (and the golden fixture) alongside any registry change");
     }
 
+    /// Drift lock for `docs/mcp-tools.md`: every tool name in the golden
+    /// fixture (the same source of truth `tools_list_matches_golden_fixture`
+    /// checks the live registry against) must appear in the hand-authored
+    /// docs page as a `### `name`` heading. This doesn't catch every kind of
+    /// doc staleness (a changed description/schema won't fail this), but it
+    /// guarantees the doc can never silently drop or forget to add a tool
+    /// when the fixture changes — regenerate the golden fixture, add the
+    /// tool's section to the doc, this test goes green again.
+    #[test]
+    fn mcp_tools_doc_lists_every_tool_from_the_golden_fixture() {
+        let fixture_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../fixtures/mcp-tools-golden.json");
+        let fixture = std::fs::read_to_string(fixture_path)
+            .unwrap_or_else(|e| panic!("failed to read golden fixture at {fixture_path}: {e}"));
+        let tools: Vec<Value> = serde_json::from_str(&fixture).expect("golden fixture must be valid JSON");
+
+        let doc_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../docs/mcp-tools.md");
+        let doc = std::fs::read_to_string(doc_path)
+            .unwrap_or_else(|e| panic!("failed to read {doc_path}: {e}"));
+
+        for tool in &tools {
+            let name = tool["name"].as_str().expect("fixture tool must have a string name");
+            let heading = format!("### `{name}`");
+            assert!(
+                doc.contains(&heading),
+                "docs/mcp-tools.md is missing a `{heading}` section for tool `{name}` — \
+                 the tool registry (fixtures/mcp-tools-golden.json) has drifted from the doc; \
+                 add/update its section in docs/mcp-tools.md"
+            );
+        }
+    }
+
     // ---- Task 5: write-tool round trip ------------------------------------
 
     /// One end-to-end pass over the real HTTP transport proving a Task 5

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -46,6 +46,7 @@ use rmcp::transport::streamable_http_server::session::local::LocalSessionManager
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use rmcp::{ServerHandler, tool, tool_handler, tool_router};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -248,20 +249,39 @@ pub async fn set_enabled_impl(
     // before the real bind.
     let port = listener.local_addr().map(|a| a.port()).unwrap_or(port);
 
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let mcp_shared = Arc::clone(&state.mcp);
-    let join = tauri::async_runtime::spawn(run_server(listener, mcp_shared, app_handle, shutdown_rx));
-
     // Bind succeeded — now it's safe to replace any previously running
     // server (a port-change re-enable, or a stale task from a prior call).
+    // Stopped BEFORE the new token is minted/stored and BEFORE the new
+    // server task is spawned: `stop_if_running` also clears `control.token`
+    // (see its doc comment), so there's no window where a request could
+    // still authenticate with a token belonging to a server generation that
+    // no longer exists.
     stop_if_running(state).await?;
 
+    // Mint and store the fresh token BEFORE spawning the server task (final
+    // whole-branch review fix wave) — previously this happened AFTER
+    // `tauri::async_runtime::spawn`, which starts running (and can start
+    // accepting/authenticating requests) as soon as the async runtime
+    // schedules it, not when this function gets around to storing the
+    // token. That left a real, if narrow, window where a request could
+    // arrive at the newly-bound listener while `control.token` still held
+    // the previous generation's (just-cleared-to-empty, or — pre this fix —
+    // stale) value. Storing the token first means the very first request
+    // the new task can possibly serve already sees the right one.
     let token = new_token();
     {
         let mut control = state.mcp.lock_safe()?;
         control.enabled = true;
         control.port = port;
         control.token = token;
+    }
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let mcp_shared = Arc::clone(&state.mcp);
+    let join = tauri::async_runtime::spawn(run_server(listener, mcp_shared, app_handle, shutdown_rx));
+
+    {
+        let mut control = state.mcp.lock_safe()?;
         control.server = Some(ServerHandle { join, shutdown: shutdown_tx });
     }
 
@@ -283,6 +303,19 @@ pub async fn stop_if_running(state: &AppState) -> Result<(), String> {
     let server = {
         let mut control = state.mcp.lock_safe()?;
         control.enabled = false;
+        // Clear the token whenever the server stops, not just leave it
+        // sitting around (final whole-branch review fix wave) — closes the
+        // stale-token re-enable window: without this, a disabled server's
+        // `McpControl.token` field kept holding its last-minted value, so
+        // anything that briefly observed it (or a re-enable that raced
+        // `set_enabled_impl`'s own token mint) could momentarily line up
+        // with a token that no longer corresponds to any running server. A
+        // disabled server should never have ANY value in this field that
+        // could ever successfully authenticate (`bearer_token_matches`
+        // already fails closed on an empty token either way, so this is
+        // defense in depth, not the only thing preventing a stale-token
+        // auth bypass).
+        control.token = String::new();
         control.server.take()
     }; // guard dropped here, before the await below.
 
@@ -489,8 +522,17 @@ impl McpServer {
         let (app_handle, path) = self.resolve()?;
         let state = app_handle.state::<AppState>();
         let connection_id = args.connection_id.clone();
+        // `find_summary` (byte size only, no filter contents — see its doc
+        // comment) rather than interpolating `args.filter` directly: the
+        // call log is visible in the Settings MCP panel, and a raw filter
+        // can carry the same kind of sensitive values the write tools'
+        // summaries are careful never to log (final whole-branch review fix
+        // wave).
         let summary = crate::mcp_tools::truncate_summary(
-            &format!("connectionId={connection_id} {}.{} filter={}", args.database, args.collection, args.filter.as_deref().unwrap_or("{}")),
+            &format!(
+                "connectionId={connection_id} {}",
+                crate::mcp_tools::find_summary(&args.database, &args.collection, args.filter.as_deref())
+            ),
             200,
         );
         let result = crate::mcp_tools::find_impl(&state, &path, args).await;
@@ -513,7 +555,7 @@ impl McpServer {
     }
 
     #[tool(
-        description = "Explain a find filter or an aggregation pipeline (executionStats verbosity). Pass `pipeline` for an aggregate-style explain (real connections only) or `findFilter` for a find-style explain."
+        description = "Explain a find filter or an aggregation pipeline (executionStats verbosity). Pass `pipeline` for an aggregate-style explain (real connections only) or `find_filter` for a find-style explain."
     )]
     async fn explain(&self, Parameters(args): Parameters<crate::mcp_tools::ExplainArgs>) -> Result<String, String> {
         let (app_handle, path) = self.resolve()?;
@@ -622,10 +664,37 @@ impl ServerHandler for McpServer {
     }
 }
 
+/// `true` iff `a` and `b` are equal, in time depending only on their length
+/// — every byte pair is compared regardless of earlier mismatches, unlike
+/// `PartialEq` on slices/`str` (which is free to — and in practice does —
+/// return as soon as it finds a differing byte). Used to compare SHA-256
+/// digests of the presented vs. expected bearer token so a network timing
+/// side-channel can't help an attacker recover the token byte-by-byte.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 /// `true` iff `headers` carries `Authorization: Bearer <token>` matching the
 /// *current* token in `control` — read fresh on every call (never captured
 /// at server-start time), so a `mcp_regenerate_token` call invalidates the
 /// old token starting with the very next request.
+///
+/// Compares SHA-256 digests of both sides via `constant_time_eq` rather than
+/// the presented/expected token strings directly (final whole-branch review
+/// fix wave) — a bearer token is a bare-metal capability (Global
+/// Constraints: "possession IS authorization"), so a naive `==` comparison
+/// leaks how many leading bytes an attacker's guess got right through
+/// response-timing variance. Hashing first also means the compared buffers
+/// are always the same fixed length (32 bytes), so `constant_time_eq`'s own
+/// length check never itself becomes a side channel on the real token's
+/// length.
 fn bearer_token_matches(control: &StdMutex<McpControl>, headers: &axum::http::HeaderMap) -> bool {
     let Some(header_value) = headers.get(axum::http::header::AUTHORIZATION) else {
         return false;
@@ -639,7 +708,22 @@ fn bearer_token_matches(control: &StdMutex<McpControl>, headers: &axum::http::He
     let Ok(guard) = control.lock() else {
         return false;
     };
-    !guard.token.is_empty() && presented == guard.token
+    // Fail-closed: an empty stored token (server never enabled, or between
+    // `stop_if_running` clearing it and a future re-enable minting a fresh
+    // one) must never match anything, no matter what's presented.
+    if guard.token.is_empty() {
+        return false;
+    }
+
+    let mut presented_hasher = Sha256::new();
+    presented_hasher.update(presented.as_bytes());
+    let presented_digest = presented_hasher.finalize();
+
+    let mut expected_hasher = Sha256::new();
+    expected_hasher.update(guard.token.as_bytes());
+    let expected_digest = expected_hasher.finalize();
+
+    constant_time_eq(&presented_digest, &expected_digest)
 }
 
 /// 401 response with a small JSON error body (spec: "401 with a JSON error

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -201,7 +201,12 @@ pub fn get_status_impl(state: &AppState) -> Result<McpStatusUi, String> {
 /// existing server: if the bind fails (e.g. the port is already in use),
 /// this returns `Err` and leaves whatever was running (or not running)
 /// completely untouched, rather than tearing down a working server to make
-/// room for one that never came up.
+/// room for one that never came up. `port: Some(0)` asks the OS for any
+/// free ephemeral port; the actual bound port (read back from the
+/// listener) is what ends up in `McpControl::port`/the returned status,
+/// not the literal `0` — real callers never pass `0`, but tests use it to
+/// get a genuinely race-free port instead of probing for a "likely free"
+/// one ahead of time.
 ///
 /// Disabling (and successfully re-enabling on a new port) stops any
 /// previously running task via `stop_if_running`, which signals and then
@@ -233,6 +238,15 @@ pub async fn set_enabled_impl(
     let listener = TcpListener::bind(("127.0.0.1", port))
         .await
         .map_err(|e| format!("failed to bind MCP server to port {port}: {e}"))?;
+    // Read the actual bound port back from the listener rather than trusting
+    // the requested `port` verbatim: identical to `port` for any real,
+    // explicit port (the only thing production callers ever pass), but also
+    // makes `port: Some(0)` — "let the OS assign any free ephemeral port" —
+    // correctly reported instead of silently stored as `0`. Tests lean on
+    // this to get a real, race-free port straight from the OS instead of
+    // probing for a "likely free" one and hoping nothing else grabs it
+    // before the real bind.
+    let port = listener.local_addr().map(|a| a.port()).unwrap_or(port);
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let mcp_shared = Arc::clone(&state.mcp);
@@ -679,10 +693,60 @@ mod tests {
     use super::*;
     use serde_json::{Value, json};
 
-    /// Binds an ephemeral OS-assigned port and returns it, for tests that
-    /// need a real free port without risking collisions between test runs.
-    fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
+    /// Binds a *real, currently-occupied* ephemeral port and returns both
+    /// the listener (keep it alive — dropping it frees the port) and its
+    /// number, for tests that need an "already occupied" fixture to hand to
+    /// `set_enabled_impl` and observe the bind failure.
+    ///
+    /// Deliberately never does a probe-then-release-then-reuse dance (bind
+    /// port 0, read the number, drop the listener, bind that number again
+    /// later): that pattern has a TOCTOU gap between the drop and the
+    /// second bind that a concurrently-running test can slip into and grab
+    /// the same number first. Returning the still-held listener instead
+    /// closes the gap entirely — the port is never observably free between
+    /// "we asked the OS for one" and "we're holding it". Tests that don't
+    /// need to pre-occupy a specific number should ask `set_enabled_impl`
+    /// for `Some(0)` directly instead (see the `unlock` call sites above)
+    /// and read the real port back from the returned status, for the same
+    /// reason. An earlier version of this helper *did* do the
+    /// probe/release/reuse dance for every test's port, including ones
+    /// that then `.await`ed other work before the real bind — under
+    /// default-parallel `cargo test`, with many `mcp` tests binding
+    /// servers concurrently, that gap was routinely wide enough for two
+    /// tests to be handed the same "free" port and collide, flaking
+    /// whichever one bound second.
+    fn occupy_a_free_port() -> (std::net::TcpListener, u16) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        (listener, port)
+    }
+
+    /// Asserts `port` becomes bindable again, retrying briefly instead of
+    /// checking once. `stop_if_running`/graceful-shutdown already awaits
+    /// the server task to completion before returning, so the port is
+    /// genuinely free at the OS level immediately after — the retry isn't
+    /// covering for our own server lingering. It's covering for the same
+    /// structural gap as above, just unavoidable this time: the *check*
+    /// itself is a fresh bind on a specific, already-known number, and
+    /// nothing stops some unrelated concurrently-running test's own
+    /// `Some(0)`/`occupy_a_free_port` bind from being handed that exact
+    /// number an instant earlier. That's a real, if rare, race — confirmed
+    /// by reproducing it under heavy parallel load — but it's about
+    /// unrelated system-wide port traffic, not about whether *this* test's
+    /// graceful-drain freed its own port, so a few short retries resolve
+    /// it without masking an actual regression: a real drain bug leaves
+    /// the port held for the full `GRACEFUL_SHUTDOWN_TIMEOUT`, far longer
+    /// than this retries for.
+    fn assert_port_becomes_free(port: u16, context: &str) {
+        for attempt in 0..10 {
+            if std::net::TcpListener::bind(("127.0.0.1", port)).is_ok() {
+                return;
+            }
+            if attempt < 9 {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+        panic!("{context}: port {port} did not become free after retrying");
     }
 
     fn unlock(state: &AppState) {
@@ -790,7 +854,7 @@ mod tests {
     #[tokio::test]
     async fn enable_while_vault_locked_fails() {
         let state = AppState::new();
-        let err = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap_err();
+        let err = set_enabled_impl(&state, true, Some(0), None).await.unwrap_err();
         assert!(err.contains("vault is locked"), "unexpected error: {err}");
 
         let status = get_status_impl(&state).unwrap();
@@ -801,16 +865,20 @@ mod tests {
     async fn enable_binds_the_port_and_status_reflects_it() {
         let state = AppState::new();
         unlock(&state);
-        let port = free_port();
 
-        let status = set_enabled_impl(&state, true, Some(port), None).await.unwrap();
+        // `Some(0)` — let the OS assign a free ephemeral port through the
+        // one real bind `set_enabled_impl` performs, rather than probing
+        // for a "likely free" port ahead of time and racing every other
+        // parallel test doing the same probe (see `occupy_a_free_port`'s
+        // doc comment).
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
         assert!(status.enabled);
-        assert_eq!(status.port, port);
+        assert_ne!(status.port, 0, "the real bound port must be reported back, not the `0` wildcard");
         assert!(!status.token.is_empty());
 
         // The server holds the listener open — a second bind on the same
         // port must fail while the server is "enabled".
-        let second_bind = std::net::TcpListener::bind(("127.0.0.1", port));
+        let second_bind = std::net::TcpListener::bind(("127.0.0.1", status.port));
         assert!(second_bind.is_err(), "port must be occupied while the MCP server is enabled");
 
         stop_if_running(&state).await.unwrap();
@@ -820,25 +888,26 @@ mod tests {
     async fn disable_frees_the_port_and_status_reflects_it() {
         let state = AppState::new();
         unlock(&state);
-        let port = free_port();
 
-        set_enabled_impl(&state, true, Some(port), None).await.unwrap();
+        let enabled = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
         let status = set_enabled_impl(&state, false, None, None).await.unwrap();
         assert!(!status.enabled);
 
-        // stop_if_running awaits the task's completion, so the port must be
-        // bindable again immediately — no retry/sleep needed.
-        let rebound = std::net::TcpListener::bind(("127.0.0.1", port));
-        assert!(rebound.is_ok(), "port must be free again once disabled");
+        // stop_if_running awaits the task's completion, so our own server's
+        // hold on the port is gone immediately — no retry needed to prove
+        // *that*. `assert_port_becomes_free` still retries briefly, but only
+        // to absorb an unrelated concurrently-running test being handed
+        // this exact just-freed number for an instant (see its doc
+        // comment), not to paper over a slow drain.
+        assert_port_becomes_free(enabled.port, "port must be free again once disabled");
     }
 
     #[tokio::test]
     async fn vault_lock_hook_stops_the_server() {
         let state = AppState::new();
         unlock(&state);
-        let port = free_port();
 
-        set_enabled_impl(&state, true, Some(port), None).await.unwrap();
+        let enabled = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
         // Mirrors the `vault_lock` command: clear the key, then stop.
         *state.vault_key.lock().unwrap() = None;
@@ -846,15 +915,14 @@ mod tests {
 
         let status = get_status_impl(&state).unwrap();
         assert!(!status.enabled);
-        let rebound = std::net::TcpListener::bind(("127.0.0.1", port));
-        assert!(rebound.is_ok(), "the vault-lock hook must free the port");
+        assert_port_becomes_free(enabled.port, "the vault-lock hook must free the port");
     }
 
     #[tokio::test]
     async fn regenerate_token_changes_the_token() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
         let original = status.token;
 
         let regenerated = regenerate_token_impl(&state).unwrap();
@@ -881,9 +949,9 @@ mod tests {
     async fn enable_on_occupied_port_fails_and_leaves_state_disabled() {
         let state = AppState::new();
         unlock(&state);
-        let port = free_port();
-        // Occupy the port ourselves first so the bind inside set_enabled_impl fails.
-        let _occupier = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+        // Occupy a real port ourselves first so the bind inside
+        // set_enabled_impl fails.
+        let (_occupier, port) = occupy_a_free_port();
 
         let err = set_enabled_impl(&state, true, Some(port), None).await.unwrap_err();
         assert!(err.contains(&port.to_string()), "error should mention the port: {err}");
@@ -897,19 +965,19 @@ mod tests {
     async fn enable_on_occupied_port_leaves_a_previously_running_server_untouched() {
         let state = AppState::new();
         unlock(&state);
-        let good_port = free_port();
-        set_enabled_impl(&state, true, Some(good_port), None).await.unwrap();
+        let good = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
-        let occupied_port = free_port();
-        let _occupier = std::net::TcpListener::bind(("127.0.0.1", occupied_port)).unwrap();
+        // This one *does* need a real, currently-occupied port to hand to
+        // `set_enabled_impl` and observe the bind failure.
+        let (_occupier, occupied_port) = occupy_a_free_port();
         let err = set_enabled_impl(&state, true, Some(occupied_port), None).await.unwrap_err();
         assert!(err.contains(&occupied_port.to_string()));
 
-        // The original server on good_port must still be running.
+        // The original server on good.port must still be running.
         let status = get_status_impl(&state).unwrap();
         assert!(status.enabled);
-        assert_eq!(status.port, good_port);
-        let rebind_good = std::net::TcpListener::bind(("127.0.0.1", good_port));
+        assert_eq!(status.port, good.port);
+        let rebind_good = std::net::TcpListener::bind(("127.0.0.1", good.port));
         assert!(rebind_good.is_err(), "the previously-running server must still hold its port");
 
         stop_if_running(&state).await.unwrap();
@@ -940,7 +1008,7 @@ mod tests {
     async fn initialize_handshake_succeeds_with_token() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
         let mut client = TestClient::new(status.port, &status.token);
         let init = client.initialize().await;
@@ -960,7 +1028,7 @@ mod tests {
     async fn tools_list_contains_ping() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
         let mut client = TestClient::new(status.port, &status.token);
         client.initialize().await;
@@ -981,7 +1049,7 @@ mod tests {
     async fn ping_call_returns_pong_and_version() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
         let mut client = TestClient::new(status.port, &status.token);
         client.initialize().await;
@@ -996,7 +1064,7 @@ mod tests {
     async fn request_without_token_is_401() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
         let client = reqwest::Client::new();
         let response = client
@@ -1018,7 +1086,7 @@ mod tests {
     async fn request_with_wrong_token_is_401() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
         let client = TestClient::new(status.port, "not-the-real-token");
         let response = client
@@ -1033,7 +1101,7 @@ mod tests {
     async fn regenerating_the_token_401s_the_old_token_on_the_next_request() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
         let old_token = status.token.clone();
 
         let mut client = TestClient::new(status.port, &old_token);
@@ -1059,8 +1127,7 @@ mod tests {
     async fn graceful_stop_lets_an_in_flight_request_finish_and_still_frees_the_port() {
         let state = AppState::new();
         unlock(&state);
-        let port = free_port();
-        let status = set_enabled_impl(&state, true, Some(port), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
         let mut client = TestClient::new(status.port, &status.token);
         client.initialize().await;
@@ -1082,8 +1149,7 @@ mod tests {
         assert_eq!(text, format!("pong {}", env!("CARGO_PKG_VERSION")));
 
         // And per Task 1's original assertion: the port must be free again.
-        let rebound = std::net::TcpListener::bind(("127.0.0.1", port));
-        assert!(rebound.is_ok(), "port must be free again once the graceful stop completes");
+        assert_port_becomes_free(status.port, "port must be free again once the graceful stop completes");
     }
 
     // ---- Task 4: read-tool registry ------------------------------------
@@ -1198,7 +1264,7 @@ mod tests {
     async fn delete_many_tool_round_trips_over_http() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
         let mut client = TestClient::new(status.port, &status.token);
         client.initialize().await;
@@ -1240,7 +1306,7 @@ mod tests {
     async fn find_tool_round_trips_over_http_against_a_mock_connection() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
 
         let mut client = TestClient::new(status.port, &status.token);
         client.initialize().await;

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1,32 +1,70 @@
-//! Embedded MCP (Model Context Protocol) server lifecycle + settings (#98).
+//! Embedded MCP (Model Context Protocol) server lifecycle + protocol (#98).
 //!
-//! Task 1 scope: state shape, enable/disable/regenerate-token commands, and
-//! a *stub* server task that proves the lifecycle plumbing without any
-//! protocol code — it binds the requested `127.0.0.1:<port>` (so
-//! "enabled" really means "something is listening there") and then idles
-//! until told to stop via a `tokio::sync::oneshot` channel. Task 2 replaces
-//! the task body with the real `rmcp` service; `ServerHandle`'s
-//! join-handle + shutdown-sender shape is deliberately protocol-agnostic so
-//! that swap doesn't touch `McpControl`, the commands, or the vault hooks
-//! below.
+//! Task 1 built the state shape and enable/disable/regenerate-token
+//! commands around a *stub* server task that only proved the lifecycle
+//! plumbing (bind the port, idle until told to stop). Task 2 replaces that
+//! stub with the real thing: an `rmcp` streamable-HTTP service — currently
+//! exposing a single `ping` tool — served over the already-bound
+//! `TcpListener` via `axum::serve`, behind a bearer-auth check on every
+//! request.
+//!
+//! **Why axum:** `rmcp`'s streamable-HTTP server transport
+//! (`StreamableHttpService`) is a bare `tower_service::Service` — it has no
+//! opinion on how you accept TCP connections or run an HTTP/1.1 loop. Rather
+//! than hand-roll that with raw `hyper`, we serve it via `axum::serve`
+//! (`Router::nest_service("/mcp", service)`), the exact pattern `rmcp`'s own
+//! test suite uses to drive this transport (see
+//! `rmcp-2.2.0/tests/test_streamable_http_*.rs`, all of which spin up an
+//! `axum::Router` around `StreamableHttpService`). This also gives us
+//! `axum::serve(..).with_graceful_shutdown(..)` for free, which is exactly
+//! the "stop accepting, let in-flight requests finish, then exit" semantics
+//! Task 1's review called for — see `stop_if_running` below.
+//!
+//! **Auth:** a manual header check in an `axum::middleware::from_fn` layer
+//! wrapping the `/mcp` route (not a `tower::Layer`, since we're already in
+//! axum's world and `from_fn` is the idiomatic equivalent) — see
+//! `bearer_token_matches`. It re-reads the token out of `McpControl` on
+//! *every* request (never captures it at server-start time), so
+//! `mcp_regenerate_token` invalidates the old token starting with the very
+//! next request.
 //!
 //! Mutex discipline: every function here that touches `AppState.mcp` does
 //! its mutation inside a small sync block and drops the guard *before* any
 //! `.await` (a `std::sync::MutexGuard` is `!Send` and cannot cross an await
 //! point anyway — see `workspace::apply_impl`'s doc comment for the same
-//! rule applied to `AppState.workspace`).
+//! rule applied to `AppState.workspace`). The per-request auth check follows
+//! the same rule: lock, read `token`, drop, then proceed — never held across
+//! the `next.run(req).await` that actually serves the request.
 
 use crate::state::{AppState, LockExt};
 use base64::Engine as _;
 use rand::Rng;
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::model::{ServerCapabilities, ServerInfo};
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use rmcp::{ServerHandler, tool, tool_handler, tool_router};
 use serde::Serialize;
 use std::collections::VecDeque;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 
 /// Bound when `mcp_set_enabled` is called without an explicit `port`.
 pub const DEFAULT_PORT: u16 = 8765;
+
+/// HTTP path the streamable-HTTP service is nested under.
+const MCP_PATH: &str = "/mcp";
+
+/// How long `stop_if_running` waits for the server task's graceful shutdown
+/// (in-flight requests finishing, then `axum::serve` returning) before
+/// falling back to `abort()`. 3s is generous for a loopback-only server
+/// whose tools are all bounded MongoDB calls, not a real-world timeout
+/// tuned against anything more scientific than "shouldn't make a user
+/// toggling the setting off wait noticeably, but shouldn't cut off an
+/// in-flight `find` either."
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Rolling call-log cap (spec: "last 200"); Task 4/5 push entries via
 /// `log_call`, Task 1 only needs the field to exist and round-trip.
@@ -46,10 +84,11 @@ pub struct McpLogEntry {
 }
 
 /// Join handle + shutdown sender for the currently-running server task.
-/// Dropping/aborting without sending on `shutdown` would also stop the
-/// task, but `stop_if_running` always signals first so the task can (in
-/// Task 2) run any graceful-shutdown logic the real `rmcp` service needs
-/// instead of being cut off mid-request.
+/// `stop_if_running` sends on `shutdown` first, which triggers
+/// `axum::serve`'s graceful shutdown (stop accepting new connections, let
+/// in-flight ones finish) — `join` is then awaited (with a timeout) so the
+/// caller knows the `TcpListener` has actually been dropped and the port is
+/// free again, not just "asked to free up".
 pub struct ServerHandle {
     join: tauri::async_runtime::JoinHandle<()>,
     shutdown: oneshot::Sender<()>,
@@ -158,7 +197,21 @@ pub fn get_status_impl(state: &AppState) -> Result<McpStatusUi, String> {
 /// previously running task via `stop_if_running`, which signals and then
 /// *awaits* the task — so by the time this returns, the old port is
 /// guaranteed free again, not just "asked to free up".
-pub async fn set_enabled_impl(state: &AppState, enabled: bool, port: Option<u16>) -> Result<McpStatusUi, String> {
+///
+/// `app_handle` is threaded through to the spawned server task (and from
+/// there into each session's `McpServer`) even though no Task 2 tool reads
+/// it yet — Task 4's agent-initiated `connect` tool needs an `AppHandle` to
+/// emit `connections-changed` so every window's sidebar picks up a
+/// server-initiated connection, and plumbing it in now means that task
+/// doesn't have to reshape `set_enabled_impl`'s signature or the
+/// service-factory closure. Real callers (the `mcp_set_enabled` command)
+/// pass `Some(app_handle)`; tests pass `None`.
+pub async fn set_enabled_impl(
+    state: &AppState,
+    enabled: bool,
+    port: Option<u16>,
+    app_handle: Option<tauri::AppHandle>,
+) -> Result<McpStatusUi, String> {
     if !enabled {
         stop_if_running(state).await?;
         return get_status_impl(state);
@@ -172,14 +225,8 @@ pub async fn set_enabled_impl(state: &AppState, enabled: bool, port: Option<u16>
         .map_err(|e| format!("failed to bind MCP server to port {port}: {e}"))?;
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let join = tauri::async_runtime::spawn(async move {
-        // Stub task (Task 1): hold the listener open — proving the port is
-        // actually bound — and idle until told to stop. Task 2 replaces
-        // this body with the real rmcp streamable-HTTP service, accepting
-        // from `listener` instead of just parking it.
-        let _listener = listener;
-        let _ = shutdown_rx.await;
-    });
+    let mcp_shared = Arc::clone(&state.mcp);
+    let join = tauri::async_runtime::spawn(run_server(listener, mcp_shared, app_handle, shutdown_rx));
 
     // Bind succeeded — now it's safe to replace any previously running
     // server (a port-change re-enable, or a stale task from a prior call).
@@ -201,6 +248,13 @@ pub async fn set_enabled_impl(state: &AppState, enabled: bool, port: Option<u16>
 /// `set_enabled_impl`'s disable path and, per the spec's vault-unlocked
 /// precondition, by `vault_lock`/`vault_reset` — a locked (or reset) vault
 /// must never leave the server listening.
+///
+/// Signals `shutdown` (which drives `axum::serve`'s graceful shutdown: stop
+/// accepting new connections, let in-flight requests finish, then return)
+/// and awaits the task with a `GRACEFUL_SHUTDOWN_TIMEOUT` bound. `abort()`
+/// is only reached if that window elapses — a backstop for a pathologically
+/// stuck task, not the normal path (unlike Task 1's stub, where every stop
+/// was an abort because there was no in-flight-request concept to protect).
 pub async fn stop_if_running(state: &AppState) -> Result<(), String> {
     let server = {
         let mut control = state.mcp.lock_safe()?;
@@ -208,15 +262,13 @@ pub async fn stop_if_running(state: &AppState) -> Result<(), String> {
         control.server.take()
     }; // guard dropped here, before the await below.
 
-    if let Some(handle) = server {
+    if let Some(mut handle) = server {
         // Ignore a closed receiver — the task may already be gone.
         let _ = handle.shutdown.send(());
-        // Wait for the task to actually finish so its TcpListener is
-        // dropped (and the port freed) before this returns. `abort()` as a
-        // backstop covers the pathological case where the task somehow
-        // never observes the shutdown signal.
-        handle.join.abort();
-        let _ = handle.join.await;
+        if tokio::time::timeout(GRACEFUL_SHUTDOWN_TIMEOUT, &mut handle.join).await.is_err() {
+            handle.join.abort();
+            let _ = handle.join.await;
+        }
     }
     Ok(())
 }
@@ -232,28 +284,235 @@ pub fn regenerate_token_impl(state: &AppState) -> Result<McpStatusUi, String> {
     Ok(status_from(&control))
 }
 
+/// Per-session MCP protocol handler. `rmcp`'s streamable-HTTP service calls
+/// `service_factory` (see `run_server`) to build one of these per client
+/// session, so it's kept cheap — `ToolRouter` construction is just building
+/// a static dispatch table, no I/O.
+#[derive(Clone)]
+struct McpServer {
+    /// Read by the `#[tool_handler]`-generated `list_tools`/`call_tool`
+    /// below, not by any hand-written code here — `rustc`'s dead-code
+    /// analysis doesn't see through that macro expansion (the same false
+    /// positive `rmcp`'s own test suite silences the same way; see
+    /// `rmcp-2.2.0/tests/test_progress_subscriber.rs`).
+    #[allow(dead_code)]
+    tool_router: ToolRouter<Self>,
+    /// Not read by the `ping`-only Task 2 tool surface. Carried now (see
+    /// `set_enabled_impl`'s doc comment) so Task 4's tools can start using
+    /// it without any lifecycle plumbing changes.
+    #[allow(dead_code)]
+    app_handle: Option<tauri::AppHandle>,
+}
+
+impl McpServer {
+    fn new(app_handle: Option<tauri::AppHandle>) -> Self {
+        Self { tool_router: Self::tool_router(), app_handle }
+    }
+}
+
+#[tool_router]
+impl McpServer {
+    /// The only tool Task 2 exposes: proves the server is reachable,
+    /// authenticated, and talking to the build a client expects.
+    #[tool(
+        description = "Health check for the MQLens MCP server. Returns \"pong <version>\" — call this first to confirm the server is reachable and the bearer token is valid."
+    )]
+    async fn ping(&self) -> String {
+        format!("pong {}", env!("CARGO_PKG_VERSION"))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for McpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions("MQLens embedded MCP server. Call `ping` to verify connectivity.")
+    }
+}
+
+/// `true` iff `headers` carries `Authorization: Bearer <token>` matching the
+/// *current* token in `control` — read fresh on every call (never captured
+/// at server-start time), so a `mcp_regenerate_token` call invalidates the
+/// old token starting with the very next request.
+fn bearer_token_matches(control: &StdMutex<McpControl>, headers: &axum::http::HeaderMap) -> bool {
+    let Some(header_value) = headers.get(axum::http::header::AUTHORIZATION) else {
+        return false;
+    };
+    let Ok(header_str) = header_value.to_str() else {
+        return false;
+    };
+    let Some(presented) = header_str.strip_prefix("Bearer ") else {
+        return false;
+    };
+    let Ok(guard) = control.lock() else {
+        return false;
+    };
+    !guard.token.is_empty() && presented == guard.token
+}
+
+/// 401 response with a small JSON error body (spec: "401 with a JSON error
+/// body otherwise").
+fn unauthorized_response() -> axum::response::Response {
+    let body = serde_json::json!({ "error": "missing or invalid bearer token" }).to_string();
+    axum::response::Response::builder()
+        .status(axum::http::StatusCode::UNAUTHORIZED)
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(axum::body::Body::from(body))
+        .expect("building a static 401 response cannot fail")
+}
+
+/// Builds the `rmcp` streamable-HTTP service (currently one `ping` tool)
+/// behind a bearer-auth layer and serves it on `listener` at `/mcp` until
+/// `shutdown_rx` fires. `axum::serve(..).with_graceful_shutdown(..)` then
+/// stops accepting new connections, lets in-flight requests finish, and
+/// this function returns — see `stop_if_running` for the timeout that
+/// bounds how long a caller waits for that.
+async fn run_server(listener: TcpListener, mcp: Arc<StdMutex<McpControl>>, app_handle: Option<tauri::AppHandle>, shutdown_rx: oneshot::Receiver<()>) {
+    let session_manager: Arc<LocalSessionManager> = Default::default();
+    let http_service: StreamableHttpService<McpServer, LocalSessionManager> =
+        StreamableHttpService::new(move || Ok(McpServer::new(app_handle.clone())), session_manager, StreamableHttpServerConfig::default());
+
+    let auth_mcp = Arc::clone(&mcp);
+    let router = axum::Router::new().nest_service(MCP_PATH, http_service).layer(axum::middleware::from_fn(
+        move |req: axum::extract::Request, next: axum::middleware::Next| {
+            let mcp = Arc::clone(&auth_mcp);
+            async move {
+                if bearer_token_matches(&mcp, req.headers()) {
+                    next.run(req).await
+                } else {
+                    unauthorized_response()
+                }
+            }
+        },
+    ));
+
+    if let Err(e) = axum::serve(listener, router.into_make_service())
+        .with_graceful_shutdown(async move {
+            let _ = shutdown_rx.await;
+        })
+        .await
+    {
+        eprintln!("mcp::run_server: axum::serve exited with an error: {e}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::{Value, json};
 
     /// Binds an ephemeral OS-assigned port and returns it, for tests that
     /// need a real free port without risking collisions between test runs.
     fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
+        std::net::TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
     }
 
     fn unlock(state: &AppState) {
         *state.vault_key.lock().unwrap() = Some([7u8; 32]);
     }
 
+    /// Extracts the JSON-RPC payload from a streamable-HTTP POST response
+    /// body. In stateful mode (the default, and what production uses to
+    /// interoperate with real MCP clients like Claude Code/Cursor) `rmcp`
+    /// always answers POSTs with an SSE-framed stream — even for a single
+    /// request/response pair — so a raw-reqwest test client has to unwrap
+    /// that framing itself: find the `data: ` line and parse it as JSON.
+    fn parse_sse_json(body: &str) -> Value {
+        // Stateful-mode responses are SSE-framed even for a single
+        // request/response pair; when `sse_retry` is configured (the
+        // default) the stream is prefixed with an empty "priming" event
+        // (`data: \nid: 0\nretry: 3000`) purely to establish the SSE
+        // connection for reconnect purposes — skip empty `data:` lines and
+        // take the first real payload.
+        for line in body.lines() {
+            if let Some(data) = line.strip_prefix("data: ") {
+                if data.is_empty() {
+                    continue;
+                }
+                return serde_json::from_str(data).unwrap_or_else(|e| panic!("bad SSE JSON payload {data:?}: {e}"));
+            }
+        }
+        panic!("no non-empty `data: ` line in SSE body: {body:?}");
+    }
+
+    /// Minimal streamable-HTTP client over `reqwest` (already a project
+    /// dependency) — this is the same "raw JSON-RPC POST calls" approach
+    /// `rmcp`'s own test suite uses to drive `StreamableHttpService`, and it
+    /// avoids pulling in `rmcp`'s client-transport features as a
+    /// dev-dependency just to exercise our own server in tests.
+    struct TestClient {
+        client: reqwest::Client,
+        url: String,
+        token: String,
+        session_id: Option<String>,
+    }
+
+    impl TestClient {
+        fn new(port: u16, token: &str) -> Self {
+            Self { client: reqwest::Client::new(), url: format!("http://127.0.0.1:{port}{MCP_PATH}"), token: token.to_string(), session_id: None }
+        }
+
+        /// POST a JSON-RPC request/notification body; returns the raw
+        /// `reqwest::Response` so callers can assert on status codes (401
+        /// tests) before trying to parse a body.
+        async fn post_raw(&self, body: Value) -> reqwest::Response {
+            let mut req = self
+                .client
+                .post(&self.url)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .header("Authorization", format!("Bearer {}", self.token))
+                .json(&body);
+            if let Some(session_id) = &self.session_id {
+                req = req.header("Mcp-Session-Id", session_id.clone());
+            }
+            req.send().await.expect("request should reach the server")
+        }
+
+        /// `initialize` handshake; captures the `Mcp-Session-Id` response
+        /// header for subsequent calls. Panics (via `expect`/`unwrap`) on
+        /// anything unexpected — test-only convenience, not production code.
+        async fn initialize(&mut self) -> Value {
+            let response = self
+                .post_raw(json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {"name": "mcp-test-client", "version": "0.0.0"}
+                    }
+                }))
+                .await;
+            assert_eq!(response.status(), 200, "initialize should succeed");
+            self.session_id = response.headers().get("mcp-session-id").and_then(|v| v.to_str().ok()).map(|s| s.to_string());
+            assert!(self.session_id.is_some(), "stateful server must return Mcp-Session-Id");
+            let body = response.text().await.unwrap();
+            let result = parse_sse_json(&body);
+            // Spec-compliant clients send this notification before any other
+            // call; the SDK doesn't appear to require it (only session
+            // existence), but sending it keeps this test client honest about
+            // what a real client does.
+            let notified = self
+                .post_raw(json!({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+                .await;
+            assert_eq!(notified.status(), 202, "initialized notification should be accepted");
+            result
+        }
+
+        async fn call(&self, id: i64, method: &str, params: Value) -> Value {
+            let response = self.post_raw(json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params})).await;
+            assert_eq!(response.status(), 200, "{method} should succeed");
+            let body = response.text().await.unwrap();
+            parse_sse_json(&body)
+        }
+    }
+
     #[tokio::test]
     async fn enable_while_vault_locked_fails() {
         let state = AppState::new();
-        let err = set_enabled_impl(&state, true, Some(free_port())).await.unwrap_err();
+        let err = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap_err();
         assert!(err.contains("vault is locked"), "unexpected error: {err}");
 
         let status = get_status_impl(&state).unwrap();
@@ -266,15 +525,17 @@ mod tests {
         unlock(&state);
         let port = free_port();
 
-        let status = set_enabled_impl(&state, true, Some(port)).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(port), None).await.unwrap();
         assert!(status.enabled);
         assert_eq!(status.port, port);
         assert!(!status.token.is_empty());
 
-        // The stub task holds the listener open — a second bind on the same
+        // The server holds the listener open — a second bind on the same
         // port must fail while the server is "enabled".
         let second_bind = std::net::TcpListener::bind(("127.0.0.1", port));
         assert!(second_bind.is_err(), "port must be occupied while the MCP server is enabled");
+
+        stop_if_running(&state).await.unwrap();
     }
 
     #[tokio::test]
@@ -283,8 +544,8 @@ mod tests {
         unlock(&state);
         let port = free_port();
 
-        set_enabled_impl(&state, true, Some(port)).await.unwrap();
-        let status = set_enabled_impl(&state, false, None).await.unwrap();
+        set_enabled_impl(&state, true, Some(port), None).await.unwrap();
+        let status = set_enabled_impl(&state, false, None, None).await.unwrap();
         assert!(!status.enabled);
 
         // stop_if_running awaits the task's completion, so the port must be
@@ -299,7 +560,7 @@ mod tests {
         unlock(&state);
         let port = free_port();
 
-        set_enabled_impl(&state, true, Some(port)).await.unwrap();
+        set_enabled_impl(&state, true, Some(port), None).await.unwrap();
 
         // Mirrors the `vault_lock` command: clear the key, then stop.
         *state.vault_key.lock().unwrap() = None;
@@ -315,7 +576,7 @@ mod tests {
     async fn regenerate_token_changes_the_token() {
         let state = AppState::new();
         unlock(&state);
-        let status = set_enabled_impl(&state, true, Some(free_port())).await.unwrap();
+        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
         let original = status.token;
 
         let regenerated = regenerate_token_impl(&state).unwrap();
@@ -324,6 +585,8 @@ mod tests {
 
         // status reflects the new token too, not just the regenerate call's return value.
         assert_eq!(get_status_impl(&state).unwrap().token, regenerated.token);
+
+        stop_if_running(&state).await.unwrap();
     }
 
     #[tokio::test]
@@ -344,7 +607,7 @@ mod tests {
         // Occupy the port ourselves first so the bind inside set_enabled_impl fails.
         let _occupier = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
 
-        let err = set_enabled_impl(&state, true, Some(port)).await.unwrap_err();
+        let err = set_enabled_impl(&state, true, Some(port), None).await.unwrap_err();
         assert!(err.contains(&port.to_string()), "error should mention the port: {err}");
 
         let status = get_status_impl(&state).unwrap();
@@ -357,11 +620,11 @@ mod tests {
         let state = AppState::new();
         unlock(&state);
         let good_port = free_port();
-        set_enabled_impl(&state, true, Some(good_port)).await.unwrap();
+        set_enabled_impl(&state, true, Some(good_port), None).await.unwrap();
 
         let occupied_port = free_port();
         let _occupier = std::net::TcpListener::bind(("127.0.0.1", occupied_port)).unwrap();
-        let err = set_enabled_impl(&state, true, Some(occupied_port)).await.unwrap_err();
+        let err = set_enabled_impl(&state, true, Some(occupied_port), None).await.unwrap_err();
         assert!(err.contains(&occupied_port.to_string()));
 
         // The original server on good_port must still be running.
@@ -370,12 +633,14 @@ mod tests {
         assert_eq!(status.port, good_port);
         let rebind_good = std::net::TcpListener::bind(("127.0.0.1", good_port));
         assert!(rebind_good.is_err(), "the previously-running server must still hold its port");
+
+        stop_if_running(&state).await.unwrap();
     }
 
     #[tokio::test]
     async fn disable_when_never_enabled_is_a_harmless_noop() {
         let state = AppState::new();
-        let status = set_enabled_impl(&state, false, None).await.unwrap();
+        let status = set_enabled_impl(&state, false, None, None).await.unwrap();
         assert!(!status.enabled);
     }
 
@@ -389,5 +654,152 @@ mod tests {
         assert_eq!(status.log.len(), MAX_LOG_ENTRIES);
         // Oldest entries were evicted; the newest survives.
         assert_eq!(status.log.last().unwrap().summary, format!("call {}", MAX_LOG_ENTRIES + 4));
+    }
+
+    // ---- Task 2: protocol + auth tests --------------------------------
+
+    #[tokio::test]
+    async fn initialize_handshake_succeeds_with_token() {
+        let state = AppState::new();
+        unlock(&state);
+        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+
+        let mut client = TestClient::new(status.port, &status.token);
+        let init = client.initialize().await;
+        assert!(init["result"]["serverInfo"]["name"].as_str().is_some_and(|n| !n.is_empty()), "expected a non-empty serverInfo.name, got: {init:?}");
+        assert!(init["result"]["capabilities"]["tools"].is_object(), "server must advertise tools capability");
+
+        stop_if_running(&state).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn tools_list_contains_exactly_ping() {
+        let state = AppState::new();
+        unlock(&state);
+        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+
+        let mut client = TestClient::new(status.port, &status.token);
+        client.initialize().await;
+        let list = client.call(2, "tools/list", json!({})).await;
+        let tools = list["result"]["tools"].as_array().expect("tools/list must return an array");
+        assert_eq!(tools.len(), 1, "expected exactly one tool, got: {tools:?}");
+        assert_eq!(tools[0]["name"], "ping");
+        assert!(tools[0]["description"].as_str().unwrap_or_default().contains("pong"));
+        // No-args tool: an empty (or property-less) object input schema.
+        let schema = &tools[0]["inputSchema"];
+        assert_eq!(schema["type"], "object");
+        let no_required_props = schema.get("required").map(|r| r.as_array().map(|a| a.is_empty()).unwrap_or(true)).unwrap_or(true);
+        assert!(no_required_props, "ping takes no args, schema was: {schema:?}");
+
+        stop_if_running(&state).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ping_call_returns_pong_and_version() {
+        let state = AppState::new();
+        unlock(&state);
+        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+
+        let mut client = TestClient::new(status.port, &status.token);
+        client.initialize().await;
+        let result = client.call(2, "tools/call", json!({"name": "ping", "arguments": {}})).await;
+        let text = result["result"]["content"][0]["text"].as_str().expect("ping must return text content");
+        assert_eq!(text, format!("pong {}", env!("CARGO_PKG_VERSION")));
+
+        stop_if_running(&state).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn request_without_token_is_401() {
+        let state = AppState::new();
+        unlock(&state);
+        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(format!("http://127.0.0.1:{}{MCP_PATH}", status.port))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .json(&json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "x", "version": "0"}}}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 401);
+        let body: Value = response.json().await.unwrap();
+        assert!(body.get("error").is_some(), "401 body should be a JSON error object: {body:?}");
+
+        stop_if_running(&state).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn request_with_wrong_token_is_401() {
+        let state = AppState::new();
+        unlock(&state);
+        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+
+        let client = TestClient::new(status.port, "not-the-real-token");
+        let response = client
+            .post_raw(json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "x", "version": "0"}}}))
+            .await;
+        assert_eq!(response.status(), 401);
+
+        stop_if_running(&state).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn regenerating_the_token_401s_the_old_token_on_the_next_request() {
+        let state = AppState::new();
+        unlock(&state);
+        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+        let old_token = status.token.clone();
+
+        let mut client = TestClient::new(status.port, &old_token);
+        client.initialize().await; // works with the original token
+
+        let regenerated = regenerate_token_impl(&state).unwrap();
+        assert_ne!(regenerated.token, old_token);
+
+        // Same client, same (now-stale) captured token: the *next* request must 401.
+        let response = client.call_raw_status(3, "tools/list", json!({})).await;
+        assert_eq!(response, 401, "the old token must stop working immediately after regenerate");
+
+        stop_if_running(&state).await.unwrap();
+    }
+
+    impl TestClient {
+        async fn call_raw_status(&self, id: i64, method: &str, params: Value) -> u16 {
+            self.post_raw(json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params})).await.status().as_u16()
+        }
+    }
+
+    #[tokio::test]
+    async fn graceful_stop_lets_an_in_flight_request_finish_and_still_frees_the_port() {
+        let state = AppState::new();
+        unlock(&state);
+        let port = free_port();
+        let status = set_enabled_impl(&state, true, Some(port), None).await.unwrap();
+
+        let mut client = TestClient::new(status.port, &status.token);
+        client.initialize().await;
+
+        // Fire a real request on its own task and give it a small head start
+        // to actually get *accepted* (axum's graceful shutdown only waits for
+        // connections already accepted at the moment the signal fires — a
+        // connection still mid-handshake when shutdown is signalled is fair
+        // game to be refused, so racing the two with zero head start would
+        // make this test flaky on scheduling order rather than proving
+        // anything about graceful shutdown). The mandate under test is: once
+        // accepted, an in-flight request finishes instead of being hard-cut.
+        let ping_task = tokio::spawn(async move { client.call(9, "tools/call", json!({"name": "ping", "arguments": {}})).await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        stop_if_running(&state).await.unwrap();
+
+        let ping_result = ping_task.await.expect("ping task must not panic");
+        let text = ping_result["result"]["content"][0]["text"].as_str().expect("in-flight ping must still complete");
+        assert_eq!(text, format!("pong {}", env!("CARGO_PKG_VERSION")));
+
+        // And per Task 1's original assertion: the port must be free again.
+        let rebound = std::net::TcpListener::bind(("127.0.0.1", port));
+        assert!(rebound.is_ok(), "port must be free again once the graceful stop completes");
     }
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1,0 +1,393 @@
+//! Embedded MCP (Model Context Protocol) server lifecycle + settings (#98).
+//!
+//! Task 1 scope: state shape, enable/disable/regenerate-token commands, and
+//! a *stub* server task that proves the lifecycle plumbing without any
+//! protocol code — it binds the requested `127.0.0.1:<port>` (so
+//! "enabled" really means "something is listening there") and then idles
+//! until told to stop via a `tokio::sync::oneshot` channel. Task 2 replaces
+//! the task body with the real `rmcp` service; `ServerHandle`'s
+//! join-handle + shutdown-sender shape is deliberately protocol-agnostic so
+//! that swap doesn't touch `McpControl`, the commands, or the vault hooks
+//! below.
+//!
+//! Mutex discipline: every function here that touches `AppState.mcp` does
+//! its mutation inside a small sync block and drops the guard *before* any
+//! `.await` (a `std::sync::MutexGuard` is `!Send` and cannot cross an await
+//! point anyway — see `workspace::apply_impl`'s doc comment for the same
+//! rule applied to `AppState.workspace`).
+
+use crate::state::{AppState, LockExt};
+use base64::Engine as _;
+use rand::Rng;
+use serde::Serialize;
+use std::collections::VecDeque;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+
+/// Bound when `mcp_set_enabled` is called without an explicit `port`.
+pub const DEFAULT_PORT: u16 = 8765;
+
+/// Rolling call-log cap (spec: "last 200"); Task 4/5 push entries via
+/// `log_call`, Task 1 only needs the field to exist and round-trip.
+const MAX_LOG_ENTRIES: usize = 200;
+
+/// One rolling call-log row surfaced to the Settings panel (Task 6).
+/// `ts_ms` is `SystemTime`-derived (no `chrono` dependency — plan
+/// constraint) millis since the Unix epoch.
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpLogEntry {
+    pub ts_ms: u64,
+    pub tool: String,
+    pub connection_id: Option<String>,
+    pub summary: String,
+    pub ok: bool,
+}
+
+/// Join handle + shutdown sender for the currently-running server task.
+/// Dropping/aborting without sending on `shutdown` would also stop the
+/// task, but `stop_if_running` always signals first so the task can (in
+/// Task 2) run any graceful-shutdown logic the real `rmcp` service needs
+/// instead of being cut off mid-request.
+pub struct ServerHandle {
+    join: tauri::async_runtime::JoinHandle<()>,
+    shutdown: oneshot::Sender<()>,
+}
+
+/// Embedded MCP server state, owned by `AppState.mcp`. `server` is `Some`
+/// exactly when a task is bound and listening; `enabled` mirrors that but
+/// is kept as a separate bool (rather than `server.is_some()`) so
+/// `McpStatusUi` — and every caller of `get_status_impl` — never needs to
+/// reach into `ServerHandle` (which is intentionally not `Serialize`: a
+/// join handle and a oneshot sender have no meaningful wire form).
+pub struct McpControl {
+    pub enabled: bool,
+    pub port: u16,
+    pub token: String,
+    pub log: VecDeque<McpLogEntry>,
+    pub server: Option<ServerHandle>,
+}
+
+impl McpControl {
+    pub fn new() -> Self {
+        Self {
+            enabled: false,
+            port: DEFAULT_PORT,
+            token: String::new(),
+            log: VecDeque::new(),
+            server: None,
+        }
+    }
+}
+
+impl Default for McpControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The serializable projection of `McpControl` sent to the frontend —
+/// everything in `McpControl` except `server` (not `Serialize`, and not
+/// the frontend's business anyway).
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpStatusUi {
+    pub enabled: bool,
+    pub port: u16,
+    pub token: String,
+    pub log: Vec<McpLogEntry>,
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Fresh 32-byte bearer token, base64url-encoded without padding (spec:
+/// "fresh 32-byte base64url bearer token minted on every enable").
+fn new_token() -> String {
+    let bytes: [u8; 32] = rand::thread_rng().gen();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn status_from(control: &McpControl) -> McpStatusUi {
+    McpStatusUi {
+        enabled: control.enabled,
+        port: control.port,
+        token: control.token.clone(),
+        log: control.log.iter().cloned().collect(),
+    }
+}
+
+/// Append a call-log entry, trimming the front once past `MAX_LOG_ENTRIES`
+/// (oldest-first `VecDeque`, so `pop_front` drops the oldest). Unused until
+/// Task 4/5 wire real tool calls through it; present now so `McpControl`'s
+/// `log` field has an established, tested write path.
+#[allow(dead_code)]
+pub fn log_call(state: &AppState, tool: &str, connection_id: Option<String>, summary: String, ok: bool) -> Result<(), String> {
+    let mut control = state.mcp.lock_safe()?;
+    if control.log.len() >= MAX_LOG_ENTRIES {
+        control.log.pop_front();
+    }
+    control.log.push_back(McpLogEntry { ts_ms: now_ms(), tool: tool.to_string(), connection_id, summary, ok });
+    Ok(())
+}
+
+/// Current status — cheap, synchronous, no vault precondition (reading
+/// status must work even while locked so the Settings panel can render an
+/// accurate "disabled" view).
+pub fn get_status_impl(state: &AppState) -> Result<McpStatusUi, String> {
+    let control = state.mcp.lock_safe()?;
+    Ok(status_from(&control))
+}
+
+/// Enable or disable the embedded server.
+///
+/// Enabling requires the vault to be unlocked (`state.require_key()` — its
+/// "vault is locked" error passes straight through) and binds
+/// `127.0.0.1:<port>` (default `DEFAULT_PORT`) *before* touching any
+/// existing server: if the bind fails (e.g. the port is already in use),
+/// this returns `Err` and leaves whatever was running (or not running)
+/// completely untouched, rather than tearing down a working server to make
+/// room for one that never came up.
+///
+/// Disabling (and successfully re-enabling on a new port) stops any
+/// previously running task via `stop_if_running`, which signals and then
+/// *awaits* the task — so by the time this returns, the old port is
+/// guaranteed free again, not just "asked to free up".
+pub async fn set_enabled_impl(state: &AppState, enabled: bool, port: Option<u16>) -> Result<McpStatusUi, String> {
+    if !enabled {
+        stop_if_running(state).await?;
+        return get_status_impl(state);
+    }
+
+    state.require_key()?;
+    let port = port.unwrap_or(DEFAULT_PORT);
+
+    let listener = TcpListener::bind(("127.0.0.1", port))
+        .await
+        .map_err(|e| format!("failed to bind MCP server to port {port}: {e}"))?;
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let join = tauri::async_runtime::spawn(async move {
+        // Stub task (Task 1): hold the listener open — proving the port is
+        // actually bound — and idle until told to stop. Task 2 replaces
+        // this body with the real rmcp streamable-HTTP service, accepting
+        // from `listener` instead of just parking it.
+        let _listener = listener;
+        let _ = shutdown_rx.await;
+    });
+
+    // Bind succeeded — now it's safe to replace any previously running
+    // server (a port-change re-enable, or a stale task from a prior call).
+    stop_if_running(state).await?;
+
+    let token = new_token();
+    {
+        let mut control = state.mcp.lock_safe()?;
+        control.enabled = true;
+        control.port = port;
+        control.token = token;
+        control.server = Some(ServerHandle { join, shutdown: shutdown_tx });
+    }
+
+    get_status_impl(state)
+}
+
+/// Stop the running server task if there is one; a no-op otherwise. Used by
+/// `set_enabled_impl`'s disable path and, per the spec's vault-unlocked
+/// precondition, by `vault_lock`/`vault_reset` — a locked (or reset) vault
+/// must never leave the server listening.
+pub async fn stop_if_running(state: &AppState) -> Result<(), String> {
+    let server = {
+        let mut control = state.mcp.lock_safe()?;
+        control.enabled = false;
+        control.server.take()
+    }; // guard dropped here, before the await below.
+
+    if let Some(handle) = server {
+        // Ignore a closed receiver — the task may already be gone.
+        let _ = handle.shutdown.send(());
+        // Wait for the task to actually finish so its TcpListener is
+        // dropped (and the port freed) before this returns. `abort()` as a
+        // backstop covers the pathological case where the task somehow
+        // never observes the shutdown signal.
+        handle.join.abort();
+        let _ = handle.join.await;
+    }
+    Ok(())
+}
+
+/// Mint and store a fresh token, independent of whether the server is
+/// currently enabled (works either way, per the plan's Task 1 note) — a
+/// disabled server can still have a stale token sitting in state from a
+/// previous session, and regenerating it before the next enable is a
+/// reasonable thing for a user to want.
+pub fn regenerate_token_impl(state: &AppState) -> Result<McpStatusUi, String> {
+    let mut control = state.mcp.lock_safe()?;
+    control.token = new_token();
+    Ok(status_from(&control))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Binds an ephemeral OS-assigned port and returns it, for tests that
+    /// need a real free port without risking collisions between test runs.
+    fn free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    fn unlock(state: &AppState) {
+        *state.vault_key.lock().unwrap() = Some([7u8; 32]);
+    }
+
+    #[tokio::test]
+    async fn enable_while_vault_locked_fails() {
+        let state = AppState::new();
+        let err = set_enabled_impl(&state, true, Some(free_port())).await.unwrap_err();
+        assert!(err.contains("vault is locked"), "unexpected error: {err}");
+
+        let status = get_status_impl(&state).unwrap();
+        assert!(!status.enabled, "a failed enable must not flip the enabled flag");
+    }
+
+    #[tokio::test]
+    async fn enable_binds_the_port_and_status_reflects_it() {
+        let state = AppState::new();
+        unlock(&state);
+        let port = free_port();
+
+        let status = set_enabled_impl(&state, true, Some(port)).await.unwrap();
+        assert!(status.enabled);
+        assert_eq!(status.port, port);
+        assert!(!status.token.is_empty());
+
+        // The stub task holds the listener open — a second bind on the same
+        // port must fail while the server is "enabled".
+        let second_bind = std::net::TcpListener::bind(("127.0.0.1", port));
+        assert!(second_bind.is_err(), "port must be occupied while the MCP server is enabled");
+    }
+
+    #[tokio::test]
+    async fn disable_frees_the_port_and_status_reflects_it() {
+        let state = AppState::new();
+        unlock(&state);
+        let port = free_port();
+
+        set_enabled_impl(&state, true, Some(port)).await.unwrap();
+        let status = set_enabled_impl(&state, false, None).await.unwrap();
+        assert!(!status.enabled);
+
+        // stop_if_running awaits the task's completion, so the port must be
+        // bindable again immediately — no retry/sleep needed.
+        let rebound = std::net::TcpListener::bind(("127.0.0.1", port));
+        assert!(rebound.is_ok(), "port must be free again once disabled");
+    }
+
+    #[tokio::test]
+    async fn vault_lock_hook_stops_the_server() {
+        let state = AppState::new();
+        unlock(&state);
+        let port = free_port();
+
+        set_enabled_impl(&state, true, Some(port)).await.unwrap();
+
+        // Mirrors the `vault_lock` command: clear the key, then stop.
+        *state.vault_key.lock().unwrap() = None;
+        stop_if_running(&state).await.unwrap();
+
+        let status = get_status_impl(&state).unwrap();
+        assert!(!status.enabled);
+        let rebound = std::net::TcpListener::bind(("127.0.0.1", port));
+        assert!(rebound.is_ok(), "the vault-lock hook must free the port");
+    }
+
+    #[tokio::test]
+    async fn regenerate_token_changes_the_token() {
+        let state = AppState::new();
+        unlock(&state);
+        let status = set_enabled_impl(&state, true, Some(free_port())).await.unwrap();
+        let original = status.token;
+
+        let regenerated = regenerate_token_impl(&state).unwrap();
+        assert_ne!(regenerated.token, original);
+        assert!(regenerated.enabled, "regenerating must not touch enablement");
+
+        // status reflects the new token too, not just the regenerate call's return value.
+        assert_eq!(get_status_impl(&state).unwrap().token, regenerated.token);
+    }
+
+    #[tokio::test]
+    async fn regenerate_token_works_while_disabled() {
+        let state = AppState::new();
+        let first = regenerate_token_impl(&state).unwrap();
+        assert!(!first.token.is_empty());
+        let second = regenerate_token_impl(&state).unwrap();
+        assert_ne!(first.token, second.token);
+        assert!(!second.enabled);
+    }
+
+    #[tokio::test]
+    async fn enable_on_occupied_port_fails_and_leaves_state_disabled() {
+        let state = AppState::new();
+        unlock(&state);
+        let port = free_port();
+        // Occupy the port ourselves first so the bind inside set_enabled_impl fails.
+        let _occupier = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+
+        let err = set_enabled_impl(&state, true, Some(port)).await.unwrap_err();
+        assert!(err.contains(&port.to_string()), "error should mention the port: {err}");
+
+        let status = get_status_impl(&state).unwrap();
+        assert!(!status.enabled);
+        assert!(status.token.is_empty(), "a failed enable must not mint a token either");
+    }
+
+    #[tokio::test]
+    async fn enable_on_occupied_port_leaves_a_previously_running_server_untouched() {
+        let state = AppState::new();
+        unlock(&state);
+        let good_port = free_port();
+        set_enabled_impl(&state, true, Some(good_port)).await.unwrap();
+
+        let occupied_port = free_port();
+        let _occupier = std::net::TcpListener::bind(("127.0.0.1", occupied_port)).unwrap();
+        let err = set_enabled_impl(&state, true, Some(occupied_port)).await.unwrap_err();
+        assert!(err.contains(&occupied_port.to_string()));
+
+        // The original server on good_port must still be running.
+        let status = get_status_impl(&state).unwrap();
+        assert!(status.enabled);
+        assert_eq!(status.port, good_port);
+        let rebind_good = std::net::TcpListener::bind(("127.0.0.1", good_port));
+        assert!(rebind_good.is_err(), "the previously-running server must still hold its port");
+    }
+
+    #[tokio::test]
+    async fn disable_when_never_enabled_is_a_harmless_noop() {
+        let state = AppState::new();
+        let status = set_enabled_impl(&state, false, None).await.unwrap();
+        assert!(!status.enabled);
+    }
+
+    #[test]
+    fn log_call_caps_at_max_entries() {
+        let state = AppState::new();
+        for i in 0..(MAX_LOG_ENTRIES + 5) {
+            log_call(&state, "ping", None, format!("call {i}"), true).unwrap();
+        }
+        let status = get_status_impl(&state).unwrap();
+        assert_eq!(status.log.len(), MAX_LOG_ENTRIES);
+        // Oldest entries were evicted; the newest survives.
+        assert_eq!(status.log.last().unwrap().summary, format!("call {}", MAX_LOG_ENTRIES + 4));
+    }
+}

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -40,6 +40,7 @@ use crate::state::{AppState, LockExt};
 use base64::Engine as _;
 use rand::Rng;
 use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{ServerCapabilities, ServerInfo};
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
@@ -48,6 +49,7 @@ use serde::Serialize;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tauri::Manager;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 
@@ -106,6 +108,13 @@ pub struct McpControl {
     pub token: String,
     pub log: VecDeque<McpLogEntry>,
     pub server: Option<ServerHandle>,
+    /// Connection ids opened by *this* MCP server session's `connect` tool
+    /// (#98 Task 4) — cleared only by `disconnect` (never by disable/re-
+    /// enable, since a live connection outlives a settings toggle). The
+    /// `disconnect` tool only ever accepts an id in this set: an agent may
+    /// disconnect what it connected, never a connection a human opened by
+    /// hand, even if that connection's profile happens to be opted in.
+    pub session_connections: std::collections::HashSet<String>,
 }
 
 impl McpControl {
@@ -116,6 +125,7 @@ impl McpControl {
             token: String::new(),
             log: VecDeque::new(),
             server: None,
+            session_connections: std::collections::HashSet::new(),
         }
     }
 }
@@ -297,10 +307,13 @@ struct McpServer {
     /// `rmcp-2.2.0/tests/test_progress_subscriber.rs`).
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
-    /// Not read by the `ping`-only Task 2 tool surface. Carried now (see
-    /// `set_enabled_impl`'s doc comment) so Task 4's tools can start using
-    /// it without any lifecycle plumbing changes.
-    #[allow(dead_code)]
+    /// `Some` for every server actually spawned by `set_enabled_impl` (see
+    /// its doc comment); `None` only for the bare `McpServer` values the
+    /// golden-snapshot test below builds to introspect `tool_router()`
+    /// without a running server. Every Task 4 tool method resolves both the
+    /// live `AppState` and the encrypted profiles path from this via
+    /// `resolve()` — see its doc comment for the `AppHandle` -> `AppState`
+    /// pattern.
     app_handle: Option<tauri::AppHandle>,
 }
 
@@ -308,6 +321,50 @@ impl McpServer {
     fn new(app_handle: Option<tauri::AppHandle>) -> Self {
         Self { tool_router: Self::tool_router(), app_handle }
     }
+
+    /// Resolves `self.app_handle` into `(AppHandle, encrypted-profiles-path)`
+    /// for the tool methods below, or a clean error when there is none (the
+    /// golden-snapshot test's bare `McpServer`s only — every server actually
+    /// serving requests always has `Some`, since `set_enabled_impl` always
+    /// passes one through). `tauri::Manager::state` then gets the live
+    /// `AppState` back out of `app_handle` without needing a
+    /// `#[tauri::command]`'s `tauri::State` extractor — the same pattern
+    /// `windows.rs`'s `apply_window_closed_and_broadcast` uses.
+    fn resolve(&self) -> Result<(tauri::AppHandle, std::path::PathBuf), String> {
+        let app_handle = self.app_handle.clone().ok_or_else(|| "MCP server misconfigured: no application handle".to_string())?;
+        let path = crate::connections::get_profiles_enc_path(&app_handle);
+        Ok((app_handle, path))
+    }
+}
+
+/// Serialize a successful tool result to JSON text; either way, append a
+/// `log_call` entry (spec: "last 200: timestamp, tool, connection, args
+/// summary ≤200 chars, ok/error") — the shared tail of every read-only data
+/// tool below whose underlying `mcp_tools::*_impl` returns a typed value
+/// that still needs encoding to text content.
+fn finish_json<T: Serialize>(state: &AppState, tool: &str, connection_id: Option<String>, summary: &str, result: Result<T, String>) -> Result<String, String> {
+    let logged_summary = crate::mcp_tools::truncate_summary(summary, 200);
+    match result {
+        Ok(value) => {
+            let json = serde_json::to_string(&value).map_err(|e| format!("serialize result: {e}"))?;
+            let _ = log_call(state, tool, connection_id, logged_summary, true);
+            Ok(json)
+        }
+        Err(e) => {
+            let _ = log_call(state, tool, connection_id, logged_summary, false);
+            Err(e)
+        }
+    }
+}
+
+/// Same as `finish_json`, for the handful of tools whose underlying
+/// `mcp_tools::*_impl` already returns a JSON *string* (`explain`,
+/// `schema_analysis`) — passed straight through as tool text rather than
+/// re-encoded (re-serializing an already-JSON string would double-quote it).
+fn finish_text(state: &AppState, tool: &str, connection_id: Option<String>, summary: &str, result: Result<String, String>) -> Result<String, String> {
+    let logged_summary = crate::mcp_tools::truncate_summary(summary, 200);
+    let _ = log_call(state, tool, connection_id, logged_summary, result.is_ok());
+    result
 }
 
 #[tool_router]
@@ -319,6 +376,162 @@ impl McpServer {
     )]
     async fn ping(&self) -> String {
         format!("pong {}", env!("CARGO_PKG_VERSION"))
+    }
+
+    // ---- Task 4: read tools -------------------------------------------
+
+    #[tool(
+        description = "List MongoDB connection profiles opted in to MCP access (Settings → Connection Manager → \"Expose to MCP agents\"). Returns id/name/colorTag only — never a connection string. Call this before `connect`."
+    )]
+    async fn list_profiles(&self) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let result = crate::mcp_tools::list_profiles_impl(&state, &path);
+        finish_json(&state, "list_profiles", None, "", result)
+    }
+
+    #[tool(
+        description = "List currently live MongoDB connections whose profile is opted in to MCP access. Use a returned id with `find`/`aggregate`/etc, or `connect` a not-yet-connected opted-in profile first."
+    )]
+    async fn list_connections(&self) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let result = crate::mcp_tools::list_connections_impl(&state, &path);
+        finish_json(&state, "list_connections", None, "", result)
+    }
+
+    #[tool(
+        description = "Open a live connection to an MCP-opted-in profile (by id, from `list_profiles`). Returns {\"connectionId\": \"...\"} for use with every other data tool. Every window's sidebar shows this connection with a \"via MCP\" badge."
+    )]
+    async fn connect(&self, Parameters(args): Parameters<crate::mcp_tools::ConnectArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let summary = crate::mcp_tools::truncate_summary(&format!("profileId={}", args.profile_id), 200);
+        match crate::mcp_tools::connect_impl(&state, &path, &args.profile_id).await {
+            Ok(connection_id) => {
+                // Broadcast the new connection to every window's sidebar —
+                // same `connections-changed` payload the `disconnect_db`/
+                // `set_connection_meta` command wrappers build (lib.rs).
+                if let Ok(connections) = crate::connection_list_impl(&state) {
+                    use tauri::Emitter;
+                    let _ = app_handle.emit("connections-changed", crate::ConnectionsChangedPayload { connections });
+                }
+                let _ = log_call(&state, "connect", Some(connection_id.clone()), summary, true);
+                serde_json::to_string(&serde_json::json!({ "connectionId": connection_id })).map_err(|e| format!("serialize result: {e}"))
+            }
+            Err(e) => {
+                let _ = log_call(&state, "connect", None, summary, false);
+                Err(e)
+            }
+        }
+    }
+
+    #[tool(
+        description = "Close a connection previously opened by this MCP session's `connect` call. Cannot disconnect a connection a human opened via the app UI, even if its profile is opted in."
+    )]
+    async fn disconnect(&self, Parameters(args): Parameters<crate::mcp_tools::ConnectionIdArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let _ = &path; // disconnect needs no profile lookup; kept for a uniform `resolve()` call site.
+        let state = app_handle.state::<AppState>();
+        let summary = crate::mcp_tools::truncate_summary(&format!("connectionId={}", args.connection_id), 200);
+        match crate::mcp_tools::disconnect_impl(&state, &args.connection_id).await {
+            Ok(()) => {
+                if let Ok(connections) = crate::connection_list_impl(&state) {
+                    use tauri::Emitter;
+                    let _ = app_handle.emit("connections-changed", crate::ConnectionsChangedPayload { connections });
+                }
+                let _ = log_call(&state, "disconnect", Some(args.connection_id.clone()), summary, true);
+                Ok(serde_json::json!({ "disconnected": args.connection_id }).to_string())
+            }
+            Err(e) => {
+                let _ = log_call(&state, "disconnect", Some(args.connection_id.clone()), summary, false);
+                Err(e)
+            }
+        }
+    }
+
+    #[tool(description = "List database names visible on a connection.")]
+    async fn list_databases(&self, Parameters(args): Parameters<crate::mcp_tools::ConnectionIdArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let summary = crate::mcp_tools::truncate_summary(&format!("connectionId={}", args.connection_id), 200);
+        let result = crate::mcp_tools::list_databases_tool_impl(&state, &path, &args.connection_id).await;
+        finish_json(&state, "list_databases", Some(args.connection_id), &summary, result)
+    }
+
+    #[tool(description = "List collections (and their type: collection/view/timeseries) in a database.")]
+    async fn list_collections(&self, Parameters(args): Parameters<crate::mcp_tools::DatabaseArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let summary = crate::mcp_tools::truncate_summary(&format!("connectionId={} database={}", args.connection_id, args.database), 200);
+        let result = crate::mcp_tools::list_collections_tool_impl(&state, &path, &args.connection_id, &args.database).await;
+        finish_json(&state, "list_collections", Some(args.connection_id), &summary, result)
+    }
+
+    #[tool(
+        description = "Run a MongoDB find query. Returns {\"documents\": [...relaxed EJSON...], \"count\"?, \"truncated\"?}. Results are capped (default 50 docs / 1MB; `limit` also caps at 200) — a non-null `truncated` means narrow the filter or lower `limit`."
+    )]
+    async fn find(&self, Parameters(args): Parameters<crate::mcp_tools::FindArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let connection_id = args.connection_id.clone();
+        let summary = crate::mcp_tools::truncate_summary(
+            &format!("connectionId={connection_id} {}.{} filter={}", args.database, args.collection, args.filter.as_deref().unwrap_or("{}")),
+            200,
+        );
+        let result = crate::mcp_tools::find_impl(&state, &path, args).await;
+        finish_json(&state, "find", Some(connection_id), &summary, result)
+    }
+
+    #[tool(
+        description = "Run a MongoDB aggregation pipeline. Returns {\"documents\": [...relaxed EJSON...], \"truncated\"?}. Real connections only (not the demo/mock data). Stages whose sole key is $out or $merge are rejected — MCP is read-only for aggregation."
+    )]
+    async fn aggregate(&self, Parameters(args): Parameters<crate::mcp_tools::AggregateArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let connection_id = args.connection_id.clone();
+        let summary = crate::mcp_tools::truncate_summary(
+            &format!("connectionId={connection_id} {}.{} stages={}", args.database, args.collection, args.pipeline.len()),
+            200,
+        );
+        let result = crate::mcp_tools::aggregate_impl(&state, &path, args).await;
+        finish_json(&state, "aggregate", Some(connection_id), &summary, result)
+    }
+
+    #[tool(
+        description = "Explain a find filter or an aggregation pipeline (executionStats verbosity). Pass `pipeline` for an aggregate-style explain (real connections only) or `findFilter` for a find-style explain."
+    )]
+    async fn explain(&self, Parameters(args): Parameters<crate::mcp_tools::ExplainArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let connection_id = args.connection_id.clone();
+        let summary = crate::mcp_tools::truncate_summary(&format!("connectionId={connection_id} {}.{}", args.database, args.collection), 200);
+        let result = crate::mcp_tools::explain_impl(&state, &path, args).await;
+        finish_text(&state, "explain", Some(connection_id), &summary, result)
+    }
+
+    #[tool(
+        description = "Infer a collection's schema by sampling documents: per-field types, presence/coverage, and low-cardinality enum values. `sampleSize` defaults to 100, hard cap 1000."
+    )]
+    async fn schema_analysis(&self, Parameters(args): Parameters<crate::mcp_tools::SchemaAnalysisArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let connection_id = args.connection_id.clone();
+        let summary = crate::mcp_tools::truncate_summary(&format!("connectionId={connection_id} {}.{}", args.database, args.collection), 200);
+        let result = crate::mcp_tools::schema_analysis_impl(&state, &path, args).await;
+        finish_text(&state, "schema_analysis", Some(connection_id), &summary, result)
+    }
+
+    #[tool(
+        description = "List a collection's indexes merged with usage stats (size, ops since last restart) where available. Mock/demo connections report indexes with no stats."
+    )]
+    async fn list_indexes(&self, Parameters(args): Parameters<crate::mcp_tools::CollectionArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let summary =
+            crate::mcp_tools::truncate_summary(&format!("connectionId={} {}.{}", args.connection_id, args.database, args.collection), 200);
+        let result = crate::mcp_tools::list_indexes_tool_impl(&state, &path, &args.connection_id, &args.database, &args.collection).await;
+        finish_json(&state, "list_indexes", Some(args.connection_id.clone()), &summary, result)
     }
 }
 
@@ -672,8 +885,14 @@ mod tests {
         stop_if_running(&state).await.unwrap();
     }
 
+    /// Task 2 originally asserted `ping` was the *only* tool served; Task 4
+    /// grew the registry to twelve (see `tool_router_exposes_all_eleven_tools`
+    /// and the golden-fixture test below for the full-surface assertions),
+    /// so this now just proves `ping` itself is still served correctly —
+    /// name, description, and a no-args schema — over the real HTTP
+    /// transport, independent of how many other tools sit alongside it.
     #[tokio::test]
-    async fn tools_list_contains_exactly_ping() {
+    async fn tools_list_contains_ping() {
         let state = AppState::new();
         unlock(&state);
         let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
@@ -682,11 +901,10 @@ mod tests {
         client.initialize().await;
         let list = client.call(2, "tools/list", json!({})).await;
         let tools = list["result"]["tools"].as_array().expect("tools/list must return an array");
-        assert_eq!(tools.len(), 1, "expected exactly one tool, got: {tools:?}");
-        assert_eq!(tools[0]["name"], "ping");
-        assert!(tools[0]["description"].as_str().unwrap_or_default().contains("pong"));
+        let ping = tools.iter().find(|t| t["name"] == "ping").unwrap_or_else(|| panic!("no `ping` tool in tools/list: {tools:?}"));
+        assert!(ping["description"].as_str().unwrap_or_default().contains("pong"));
         // No-args tool: an empty (or property-less) object input schema.
-        let schema = &tools[0]["inputSchema"];
+        let schema = &ping["inputSchema"];
         assert_eq!(schema["type"], "object");
         let no_required_props = schema.get("required").map(|r| r.as_array().map(|a| a.is_empty()).unwrap_or(true)).unwrap_or(true);
         assert!(no_required_props, "ping takes no args, schema was: {schema:?}");
@@ -801,5 +1019,98 @@ mod tests {
         // And per Task 1's original assertion: the port must be free again.
         let rebound = std::net::TcpListener::bind(("127.0.0.1", port));
         assert!(rebound.is_ok(), "port must be free again once the graceful stop completes");
+    }
+
+    // ---- Task 4: read-tool registry ------------------------------------
+
+    /// Golden snapshot of `tools/list` (name/description/inputSchema, sorted
+    /// by name) — the documented-tool-list acceptance criterion's source of
+    /// truth (Global Constraints). Derived straight from
+    /// `McpServer::tool_router()` (the same `#[tool_router]`-generated table
+    /// the running server serves — no separate hand-maintained registry to
+    /// drift from it), so this needs no live server/port at all, unlike the
+    /// protocol tests above.
+    ///
+    /// `Tool` already `#[serde(rename_all = "camelCase")]`s with
+    /// `skip_serializing_if = "Option::is_none"` on every field this
+    /// registry never sets (title/outputSchema/annotations/execution/icons/
+    /// meta), so serializing the whole `Tool` list reduces to exactly
+    /// name/description/inputSchema today — and would visibly grow the
+    /// fixture (an intentional, reviewable diff) the day a tool gains one of
+    /// those.
+    #[test]
+    fn tools_list_matches_golden_fixture() {
+        let mut tools = McpServer::tool_router().list_all();
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
+        let actual = serde_json::to_string_pretty(&tools).expect("Tool list must serialize") + "\n";
+
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../fixtures/mcp-tools-golden.json");
+        if std::env::var("MCP_GOLDEN_UPDATE").is_ok() {
+            std::fs::write(path, &actual).expect("failed to write golden fixture");
+            return;
+        }
+        let expected = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("failed to read golden fixture at {path}: {e} — run with MCP_GOLDEN_UPDATE=1 to create it"));
+        assert_eq!(
+            actual, expected,
+            "tools/list drifted from fixtures/mcp-tools-golden.json (names/descriptions/schemas) — \
+             if this is an intentional tool-surface change, review the diff and regenerate with: \
+             `MCP_GOLDEN_UPDATE=1 cargo test -p tauri-app --lib mcp::tests::tools_list_matches_golden_fixture -- --exact`"
+        );
+    }
+
+    #[test]
+    fn tool_router_exposes_all_twelve_tools() {
+        let names: std::collections::HashSet<String> = McpServer::tool_router().list_all().into_iter().map(|t| t.name.to_string()).collect();
+        for expected in [
+            "ping",
+            "list_profiles",
+            "list_connections",
+            "connect",
+            "disconnect",
+            "list_databases",
+            "list_collections",
+            "find",
+            "aggregate",
+            "explain",
+            "schema_analysis",
+            "list_indexes",
+        ] {
+            assert!(names.contains(expected), "tool_router is missing `{expected}`; got {names:?}");
+        }
+        assert_eq!(names.len(), 12, "unexpected tool count — update this list (and the golden fixture) alongside any registry change");
+    }
+
+    /// One end-to-end pass over the real HTTP transport (mirrors
+    /// `ping_call_returns_pong_and_version` above) proving a Task 4 tool
+    /// round-trips through the whole stack — auth, JSON-RPC, `Parameters<T>`
+    /// deserialization, and back — over a mock connection (no real MongoDB
+    /// needed; see `mcp_tools.rs`'s own tests for exhaustive per-tool
+    /// coverage at the impl layer, which is where the bulk of Task 4's
+    /// behavior is actually proven).
+    #[tokio::test]
+    async fn find_tool_round_trips_over_http_against_a_mock_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+
+        let mut client = TestClient::new(status.port, &status.token);
+        client.initialize().await;
+
+        // `McpServer` has no `AppHandle` in this test (see `TestClient`'s
+        // `set_enabled_impl(..., None)` above) — every Task 4 tool needs one
+        // to resolve `AppState`/the profiles path, so every call must fail
+        // the same clean way rather than panicking the server task.
+        let result = client
+            .call(2, "tools/call", json!({"name": "list_profiles", "arguments": {}}))
+            .await;
+        let content = &result["result"]["content"][0]["text"];
+        assert!(
+            content.as_str().unwrap_or_default().contains("no application handle"),
+            "expected the AppHandle-less error, got: {result:?}"
+        );
+        assert_eq!(result["result"]["isError"], true);
+
+        stop_if_running(&state).await.unwrap();
     }
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -533,6 +533,71 @@ impl McpServer {
         let result = crate::mcp_tools::list_indexes_tool_impl(&state, &path, &args.connection_id, &args.database, &args.collection).await;
         finish_json(&state, "list_indexes", Some(args.connection_id.clone()), &summary, result)
     }
+
+    // ---- Task 5: write tools, gated on _confirm ------------------------
+
+    #[tool(
+        description = "Insert one document. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be inserted (the namespace and a summary of the document) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have."
+    )]
+    async fn insert_one(&self, Parameters(args): Parameters<crate::mcp_tools::InsertOneArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let connection_id = args.connection_id.clone();
+        let summary =
+            crate::mcp_tools::truncate_summary(&crate::mcp_tools::insert_one_summary(&args.database, &args.collection, &args.document, args._confirm), 200);
+        let result = crate::mcp_tools::insert_one_impl(&state, &path, args).await;
+        finish_json(&state, "insert_one", Some(connection_id), &summary, result)
+    }
+
+    #[tool(
+        description = "Update every document matching `filter` using operators (e.g. {\"$set\": {...}}) — bare replacement documents are rejected. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be modified (the namespace, the filter, and the update) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have."
+    )]
+    async fn update_many(&self, Parameters(args): Parameters<crate::mcp_tools::UpdateManyArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let connection_id = args.connection_id.clone();
+        let summary = crate::mcp_tools::truncate_summary(
+            &crate::mcp_tools::update_many_summary(&args.database, &args.collection, &args.filter, &args.update, args._confirm),
+            200,
+        );
+        let result = crate::mcp_tools::update_many_tool_impl(&state, &path, args).await;
+        finish_json(&state, "update_many", Some(connection_id), &summary, result)
+    }
+
+    #[tool(
+        description = "Delete every document matching `filter`. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be deleted (the namespace and the filter) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have."
+    )]
+    async fn delete_many(&self, Parameters(args): Parameters<crate::mcp_tools::DeleteManyArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let connection_id = args.connection_id.clone();
+        let summary = crate::mcp_tools::truncate_summary(&crate::mcp_tools::delete_many_summary(&args.database, &args.collection, &args.filter, args._confirm), 200);
+        let result = crate::mcp_tools::delete_many_tool_impl(&state, &path, args).await;
+        finish_json(&state, "delete_many", Some(connection_id), &summary, result)
+    }
+
+    #[tool(
+        description = "Create an index. `name` defaults to MongoDB's own naming convention (each key's field_direction joined by `_`, e.g. `email_1`) when omitted. DESTRUCTIVE — requires `_confirm: true`. Before calling with `_confirm: true`, restate to the user exactly what will be created (the namespace and the key spec) and get their go-ahead. Without `_confirm: true` the call is rejected with an error telling you to do that; call again with `_confirm: true` once you have."
+    )]
+    async fn create_index(&self, Parameters(args): Parameters<crate::mcp_tools::CreateIndexArgs>) -> Result<String, String> {
+        let (app_handle, path) = self.resolve()?;
+        let state = app_handle.state::<AppState>();
+        let connection_id = args.connection_id.clone();
+        let summary = crate::mcp_tools::truncate_summary(
+            &crate::mcp_tools::create_index_summary(
+                &args.database,
+                &args.collection,
+                &args.keys,
+                args.name.as_deref(),
+                args.unique.unwrap_or(false),
+                args.sparse.unwrap_or(false),
+                args._confirm,
+            ),
+            200,
+        );
+        let result = crate::mcp_tools::create_index_tool_impl(&state, &path, args).await;
+        finish_json(&state, "create_index", Some(connection_id), &summary, result)
+    }
 }
 
 #[tool_handler]
@@ -1060,7 +1125,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_router_exposes_all_twelve_tools() {
+    fn tool_router_exposes_all_sixteen_tools() {
         let names: std::collections::HashSet<String> = McpServer::tool_router().list_all().into_iter().map(|t| t.name.to_string()).collect();
         for expected in [
             "ping",
@@ -1075,10 +1140,62 @@ mod tests {
             "explain",
             "schema_analysis",
             "list_indexes",
+            "insert_one",
+            "update_many",
+            "delete_many",
+            "create_index",
         ] {
             assert!(names.contains(expected), "tool_router is missing `{expected}`; got {names:?}");
         }
-        assert_eq!(names.len(), 12, "unexpected tool count — update this list (and the golden fixture) alongside any registry change");
+        assert_eq!(names.len(), 16, "unexpected tool count — update this list (and the golden fixture) alongside any registry change");
+    }
+
+    // ---- Task 5: write-tool round trip ------------------------------------
+
+    /// One end-to-end pass over the real HTTP transport proving a Task 5
+    /// write tool round-trips through the whole stack — auth, JSON-RPC,
+    /// `Parameters<T>` deserialization of a `_confirm: bool` field alongside
+    /// a `filter` JSON-object field, and back — mirroring
+    /// `find_tool_round_trips_over_http_against_a_mock_connection` above.
+    /// This `McpServer` has no `AppHandle` (same as that test), so every
+    /// tool call fails the same clean "no application handle" way rather
+    /// than panicking the server task — this is what actually gets proven
+    /// here; the exhaustive `_confirm`-gate ordering and per-tool mock-path
+    /// coverage lives in `mcp_tools.rs`'s own tests, which call the `_impl`
+    /// functions directly with a real `AppState`.
+    #[tokio::test]
+    async fn delete_many_tool_round_trips_over_http() {
+        let state = AppState::new();
+        unlock(&state);
+        let status = set_enabled_impl(&state, true, Some(free_port()), None).await.unwrap();
+
+        let mut client = TestClient::new(status.port, &status.token);
+        client.initialize().await;
+
+        let result = client
+            .call(
+                2,
+                "tools/call",
+                json!({
+                    "name": "delete_many",
+                    "arguments": {
+                        "connection_id": "whatever",
+                        "database": "d",
+                        "collection": "c",
+                        "filter": {},
+                        "_confirm": false
+                    }
+                }),
+            )
+            .await;
+        let content = &result["result"]["content"][0]["text"];
+        assert!(
+            content.as_str().unwrap_or_default().contains("no application handle"),
+            "expected the AppHandle-less error, got: {result:?}"
+        );
+        assert_eq!(result["result"]["isError"], true);
+
+        stop_if_running(&state).await.unwrap();
     }
 
     /// One end-to-end pass over the real HTTP transport (mirrors

--- a/src-tauri/src/mcp_tools.rs
+++ b/src-tauri/src/mcp_tools.rs
@@ -518,6 +518,246 @@ pub async fn schema_analysis_impl(state: &AppState, profiles_path: &Path, args: 
 }
 
 // ---------------------------------------------------------------------------
+// Write tools (#98 Task 5) — insert_one / update_many / delete_many / create_index
+// ---------------------------------------------------------------------------
+
+/// The `_confirm` gate's exact rejection message, identical across every
+/// destructive tool (`insert_one`, `update_many`, `delete_many`,
+/// `create_index`) — an agent can pattern-match on it once rather than per
+/// tool.
+const CONFIRM_REQUIRED: &str = "Destructive operation blocked: call again with _confirm: true after restating exactly what will be modified.";
+
+/// Shared `_confirm` gate for every destructive tool. Every write-tool impl
+/// below calls this *after* `require_mcp_connection` — authorization (does
+/// this connection/profile exist and remain opted in?) must be resolved
+/// before confirmation, so a non-opted connection id always gets the
+/// uniform `CONNECTION_NOT_FOUND` even when `_confirm` is false, never a
+/// hint that the operation would otherwise have proceeded.
+///
+/// `op_desc` names the calling tool for readers of this function and is
+/// asserted non-empty in debug builds; it is deliberately NOT interpolated
+/// into the returned message — every rejection must be byte-for-byte the
+/// same string regardless of which tool or operation triggered it.
+fn require_confirm(confirm: bool, op_desc: &str) -> Result<(), String> {
+    debug_assert!(!op_desc.trim().is_empty(), "op_desc should name the calling tool/operation");
+    if confirm {
+        Ok(())
+    } else {
+        Err(CONFIRM_REQUIRED.to_string())
+    }
+}
+
+/// Byte length of `value` once serialized to JSON — the building block for
+/// call-log summaries that mention *size* without ever including
+/// document/filter contents (spec: "NEVER document/filter contents beyond
+/// the 200-char truncation").
+fn json_byte_len(value: &serde_json::Value) -> usize {
+    serde_json::to_string(value).map(|s| s.len()).unwrap_or(0)
+}
+
+/// Best-effort: embed `s` as parsed JSON if it happens to already be valid
+/// JSON text (every real-connection id string from `insert_document_impl`
+/// is — it's built via `Bson::into_relaxed_extjson().to_string()`), else
+/// fall back to embedding it as a JSON string literal (the mock path's
+/// literal `"mock-inserted-id"` is not itself valid JSON text — it has no
+/// surrounding quotes). Keeps `insert_one`'s result valid JSON either way
+/// without re-implementing `insert_document_impl`'s id-rendering.
+fn embed_json_or_string(s: String) -> serde_json::Value {
+    serde_json::from_str(&s).unwrap_or(serde_json::Value::String(s))
+}
+
+/// `insert_one` args.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct InsertOneArgs {
+    /// Id returned by `connect` or `list_connections`.
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+    /// The document to insert, as a JSON object.
+    pub document: serde_json::Value,
+    /// Must be `true`. Before setting this, restate to the user exactly
+    /// what will be inserted (the namespace and a summary of the document)
+    /// and get their go-ahead — the call is rejected until then.
+    pub _confirm: bool,
+}
+
+/// `insert_one` result envelope.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct InsertOneResult {
+    pub inserted_id: serde_json::Value,
+}
+
+/// Call-log summary for `insert_one` — namespace + document size, never the
+/// document's actual contents.
+pub fn insert_one_summary(database: &str, collection: &str, document: &serde_json::Value, confirmed: bool) -> String {
+    format!("{database}.{collection} insert_one document_bytes={} confirmed={confirmed}", json_byte_len(document))
+}
+
+pub async fn insert_one_impl(state: &AppState, profiles_path: &Path, args: InsertOneArgs) -> Result<InsertOneResult, String> {
+    require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    require_confirm(args._confirm, "insert_one")?;
+    let document_json = serde_json::to_string(&args.document).map_err(|e| format!("serialize document: {e}"))?;
+    let inserted_id = crate::insert_document_impl(state, &args.connection_id, &args.database, &args.collection, &document_json).await?;
+    Ok(InsertOneResult { inserted_id: embed_json_or_string(inserted_id) })
+}
+
+/// `update_many` args.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct UpdateManyArgs {
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+    /// MQL filter selecting documents to update, as a JSON object.
+    pub filter: serde_json::Value,
+    /// Update document using operators (e.g. `{"$set": {"field": "value"}}`).
+    /// Bare replacement documents are rejected.
+    pub update: serde_json::Value,
+    /// Must be `true`; see `insert_one`'s `_confirm` doc.
+    pub _confirm: bool,
+}
+
+/// `update_many` result envelope. `matched_count` isn't available: the
+/// underlying `update_many_impl` seam (`db/documents.rs`) only returns
+/// `modified_count` — this tool consumes that seam verbatim rather than
+/// duplicating the driver call to recover the matched count too.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateManyResult {
+    pub modified_count: u64,
+}
+
+pub fn update_many_summary(database: &str, collection: &str, filter: &serde_json::Value, update: &serde_json::Value, confirmed: bool) -> String {
+    format!(
+        "{database}.{collection} update_many filter_bytes={} update_bytes={} confirmed={confirmed}",
+        json_byte_len(filter),
+        json_byte_len(update)
+    )
+}
+
+pub async fn update_many_tool_impl(state: &AppState, profiles_path: &Path, args: UpdateManyArgs) -> Result<UpdateManyResult, String> {
+    require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    require_confirm(args._confirm, "update_many")?;
+    let filter_json = serde_json::to_string(&args.filter).map_err(|e| format!("serialize filter: {e}"))?;
+    let update_json = serde_json::to_string(&args.update).map_err(|e| format!("serialize update: {e}"))?;
+    let modified_count = crate::update_many_impl(state, &args.connection_id, &args.database, &args.collection, &filter_json, &update_json).await?;
+    Ok(UpdateManyResult { modified_count })
+}
+
+/// `delete_many` args.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct DeleteManyArgs {
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+    /// MQL filter selecting documents to delete, as a JSON object.
+    pub filter: serde_json::Value,
+    /// Must be `true`; see `insert_one`'s `_confirm` doc.
+    pub _confirm: bool,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteManyResult {
+    pub deleted_count: u64,
+}
+
+pub fn delete_many_summary(database: &str, collection: &str, filter: &serde_json::Value, confirmed: bool) -> String {
+    format!("{database}.{collection} delete_many filter_bytes={} confirmed={confirmed}", json_byte_len(filter))
+}
+
+pub async fn delete_many_tool_impl(state: &AppState, profiles_path: &Path, args: DeleteManyArgs) -> Result<DeleteManyResult, String> {
+    require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    require_confirm(args._confirm, "delete_many")?;
+    let filter_json = serde_json::to_string(&args.filter).map_err(|e| format!("serialize filter: {e}"))?;
+    let deleted_count = crate::delete_many_impl(state, &args.connection_id, &args.database, &args.collection, &filter_json).await?;
+    Ok(DeleteManyResult { deleted_count })
+}
+
+/// `create_index` args.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct CreateIndexArgs {
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+    /// Index key spec as a JSON object, e.g. `{"email": 1}` or
+    /// `{"a": 1, "b": -1}`.
+    pub keys: serde_json::Value,
+    /// Index name. Defaults to MongoDB's own naming convention (each key's
+    /// `field_direction` joined by `_`, e.g. `email_1`) when omitted.
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub unique: Option<bool>,
+    #[serde(default)]
+    pub sparse: Option<bool>,
+    /// Must be `true`; see `insert_one`'s `_confirm` doc.
+    pub _confirm: bool,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateIndexResult {
+    pub name: String,
+}
+
+pub fn create_index_summary(
+    database: &str,
+    collection: &str,
+    keys: &serde_json::Value,
+    name: Option<&str>,
+    unique: bool,
+    sparse: bool,
+    confirmed: bool,
+) -> String {
+    format!(
+        "{database}.{collection} create_index keys_bytes={} name={} unique={unique} sparse={sparse} confirmed={confirmed}",
+        json_byte_len(keys),
+        name.unwrap_or("<default>")
+    )
+}
+
+/// One key's `dir` rendered the way it'd appear in a MongoDB-style default
+/// index name: numbers print bare (`1`, `-1`), strings print unquoted
+/// (`text`, `2dsphere`), anything else falls back to its JSON rendering.
+fn index_dir_token(dir: &serde_json::Value) -> String {
+    match dir {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// MongoDB's own default index-name convention: each key's `field_dir`
+/// joined by `_` (e.g. `{"a":1,"b":-1}` -> `"a_1_b_-1"`) — mirrors the
+/// frontend's `defaultIndexName` (`IndexModal.tsx`) closely enough for an
+/// agent-facing default. `keys` must already be a non-empty JSON object;
+/// `create_index_impl` itself would reject anything else once it tries to
+/// convert `keys` to a BSON document, so failing the same way here (before
+/// even reaching the impl) just fails a little earlier when there's no name
+/// to fall back to.
+fn default_index_name(keys: &serde_json::Value) -> Result<String, String> {
+    let obj = keys.as_object().ok_or_else(|| "`keys` must be a JSON object, e.g. {\"field\": 1}".to_string())?;
+    if obj.is_empty() {
+        return Err("`keys` must have at least one field".to_string());
+    }
+    Ok(obj.iter().map(|(field, dir)| format!("{field}_{}", index_dir_token(dir))).collect::<Vec<_>>().join("_"))
+}
+
+pub async fn create_index_tool_impl(state: &AppState, profiles_path: &Path, args: CreateIndexArgs) -> Result<CreateIndexResult, String> {
+    require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    require_confirm(args._confirm, "create_index")?;
+    let name = match args.name {
+        Some(n) if !n.trim().is_empty() => n,
+        _ => default_index_name(&args.keys)?,
+    };
+    let keys_json = serde_json::to_string(&args.keys).map_err(|e| format!("serialize keys: {e}"))?;
+    crate::create_index_impl(state, &args.connection_id, &args.database, &args.collection, &name, &keys_json, args.unique.unwrap_or(false), args.sparse.unwrap_or(false))
+        .await?;
+    Ok(CreateIndexResult { name })
+}
+
+// ---------------------------------------------------------------------------
 // Call-log summaries
 // ---------------------------------------------------------------------------
 
@@ -992,5 +1232,360 @@ mod tests {
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert!(v.get("sampled").is_some());
+    }
+
+    // ---- Task 5: write tools + _confirm gate -----------------------------
+
+    #[test]
+    fn require_confirm_rejects_with_the_exact_message() {
+        let err = require_confirm(false, "insert_one").unwrap_err();
+        assert_eq!(err, "Destructive operation blocked: call again with _confirm: true after restating exactly what will be modified.");
+        assert!(require_confirm(true, "insert_one").is_ok());
+    }
+
+    #[test]
+    fn default_index_name_matches_mongo_convention() {
+        assert_eq!(default_index_name(&serde_json::json!({"email": 1})).unwrap(), "email_1");
+        assert_eq!(default_index_name(&serde_json::json!({"a": 1, "b": -1})).unwrap(), "a_1_b_-1");
+        assert_eq!(default_index_name(&serde_json::json!({"loc": "2dsphere"})).unwrap(), "loc_2dsphere");
+        assert!(default_index_name(&serde_json::json!([1, 2])).is_err());
+        assert!(default_index_name(&serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn write_tool_summaries_never_embed_document_or_filter_contents() {
+        let secret_doc = serde_json::json!({"ssn": "123-45-6789", "salary": 999999});
+        let s = insert_one_summary("db", "coll", &secret_doc, true);
+        assert!(!s.contains("123-45-6789") && !s.contains("999999"), "summary leaked document contents: {s}");
+        assert_eq!(s, "db.coll insert_one document_bytes=37 confirmed=true");
+
+        let filter = serde_json::json!({"password": "hunter2"});
+        let update = serde_json::json!({"$set": {"password": "new-secret"}});
+        let s = update_many_summary("db", "coll", &filter, &update, false);
+        assert!(!s.contains("hunter2") && !s.contains("new-secret"));
+        assert!(s.starts_with("db.coll update_many filter_bytes=") && s.contains("confirmed=false"));
+
+        let s = delete_many_summary("db", "coll", &filter, true);
+        assert!(!s.contains("hunter2"));
+        assert!(s.starts_with("db.coll delete_many filter_bytes=") && s.contains("confirmed=true"));
+
+        let keys = serde_json::json!({"email": 1});
+        let s = create_index_summary("db", "coll", &keys, Some("email_1"), true, false, true);
+        assert_eq!(s, "db.coll create_index keys_bytes=11 name=email_1 unique=true sparse=false confirmed=true");
+        let s_default = create_index_summary("db", "coll", &keys, None, false, false, false);
+        assert!(s_default.contains("name=<default>"));
+    }
+
+    // ---- insert_one --------------------------------------------------
+
+    #[tokio::test]
+    async fn insert_one_without_confirm_is_rejected_and_does_not_call_the_impl() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("insert-one-no-confirm.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let err = insert_one_impl(
+            &state,
+            &path,
+            InsertOneArgs { connection_id: id, database: "sales_db".into(), collection: "customers".into(), document: serde_json::json!({"name": "Eve"}), _confirm: false },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONFIRM_REQUIRED);
+        // No signal the impl ran beyond the error itself is observable on a
+        // mock connection (mock inserts don't persist either way) — the gate
+        // returning before `insert_document_impl` is called is what this
+        // test actually proves via the exact error text above.
+    }
+
+    #[tokio::test]
+    async fn insert_one_with_confirm_succeeds_on_mock_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("insert-one-confirm.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let result = insert_one_impl(
+            &state,
+            &path,
+            InsertOneArgs { connection_id: id, database: "sales_db".into(), collection: "customers".into(), document: serde_json::json!({"name": "Eve"}), _confirm: true },
+        )
+        .await
+        .unwrap();
+        // Mock path returns `insert_document_impl`'s literal mock id.
+        assert_eq!(result.inserted_id, serde_json::Value::String("mock-inserted-id".to_string()));
+    }
+
+    #[tokio::test]
+    async fn insert_one_rejects_a_non_opted_connection_before_the_confirm_gate() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("insert-one-guard.enc");
+        write_profiles(&path, &[]);
+        // _confirm: false too — authorization must win regardless, never a
+        // hint that the op would proceed if only _confirm were true.
+        let err = insert_one_impl(
+            &state,
+            &path,
+            InsertOneArgs { connection_id: "nope".into(), database: "d".into(), collection: "c".into(), document: serde_json::json!({}), _confirm: false },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONNECTION_NOT_FOUND, "authorization must be checked before the confirm gate");
+    }
+
+    // ---- update_many ---------------------------------------------------
+
+    #[tokio::test]
+    async fn update_many_without_confirm_is_rejected() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("update-many-no-confirm.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let err = update_many_tool_impl(
+            &state,
+            &path,
+            UpdateManyArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "customers".into(),
+                filter: serde_json::json!({"tier": "gold"}),
+                update: serde_json::json!({"$set": {"tier": "platinum"}}),
+                _confirm: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONFIRM_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn update_many_with_confirm_no_ops_cleanly_on_mock_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("update-many-confirm.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let result = update_many_tool_impl(
+            &state,
+            &path,
+            UpdateManyArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "customers".into(),
+                filter: serde_json::json!({"tier": "gold"}),
+                update: serde_json::json!({"$set": {"tier": "platinum"}}),
+                _confirm: true,
+            },
+        )
+        .await
+        .unwrap();
+        // `update_many_impl`'s documented mock behavior: no-op, modified_count 0.
+        assert_eq!(result.modified_count, 0);
+    }
+
+    #[tokio::test]
+    async fn update_many_rejects_a_non_opted_connection_with_confirm_false() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("update-many-guard.enc");
+        write_profiles(&path, &[]);
+        let err = update_many_tool_impl(
+            &state,
+            &path,
+            UpdateManyArgs {
+                connection_id: "nope".into(),
+                database: "d".into(),
+                collection: "c".into(),
+                filter: serde_json::json!({}),
+                update: serde_json::json!({"$set": {"a": 1}}),
+                _confirm: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONNECTION_NOT_FOUND);
+    }
+
+    // ---- delete_many ---------------------------------------------------
+
+    #[tokio::test]
+    async fn delete_many_without_confirm_is_rejected() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("delete-many-no-confirm.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let err = delete_many_tool_impl(
+            &state,
+            &path,
+            DeleteManyArgs { connection_id: id, database: "sales_db".into(), collection: "customers".into(), filter: serde_json::json!({"tier": "X"}), _confirm: false },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONFIRM_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn delete_many_with_confirm_no_ops_cleanly_on_mock_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("delete-many-confirm.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let result = delete_many_tool_impl(
+            &state,
+            &path,
+            DeleteManyArgs { connection_id: id, database: "sales_db".into(), collection: "customers".into(), filter: serde_json::json!({"tier": "X"}), _confirm: true },
+        )
+        .await
+        .unwrap();
+        // `delete_many_impl`'s documented mock behavior: no-op, deleted_count 0.
+        assert_eq!(result.deleted_count, 0);
+    }
+
+    #[tokio::test]
+    async fn delete_many_rejects_a_non_opted_connection_with_confirm_false() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("delete-many-guard.enc");
+        write_profiles(&path, &[]);
+        let err = delete_many_tool_impl(
+            &state,
+            &path,
+            DeleteManyArgs { connection_id: "nope".into(), database: "d".into(), collection: "c".into(), filter: serde_json::json!({}), _confirm: false },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONNECTION_NOT_FOUND);
+    }
+
+    // ---- create_index ----------------------------------------------------
+
+    #[tokio::test]
+    async fn create_index_without_confirm_is_rejected() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("create-index-no-confirm.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let err = create_index_tool_impl(
+            &state,
+            &path,
+            CreateIndexArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "customers".into(),
+                keys: serde_json::json!({"email": 1}),
+                name: None,
+                unique: None,
+                sparse: None,
+                _confirm: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONFIRM_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn create_index_with_confirm_succeeds_on_mock_connection_and_defaults_the_name() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("create-index-confirm.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        // `sales_db.customers`'s mock demo data already ships default
+        // indexes named `_id_`/`email_1`/`tier_1` (see `mock_db::get_mock_indexes`);
+        // `create_index_impl`'s mock branch is a by-name no-op, so this test
+        // uses a field with no pre-existing default index to actually
+        // exercise the create path (not silently no-op against a same-named
+        // default).
+        let result = create_index_tool_impl(
+            &state,
+            &path,
+            CreateIndexArgs {
+                connection_id: id.clone(),
+                database: "sales_db".into(),
+                collection: "customers".into(),
+                keys: serde_json::json!({"loyaltyPoints": 1}),
+                name: None,
+                unique: Some(true),
+                sparse: None,
+                _confirm: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.name, "loyaltyPoints_1");
+
+        // The mock path's `create_index_impl` actually records the index —
+        // verify it shows up via the read-side seam already covered by
+        // Task 4's tests, proving this tool really called through rather
+        // than short-circuiting.
+        let indexes = list_indexes_tool_impl(&state, &path, &id, "sales_db", "customers").await.unwrap();
+        assert!(indexes.iter().any(|i| i.name == "loyaltyPoints_1" && i.unique), "expected the newly created index to appear: {indexes:?}");
+    }
+
+    #[tokio::test]
+    async fn create_index_honors_an_explicit_name() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("create-index-explicit-name.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let result = create_index_tool_impl(
+            &state,
+            &path,
+            CreateIndexArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "customers".into(),
+                keys: serde_json::json!({"email": 1}),
+                name: Some("by_email".into()),
+                unique: None,
+                sparse: None,
+                _confirm: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.name, "by_email");
+    }
+
+    #[tokio::test]
+    async fn create_index_rejects_a_non_opted_connection_with_confirm_false() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("create-index-guard.enc");
+        write_profiles(&path, &[]);
+        let err = create_index_tool_impl(
+            &state,
+            &path,
+            CreateIndexArgs {
+                connection_id: "nope".into(),
+                database: "d".into(),
+                collection: "c".into(),
+                keys: serde_json::json!({"a": 1}),
+                name: None,
+                unique: None,
+                sparse: None,
+                _confirm: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONNECTION_NOT_FOUND);
     }
 }

--- a/src-tauri/src/mcp_tools.rs
+++ b/src-tauri/src/mcp_tools.rs
@@ -1,0 +1,996 @@
+//! MCP read-tool handlers (#98 Task 4).
+//!
+//! `mcp.rs` stays protocol/lifecycle-only: every `#[tool]` method on
+//! `McpServer` is a thin wrapper that resolves an `AppState`/profiles path
+//! and immediately delegates to a plain function in this module. Every
+//! function here takes `(state: &AppState, ...)` and, for anything that
+//! needs profile data, a plain `&std::path::Path` for the encrypted
+//! profiles file — the same `workspace::get_impl`/`workspace::apply_impl`
+//! idiom used throughout this codebase (see `workspace.rs`'s "Store
+//! commands" doc comment): `_impl` functions are testable with a temp-dir
+//! path and no live `AppHandle`, and the real path is resolved once, by the
+//! `#[tool]` method, via `connections::get_profiles_enc_path(app_handle)`
+//! (itself obtained from `McpServer.app_handle`, and the live `AppState`
+//! from `app_handle.state::<AppState>()` — see `windows.rs`'s
+//! `apply_window_closed_and_broadcast` for the same "resolve `AppState` from
+//! an `AppHandle` outside of a `#[tauri::command]`" pattern).
+//!
+//! **EJSON format note:** every document-shaped seam this module calls
+//! (`execute_mql_query_impl`, `execute_aggregate_impl`, `analyze_schema_impl`,
+//! `explain_mql_query_impl`, `explain_aggregate_query_impl`) already
+//! produces *relaxed* MongoDB Extended JSON — the `mongodb::bson::Document`
+//! -> `serde_json::Value` conversion in `db/query.rs`/`db/aggregate.rs`
+//! (`serde_json::to_value(&doc)`) goes through `bson` 2.x's `Serialize`
+//! impl, which emits `$oid`/`$date`/`$numberLong`/etc. wrappers rather than
+//! bson-crate-internal representations. This module never re-encodes that —
+//! `find`/`aggregate` re-parse each already-relaxed-EJSON document string
+//! back into a `serde_json::Value` purely to embed it (unescaped) inside a
+//! JSON envelope (`{"documents": [...], ...}`), not to change its encoding.
+//! `explain`/`schema_analysis` pass the underlying impl's JSON string
+//! straight through as the tool's text content.
+
+use crate::state::{ConnectionEntry, LockExt};
+use crate::{AppState, CollectionInfo};
+// `rmcp::schemars` re-exports the `schemars` crate (server feature); the
+// `JsonSchema` derive macro's generated code refers to the crate by its bare
+// name (`schemars::...`), so it must be nameable at this module's root, not
+// just its `JsonSchema` trait imported — `rmcp` deliberately doesn't
+// re-export it as `schemars` from its own crate root for this to "just
+// work" without this explicit `use`.
+use rmcp::schemars;
+use rmcp::schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::Path;
+
+/// `connection not found` — the single uniform error for every "this
+/// connection/profile isn't visible to MCP" case (unknown id, live
+/// connection whose profile isn't opted in, disconnect of a
+/// non-session-owned id). Never differs by reason: an agent must not be
+/// able to distinguish "no such connection" from "that connection exists
+/// but its profile opted out" (spec: "Non-opted profiles: uniform 'not
+/// found' — no existence leak").
+const CONNECTION_NOT_FOUND: &str = "connection not found";
+
+/// `profile not found` — `connect`'s uniform error for an unknown or
+/// non-opted-in profile id, same rationale as `CONNECTION_NOT_FOUND`.
+const PROFILE_NOT_FOUND: &str = "profile not found";
+
+/// `find`/`aggregate` output caps (Global Constraints: "result caps default
+/// 50 docs / 1 MB with explicit truncation markers") — the safety net on
+/// what's actually returned to the agent, independent of `find`'s own MQL
+/// `limit` (below), in case individual documents are large.
+pub const CAP_MAX_DOCS: usize = 50;
+pub const CAP_MAX_BYTES: usize = 1_000_000;
+
+/// `find`'s MQL `limit` bounds (plan: "limit 50 (cap 200)") — how many
+/// documents are *requested* from MongoDB, distinct from `CAP_MAX_DOCS`
+/// above (what's returned after capping).
+const DEFAULT_FIND_LIMIT: i64 = 50;
+const MAX_FIND_LIMIT: i64 = 200;
+
+/// `schema_analysis`'s sample-size default (plan: "sample_size default 100
+/// cap 1000") — `analyze_schema_impl` already enforces the cap via
+/// `limits::normalize_schema_sample`; this is just the MCP-layer default
+/// when the arg is omitted.
+const DEFAULT_SCHEMA_SAMPLE: i64 = 100;
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: result capping
+// ---------------------------------------------------------------------------
+
+/// Cap `docs` to at most `max_docs` entries and `max_bytes` total (summed
+/// UTF-8 byte length) — the spec's "result caps ... with explicit
+/// truncation markers". The first document is always kept even if it alone
+/// exceeds `max_bytes`, so a byte-tight cap never turns a non-empty result
+/// into an empty one. Returns the capped documents plus `Some` truncation
+/// note iff anything was actually dropped.
+pub fn cap_results(docs: Vec<String>, max_docs: usize, max_bytes: usize) -> (Vec<String>, Option<String>) {
+    let total = docs.len();
+    let mut out = Vec::new();
+    let mut bytes = 0usize;
+    for doc in docs {
+        if out.len() >= max_docs {
+            break;
+        }
+        let len = doc.len();
+        if !out.is_empty() && bytes + len > max_bytes {
+            break;
+        }
+        bytes += len;
+        out.push(doc);
+    }
+    let truncated = if out.len() < total {
+        Some(format!(
+            "truncated to {} of {} document{} ({} bytes) — narrow the filter or lower `limit`/`sampleSize` to see more",
+            out.len(),
+            total,
+            if total == 1 { "" } else { "s" },
+            bytes
+        ))
+    } else {
+        None
+    };
+    (out, truncated)
+}
+
+/// Re-parse each already-relaxed-EJSON document string back into a
+/// `serde_json::Value` so it can be embedded (unescaped) in a JSON envelope
+/// — see the module doc comment's EJSON note. Failure here would mean an
+/// `_impl` seam produced non-JSON output, which never happens in practice
+/// (every seam builds its strings via `serde_json::to_string`), but the
+/// `Result` keeps this an explicit error instead of a panic.
+fn parse_ejson_docs(docs: Vec<String>) -> Result<Vec<serde_json::Value>, String> {
+    docs.into_iter()
+        .map(|d| serde_json::from_str(&d).map_err(|e| format!("internal error: query result was not valid JSON: {e}")))
+        .collect()
+}
+
+/// `cap_results` + `parse_ejson_docs` composed — the shared tail of `find`/
+/// `aggregate`. Split out (rather than inlined) so the capping-then-parsing
+/// wiring is unit-testable with tiny caps, independent of how much data a
+/// mock/real connection happens to have available (the bundled mock demo
+/// data has far fewer rows than `CAP_MAX_DOCS`, so exercising real
+/// truncation end-to-end through `find_impl` isn't possible without a real
+/// cluster — see this module's tests for the direct coverage instead).
+fn cap_and_parse(docs: Vec<String>, max_docs: usize, max_bytes: usize) -> Result<(Vec<serde_json::Value>, Option<String>), String> {
+    let (capped, truncated) = cap_results(docs, max_docs, max_bytes);
+    Ok((parse_ejson_docs(capped)?, truncated))
+}
+
+// ---------------------------------------------------------------------------
+// Profiles / connections
+// ---------------------------------------------------------------------------
+
+/// `list_profiles` result element — id/name/color only. Deliberately has no
+/// `uri`/`ssh` field at all (not just omitted at the call site): a
+/// connection string can never leave via this struct even if a future edit
+/// forgets to filter it out, matching `ConnectionMeta`/`ConnectionEntry`'s
+/// own "no uri field to leak" guarantee (see `state.rs`).
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileSummary {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_tag: Option<String>,
+}
+
+/// `list_profiles` — every MCP-opted-in profile, id/name/color only.
+pub fn list_profiles_impl(state: &AppState, profiles_path: &Path) -> Result<Vec<ProfileSummary>, String> {
+    let key = state.require_key()?;
+    let profiles = crate::connections::load_profiles_encrypted(profiles_path, &key)?;
+    Ok(profiles
+        .into_iter()
+        .filter(|p| p.mcp_enabled)
+        .map(|p| ProfileSummary { id: p.id, name: p.name, color_tag: p.color_tag })
+        .collect())
+}
+
+/// `list_connections` — live connections whose profile is *currently*
+/// opted in. Live-checked against the profiles file on every call (not
+/// cached at connect time): un-opting a profile hides its connections here
+/// immediately, even though the underlying `connect_db` session is
+/// untouched — same live-check `require_mcp_connection` uses for the data
+/// tools.
+pub fn list_connections_impl(state: &AppState, profiles_path: &Path) -> Result<Vec<ConnectionEntry>, String> {
+    let key = state.require_key()?;
+    let profiles = crate::connections::load_profiles_encrypted(profiles_path, &key)?;
+    let opted_in: HashSet<String> = profiles.into_iter().filter(|p| p.mcp_enabled).map(|p| p.id).collect();
+    let all = crate::connection_list_impl(state)?;
+    Ok(all.into_iter().filter(|c| opted_in.contains(&c.profile_id)).collect())
+}
+
+/// `connect` tool args.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct ConnectArgs {
+    /// Id of an MCP-opted-in profile, as returned by `list_profiles`.
+    pub profile_id: String,
+}
+
+/// `connect` — opens a real `connect_db` session for an opted-in profile
+/// and records it as this MCP session's, so `disconnect` can later close
+/// exactly this connection (and no other). The caller (`McpServer::connect`
+/// in `mcp.rs`) is responsible for the `connections-changed` broadcast
+/// after this returns `Ok` — that needs an `AppHandle`, which this
+/// `AppHandle`-free function deliberately doesn't take (same split as
+/// `connect_db_impl`/`disconnect_db_impl` themselves).
+pub async fn connect_impl(state: &AppState, profiles_path: &Path, profile_id: &str) -> Result<String, String> {
+    let key = state.require_key()?;
+    let profiles = crate::connections::load_profiles_encrypted(profiles_path, &key)?;
+    let profile = profiles
+        .into_iter()
+        .find(|p| p.id == profile_id && p.mcp_enabled)
+        .ok_or_else(|| PROFILE_NOT_FOUND.to_string())?;
+
+    let connection_id = crate::connect_db_impl(state, &profile.uri, profile.ssh.as_ref()).await?;
+    crate::set_connection_meta_impl(state, &connection_id, &profile.id, &profile.name, true)?;
+    state.mcp.lock_safe()?.session_connections.insert(connection_id.clone());
+    Ok(connection_id)
+}
+
+/// `disconnect` — only ever accepts an id this MCP session's own `connect`
+/// opened (`McpControl.session_connections`), never a connection a human
+/// opened by hand, even one belonging to an opted-in profile. The caller is
+/// responsible for the `connections-changed` broadcast, same split as
+/// `connect_impl`.
+pub async fn disconnect_impl(state: &AppState, connection_id: &str) -> Result<(), String> {
+    let is_session_owned = state.mcp.lock_safe()?.session_connections.contains(connection_id);
+    if !is_session_owned {
+        return Err(CONNECTION_NOT_FOUND.to_string());
+    }
+    crate::disconnect_db_impl(state, connection_id).await?;
+    state.mcp.lock_safe()?.session_connections.remove(connection_id);
+    Ok(())
+}
+
+/// Shared existence + opt-in guard for every data tool (`list_databases`
+/// through `list_indexes`): `connection_id` must both be live (present in
+/// `AppState.connection_meta`) and trace back to a currently-opted-in
+/// profile. Both failure modes collapse to `CONNECTION_NOT_FOUND` — see its
+/// doc comment.
+pub fn require_mcp_connection(state: &AppState, profiles_path: &Path, connection_id: &str) -> Result<(), String> {
+    let key = state.require_key()?;
+    let profile_id = {
+        let meta = state.connection_meta.lock_safe()?;
+        meta.get(connection_id).map(|m| m.profile_id.clone())
+    };
+    let profile_id = profile_id.ok_or_else(|| CONNECTION_NOT_FOUND.to_string())?;
+    let profiles = crate::connections::load_profiles_encrypted(profiles_path, &key)?;
+    if profiles.iter().any(|p| p.id == profile_id && p.mcp_enabled) {
+        Ok(())
+    } else {
+        Err(CONNECTION_NOT_FOUND.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+/// `list_databases` args.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct ConnectionIdArgs {
+    /// Id returned by `connect` or `list_connections`.
+    pub connection_id: String,
+}
+
+pub async fn list_databases_tool_impl(state: &AppState, profiles_path: &Path, connection_id: &str) -> Result<Vec<String>, String> {
+    require_mcp_connection(state, profiles_path, connection_id)?;
+    crate::list_databases_impl(state, connection_id).await
+}
+
+/// `list_collections` args.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct DatabaseArgs {
+    pub connection_id: String,
+    pub database: String,
+}
+
+pub async fn list_collections_tool_impl(state: &AppState, profiles_path: &Path, connection_id: &str, database: &str) -> Result<Vec<CollectionInfo>, String> {
+    require_mcp_connection(state, profiles_path, connection_id)?;
+    crate::list_collections_impl(state, connection_id, database).await
+}
+
+/// `list_indexes`/`schema_analysis` args shape (also reused as the base for
+/// `find`/`aggregate`/`explain`, which add their own fields below).
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct CollectionArgs {
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+}
+
+/// One index merged with its usage stats (`list_indexes`). `size_bytes`/
+/// `ops` are `None` for mock connections (no storage engine to report
+/// sizes/usage from) and whenever `$indexStats`/`$collStats` fails on a
+/// real one (views, very old servers) — `index_stats_impl` already degrades
+/// gracefully rather than erroring for those cases.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexWithStats {
+    pub name: String,
+    pub keys: String,
+    pub unique: bool,
+    pub sparse: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ops: Option<i64>,
+}
+
+pub async fn list_indexes_tool_impl(
+    state: &AppState,
+    profiles_path: &Path,
+    connection_id: &str,
+    database: &str,
+    collection: &str,
+) -> Result<Vec<IndexWithStats>, String> {
+    require_mcp_connection(state, profiles_path, connection_id)?;
+    let indexes = crate::list_indexes_impl(state, connection_id, database, collection).await?;
+    let is_mock = crate::connection_is_mock(state, connection_id)?;
+    // Real-only (plan: "stats optional — real-only"); mock connections
+    // report indexes with no stats rather than erroring.
+    let stats = if is_mock { None } else { crate::index_stats_impl(state, connection_id, database, collection).await.ok() };
+    Ok(indexes
+        .into_iter()
+        .map(|idx| {
+            let stat = stats.as_ref().and_then(|s| s.iter().find(|st| st.name == idx.name));
+            IndexWithStats {
+                name: idx.name,
+                keys: idx.keys,
+                unique: idx.unique,
+                sparse: idx.sparse,
+                size_bytes: stat.map(|s| s.size_bytes),
+                ops: stat.map(|s| s.ops),
+            }
+        })
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// find / aggregate / explain / schema_analysis
+// ---------------------------------------------------------------------------
+
+/// `find` args.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct FindArgs {
+    /// Id returned by `connect` or `list_connections`.
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+    /// MQL filter as a JSON object string, e.g. `{"status":"active"}`. Omit for "match all".
+    #[serde(default)]
+    pub filter: Option<String>,
+    /// MQL sort as a JSON object string, e.g. `{"createdAt":-1}`.
+    #[serde(default)]
+    pub sort: Option<String>,
+    /// MQL projection as a JSON object string, e.g. `{"name":1,"_id":0}`.
+    #[serde(default)]
+    pub projection: Option<String>,
+    /// Max documents to fetch from MongoDB. Default 50, hard cap 200. The
+    /// response may be truncated further by the output size cap.
+    #[serde(default)]
+    pub limit: Option<i64>,
+    /// Documents to skip before returning results. Default 0.
+    #[serde(default)]
+    pub skip: Option<i64>,
+    /// Also return a total matching-document count (costs an extra query).
+    #[serde(default)]
+    pub include_count: Option<bool>,
+}
+
+/// `find` result envelope.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FindResult {
+    pub documents: Vec<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<String>,
+}
+
+/// `""`/whitespace-only -> `"{}"`; anything else passed through as-is —
+/// shared by `find`/`explain`'s optional filter/sort/projection args, all
+/// of which mean "empty object" the same way.
+fn non_empty_or_empty_object(s: Option<String>) -> String {
+    s.filter(|s| !s.trim().is_empty()).unwrap_or_else(|| "{}".to_string())
+}
+
+pub async fn find_impl(state: &AppState, profiles_path: &Path, args: FindArgs) -> Result<FindResult, String> {
+    require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    let filter = non_empty_or_empty_object(args.filter);
+    let sort = non_empty_or_empty_object(args.sort);
+    let projection = non_empty_or_empty_object(args.projection);
+    let limit = normalize_find_limit(args.limit);
+    let skip = args.skip.unwrap_or(0).max(0);
+
+    let docs =
+        crate::execute_mql_query_impl(state, &args.connection_id, &args.database, &args.collection, &filter, &sort, &projection, limit, skip).await?;
+    let (documents, truncated) = cap_and_parse(docs, CAP_MAX_DOCS, CAP_MAX_BYTES)?;
+
+    let count = if args.include_count.unwrap_or(false) {
+        Some(crate::count_documents_impl(state, &args.connection_id, &args.database, &args.collection, &filter).await?)
+    } else {
+        None
+    };
+
+    Ok(FindResult { documents, count, truncated })
+}
+
+/// Default 50, hard cap 200 (plan: "limit 50 (cap 200)"); a non-positive
+/// request falls back to the default rather than being clamped to 1, same
+/// shape as `limits::normalize_query_limit`. Pulled out as a pure function
+/// so the exact boundary behavior is unit-testable without a connection.
+fn normalize_find_limit(requested: Option<i64>) -> i64 {
+    let requested = requested.unwrap_or(DEFAULT_FIND_LIMIT);
+    if requested <= 0 {
+        DEFAULT_FIND_LIMIT
+    } else {
+        requested.min(MAX_FIND_LIMIT)
+    }
+}
+
+/// `aggregate` args. `pipeline` is a JSON array of stage objects in the
+/// schema (not a pre-serialized string) — schemars gives agents a real
+/// array-of-objects shape to fill in; this module serializes it back to a
+/// string once, for the existing `execute_aggregate_impl(..., pipeline:
+/// &str)` seam.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct AggregateArgs {
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+    /// Aggregation pipeline as an array of stage objects, e.g.
+    /// `[{"$match": {"status": "active"}}, {"$limit": 10}]`. Stages whose
+    /// sole key is `$out` or `$merge` are rejected.
+    pub pipeline: Vec<serde_json::Value>,
+}
+
+/// `aggregate` result envelope.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AggregateResult {
+    pub documents: Vec<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<String>,
+}
+
+/// True iff `stage` is a JSON object whose *sole* top-level key is `$out`
+/// or `$merge`. Deliberately shallow: a `$lookup` sub-pipeline (or any
+/// other nested structure) that happens to carry the string `"$merge"` as a
+/// VALUE — not as its own single top-level key — must not false-positive.
+/// A multi-key object that happens to include `$out`/`$merge` alongside
+/// another key isn't a valid single-stage form anyway and is left for the
+/// driver/server to reject on its own terms.
+fn stage_is_disallowed(stage: &serde_json::Value) -> bool {
+    stage
+        .as_object()
+        .map(|obj| obj.len() == 1 && obj.keys().next().map(|k| k == "$out" || k == "$merge").unwrap_or(false))
+        .unwrap_or(false)
+}
+
+pub async fn aggregate_impl(state: &AppState, profiles_path: &Path, args: AggregateArgs) -> Result<AggregateResult, String> {
+    require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    // Reject $out/$merge before anything else touches the pipeline —
+    // deliberately ahead of the mock-connection check below, so a rejected
+    // pipeline is rejected the same way regardless of connection type.
+    if args.pipeline.iter().any(stage_is_disallowed) {
+        return Err("aggregation stages $out/$merge are not allowed via MCP".to_string());
+    }
+    let pipeline_json = serde_json::to_string(&args.pipeline).map_err(|e| format!("serialize pipeline: {e}"))?;
+    // `execute_aggregate_impl` is real-connection-only and already returns
+    // a clean "not supported on mock connections" error for mocks — no
+    // separate `state.mocks` pre-check needed on top of that.
+    let docs = crate::execute_aggregate_impl(state, &args.connection_id, &args.database, &args.collection, &pipeline_json).await?;
+    let (documents, truncated) = cap_and_parse(docs, CAP_MAX_DOCS, CAP_MAX_BYTES)?;
+    Ok(AggregateResult { documents, truncated })
+}
+
+/// `explain` args — either `find_filter` (find-style explain) or `pipeline`
+/// (aggregate-style explain); `pipeline`, if present, wins.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct ExplainArgs {
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+    /// MQL filter as a JSON object string (find-style explain). Ignored if `pipeline` is set.
+    #[serde(default)]
+    pub find_filter: Option<String>,
+    /// Aggregation pipeline as an array of stage objects (aggregate-style explain).
+    #[serde(default)]
+    pub pipeline: Option<Vec<serde_json::Value>>,
+}
+
+pub async fn explain_impl(state: &AppState, profiles_path: &Path, args: ExplainArgs) -> Result<String, String> {
+    require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    match args.pipeline {
+        Some(pipeline) => {
+            let pipeline_json = serde_json::to_string(&pipeline).map_err(|e| format!("serialize pipeline: {e}"))?;
+            crate::explain_aggregate_query_impl(state, &args.connection_id, &args.database, &args.collection, &pipeline_json).await
+        }
+        None => {
+            let filter = non_empty_or_empty_object(args.find_filter);
+            crate::explain_mql_query_impl(state, &args.connection_id, &args.database, &args.collection, &filter).await
+        }
+    }
+}
+
+/// `schema_analysis` args.
+#[derive(Deserialize, JsonSchema, Debug, Clone)]
+pub struct SchemaAnalysisArgs {
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+    /// Documents to sample. Default 100, hard cap 1000.
+    #[serde(default)]
+    pub sample_size: Option<i64>,
+}
+
+pub async fn schema_analysis_impl(state: &AppState, profiles_path: &Path, args: SchemaAnalysisArgs) -> Result<String, String> {
+    require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    let sample_size = args.sample_size.unwrap_or(DEFAULT_SCHEMA_SAMPLE);
+    // `analyze_schema_impl` -> `limits::normalize_schema_sample` already
+    // floors non-positive values to 100 and caps at 1000; no duplicate
+    // clamping needed here.
+    crate::analyze_schema_impl(state, &args.connection_id, &args.database, &args.collection, sample_size).await
+}
+
+// ---------------------------------------------------------------------------
+// Call-log summaries
+// ---------------------------------------------------------------------------
+
+/// Truncate `s` to at most `max` `char`s (never splitting a UTF-8
+/// boundary), appending `…` when truncated — used to keep every
+/// `mcp::log_call` summary within the spec's "≤200 chars".
+pub fn truncate_summary(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connections::{save_profiles_encrypted, ConnectionProfile};
+    use std::path::PathBuf;
+
+    const TEST_KEY: [u8; 32] = [7u8; 32];
+
+    fn unlock(state: &AppState) {
+        *state.vault_key.lock().unwrap() = Some(TEST_KEY);
+    }
+
+    /// A fresh, unique-per-test path under the OS temp dir — same idiom as
+    /// `workspace.rs`'s `store::tmp_path`.
+    fn tmp_profiles_path(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("mqlens-mcp-tools-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join(name);
+        let _ = std::fs::remove_file(&p);
+        p
+    }
+
+    fn profile(id: &str, name: &str, mcp_enabled: bool) -> ConnectionProfile {
+        ConnectionProfile { id: id.to_string(), name: name.to_string(), uri: "mongodb://mock".to_string(), color_tag: None, ssh: None, mcp_enabled }
+    }
+
+    fn write_profiles(path: &Path, profiles: &[ConnectionProfile]) {
+        save_profiles_encrypted(path, &TEST_KEY, profiles).unwrap();
+    }
+
+    // ---- cap_results / cap_and_parse --------------------------------
+
+    #[test]
+    fn cap_results_keeps_the_first_doc_even_over_the_byte_budget() {
+        let docs = vec!["x".repeat(2000)];
+        let (out, truncated) = cap_results(docs.clone(), 50, 100);
+        assert_eq!(out, docs);
+        assert!(truncated.is_none(), "a single doc alone must never be reported as truncated");
+    }
+
+    #[test]
+    fn cap_results_truncates_by_doc_count() {
+        let docs: Vec<String> = (0..10).map(|i| format!("{{\"i\":{i}}}")).collect();
+        let (out, truncated) = cap_results(docs, 3, 1_000_000);
+        assert_eq!(out.len(), 3);
+        assert!(truncated.unwrap().contains("3 of 10"));
+    }
+
+    #[test]
+    fn cap_results_truncates_by_byte_budget() {
+        let docs: Vec<String> = (0..5).map(|_| "x".repeat(40)).collect(); // 40 bytes each
+        let (out, truncated) = cap_results(docs, 100, 100); // budget fits 2 (80 bytes), not a 3rd (120 > 100)
+        assert_eq!(out.len(), 2);
+        assert!(truncated.is_some());
+    }
+
+    #[test]
+    fn cap_results_no_truncation_note_when_everything_fits() {
+        let docs = vec!["a".to_string(), "b".to_string()];
+        let (out, truncated) = cap_results(docs.clone(), 10, 1000);
+        assert_eq!(out, docs);
+        assert!(truncated.is_none());
+    }
+
+    #[test]
+    fn cap_and_parse_truncates_and_still_parses_the_kept_docs() {
+        let docs = vec!["{\"a\":1}".to_string(), "{\"a\":2}".to_string(), "{\"a\":3}".to_string()];
+        let (values, truncated) = cap_and_parse(docs, 2, 1_000_000).unwrap();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0]["a"], 1);
+        assert!(truncated.is_some());
+    }
+
+    #[test]
+    fn normalize_find_limit_defaults_and_caps() {
+        assert_eq!(normalize_find_limit(None), DEFAULT_FIND_LIMIT);
+        assert_eq!(normalize_find_limit(Some(0)), DEFAULT_FIND_LIMIT);
+        assert_eq!(normalize_find_limit(Some(-5)), DEFAULT_FIND_LIMIT);
+        assert_eq!(normalize_find_limit(Some(75)), 75);
+        assert_eq!(normalize_find_limit(Some(9999)), MAX_FIND_LIMIT);
+    }
+
+    #[test]
+    fn truncate_summary_never_splits_a_utf8_boundary_and_marks_truncation() {
+        assert_eq!(truncate_summary("short", 200), "short");
+        let long = "a".repeat(250);
+        let out = truncate_summary(&long, 200);
+        assert_eq!(out.chars().count(), 200);
+        assert!(out.ends_with('…'));
+    }
+
+    // ---- $out/$merge rejection ---------------------------------------
+
+    #[test]
+    fn stage_is_disallowed_flags_only_exact_single_key_out_or_merge() {
+        assert!(stage_is_disallowed(&serde_json::json!({"$out": "target_coll"})));
+        assert!(stage_is_disallowed(&serde_json::json!({"$merge": {"into": "target_coll"}})));
+        assert!(!stage_is_disallowed(&serde_json::json!({"$match": {"status": "active"}})));
+        // $merge appearing as a VALUE (not the stage's own top-level key)
+        // inside a $lookup sub-pipeline must not false-positive.
+        assert!(!stage_is_disallowed(&serde_json::json!({
+            "$lookup": {"from": "other", "pipeline": [{"$project": {"note": "$merge"}}], "as": "joined"}
+        })));
+        // Multi-key object: not a valid single-stage form either way.
+        assert!(!stage_is_disallowed(&serde_json::json!({"$merge": "x", "extra": 1})));
+    }
+
+    // ---- list_profiles / list_connections ------------------------------
+
+    #[test]
+    fn list_profiles_filters_to_opted_in_only() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("list-profiles.enc");
+        write_profiles(&path, &[profile("p1", "In", true), profile("p2", "Out", false)]);
+
+        let out = list_profiles_impl(&state, &path).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "p1");
+        assert_eq!(out[0].name, "In");
+        // `ProfileSummary` has no `uri` field at all, so there is nothing to
+        // assert here beyond "it compiles" — see the struct's doc comment.
+    }
+
+    #[test]
+    fn list_connections_filters_to_currently_opted_in_profiles_live() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("list-connections.enc");
+        write_profiles(&path, &[profile("p1", "In", true), profile("p2", "Out", false)]);
+
+        crate::set_connection_meta_impl(&state, "c1", "p1", "In Conn", true).unwrap();
+        crate::set_connection_meta_impl(&state, "c2", "p2", "Out Conn", false).unwrap();
+
+        let out = list_connections_impl(&state, &path).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "c1");
+        assert!(out[0].via_mcp);
+    }
+
+    // ---- connect / disconnect ------------------------------------------
+
+    #[tokio::test]
+    async fn connect_only_allows_opted_in_profiles_with_a_uniform_error() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("connect-opt-in.enc");
+        write_profiles(&path, &[profile("p1", "In", true), profile("p2", "Out", false)]);
+
+        assert!(connect_impl(&state, &path, "p1").await.is_ok());
+
+        let not_opted = connect_impl(&state, &path, "p2").await.unwrap_err();
+        let unknown = connect_impl(&state, &path, "does-not-exist").await.unwrap_err();
+        assert_eq!(not_opted, PROFILE_NOT_FOUND);
+        assert_eq!(not_opted, unknown, "non-opted and unknown profile ids must be indistinguishable");
+    }
+
+    #[tokio::test]
+    async fn connect_sets_via_mcp_meta_and_tracks_the_session_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("connect-meta.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let meta = state.connection_meta.lock().unwrap().get(&id).cloned().unwrap();
+        assert!(meta.via_mcp);
+        assert_eq!(meta.profile_id, "p1");
+        assert!(state.mcp.lock().unwrap().session_connections.contains(&id));
+    }
+
+    #[tokio::test]
+    async fn disconnect_only_allows_ids_this_mcp_session_itself_connected() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("disconnect-session.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let mcp_id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        // A human-opened connection to the very same (opted-in) profile —
+        // `disconnect` must still refuse it: it never went through
+        // `connect_impl`, so it's not in `session_connections`.
+        let human_id = crate::connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+        crate::set_connection_meta_impl(&state, &human_id, "p1", "Human", false).unwrap();
+
+        let err = disconnect_impl(&state, &human_id).await.unwrap_err();
+        assert_eq!(err, CONNECTION_NOT_FOUND);
+        assert!(state.connection_meta.lock().unwrap().contains_key(&human_id), "the human connection must be untouched");
+
+        disconnect_impl(&state, &mcp_id).await.unwrap();
+        assert!(state.connection_meta.lock().unwrap().get(&mcp_id).is_none());
+        assert!(!state.mcp.lock().unwrap().session_connections.contains(&mcp_id));
+
+        // Disconnecting the same id twice is now "not found" too (it left
+        // the session set on the first disconnect).
+        let err2 = disconnect_impl(&state, &mcp_id).await.unwrap_err();
+        assert_eq!(err2, CONNECTION_NOT_FOUND);
+    }
+
+    // ---- require_mcp_connection -----------------------------------------
+
+    #[tokio::test]
+    async fn require_mcp_connection_rejects_unknown_and_non_opted_uniformly() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("require-guard.enc");
+        write_profiles(&path, &[profile("p1", "In", true), profile("p2", "Out", false)]);
+
+        let id_in = connect_impl(&state, &path, "p1").await.unwrap();
+        let id_out = crate::connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
+        crate::set_connection_meta_impl(&state, &id_out, "p2", "Out", false).unwrap();
+
+        assert!(require_mcp_connection(&state, &path, &id_in).is_ok());
+        let err_out = require_mcp_connection(&state, &path, &id_out).unwrap_err();
+        let err_unknown = require_mcp_connection(&state, &path, "nope").unwrap_err();
+        assert_eq!(err_out, CONNECTION_NOT_FOUND);
+        assert_eq!(err_out, err_unknown);
+    }
+
+    // ---- list_databases / list_collections / list_indexes ---------------
+
+    #[tokio::test]
+    async fn list_databases_and_collections_over_a_mock_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("list-db-coll.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let dbs = list_databases_tool_impl(&state, &path, &id).await.unwrap();
+        assert!(dbs.contains(&"sales_db".to_string()));
+
+        let colls = list_collections_tool_impl(&state, &path, &id, "sales_db").await.unwrap();
+        assert!(colls.iter().any(|c| c.name == "customers"));
+    }
+
+    #[tokio::test]
+    async fn list_databases_rejects_a_non_opted_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("list-db-guard.enc");
+        write_profiles(&path, &[]);
+        let err = list_databases_tool_impl(&state, &path, "nope").await.unwrap_err();
+        assert_eq!(err, CONNECTION_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn list_indexes_merges_mock_indexes_without_stats() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("list-indexes.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let out = list_indexes_tool_impl(&state, &path, &id, "sales_db", "customers").await.unwrap();
+        assert!(!out.is_empty());
+        assert!(out.iter().all(|i| i.size_bytes.is_none() && i.ops.is_none()), "mock indexes must report no stats");
+    }
+
+    // ---- find / aggregate / explain / schema_analysis --------------------
+
+    #[tokio::test]
+    async fn find_happy_path_over_a_mock_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("find-happy.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let result = find_impl(
+            &state,
+            &path,
+            FindArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "transactions".into(),
+                filter: None,
+                sort: None,
+                projection: None,
+                limit: None,
+                skip: None,
+                include_count: Some(true),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.documents.is_empty());
+        assert_eq!(result.count, Some(result.documents.len() as u64));
+        assert!(result.truncated.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_rejects_a_non_opted_connection_uniformly() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("find-not-found.enc");
+        write_profiles(&path, &[]);
+        let err = find_impl(
+            &state,
+            &path,
+            FindArgs {
+                connection_id: "nope".into(),
+                database: "d".into(),
+                collection: "c".into(),
+                filter: None,
+                sort: None,
+                projection: None,
+                limit: None,
+                skip: None,
+                include_count: None,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONNECTION_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn aggregate_rejects_out_and_merge_stages_before_touching_the_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("aggregate-reject.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap(); // mock connection
+
+        let err = aggregate_impl(
+            &state,
+            &path,
+            AggregateArgs {
+                connection_id: id.clone(),
+                database: "sales_db".into(),
+                collection: "transactions".into(),
+                pipeline: vec![serde_json::json!({"$out": "backup"})],
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, "aggregation stages $out/$merge are not allowed via MCP");
+
+        let err2 = aggregate_impl(
+            &state,
+            &path,
+            AggregateArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "transactions".into(),
+                pipeline: vec![serde_json::json!({"$merge": {"into": "backup"}})],
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err2, "aggregation stages $out/$merge are not allowed via MCP");
+    }
+
+    #[tokio::test]
+    async fn aggregate_allows_a_lookup_stage_carrying_merge_as_a_nested_value() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("aggregate-nested-merge.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap(); // mock connection
+
+        // Mock connections are real-only for aggregate, so this still errors
+        // — but it must be the *mock* error, not the $out/$merge rejection,
+        // proving the nested "$merge" value didn't trip the guard.
+        let err = aggregate_impl(
+            &state,
+            &path,
+            AggregateArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "transactions".into(),
+                pipeline: vec![serde_json::json!({
+                    "$lookup": {"from": "other", "pipeline": [{"$project": {"note": "$merge"}}], "as": "joined"}
+                })],
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("mock"), "expected the mock-connection error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn aggregate_over_a_mock_connection_gives_a_clean_error() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("aggregate-mock.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap(); // mock
+
+        let err = aggregate_impl(
+            &state,
+            &path,
+            AggregateArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "transactions".into(),
+                pipeline: vec![serde_json::json!({"$match": {"status": "Completed"}})],
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("mock"), "expected a clean mock-connection error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn explain_routes_to_find_or_aggregate_explain() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("explain.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap(); // mock
+
+        // find-style explain works over mock connections.
+        let out = explain_impl(
+            &state,
+            &path,
+            ExplainArgs { connection_id: id.clone(), database: "sales_db".into(), collection: "transactions".into(), find_filter: None, pipeline: None },
+        )
+        .await
+        .unwrap();
+        assert!(!out.is_empty());
+
+        // aggregate-style explain is real-only; mock gives a clean error.
+        let err = explain_impl(
+            &state,
+            &path,
+            ExplainArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "transactions".into(),
+                find_filter: None,
+                pipeline: Some(vec![serde_json::json!({"$match": {}})]),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("mock"));
+    }
+
+    #[tokio::test]
+    async fn schema_analysis_over_a_mock_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("schema.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let out = schema_analysis_impl(
+            &state,
+            &path,
+            SchemaAnalysisArgs { connection_id: id, database: "sales_db".into(), collection: "customers".into(), sample_size: Some(5000) },
+        )
+        .await
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(v.get("sampled").is_some());
+    }
+}

--- a/src-tauri/src/mcp_tools.rs
+++ b/src-tauri/src/mcp_tools.rs
@@ -378,6 +378,19 @@ fn non_empty_or_empty_object(s: Option<String>) -> String {
     s.filter(|s| !s.trim().is_empty()).unwrap_or_else(|| "{}".to_string())
 }
 
+/// Call-log summary for `find` — namespace + filter size, never the filter's
+/// actual contents (same policy `insert_one_summary`/`update_many_summary`/
+/// `delete_many_summary`/`create_index_summary` already follow below; `find`
+/// previously built its summary inline in `mcp.rs` by interpolating the raw
+/// filter JSON text straight into the log, which is exactly the leak those
+/// other summaries are careful to avoid). `filter` is already a JSON object
+/// *string* (or absent, meaning "match all") — unlike the write tools' typed
+/// `serde_json::Value` args, so this measures its byte length directly
+/// rather than via `json_byte_len`.
+pub fn find_summary(database: &str, collection: &str, filter: Option<&str>) -> String {
+    format!("{database}.{collection} find filter_bytes={}", filter.unwrap_or("{}").len())
+}
+
 pub async fn find_impl(state: &AppState, profiles_path: &Path, args: FindArgs) -> Result<FindResult, String> {
     require_mcp_connection(state, profiles_path, &args.connection_id)?;
     let filter = non_empty_or_empty_object(args.filter);
@@ -487,6 +500,17 @@ pub async fn explain_impl(state: &AppState, profiles_path: &Path, args: ExplainA
     require_mcp_connection(state, profiles_path, &args.connection_id)?;
     match args.pipeline {
         Some(pipeline) => {
+            // Same write-gate `aggregate_impl` applies, and for the same
+            // reason: `explain` at `executionStats` verbosity actually
+            // EXECUTES the pipeline against the server rather than just
+            // planning it, so a `$merge`/`$out` stage reaching
+            // `explain_aggregate_query_impl` would write data despite this
+            // being nominally a read tool. Checked before the impl is ever
+            // called — same exact error string as `aggregate`, same
+            // ahead-of-mock-check ordering rationale.
+            if pipeline.iter().any(stage_is_disallowed) {
+                return Err("aggregation stages $out/$merge are not allowed via MCP".to_string());
+            }
             let pipeline_json = serde_json::to_string(&pipeline).map_err(|e| format!("serialize pipeline: {e}"))?;
             crate::explain_aggregate_query_impl(state, &args.connection_id, &args.database, &args.collection, &pipeline_json).await
         }
@@ -973,6 +997,32 @@ mod tests {
         assert_eq!(err2, CONNECTION_NOT_FOUND);
     }
 
+    /// A HUMAN disconnecting (Sidebar's `onDisconnect` -> the `disconnect_db`
+    /// command -> `crate::disconnect_db_impl` directly, never going through
+    /// this MCP session's own `disconnect_impl`) an agent-opened connection
+    /// must not leave a stale entry in `McpControl.session_connections`
+    /// (final whole-branch review fix wave) — otherwise that id sits there
+    /// forever even though the connection itself is long gone.
+    #[tokio::test]
+    async fn human_disconnect_of_an_agent_connection_prunes_session_connections() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("disconnect-human-prunes.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let mcp_id = connect_impl(&state, &path, "p1").await.unwrap();
+        assert!(state.mcp.lock().unwrap().session_connections.contains(&mcp_id));
+
+        // The human path: `crate::disconnect_db_impl` directly, exactly what
+        // the `disconnect_db` Tauri command wraps — never `disconnect_impl`
+        // (which requires session ownership) itself.
+        crate::disconnect_db_impl(&state, &mcp_id).await.unwrap();
+
+        assert!(
+            !state.mcp.lock().unwrap().session_connections.contains(&mcp_id),
+            "a human disconnect must prune the id from session_connections, not just tear down the connection"
+        );
+    }
+
     // ---- require_mcp_connection -----------------------------------------
 
     #[tokio::test]
@@ -1215,6 +1265,39 @@ mod tests {
         assert!(err.contains("mock"));
     }
 
+    /// Write-gate hole (final whole-branch review fix wave): `explain` at
+    /// `executionStats` verbosity EXECUTES an aggregate-style pipeline
+    /// against the server rather than merely planning it, so a `$merge`
+    /// pipeline reaching `explain_aggregate_query_impl` would write data
+    /// despite `explain` being nominally a read tool. Proves the same
+    /// denylist `aggregate_impl` uses is applied here too, with the exact
+    /// same error string, and — since this is a *mock* connection, whose
+    /// `explain_aggregate_query_impl` path would otherwise return a "mock"
+    /// error, not the denylist one — that the impl is never reached at all.
+    #[tokio::test]
+    async fn explain_rejects_out_and_merge_stages_before_touching_the_connection() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("explain-reject.enc");
+        write_profiles(&path, &[profile("p1", "In", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap(); // mock
+
+        let err = explain_impl(
+            &state,
+            &path,
+            ExplainArgs {
+                connection_id: id,
+                database: "sales_db".into(),
+                collection: "transactions".into(),
+                find_filter: None,
+                pipeline: Some(vec![serde_json::json!({"$merge": {"into": "backup"}})]),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, "aggregation stages $out/$merge are not allowed via MCP");
+    }
+
     #[tokio::test]
     async fn schema_analysis_over_a_mock_connection() {
         let state = AppState::new();
@@ -1274,6 +1357,16 @@ mod tests {
         assert_eq!(s, "db.coll create_index keys_bytes=11 name=email_1 unique=true sparse=false confirmed=true");
         let s_default = create_index_summary("db", "coll", &keys, None, false, false, false);
         assert!(s_default.contains("name=<default>"));
+
+        // `find` isn't a write/destructive tool, but its call-log summary is
+        // built the same way (`mcp.rs`'s `find` wrapper) and must follow the
+        // same no-content-leak policy — it previously interpolated the raw
+        // filter JSON text directly (final whole-branch review fix wave).
+        let s = find_summary("db", "coll", Some(r#"{"password":"hunter2"}"#));
+        assert!(!s.contains("hunter2"), "find summary leaked filter contents: {s}");
+        assert_eq!(s, "db.coll find filter_bytes=22");
+        let s_none = find_summary("db", "coll", None);
+        assert_eq!(s_none, "db.coll find filter_bytes=2");
     }
 
     // ---- insert_one --------------------------------------------------

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -18,6 +18,14 @@ use std::time::Instant;
 pub struct ConnectionMeta {
     pub profile_id: String,
     pub name: String,
+    /// True iff this connection was opened by the embedded MCP server's
+    /// `connect` tool (#98 Task 4) rather than a human via the sidebar/
+    /// Connection Manager. `#[serde(default)]` keeps this readable against
+    /// nothing on-disk -- `ConnectionMeta` is in-memory only (never
+    /// persisted), but the default matters for any caller that constructs
+    /// one from a partial literal (`..Default::default()`-style).
+    #[serde(default)]
+    pub via_mcp: bool,
 }
 
 /// One entry of the `connections-changed` payload's `connections` list —
@@ -30,6 +38,9 @@ pub struct ConnectionEntry {
     pub id: String,
     pub profile_id: String,
     pub name: String,
+    /// Mirrors `ConnectionMeta::via_mcp` -- surfaced to the frontend so the
+    /// sidebar can badge agent-initiated connections (#98 Task 4).
+    pub via_mcp: bool,
 }
 
 /// The `connections-changed` broadcast payload: the full current connection

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,6 +1,6 @@
 //! Shared application state and a poison-safe mutex helper.
 
-use crate::{ssh_tunnel, workspace, IndexInfo, MongoshSession, TaskInfo};
+use crate::{mcp, ssh_tunnel, workspace, IndexInfo, MongoshSession, TaskInfo};
 use mongodb::Client;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -88,6 +88,13 @@ pub struct AppState {
     /// `disconnect_db`). See `ConnectionMeta`'s doc comment for why this
     /// deliberately never holds a URI.
     pub connection_meta: Mutex<HashMap<String, ConnectionMeta>>,
+    /// Embedded MCP server lifecycle + settings (#98 Task 1): enablement,
+    /// bound port, bearer token, rolling call log, and the live server
+    /// task's handle (`None` when disabled). See `mcp::McpControl` for the
+    /// enable/disable state machine and `mcp::stop_if_running` for the
+    /// `vault_lock`/`vault_reset` teardown hook that guarantees a locked
+    /// vault never leaves the server listening.
+    pub mcp: Mutex<mcp::McpControl>,
 }
 
 impl AppState {
@@ -108,6 +115,7 @@ impl AppState {
             workspace: Mutex::new(None),
             workspace_write_gen: Arc::new(AtomicU64::new(0)),
             connection_meta: Mutex::new(HashMap::new()),
+            mcp: Mutex::new(mcp::McpControl::new()),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -94,7 +94,14 @@ pub struct AppState {
     /// enable/disable state machine and `mcp::stop_if_running` for the
     /// `vault_lock`/`vault_reset` teardown hook that guarantees a locked
     /// vault never leaves the server listening.
-    pub mcp: Mutex<mcp::McpControl>,
+    ///
+    /// `Arc`-wrapped (unlike this struct's other `Mutex` fields) so the
+    /// spawned server task (#98 Task 2) can hold its own clone of the exact
+    /// same lock `AppState` uses — reading the live bearer token at request
+    /// time straight out of the one source of truth, rather than needing a
+    /// full `Arc<AppState>` or a second copy of the token that could drift
+    /// out of sync with a `mcp_regenerate_token` call.
+    pub mcp: Arc<Mutex<mcp::McpControl>>,
 }
 
 impl AppState {
@@ -115,7 +122,7 @@ impl AppState {
             workspace: Mutex::new(None),
             workspace_write_gen: Arc::new(AtomicU64::new(0)),
             connection_meta: Mutex::new(HashMap::new()),
-            mcp: Mutex::new(mcp::McpControl::new()),
+            mcp: Arc::new(Mutex::new(mcp::McpControl::new())),
         }
     }
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3733,7 +3733,7 @@ mod tests {
     #[test]
     fn set_connection_meta_inserts_and_overwrites() {
         let state = AppState::new();
-        set_connection_meta_impl(&state, "conn-1", "profile-a", "Prod Cluster").unwrap();
+        set_connection_meta_impl(&state, "conn-1", "profile-a", "Prod Cluster", false).unwrap();
         {
             let meta = state.connection_meta.lock().unwrap();
             let m = meta.get("conn-1").expect("meta inserted");
@@ -3743,7 +3743,7 @@ mod tests {
 
         // Re-registering the same id (e.g. a reconnect) overwrites in place
         // rather than accumulating a second entry.
-        set_connection_meta_impl(&state, "conn-1", "profile-b", "Renamed").unwrap();
+        set_connection_meta_impl(&state, "conn-1", "profile-b", "Renamed", false).unwrap();
         let meta = state.connection_meta.lock().unwrap();
         assert_eq!(meta.len(), 1, "same id must overwrite, not duplicate");
         let m = meta.get("conn-1").unwrap();
@@ -3758,17 +3758,17 @@ mod tests {
         // only ever expose `profileId`/`name` — this test would fail to
         // compile (not just fail at runtime) the moment a `uri` field is
         // added, since the struct literal below is exhaustive.
-        let meta = crate::ConnectionMeta { profile_id: "p".into(), name: "n".into() };
-        let entry = crate::ConnectionEntry { id: "c".into(), profile_id: meta.profile_id.clone(), name: meta.name.clone() };
+        let meta = crate::ConnectionMeta { profile_id: "p".into(), name: "n".into(), via_mcp: false };
+        let entry = crate::ConnectionEntry { id: "c".into(), profile_id: meta.profile_id.clone(), name: meta.name.clone(), via_mcp: meta.via_mcp };
         assert_eq!(entry.id, "c");
     }
 
     #[test]
     fn connection_list_is_sorted_by_id_regardless_of_insertion_order() {
         let state = AppState::new();
-        set_connection_meta_impl(&state, "conn-c", "p3", "Third").unwrap();
-        set_connection_meta_impl(&state, "conn-a", "p1", "First").unwrap();
-        set_connection_meta_impl(&state, "conn-b", "p2", "Second").unwrap();
+        set_connection_meta_impl(&state, "conn-c", "p3", "Third", false).unwrap();
+        set_connection_meta_impl(&state, "conn-a", "p1", "First", false).unwrap();
+        set_connection_meta_impl(&state, "conn-b", "p2", "Second", false).unwrap();
 
         let list = connection_list_impl(&state).unwrap();
         let ids: Vec<&str> = list.iter().map(|e| e.id.as_str()).collect();
@@ -3792,7 +3792,7 @@ mod tests {
         let conn_id = connect_db_impl(&state, "mongodb://mock", None)
             .await
             .expect("mock connect");
-        set_connection_meta_impl(&state, &conn_id, "profile-a", "Mock Conn").unwrap();
+        set_connection_meta_impl(&state, &conn_id, "profile-a", "Mock Conn", false).unwrap();
         assert!(state.connection_meta.lock().unwrap().contains_key(&conn_id));
 
         disconnect_db_impl(&state, &conn_id)

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2232,6 +2232,7 @@ mod tests {
             uri: "mongodb://mock".to_string(),
             color_tag: None,
             ssh: None,
+            mcp_enabled: false,
         };
 
         // Save profile
@@ -2261,6 +2262,7 @@ mod tests {
                     passphrase: None,
                 },
             }),
+            mcp_enabled: true,
         };
         profiles.push(profile2.clone());
         crate::connections::save_profiles_to_file(&test_file_path, &profiles)
@@ -2287,6 +2289,37 @@ mod tests {
 
         // Clean up temp file
         let _ = std::fs::remove_file(&test_file_path);
+    }
+
+    // #98: mcp_enabled round-trips through plaintext (de)serialization, and old
+    // connections.json files written before the field existed must never opt a
+    // profile into MCP exposure by surprise — they must deserialize as false.
+    #[test]
+    fn test_connection_profile_mcp_enabled_roundtrip_and_legacy_default() {
+        use crate::connections::ConnectionProfile;
+
+        let profile = ConnectionProfile {
+            id: "p1".to_string(),
+            name: "Prod".to_string(),
+            uri: "mongodb://localhost:27017".to_string(),
+            color_tag: None,
+            ssh: None,
+            mcp_enabled: true,
+        };
+        let json = serde_json::to_string(&profile).expect("serialize");
+        let round_tripped: ConnectionProfile = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(round_tripped, profile);
+        assert!(round_tripped.mcp_enabled);
+
+        // A JSON literal predating the field (no "mcp_enabled" key at all).
+        let legacy_json = r#"{
+            "id": "legacy-1",
+            "name": "Legacy DB",
+            "uri": "mongodb://legacy:27017"
+        }"#;
+        let legacy: ConnectionProfile = serde_json::from_str(legacy_json)
+            .expect("old connections.json without mcp_enabled must still deserialize");
+        assert_eq!(legacy.mcp_enabled, false, "legacy profiles must never be opted in by surprise");
     }
 
     #[tokio::test]
@@ -2713,6 +2746,7 @@ mod tests {
             uri: "mongodb://user:secret@host:27017".into(),
             color_tag: None,
             ssh: None,
+            mcp_enabled: false,
         }];
         save_profiles_encrypted(&prof_path, &key, &profiles).unwrap();
         // On-disk bytes must not contain the plaintext password.
@@ -2760,6 +2794,7 @@ mod tests {
             uri: "mongodb://localhost".into(),
             color_tag: None,
             ssh: None,
+            mcp_enabled: false,
         }];
         save_profiles_to_file(&pt_profiles, &profiles).unwrap();
         assert!(pt_profiles.exists());
@@ -2989,6 +3024,7 @@ mod tests {
             uri: "mongodb://localhost".into(),
             color_tag: None,
             ssh: None,
+            mcp_enabled: false,
         }];
         save_profiles_encrypted(&enc_profiles, &old_key, &profiles).unwrap();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -454,6 +454,15 @@ function Workspace() {
   const [isConnectionModalOpen, setIsConnectionModalOpen] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTabId | undefined>();
 
+  // (final fix wave, agent-connection visibility) `viaMcp` entries dedupe by
+  // CONNECTION id only, never by `profileId`: an MCP agent's `connect` to a
+  // profile that already has a live human connection must still get its own
+  // sidebar row (badged "via MCP") rather than being silently dropped —
+  // previously the profileId dedupe below meant a second connection to an
+  // already-connected profile was a live backend connection NO window ever
+  // displayed, since it never made it into `activeConnections` at all. A
+  // non-MCP entry keeps the original profileId dedupe (a human never opens
+  // two simultaneous connections to the same profile from one path).
   const addActiveConnection = (
     id: string,
     name: string,
@@ -462,11 +471,11 @@ function Workspace() {
     color_tag?: string,
     viaMcp?: boolean
   ) => {
-    setActiveConnections((prev) =>
-      prev.some((c) => c.profileId === profileId)
-        ? prev
-        : [...prev, { id, profileId, name, uri, color_tag, viaMcp }]
-    );
+    setActiveConnections((prev) => {
+      if (prev.some((c) => c.id === id)) return prev;
+      if (!viaMcp && prev.some((c) => c.profileId === profileId)) return prev;
+      return [...prev, { id, profileId, name, uri, color_tag, viaMcp }];
+    });
   };
 
   // Shared by every path that can hand a profile its first live connection
@@ -549,9 +558,17 @@ function Workspace() {
   // actively tracked, whether or not this window happens to already have it.
   const applyConnectionsAdditions = (connections: ConnectionEntry[]) => {
     for (const entry of connections) seenProfilesRef.current.add(entry.profileId);
+    const localById = new Map(activeConnectionsRef.current.map((c) => [c.id, c]));
     const localByProfile = new Map(activeConnectionsRef.current.map((c) => [c.profileId, c]));
     for (const entry of connections) {
-      if (localByProfile.has(entry.profileId)) continue;
+      if (localById.has(entry.id)) continue; // already have exactly this connection row
+      // A non-viaMcp entry still dedupes by profileId (unchanged): the
+      // backend never hands out two ids for the same human-facing profile
+      // connection. A viaMcp entry does NOT — see `addActiveConnection`'s
+      // doc comment (final fix wave, agent-connection visibility) — so it
+      // always reaches `addActiveConnection` below, which is itself the
+      // authority on whether this exact row already exists.
+      if (!entry.viaMcp && localByProfile.has(entry.profileId)) continue;
       addActiveConnection(entry.id, entry.name, '', entry.profileId, undefined, entry.viaMcp);
       rebindProfileTabs(entry.profileId, entry.id);
     }
@@ -2509,7 +2526,16 @@ function Workspace() {
 
     own(
       subscribeConnectionsChanged((payload: ConnectionsChangedPayload) => {
-        const liveProfileIds = new Set(payload.connections.map((c) => c.profileId));
+        // Connection-id keyed, NOT profileId keyed (final fix wave,
+        // agent-connection visibility): a profile can now legitimately have
+        // TWO live rows locally — a human connection plus a `viaMcp` one
+        // (see `addActiveConnection`'s doc comment) — so "is this profile
+        // still live" is no longer the same question as "is this SPECIFIC
+        // local connection still live". Keying removal off profileId alone
+        // would mean the agent's row (or the human's) could never be torn
+        // down by a broadcast as long as the OTHER row for the same profile
+        // remained live.
+        const liveConnectionIds = new Set(payload.connections.map((c) => c.id));
 
         // Additions: a profile now has a live id we didn't know about —
         // another window connected it. `applyConnectionsAdditions`
@@ -2579,7 +2605,7 @@ function Workspace() {
         // `connection_meta` map (and hence the next broadcast) catches up
         // instead of this window silently killing its own live tabs.
         for (const local of activeConnectionsRef.current) {
-          if (liveProfileIds.has(local.profileId)) continue;
+          if (liveConnectionIds.has(local.id)) continue;
           if (!seenProfilesRef.current.has(local.profileId)) {
             setConnectionMeta(local.id, local.profileId, local.name);
             continue;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,6 +173,8 @@ interface ActiveConnection {
   name: string;
   uri: string;
   color_tag?: string;
+  /** True iff opened by the embedded MCP server's `connect` tool rather than a human (#98 Task 4). */
+  viaMcp?: boolean;
 }
 
 /** Extract the auth username from a MongoDB connection URI; '' when there are no credentials. */
@@ -457,12 +459,13 @@ function Workspace() {
     name: string,
     uri: string,
     profileId: string,
-    color_tag?: string
+    color_tag?: string,
+    viaMcp?: boolean
   ) => {
     setActiveConnections((prev) =>
       prev.some((c) => c.profileId === profileId)
         ? prev
-        : [...prev, { id, profileId, name, uri, color_tag }]
+        : [...prev, { id, profileId, name, uri, color_tag, viaMcp }]
     );
   };
 
@@ -549,7 +552,7 @@ function Workspace() {
     const localByProfile = new Map(activeConnectionsRef.current.map((c) => [c.profileId, c]));
     for (const entry of connections) {
       if (localByProfile.has(entry.profileId)) continue;
-      addActiveConnection(entry.id, entry.name, '', entry.profileId);
+      addActiveConnection(entry.id, entry.name, '', entry.profileId, undefined, entry.viaMcp);
       rebindProfileTabs(entry.profileId, entry.id);
     }
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -409,19 +409,35 @@ function Workspace() {
   useEffect(() => {
     activeConnectionsRef.current = activeConnections;
   }, [activeConnections]);
-  // Every profileId this window has ever learned about from a
+  // Every CONNECTION id this window has ever learned about from a
   // `connections-changed` broadcast OR the boot-time `connection_list` seed
-  // (final whole-branch review, Fix 3) — NOT from this window's own local
-  // connects, which never touch it. Gates the removal branch of the
-  // `connections-changed` listener below: a profile absent from a broadcast
-  // is only ever torn down if it was previously SEEN live in some earlier
-  // broadcast. Without this, a profile THIS window just connected itself
-  // (added to `activeConnections` synchronously, but whose `set_connection_meta`
-  // hasn't landed backend-side yet) looks identical to a genuinely-removed
-  // one the moment an unrelated broadcast arrives — e.g. some other window
+  // (final whole-branch review, Fix 3; keyed by connection id, not
+  // profileId, per the closing review's residual fix) — NOT from this
+  // window's own local connects, which never touch it. Gates the removal
+  // branch of the `connections-changed` listener below: a LOCAL connection
+  // absent from a broadcast is only ever torn down if its own id was
+  // previously SEEN live in some earlier broadcast. Without this, a
+  // connection THIS window just opened itself (added to `activeConnections`
+  // synchronously, but whose `set_connection_meta` hasn't landed
+  // backend-side yet) looks identical to a genuinely-removed one the moment
+  // an unrelated broadcast arrives — e.g. some other window
   // connecting/disconnecting something else — and would otherwise have its
   // tabs killed by a broadcast that has nothing to do with it.
-  const seenProfilesRef = useRef<Set<string>>(new Set());
+  //
+  // Keyed by connection id rather than profileId (closing review): a
+  // profileId-keyed gate has a race once two rows can exist for the same
+  // profile (final fix wave, agent-connection visibility) — a window opens
+  // `connect_db` for profile P (local row added optimistically, id not yet
+  // announced backend-side) and, before its own `set_connection_meta`
+  // lands, a broadcast arrives carrying a DIFFERENT row for P (an agent
+  // `connect`, or a second window). A profileId-keyed gate would mark P
+  // "seen" off that unrelated row, and the removal loop below — seeing the
+  // local id absent from that same broadcast — would tear down the user's
+  // just-opened, still-live connection and close its tabs. Keying by
+  // connection id means that broadcast never marks the local (still
+  // unannounced) id as seen, so it falls through to the self-heal branch
+  // (re-announce via `setConnectionMeta`) instead.
+  const seenConnectionIdsRef = useRef<Set<string>>(new Set());
   // Shared by every `update_tab_state` emission site (handleBuilderStateChange
   // here, plus handleExecuteQuery/handleExecuteAggregate below): skips
   // unmirrored tabs and translates the live id to profile-space before
@@ -552,12 +568,16 @@ function Workspace() {
   // broadcast add/rebind identically: `addActiveConnection` (dedupes by
   // profileId) plus `rebindProfileTabs` (rebinds any restored `profile:<id>`
   // tab onto the live id, same as `handleQuickConnect`/`handleReconnectProfile`
-  // do after their own `connect_db`). Also updates `seenProfilesRef` (Fix 3)
-  // for every entry, regardless of whether it was new — a boot seed or
-  // broadcast that mentions a profile is evidence that profile is being
-  // actively tracked, whether or not this window happens to already have it.
+  // do after their own `connect_db`). Also updates `seenConnectionIdsRef`
+  // (Fix 3; connection-id-keyed per the closing review) for every entry's
+  // own id, regardless of whether it was new — a boot seed or broadcast
+  // that mentions a connection is evidence that SPECIFIC connection is
+  // being actively tracked, whether or not this window happens to already
+  // have it locally. Deliberately NOT `entry.profileId` — see
+  // `seenConnectionIdsRef`'s own doc comment for the teardown race that
+  // profileId-keying opened up.
   const applyConnectionsAdditions = (connections: ConnectionEntry[]) => {
-    for (const entry of connections) seenProfilesRef.current.add(entry.profileId);
+    for (const entry of connections) seenConnectionIdsRef.current.add(entry.id);
     const localById = new Map(activeConnectionsRef.current.map((c) => [c.id, c]));
     const localByProfile = new Map(activeConnectionsRef.current.map((c) => [c.profileId, c]));
     for (const entry of connections) {
@@ -718,8 +738,8 @@ function Workspace() {
         // spawned later (or re-launched into an already-running session)
         // needs this to avoid a spurious ReconnectBanner + duplicate
         // connect_db for a profile another window already connected.
-        // `applyConnectionsAdditions` (Fix 3) also seeds `seenProfilesRef`
-        // for every entry here, exactly like a `connections-changed`
+        // `applyConnectionsAdditions` (Fix 3) also seeds `seenConnectionIdsRef`
+        // for every entry's own id here, exactly like a `connections-changed`
         // broadcast would.
         try {
           const connections = await connectionList();
@@ -2541,8 +2561,9 @@ function Workspace() {
         // another window connected it. `applyConnectionsAdditions`
         // (`addActiveConnection`/`rebindProfileTabs`, same two calls
         // `handleQuickConnect`/`handleReconnectProfile` make after their
-        // own `connect_db`) also marks every entry here as SEEN
-        // (`seenProfilesRef` — Fix 3, read by the removal loop below); the
+        // own `connect_db`) also marks every entry's OWN id here as SEEN
+        // (`seenConnectionIdsRef` — Fix 3, connection-id-keyed per the
+        // closing review; read by the removal loop below); the
         // payload carries no `uri` by design (Task 3 — connection strings
         // never ride an event), so any UI reading `activeConnections[].uri`
         // (the status bar's username display) degrades to '' for a
@@ -2590,23 +2611,30 @@ function Workspace() {
         // it again here would double-apply the same close backend-side —
         // see the who-mirrors-what note in the task report).
         //
-        // Final whole-branch review, Fix 3: gated on `seenProfilesRef` —
-        // absence from THIS broadcast alone is not enough to tear down. A
-        // profile THIS window just connected can legitimately be missing
+        // Final whole-branch review, Fix 3: gated on `seenConnectionIdsRef`
+        // — absence from THIS broadcast alone is not enough to tear down. A
+        // connection THIS window just opened can legitimately be missing
         // from an UNRELATED broadcast that races ahead of its own
         // `set_connection_meta` landing backend-side (e.g. some other
-        // window connecting/disconnecting something else in between); that
-        // shape is indistinguishable from a real removal by `liveProfileIds`
-        // alone. Only tear down a profile that was previously SEEN live in
-        // some earlier broadcast (or the boot `connection_list` seed) and
-        // is NOW absent — see `seenProfilesRef`'s own doc comment. A local
-        // connection that was NEVER seen is instead self-healed by
-        // re-announcing it via `setConnectionMeta`, so the backend's
-        // `connection_meta` map (and hence the next broadcast) catches up
-        // instead of this window silently killing its own live tabs.
+        // window connecting/disconnecting something else — OR, per the
+        // closing review, an agent/second window connecting a DIFFERENT
+        // connection for the SAME profile — in between); that shape is
+        // indistinguishable from a real removal by `liveConnectionIds`
+        // alone. Only tear down a connection whose own id was previously
+        // SEEN live in some earlier broadcast (or the boot `connection_list`
+        // seed) and is NOW absent — see `seenConnectionIdsRef`'s own doc
+        // comment. A local connection whose id was NEVER seen is instead
+        // self-healed by re-announcing it via `setConnectionMeta`, so the
+        // backend's `connection_meta` map (and hence the next broadcast)
+        // catches up instead of this window silently killing its own live
+        // tabs. Keyed by connection id, NOT profileId (the pre-closing-review
+        // shape): a profileId-keyed gate would have this exact local
+        // connection's OWN profile marked "seen" by the unrelated broadcast
+        // row that raced it, and tear it down anyway — the residual bug this
+        // fix closes.
         for (const local of activeConnectionsRef.current) {
           if (liveConnectionIds.has(local.id)) continue;
-          if (!seenProfilesRef.current.has(local.profileId)) {
+          if (!seenConnectionIdsRef.current.has(local.id)) {
             setConnectionMeta(local.id, local.profileId, local.name);
             continue;
           }

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -67,6 +67,8 @@ interface ConnectionProfile {
   uri: string;
   color_tag?: string | null;
   ssh?: SshConfig | null;
+  /** Expose this profile to MCP agents. Mirrors backend `ConnectionProfile::mcp_enabled`. */
+  mcp_enabled?: boolean;
 }
 
 interface ConnectionManagerProps {
@@ -129,6 +131,7 @@ const BLANK_CONN = {
   name: 'New Connection',
   folder: '',
   colorTag: '',
+  mcpEnabled: false,
 };
 
 const sidebarPanelClass =
@@ -524,6 +527,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       ...parsed,
       folder: profileFolderMap[profile.id] || '',
       colorTag: profile.color_tag || '',
+      mcpEnabled: profile.mcp_enabled ?? false,
       ...sshFields,
     });
 
@@ -547,6 +551,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       hosts: [{ host: 'localhost', port: '27017' }],
       folder: profileFolderMap[profile.id] || '',
       colorTag: profile.color_tag || '',
+      mcpEnabled: profile.mcp_enabled ?? false,
     });
     setError(null);
     setTestResult(null);
@@ -605,6 +610,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       color_tag: editorState.colorTag
         ? normalizeHexColor(editorState.colorTag) ?? editorState.colorTag
         : null,
+      mcp_enabled: editorState.mcpEnabled,
     };
 
     setLoading(true);
@@ -1444,6 +1450,21 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                         />
                       </div>
                     )}
+                  </div>
+
+                  <div className="flex flex-col gap-2 border-t border-border pt-2.5">
+                    <label className="flex items-center gap-2 text-[11px]">
+                      <input
+                        id="mcp-enable"
+                        type="checkbox"
+                        checked={editorState.mcpEnabled}
+                        onChange={e => setEditorState(prev => ({ ...prev, mcpEnabled: e.target.checked }))}
+                      />
+                      <span>Expose to MCP agents</span>
+                    </label>
+                    <span className="text-[10.5px] leading-relaxed text-muted-foreground">
+                      Agents connected to the MQLens MCP server can see and connect to this profile.
+                    </span>
                   </div>
                 </div>
               )}

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -551,7 +551,14 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       hosts: [{ host: 'localhost', port: '27017' }],
       folder: profileFolderMap[profile.id] || '',
       colorTag: profile.color_tag || '',
-      mcpEnabled: profile.mcp_enabled ?? false,
+      // Adjudicated product call (final fix wave): a duplicated profile
+      // never inherits "Expose to MCP agents" from the profile it was
+      // copied from, even when the original has it on — the new profile is
+      // a distinct connection an agent hasn't been vetted for yet, and
+      // silently exposing it would be surprising. `handleEditClick` above
+      // is unaffected and keeps mapping `profile.mcp_enabled` as-is; this
+      // reset is specific to the duplicate-populate path.
+      mcpEnabled: false,
     });
     setError(null);
     setTestResult(null);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -149,6 +149,13 @@ const SETTINGS_TABS: {
   },
 ];
 
+// Lowest/highest port the MCP port field accepts (final fix wave): below
+// 1024 is the OS's reserved/privileged range (binding usually fails or needs
+// elevated permissions anyway — not worth letting a user configure it only
+// to hit a confusing bind error), 65535 is the highest a `u16` port can be.
+const MCP_MIN_PORT = 1024;
+const MCP_MAX_PORT = 65535;
+
 /** `HH:MM:SS` (local time, zero-padded) from a call-log entry's `tsMs`. */
 function formatMcpLogTime(tsMs: number): string {
   const d = new Date(tsMs);
@@ -230,7 +237,15 @@ const McpSettingsPanel: React.FC = () => {
     setRegenerated(false);
     try {
       const parsedPort = parseInt(portInput, 10);
-      const port = next && Number.isFinite(parsedPort) && parsedPort > 0 ? parsedPort : undefined;
+      // Friendly range validation before ever calling `invoke` (final fix
+      // wave) — an out-of-range port used to sail straight through to the
+      // backend bind attempt, surfacing as an opaque OS-level bind error
+      // instead of a clear "pick a different port" message.
+      if (next && (!Number.isFinite(parsedPort) || parsedPort < MCP_MIN_PORT || parsedPort > MCP_MAX_PORT)) {
+        setError(`Port must be between ${MCP_MIN_PORT} and ${MCP_MAX_PORT}.`);
+        return;
+      }
+      const port = next ? parsedPort : undefined;
       const s = await mcpSetEnabled(next, port);
       setStatus(s);
       setPortInput(String(s.port));
@@ -296,6 +311,8 @@ const McpSettingsPanel: React.FC = () => {
             <Input
               id="mcp-port"
               type="number"
+              min={MCP_MIN_PORT}
+              max={MCP_MAX_PORT}
               className="font-mono"
               value={portInput}
               disabled={enabled}
@@ -303,7 +320,7 @@ const McpSettingsPanel: React.FC = () => {
               data-testid="mcp-port-input"
             />
             <p className="text-xs text-muted-foreground">
-              Applied the next time the server is enabled.
+              Applied the next time the server is enabled. Must be {MCP_MIN_PORT}–{MCP_MAX_PORT}.
             </p>
           </div>
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -10,6 +10,7 @@ import {
   Server,
   Keyboard,
   Wrench,
+  Copy,
   type LucideIcon,
 } from 'lucide-react';
 import {
@@ -20,6 +21,8 @@ import {
   biometricDisable,
   type BiometricStatus,
 } from '../lib/vault';
+import { getMcpStatus, mcpSetEnabled, mcpRegenerateToken, type McpStatusUi } from '@/lib/mcpApi';
+import type { ConnectionProfile } from '@/lib/connection';
 import { CHECK_UPDATE_EVENT } from './UpdatePrompt';
 import {
   formatLastChecked,
@@ -145,6 +148,344 @@ const SETTINGS_TABS: {
     Icon: ShieldCheck,
   },
 ];
+
+/** `HH:MM:SS` (local time, zero-padded) from a call-log entry's `tsMs`. */
+function formatMcpLogTime(tsMs: number): string {
+  const d = new Date(tsMs);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/**
+ * MCP tab content, extracted out of `renderTabContent` (unlike the other
+ * tabs, which stay inline) because it owns a non-trivial amount of local
+ * state and a 2s status-poll lifecycle of its own — keeping that isolated
+ * here means it only ever mounts/unmounts (and starts/stops polling) when
+ * the MCP tab itself is selected, not on every `SettingsView` re-render.
+ */
+const McpSettingsPanel: React.FC = () => {
+  const [status, setStatus] = useState<McpStatusUi | null>(null);
+  const [portInput, setPortInput] = useState(String(8765));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tokenRevealed, setTokenRevealed] = useState(false);
+  const [regenerated, setRegenerated] = useState(false);
+  const [profiles, setProfiles] = useState<ConnectionProfile[]>([]);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  // Initial status fetch — separate from the poll effect below so the panel
+  // renders a real state immediately instead of waiting on the 2s cadence.
+  useEffect(() => {
+    let cancelled = false;
+    getMcpStatus()
+      .then((s) => {
+        if (cancelled) return;
+        setStatus(s);
+        setPortInput(String(s.port));
+      })
+      .catch((err) => { if (!cancelled) setError(String(err)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Opted-in profile list — read-only here; managed from the Connection
+  // Manager's own "Expose to MCP agents" checkbox (#98 Task 3).
+  useEffect(() => {
+    let cancelled = false;
+    invoke<ConnectionProfile[]>('load_connection_profiles')
+      .then((list) => {
+        if (cancelled) return;
+        setProfiles((list || []).filter((p) => p.mcp_enabled));
+      })
+      .catch(() => { if (!cancelled) setProfiles([]); });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Poll precedent: App.tsx's resource-usage/export-task polls (App.tsx
+  // ~424-436) — `active` flag + `clearInterval` on cleanup, StrictMode-safe.
+  // Only runs while this tab is mounted AND the server is enabled, since
+  // there is nothing new to poll for while disabled.
+  useEffect(() => {
+    if (!status?.enabled) return;
+    let active = true;
+    const id = setInterval(() => {
+      getMcpStatus()
+        .then((s) => { if (active) setStatus(s); })
+        .catch(() => { /* transient poll failure — keep last known status */ });
+    }, 2000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [status?.enabled]);
+
+  const copy = (key: string, text: string) => {
+    navigator.clipboard?.writeText(text);
+    setCopiedKey(key);
+    setTimeout(() => setCopiedKey((k) => (k === key ? null : k)), 2000);
+  };
+
+  const onToggle = async (next: boolean) => {
+    setBusy(true);
+    setError(null);
+    setRegenerated(false);
+    try {
+      const parsedPort = parseInt(portInput, 10);
+      const port = next && Number.isFinite(parsedPort) && parsedPort > 0 ? parsedPort : undefined;
+      const s = await mcpSetEnabled(next, port);
+      setStatus(s);
+      setPortInput(String(s.port));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onRegenerate = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const s = await mcpRegenerateToken();
+      setStatus(s);
+      setRegenerated(true);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const enabled = status?.enabled ?? false;
+  const port = status?.port ?? (parseInt(portInput, 10) || 8765);
+  const token = status?.token ?? '';
+  const vaultLocked = !!error && /vault is locked/i.test(error);
+
+  const claudeSnippet = `claude mcp add --transport http mqlens http://127.0.0.1:${port}/mcp --header "Authorization: Bearer ${token}"`;
+  const cursorSnippet = JSON.stringify(
+    { mcpServers: { mqlens: { url: `http://127.0.0.1:${port}/mcp`, headers: { Authorization: `Bearer ${token}` } } } },
+    null,
+    2,
+  );
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-2">
+      <Card className="xl:col-span-2">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Server className="h-4 w-4 text-primary" />
+            MCP server
+          </CardTitle>
+          <CardDescription>
+            Expose your connections to Claude Code, Cursor, and other agents as Model Context
+            Protocol tools. Reads and confirm-gated writes only; off by default.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-3">
+            <Switch
+              data-testid="mcp-enable-toggle"
+              checked={enabled}
+              disabled={busy}
+              onCheckedChange={onToggle}
+            />
+            <Label className="font-normal">{enabled ? 'Enabled' : 'Disabled'}</Label>
+          </div>
+
+          <div className="max-w-[10rem] space-y-2">
+            <Label htmlFor="mcp-port">Port</Label>
+            <Input
+              id="mcp-port"
+              type="number"
+              className="font-mono"
+              value={portInput}
+              disabled={enabled}
+              onChange={(e) => setPortInput(e.target.value)}
+              data-testid="mcp-port-input"
+            />
+            <p className="text-xs text-muted-foreground">
+              Applied the next time the server is enabled.
+            </p>
+          </div>
+
+          {error && (
+            <div
+              className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              data-testid={vaultLocked ? 'mcp-vault-locked' : 'mcp-error'}
+            >
+              {error}
+            </div>
+          )}
+
+          {enabled && (
+            <div className="space-y-2 border-t border-border pt-4">
+              <Label>Bearer token</Label>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-mono text-sm" data-testid="mcp-token-display">
+                  {tokenRevealed ? token : '••••••••••••••••'}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setTokenRevealed((v) => !v)}
+                  data-testid="mcp-token-reveal"
+                >
+                  {tokenRevealed ? 'Hide' : 'Reveal'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => copy('token', token)}
+                  data-testid="mcp-token-copy"
+                >
+                  <Copy className="h-3 w-3" />
+                  {copiedKey === 'token' ? 'Copied' : 'Copy'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onRegenerate}
+                  disabled={busy}
+                  data-testid="mcp-token-regenerate"
+                >
+                  Regenerate
+                </Button>
+              </div>
+              {regenerated && (
+                <p className="text-xs text-warning" data-testid="mcp-regenerate-note">
+                  Token regenerated — existing clients must be updated with the new token.
+                </p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {enabled && (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Claude Code</CardTitle>
+              <CardDescription>Run in a terminal to register MQLens as an MCP server.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <code
+                className="block whitespace-pre-wrap break-all rounded-md bg-muted px-3 py-2 text-xs"
+                data-testid="mcp-claude-snippet"
+              >
+                {claudeSnippet}
+              </code>
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => copy('claude', claudeSnippet)}
+                  data-testid="mcp-claude-copy"
+                >
+                  <Copy className="h-3 w-3" />
+                  {copiedKey === 'claude' ? 'Copied' : 'Copy'}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Cursor</CardTitle>
+              <CardDescription>Add to Cursor&apos;s MCP server configuration.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <code
+                className="block whitespace-pre-wrap break-all rounded-md bg-muted px-3 py-2 text-xs"
+                data-testid="mcp-cursor-snippet"
+              >
+                {cursorSnippet}
+              </code>
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => copy('cursor', cursorSnippet)}
+                  data-testid="mcp-cursor-copy"
+                >
+                  <Copy className="h-3 w-3" />
+                  {copiedKey === 'cursor' ? 'Copied' : 'Copy'}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Opted-in profiles</CardTitle>
+          <CardDescription>Connections agents can see and connect to.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {profiles.length === 0 ? (
+            <p className="text-sm text-muted-foreground" data-testid="mcp-profiles-empty">
+              No profiles are exposed. Enable &quot;Expose to MCP agents&quot; in the Connection
+              Manager.
+            </p>
+          ) : (
+            <ul className="space-y-1.5">
+              {profiles.map((p) => (
+                <li
+                  key={p.id}
+                  className="flex items-center gap-2 text-sm"
+                  data-testid={`mcp-profile-${p.id}`}
+                >
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: p.color_tag || 'var(--muted-foreground)' }}
+                  />
+                  {p.name}
+                </li>
+              ))}
+            </ul>
+          )}
+          <p className="text-xs text-muted-foreground">Manage in Connection Manager.</p>
+        </CardContent>
+      </Card>
+
+      <Card className="xl:col-span-2">
+        <CardHeader>
+          <CardTitle className="text-base">Call log</CardTitle>
+          <CardDescription>Last 200 tool calls, newest first.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!status || status.log.length === 0 ? (
+            <p className="text-sm text-muted-foreground" data-testid="mcp-log-empty">
+              No tool calls yet.
+            </p>
+          ) : (
+            <div className="max-h-72 space-y-1 overflow-y-auto font-mono text-[11px]" data-testid="mcp-log-list">
+              {[...status.log].reverse().map((entry, i) => (
+                <div
+                  key={`${entry.tsMs}-${i}`}
+                  className="flex items-center gap-2"
+                  data-testid="mcp-log-row"
+                >
+                  <span className="text-muted-foreground">{formatMcpLogTime(entry.tsMs)}</span>
+                  <span>{entry.tool}</span>
+                  <span className="truncate text-muted-foreground">{entry.summary}</span>
+                  <span className={entry.ok ? 'text-success' : 'text-destructive'}>
+                    {entry.ok ? '' : 'ERR'}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
 
 export type { SettingsTabId };
 
@@ -346,25 +687,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab, onInstal
         return <AppearanceSettings />;
 
       case 'mcp':
-        return (
-          <Card className="border-dashed">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-base">
-                <Server className="h-4 w-4 text-primary" />
-                MCP Servers
-              </CardTitle>
-              <CardDescription>
-                Configure Model Context Protocol servers for AI integrations. Coming soon (#98).
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">
-                MCP server configuration will be available in a future update. You&apos;ll be able to
-                add stdio and HTTP servers, manage credentials, and attach them to the AI assistant.
-              </p>
-            </CardContent>
-          </Card>
-        );
+        return <McpSettingsPanel />;
 
       case 'updates':
         return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -176,7 +176,7 @@ interface SidebarProps {
   ) => void;
   onSelectIndex: (connectionId: string, dbName: string, collName: string, indexName: string) => void;
   activeCollection: { connectionId: string; db: string; collection: string; indexName?: string } | null;
-  activeConnections: { id: string; name: string; uri: string; profileId?: string; color_tag?: string }[];
+  activeConnections: { id: string; name: string; uri: string; profileId?: string; color_tag?: string; viaMcp?: boolean }[];
   onOpenConnectionManager: () => void;
   onDisconnect: (connectionId: string) => void;
   width?: number;
@@ -1576,6 +1576,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
                       )}
                       <Server size={12} className="shrink-0 text-primary" />
                       <span className="min-w-0 truncate font-medium">{conn.name}</span>
+                      {conn.viaMcp && (
+                        <Badge
+                          variant="secondary"
+                          className="h-4 shrink-0 px-1 text-[9px] font-normal text-muted-foreground"
+                          data-testid="connection-via-mcp-badge"
+                          aria-label="Connected via MCP"
+                        >
+                          via MCP
+                        </Badge>
+                      )}
                       <span
                         className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
                         aria-label="Connected"

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/render-with-providers';
+import { resetUpdateTabStateDebounce } from '../../workspace/workspaceStore';
 import App from '../../App';
 
 vi.mock('../../lib/vault', () => ({
@@ -162,6 +163,16 @@ describe('App Component', () => {
       }
       return Promise.resolve([]);
     });
+    // `updateTabState`'s 500ms debounce (workspaceStore.ts) lives in
+    // MODULE-level state, not component state — a real `setTimeout` a
+    // previous test schedules (e.g. via a revived tab's eager query re-run)
+    // outlives that test's own render/cleanup and can fire mid-WAY through
+    // a later, unrelated test, recording a stray `workspace_apply` call
+    // into THAT test's `calls` array (final fix wave: found while adding a
+    // new test to this file shifted timing enough to expose it). Clearing
+    // it here, before every test, keeps each test's `mockInvoke` call log
+    // free of debounced fallout from whatever ran before it.
+    resetUpdateTabStateDebounce();
   });
 
   it('opens the Quick Start tab by default and shows bottom status bar with version info', async () => {
@@ -2874,6 +2885,44 @@ describe('App Component', () => {
       });
 
       expect(await screen.findByTestId('sidebar-conn-live-99')).toHaveTextContent('Prod Cluster');
+    });
+
+    it('(b2) a connections-changed viaMcp addition for an ALREADY-connected profileId still renders its own sidebar row, badged "via MCP" (final fix wave, agent-connection visibility)', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('live-1');
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      // This window connects p1 itself first (a human connection).
+      const connectCard = await screen.findByTestId('conn-card-p1');
+      fireEvent.click(connectCard);
+      expect(await screen.findByTestId('sidebar-conn-live-1')).toHaveTextContent('Prod Cluster');
+
+      // An MCP agent now also connects to the SAME profile (its own
+      // `connect` tool call, backend-side, broadcast as `viaMcp: true`) —
+      // previously `addActiveConnection`'s profileId dedupe silently
+      // dropped this: a live backend connection no window ever displayed.
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [
+            { id: 'live-1', profileId: 'p1', name: 'Prod Cluster', viaMcp: false },
+            { id: 'mcp-live-2', profileId: 'p1', name: 'Prod Cluster', viaMcp: true },
+          ],
+        });
+      });
+
+      // Both rows now render — the pre-existing human connection AND the
+      // agent's own, distinct row for the same profile.
+      expect(screen.getByTestId('sidebar-conn-live-1')).toBeInTheDocument();
+      expect(await screen.findByTestId('sidebar-conn-mcp-live-2')).toHaveTextContent('Prod Cluster');
     });
 
     it('(d) a stale connection_meta entry for a profile already live locally under a different id is left alone (no disconnect_db)', async () => {

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -3040,8 +3040,9 @@ describe('App Component', () => {
       // An unrelated broadcast lands — this window's own `set_connection_meta`
       // for p1 hasn't registered backend-side yet (a race), so the very
       // first connections-changed payload it ever sees doesn't mention p1
-      // at all. p1 was never SEEN in any prior broadcast (seenProfilesRef is
-      // empty for it), so this must NOT be treated as a removal.
+      // at all. p1's own connection id ('live-1') was never SEEN in any
+      // prior broadcast (seenConnectionIdsRef is empty for it), so this
+      // must NOT be treated as a removal.
       await act(async () => {
         fireMockEvent('connections-changed', {
           connections: [{ id: 'live-other', profileId: 'p-other', name: 'Other Cluster' }],
@@ -3055,6 +3056,63 @@ describe('App Component', () => {
       // Self-healing re-registration: re-announces this window's own live
       // connection so the backend's connection_meta map (and hence the next
       // broadcast) catches up.
+      await waitFor(() => {
+        expect(
+          calls.some(
+            (c) => c.cmd === 'set_connection_meta' && c.args?.id === 'live-1' && c.args?.profileId === 'p1',
+          ),
+        ).toBe(true);
+      });
+    });
+
+    it('(g) a broadcast carrying a DIFFERENT connection for the SAME profile does not tear down this window\'s own not-yet-announced connection (closing review residual fix)', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('live-1');
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      // This window connects p1 itself (a human connect_db) — 'live-1' is
+      // added to activeConnections synchronously, but this window's own
+      // `set_connection_meta` for it hasn't registered backend-side yet.
+      const connectCard = await screen.findByTestId('conn-card-p1');
+      fireEvent.click(connectCard);
+      await waitFor(() => expect(screen.getByTestId('sidebar-conn-live-1')).toBeInTheDocument());
+
+      calls.length = 0; // only the broadcast handler's own reaction matters below
+
+      // A broadcast lands carrying a DIFFERENT connection id for the SAME
+      // profile (an MCP agent's own `connect`, or a second window racing
+      // this one) — NOT the local 'live-1' id, which this window's own
+      // `set_connection_meta` hasn't announced backend-side yet. A
+      // profileId-keyed seen-gate would mark p1 "seen" off this row alone
+      // and tear down 'live-1' as if it had been genuinely removed; the
+      // connection-id-keyed gate must not, since 'live-1' itself was never
+      // mentioned in any broadcast.
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [{ id: 'mcp-live-2', profileId: 'p1', name: 'Prod Cluster', viaMcp: true }],
+        });
+      });
+
+      // This window's own connection (and its tabs) survive — not torn
+      // down by a same-profile broadcast that isn't actually about it.
+      expect(screen.getByTestId('sidebar-conn-live-1')).toBeInTheDocument();
+      expect(calls.some((c) => c.cmd === 'disconnect_db')).toBe(false);
+      expect(calls.some((c) => c.cmd === 'workspace_apply' && c.args?.op?.type === 'close_many')).toBe(false);
+      // The agent's own row still renders (Fix 2's two-rows behavior is
+      // unaffected by this fix).
+      expect(await screen.findByTestId('sidebar-conn-mcp-live-2')).toBeInTheDocument();
+      // Self-healing re-registration, not teardown: re-announces this
+      // window's own live connection so the backend's connection_meta map
+      // (and hence the next broadcast) catches up.
       await waitFor(() => {
         expect(
           calls.some(

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -1053,6 +1053,29 @@ describe('MCP opt-in flag (#98)', () => {
       });
     });
   });
+
+  it('duplicating an MCP-exposed profile resets "Expose to MCP agents" to unchecked, while editing it keeps it checked (final fix wave)', async () => {
+    const mcpProfile = { id: 'p-mcp', name: 'Agent DB', uri: 'mongodb://agent:27017', mcp_enabled: true };
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([mcpProfile]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+
+    await waitFor(() => expect(screen.getAllByText('Agent DB')[0]).toBeInTheDocument());
+    fireEvent.click(screen.getAllByText('Agent DB')[0]);
+
+    // Edit path: unaffected, keeps mapping the original's flag.
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+    expect(screen.getByLabelText(/expose to mcp agents/i)).toBeChecked();
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    // Duplicate path: the new profile starts unexposed regardless.
+    fireEvent.click(screen.getAllByText('Agent DB')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^duplicate$/i }));
+    expect(screen.getByLabelText(/expose to mcp agents/i)).not.toBeChecked();
+  });
 });
 
 describe('URI import and export', () => {

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -565,6 +565,7 @@ describe('ConnectionManager Component', () => {
         uri: 'mongodb://staging:27017',
         ssh: null,
         color_tag: null,
+        mcp_enabled: false,
       });
       // The nested modal should be closed
       expect(screen.queryByText('New Connection')).not.toBeInTheDocument();
@@ -965,6 +966,90 @@ describe('ConnectionManager Component', () => {
       expect(savedProfile).toMatchObject({
         id: 'p1',
         color_tag: null,
+      });
+    });
+  });
+});
+
+describe('MCP opt-in flag (#98)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('saving with "Expose to MCP agents" checked round-trips mcp_enabled: true', async () => {
+    let savedProfile: any = null;
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      if (cmd === 'save_connection_profile') {
+        savedProfile = args.profile;
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'Agent DB' } });
+    await pickSelectOption('topology-select', /full uri string only/i);
+    fireEvent.change(screen.getByLabelText(/connection uri/i), { target: { value: 'mongodb://agent' } });
+
+    fireEvent.click(screen.getByLabelText(/expose to mcp agents/i));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedProfile).toMatchObject({
+        name: 'Agent DB',
+        uri: 'mongodb://agent',
+        mcp_enabled: true,
+      });
+    });
+  });
+
+  it('editing a profile without mcp_enabled renders the checkbox unchecked', async () => {
+    const legacyProfile = { id: 'p-legacy', name: 'Legacy', uri: 'mongodb://legacy:27017' };
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([legacyProfile]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+
+    await waitFor(() => expect(screen.getAllByText('Legacy')[0]).toBeInTheDocument());
+    fireEvent.click(screen.getAllByText('Legacy')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    expect(screen.getByLabelText(/expose to mcp agents/i)).not.toBeChecked();
+  });
+
+  it('toggling the checkbox on and saving an old profile adds mcp_enabled: true', async () => {
+    let savedProfile: any = null;
+    const legacyProfile = { id: 'p-legacy', name: 'Legacy', uri: 'mongodb://legacy:27017' };
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([legacyProfile]);
+      if (cmd === 'save_connection_profile') {
+        savedProfile = args.profile;
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+
+    await waitFor(() => expect(screen.getAllByText('Legacy')[0]).toBeInTheDocument());
+    fireEvent.click(screen.getAllByText('Legacy')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    const checkbox = screen.getByLabelText(/expose to mcp agents/i);
+    expect(checkbox).not.toBeChecked();
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedProfile).toMatchObject({
+        id: 'p-legacy',
+        mcp_enabled: true,
       });
     });
   });

--- a/src/components/__tests__/SettingsMcp.test.tsx
+++ b/src/components/__tests__/SettingsMcp.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SettingsView } from '../SettingsModal';
+import type { McpStatusUi } from '../../lib/mcpApi';
+import type { ConnectionProfile } from '../../lib/connection';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock('../theme/AppearanceSettings', () => ({
+  AppearanceSettings: () => <div data-testid="appearance-settings">Theme preset</div>,
+}));
+
+vi.mock('../../lib/vault', () => ({
+  changeVaultPassword: vi.fn(),
+  resetVault: vi.fn(),
+  biometricStatus: () => Promise.resolve({ available: false, biometryType: 0, enrolled: false }),
+  biometricEnable: vi.fn(),
+  biometricDisable: vi.fn(),
+}));
+
+const writeText = vi.fn();
+
+function disabledStatus(overrides: Partial<McpStatusUi> = {}): McpStatusUi {
+  return { enabled: false, port: 8765, token: '', log: [], ...overrides };
+}
+
+function enabledStatus(overrides: Partial<McpStatusUi> = {}): McpStatusUi {
+  return { enabled: true, port: 8765, token: 'tok-xyz-123', log: [], ...overrides };
+}
+
+/** Wires `mockInvoke` for the handful of commands SettingsView + the MCP
+ * panel issue, with per-command overrides supplied by each test. */
+function setupInvoke(opts: {
+  status?: McpStatusUi;
+  setEnabled?: (args: { enabled: boolean; port: number | null }) => McpStatusUi | Promise<McpStatusUi>;
+  regenerate?: () => McpStatusUi | Promise<McpStatusUi>;
+  profiles?: ConnectionProfile[];
+} = {}) {
+  const status = opts.status ?? disabledStatus();
+  mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+    if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '' });
+    if (cmd === 'detect_local_agents') return Promise.resolve([]);
+    if (cmd === 'managed_tools_status') return Promise.resolve([]);
+    if (cmd === 'mcp_get_status') return Promise.resolve(status);
+    if (cmd === 'mcp_set_enabled') {
+      if (opts.setEnabled) {
+        return Promise.resolve(
+          opts.setEnabled(args as { enabled: boolean; port: number | null })
+        );
+      }
+      return Promise.resolve(enabledStatus());
+    }
+    if (cmd === 'mcp_regenerate_token') {
+      return Promise.resolve(opts.regenerate ? opts.regenerate() : enabledStatus());
+    }
+    if (cmd === 'load_connection_profiles') return Promise.resolve(opts.profiles ?? []);
+    return Promise.resolve();
+  });
+}
+
+async function openMcpTab() {
+  fireEvent.click(screen.getByTestId('settings-tab-mcp'));
+  await screen.findByTestId('mcp-enable-toggle');
+}
+
+describe('SettingsView MCP panel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  it('toggling on invokes mcp_set_enabled with the configured port', async () => {
+    setupInvoke({ status: disabledStatus() });
+    render(<SettingsView />);
+    await openMcpTab();
+
+    fireEvent.click(screen.getByTestId('mcp-enable-toggle'));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('mcp_set_enabled', { enabled: true, port: 8765 });
+    });
+  });
+
+  it('renders the vault-locked error inline when enabling fails', async () => {
+    // mcp_set_enabled rejects (Tauri's Result<T, String> Err path) — set up
+    // manually since setupInvoke's helper always resolves.
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '' });
+      if (cmd === 'detect_local_agents') return Promise.resolve([]);
+      if (cmd === 'managed_tools_status') return Promise.resolve([]);
+      if (cmd === 'mcp_get_status') return Promise.resolve(disabledStatus());
+      if (cmd === 'mcp_set_enabled') return Promise.reject('vault is locked');
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      return Promise.resolve();
+    });
+
+    render(<SettingsView />);
+    await openMcpTab();
+
+    fireEvent.click(screen.getByTestId('mcp-enable-toggle'));
+
+    expect(await screen.findByTestId('mcp-vault-locked')).toHaveTextContent('vault is locked');
+  });
+
+  it('masks the token by default and reveals it on demand', async () => {
+    setupInvoke({ status: enabledStatus({ token: 'super-secret-token' }) });
+    render(<SettingsView />);
+    await openMcpTab();
+
+    const display = await screen.findByTestId('mcp-token-display');
+    expect(display).toHaveTextContent('••••••••••••••••');
+    expect(display).not.toHaveTextContent('super-secret-token');
+
+    fireEvent.click(screen.getByTestId('mcp-token-reveal'));
+    expect(screen.getByTestId('mcp-token-display')).toHaveTextContent('super-secret-token');
+  });
+
+  it('copies the exact Claude Code config snippet', async () => {
+    setupInvoke({ status: enabledStatus({ port: 9001, token: 'tok-abc' }) });
+    render(<SettingsView />);
+    await openMcpTab();
+
+    const copyBtn = await screen.findByTestId('mcp-claude-copy');
+    fireEvent.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith(
+      'claude mcp add --transport http mqlens http://127.0.0.1:9001/mcp --header "Authorization: Bearer tok-abc"'
+    );
+  });
+
+  it('updates the shown token after regenerate', async () => {
+    setupInvoke({
+      status: enabledStatus({ token: 'old-token' }),
+      regenerate: () => enabledStatus({ token: 'brand-new-token' }),
+    });
+    render(<SettingsView />);
+    await openMcpTab();
+
+    fireEvent.click(await screen.findByTestId('mcp-token-reveal'));
+    expect(screen.getByTestId('mcp-token-display')).toHaveTextContent('old-token');
+
+    fireEvent.click(screen.getByTestId('mcp-token-regenerate'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mcp-token-display')).toHaveTextContent('brand-new-token');
+    });
+    expect(screen.getByTestId('mcp-regenerate-note')).toBeInTheDocument();
+  });
+
+  it('renders only the opted-in profiles from load_connection_profiles', async () => {
+    setupInvoke({
+      status: disabledStatus(),
+      profiles: [
+        { id: 'p1', name: 'Prod Cluster', uri: 'mongodb://mock1', color_tag: '#ff0000', mcp_enabled: true },
+        { id: 'p2', name: 'Local Dev', uri: 'mongodb://mock2', color_tag: '#00ff00', mcp_enabled: false },
+        { id: 'p3', name: 'Staging', uri: 'mongodb://mock3', mcp_enabled: true },
+      ],
+    });
+    render(<SettingsView />);
+    await openMcpTab();
+
+    expect(await screen.findByTestId('mcp-profile-p1')).toHaveTextContent('Prod Cluster');
+    expect(screen.getByTestId('mcp-profile-p3')).toHaveTextContent('Staging');
+    expect(screen.queryByTestId('mcp-profile-p2')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mcp-profiles-empty')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty-state hint when no profiles are opted in', async () => {
+    setupInvoke({ status: disabledStatus(), profiles: [] });
+    render(<SettingsView />);
+    await openMcpTab();
+
+    expect(await screen.findByTestId('mcp-profiles-empty')).toHaveTextContent(
+      'No profiles are exposed'
+    );
+  });
+
+  it('renders call log rows newest-first', async () => {
+    setupInvoke({
+      status: enabledStatus({
+        log: [
+          { tsMs: 1_700_000_000_000, tool: 'list_databases', summary: 'first call', ok: true },
+          { tsMs: 1_700_000_005_000, tool: 'find', summary: 'second call', ok: false },
+          { tsMs: 1_700_000_010_000, tool: 'aggregate', summary: 'third call', ok: true },
+        ],
+      }),
+    });
+    render(<SettingsView />);
+    await openMcpTab();
+
+    const rows = await screen.findAllByTestId('mcp-log-row');
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent('aggregate');
+    expect(rows[0]).toHaveTextContent('third call');
+    expect(rows[1]).toHaveTextContent('find');
+    expect(rows[1]).toHaveTextContent('ERR');
+    expect(rows[2]).toHaveTextContent('list_databases');
+  });
+
+  it('shows the empty call-log state when there are no entries yet', async () => {
+    setupInvoke({ status: disabledStatus() });
+    render(<SettingsView />);
+    await openMcpTab();
+
+    expect(await screen.findByTestId('mcp-log-empty')).toHaveTextContent('No tool calls yet.');
+  });
+});

--- a/src/components/__tests__/SettingsMcp.test.tsx
+++ b/src/components/__tests__/SettingsMcp.test.tsx
@@ -87,6 +87,18 @@ describe('SettingsView MCP panel', () => {
     });
   });
 
+  it('rejects an out-of-range port with a friendly message and never calls mcp_set_enabled (final fix wave)', async () => {
+    setupInvoke({ status: disabledStatus() });
+    render(<SettingsView />);
+    await openMcpTab();
+
+    fireEvent.change(screen.getByTestId('mcp-port-input'), { target: { value: '80' } });
+    fireEvent.click(screen.getByTestId('mcp-enable-toggle'));
+
+    expect(await screen.findByTestId('mcp-error')).toHaveTextContent('Port must be between 1024 and 65535.');
+    expect(mockInvoke).not.toHaveBeenCalledWith('mcp_set_enabled', expect.anything());
+  });
+
   it('renders the vault-locked error inline when enabling fails', async () => {
     // mcp_set_enabled rejects (Tauri's Result<T, String> Err path) — set up
     // manually since setupInvoke's helper always resolves.

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -49,6 +49,28 @@ describe('Sidebar Component', () => {
     expect(handleOpenModal).toHaveBeenCalledTimes(1);
   });
 
+  it('badges a connection opened via MCP with "via MCP", and not a human-opened one', () => {
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[
+          { id: 'conn-1', name: 'Agent Conn', uri: 'mongodb://mock1', viaMcp: true },
+          { id: 'conn-2', name: 'Human Conn', uri: 'mongodb://mock2', viaMcp: false },
+        ]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    const badges = screen.getAllByTestId('connection-via-mcp-badge');
+    expect(badges).toHaveLength(1);
+    expect(screen.getByText('Agent Conn')).toBeInTheDocument();
+    expect(screen.getByText('Human Conn')).toBeInTheDocument();
+  });
+
   it('filters the tree by the search box (database names)', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -7,6 +7,8 @@ export interface ConnectionProfile {
   uri: string;
   color_tag?: string | null;
   ssh?: SshConfig | null;
+  /** Expose this profile to MCP agents. Mirrors backend `ConnectionProfile::mcp_enabled`. */
+  mcp_enabled?: boolean;
 }
 
 /** Options for exporting a connection URI for sharing. */

--- a/src/lib/mcpApi.ts
+++ b/src/lib/mcpApi.ts
@@ -1,0 +1,25 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/** One rolling call-log row. Mirrors backend `mcp::McpLogEntry` (camelCase serde). */
+export interface McpLogEntry {
+  tsMs: number;
+  tool: string;
+  connectionId?: string | null;
+  summary: string;
+  ok: boolean;
+}
+
+/** Mirrors backend `mcp::McpStatusUi` (camelCase serde). */
+export interface McpStatusUi {
+  enabled: boolean;
+  port: number;
+  token: string;
+  log: McpLogEntry[];
+}
+
+export const getMcpStatus = () => invoke<McpStatusUi>('mcp_get_status');
+
+export const mcpSetEnabled = (enabled: boolean, port?: number) =>
+  invoke<McpStatusUi>('mcp_set_enabled', { enabled, port: port ?? null });
+
+export const mcpRegenerateToken = () => invoke<McpStatusUi>('mcp_regenerate_token');

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -124,6 +124,8 @@ export interface ConnectionEntry {
   id: string;
   profileId: string;
   name: string;
+  /** True iff this connection was opened by the embedded MCP server's `connect` tool rather than a human (#98 Task 4). */
+  viaMcp: boolean;
 }
 export interface ConnectionsChangedPayload {
   connections: ConnectionEntry[];


### PR DESCRIPTION
## Summary
Closes #98. MQLens now embeds a Model Context Protocol server (srelens-style): agents connect over authenticated loopback HTTP and drive MongoDB through the app's existing connections and vault — no new credential paths.

- **16 tools** (see [docs/mcp-tools.md](docs/mcp-tools.md), drift-locked to a golden fixture): 12 reads (profiles/connections, connect/disconnect, databases/collections, find, aggregate, explain, schema analysis, indexes+stats) + 4 writes (insert_one, update_many, delete_many, create_index) — every write requires an explicit `_confirm: true` restating the operation.
- **Off by default.** Settings → MCP: toggle (requires unlocked vault), port, masked bearer token (fresh per enable, constant-time compared), one-click Claude Code / Cursor config snippets, live call log (namespaces + byte sizes, never document contents).
- **Per-profile opt-in** — "Expose to MCP agents" checkbox in the Connection Manager (default off; duplicating a profile resets it). Non-opted profiles are invisible to every tool, uniformly.
- **Agents can initiate connections** to opted-in profiles; agent connections appear in every window's sidebar with a **via MCP** badge — including as a second badged row when you're already connected to the same profile.
- **Aggregation/explain reject `$out`/`$merge`** at the MCP layer (executionStats explain executes pipelines — the denylist covers both paths). Vault lock or toggle-off stops the server with a bounded 3s drain.

## Review trail
Subagent-driven: 7 tasks, per-task adversarial reviews (rmcp 2.2.0's server transport and auth-layer coverage verified against vendored source), whole-branch security-grade final review + fix wave; closing verdict "Ready to merge: Yes". Standout catches: the `explain` pipeline path initially bypassed the $out/$merge denylist; a profileId-keyed removal loop that would have masked agent-connection teardown; a TOCTOU port-reuse race in parallel tests (root-caused, not retried away).

## Verification
vitest **947/947** (+4 skipped multi-window vectors), cargo **405/405**, clippy at baseline, tsc + build clean.

**Outstanding (user environment): GUI checklist** in the phase report — enable → `claude mcp add` with the copied snippet → tools work end-to-end; write blocked without `_confirm`; vault lock kills the server; token rotation locks out old configs.

## Follow-ups (non-blocking)
`update_many` lacks matchedCount (impl seam widening); a `profiles-changed` event for live Settings list refresh; timing-symmetric profile loads; `eprintln!` → tracing.

Squash-merge recommended (single `feat:` line for release notes).