### PR TITLE
feat: support multi-URI JSON import/export with folder structure #115

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -2,7 +2,13 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { invoke, Channel } from '@tauri-apps/api/core';
 import { open, save } from '@tauri-apps/plugin-dialog';
 import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
-import { buildExportUri, findMongoUriInText } from '@/lib/connection';
+import {
+  buildExportAllUris,
+  buildExportUri,
+  parseConnectionImportFile,
+  resolveImportUri,
+  type ImportedConnection,
+} from '@/lib/connection';
 import { useDialogs } from './dialogs/DialogProvider';
 import { PasswordInput } from './PasswordInput';
 import { useEscapeClose } from '../lib/useEscapeClose';
@@ -406,9 +412,12 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
   // URI import (clipboard/file) error — shown inline next to the Import menu,
   // since those sources fail without a dialog of their own to host a message.
   const [importError, setImportError] = useState<string | null>(null);
-  // Export-URI dialog: the URI being exported and whether the source profile
-  // has an SSH tunnel (which can't be represented in a mongodb:// URI).
-  const [exportDialog, setExportDialog] = useState<{ uri: string; hasSsh: boolean } | null>(null);
+  // Export dialog: a single profile URI, or all profiles as JSON with folders.
+  const [exportDialog, setExportDialog] = useState<
+    | { mode: 'single'; uri: string; hasSsh: boolean }
+    | { mode: 'all' }
+    | null
+  >(null);
   const [exportIncludePassword, setExportIncludePassword] = useState(false);
   const [exportIncludeSettings, setExportIncludeSettings] = useState(true);
   const [editorState, setEditorState] = useState<typeof BLANK_CONN>(BLANK_CONN);
@@ -706,24 +715,147 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
     }
   };
 
-  // Apply an imported connection string → auto-detect protocol, hosts, auth,
-  // and topology. Accepts free-form text (a .env line, a note) and extracts
-  // the first mongodb:// / mongodb+srv:// URI from it.
-  const applyImportedUri = (raw: string | null | undefined, sourceHint: string) => {
-    const found = raw ? findMongoUriInText(raw) : null;
-    if (!found) {
-      setImportError(`No mongodb:// or mongodb+srv:// connection string found ${sourceHint}.`);
+  const openEditorForImport = () => {
+    if (showEditDialog) return;
+    setEditMode('new');
+    const defaultFolder = folders.length > 0 ? folders[0].id : '';
+    setEditorState({
+      ...BLANK_CONN,
+      name: 'New Connection',
+      hosts: [{ host: 'localhost', port: '27017' }],
+      folder: defaultFolder,
+    });
+    setError(null);
+    setTestResult(null);
+    setImportError(null);
+    setTesting(false);
+    setActiveEditorTab('server');
+    setShowEditDialog(true);
+  };
+
+  const applyImportedUri = (raw: string, name?: string) => {
+    const result = resolveImportUri(raw);
+    if (!result.ok) {
+      setImportError(result.error);
       return;
     }
     setImportError(null);
-    setEditorState(prev => ({ ...prev, uri: found, ...parseUriIntoFields(found) }));
+    setEditorState((prev) => ({
+      ...prev,
+      name: name || prev.name,
+      uri: result.uri,
+      ...parseUriIntoFields(result.uri),
+    }));
     setActiveEditorTab('server');
+  };
+
+  const uniqueImportName = (baseName: string, taken: Set<string>): string => {
+    let name = baseName.trim() || 'Imported Connection';
+    if (!taken.has(name.toLowerCase())) {
+      taken.add(name.toLowerCase());
+      return name;
+    }
+    let suffix = 2;
+    while (taken.has(`${name} (${suffix})`.toLowerCase())) suffix += 1;
+    const unique = `${name} (${suffix})`;
+    taken.add(unique.toLowerCase());
+    return unique;
+  };
+
+  const ensureImportFolder = (
+    folderName: string | null | undefined,
+    currentFolders: FolderNode[],
+    folderIdsByName: Map<string, string>,
+  ): { folderId: string | null; folders: FolderNode[] } => {
+    const trimmed = folderName?.trim();
+    if (!trimmed) return { folderId: null, folders: currentFolders };
+
+    const existingId = folderIdsByName.get(trimmed.toLowerCase());
+    if (existingId) return { folderId: existingId, folders: currentFolders };
+
+    const newFolder: FolderNode = {
+      id: `folder-${generateUUID()}`,
+      name: trimmed,
+      parentId: null,
+      shared: false,
+    };
+    folderIdsByName.set(trimmed.toLowerCase(), newFolder.id);
+    return { folderId: newFolder.id, folders: [...currentFolders, newFolder] };
+  };
+
+  const importParsedConnections = async (connections: ImportedConnection[]) => {
+    setImportError(null);
+    if (connections.length === 1 && !connections[0].folder) {
+      openEditorForImport();
+      applyImportedUri(connections[0].uri, connections[0].name);
+      return;
+    }
+
+    const proceed = await confirm({
+      title: 'Import connections',
+      message: `Found ${connections.length} connection URIs. Create a saved profile for each?`,
+      confirmLabel: 'Import all',
+    });
+    if (!proceed) return;
+
+    setLoading(true);
+    try {
+      const taken = new Set(profiles.map((profile) => profile.name.toLowerCase()));
+      let nextFolders = [...folders];
+      const folderIdsByName = new Map(
+        nextFolders.map((folder) => [folder.name.toLowerCase(), folder.id]),
+      );
+      const nextMap = { ...profileFolderMap };
+      let lastId: string | null = null;
+
+      for (const connection of connections) {
+        const name = uniqueImportName(connection.name, taken);
+        const profile: ConnectionProfile = {
+          id: generateUUID(),
+          name,
+          uri: connection.uri,
+          ssh: null,
+          color_tag: null,
+          mcp_enabled: false,
+        };
+        await invoke('save_connection_profile', { profile });
+
+        const ensured = ensureImportFolder(connection.folder, nextFolders, folderIdsByName);
+        nextFolders = ensured.folders;
+        if (ensured.folderId) nextMap[profile.id] = ensured.folderId;
+
+        lastId = profile.id;
+      }
+
+      saveFoldersToStorage(nextFolders, nextMap);
+      setExpandedFolders((prev) => {
+        const next = { ...prev };
+        for (const folder of nextFolders) next[folder.id] = true;
+        return next;
+      });
+      setShowEditDialog(false);
+      await loadProfiles();
+      if (lastId) setSelectedId(lastId);
+    } catch (err: unknown) {
+      setImportError(String(err));
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleImportFromClipboard = async () => {
     try {
       const text = await navigator.clipboard?.readText?.();
-      applyImportedUri(text, 'in the clipboard');
+      if (!text?.trim()) {
+        setImportError('Clipboard is empty');
+        return;
+      }
+      const result = parseConnectionImportFile(text);
+      if (!result.ok) {
+        setImportError(result.error);
+        return;
+      }
+      await importParsedConnections(result.connections);
     } catch {
       setImportError('Could not read the clipboard.');
     }
@@ -731,53 +863,116 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
 
   const handleImportFromFile = async () => {
     try {
-      const path = await open({ multiple: false, title: 'Import connection URI from file' });
+      const path = await open({
+        multiple: false,
+        directory: false,
+        title: 'Import connection URI from file',
+        filters: [
+          { name: 'JSON / Studio 3T URI', extensions: ['json', 'uri', 'txt', 'env'] },
+          { name: 'All files', extensions: ['*'] },
+        ],
+      });
       if (typeof path !== 'string') return;
       const text = await readTextFile(path);
-      applyImportedUri(text, `in ${path.split(/[\\/]/).pop()}`);
+      const result = parseConnectionImportFile(text);
+      if (!result.ok) {
+        setImportError(result.error);
+        return;
+      }
+      await importParsedConnections(result.connections);
     } catch {
       setImportError('Could not read the selected file.');
     }
   };
 
-  // Manual paste fallback (the original Import URI dialog).
+  // Manual paste — supports one or more URIs (with optional # labels / folders).
   const handleImportUri = async () => {
-    const uri = await prompt({
+    const text = await prompt({
       title: 'Import Connection URI',
-      message: `Paste a mongodb:// or mongodb+srv:// connection string. Protocol, hosts, auth, TLS, and topology are detected automatically. (${formatShortcut(shortcutById('submit-dialog')!)} to import)`,
-      placeholder: 'mongodb://user:pass@host1:27017,host2:27017/?replicaSet=rs0&tls=true',
+      message: `Paste one or more mongodb:// or mongodb+srv:// connection strings. Use # lines to name connections. (${formatShortcut(shortcutById('submit-dialog')!)} to import)`,
+      placeholder: '# Local\nmongodb://localhost:27017\n\n# Production\nmongodb://user:pass@host1:27017/?replicaSet=rs0',
       confirmLabel: 'Import',
       multiline: true,
-      validate: (v) => (/^mongodb(\+srv)?:\/\//i.test(v.trim()) ? null : 'Enter a mongodb:// or mongodb+srv:// URI'),
+      validate: (v) => {
+        const result = parseConnectionImportFile(v);
+        return result.ok ? null : result.error;
+      },
     });
-    if (!uri || !uri.trim()) return;
-    setImportError(null);
-    const clean = uri.trim();
-    setEditorState(prev => ({ ...prev, uri: clean, ...parseUriIntoFields(clean) }));
-    setActiveEditorTab('server');
+    if (!text || !text.trim()) return;
+    const result = parseConnectionImportFile(text);
+    if (!result.ok) {
+      setImportError(result.error);
+      return;
+    }
+    await importParsedConnections(result.connections);
   };
+
+  const importUriMenu = (testId = 'import-uri-btn', className?: string) => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className={cn(className)} data-testid={testId}>
+          <ClipboardPaste size={testId === 'import-uri-btn' ? 11 : 12} />
+          <span>Import URI</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className={NESTED_SELECT_Z}>
+        <DropdownMenuItem onClick={() => void handleImportFromClipboard()} data-testid="import-from-clipboard">
+          From clipboard
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => void handleImportFromFile()} data-testid="import-from-file">
+          From a file…
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => void handleImportUri()} data-testid="import-paste-manually">
+          Paste manually…
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 
   // Export a URI with the password stripped by default (SSH/proxy secrets too);
   // the toggles opt back into secrets or drop the settings query entirely.
   const openExportDialog = (uri: string, hasSsh: boolean) => {
     setExportIncludePassword(false);
     setExportIncludeSettings(true);
-    setExportDialog({ uri, hasSsh });
+    setExportDialog({ mode: 'single', uri, hasSsh });
   };
 
-  const exportPreview = exportDialog
-    ? buildExportUri(exportDialog.uri, {
-        includePassword: exportIncludePassword,
-        includeSettings: exportIncludeSettings,
-      })
-    : '';
+  const openExportAllDialog = () => {
+    setExportIncludePassword(false);
+    setExportIncludeSettings(true);
+    setExportDialog({ mode: 'all' });
+  };
+
+  const exportOpts = {
+    includePassword: exportIncludePassword,
+    includeSettings: exportIncludeSettings,
+  };
+
+  const exportPreview = !exportDialog
+    ? ''
+    : exportDialog.mode === 'all'
+      ? buildExportAllUris(profiles, exportOpts, { folders, profileFolderMap })
+      : buildExportUri(exportDialog.uri, exportOpts);
 
   const handleExportSave = async () => {
     if (!exportDialog) return;
     try {
-      const path = await save({ defaultPath: 'connection-uri.txt', title: 'Save connection URI' });
+      const isAll = exportDialog.mode === 'all';
+      const path = await save({
+        defaultPath: isAll ? 'connections.json' : 'connection-uri.txt',
+        title: isAll ? 'Save connection URIs' : 'Save connection URI',
+        filters: isAll
+          ? [
+              { name: 'JSON', extensions: ['json'] },
+              { name: 'All files', extensions: ['*'] },
+            ]
+          : [
+              { name: 'Text', extensions: ['txt', 'env'] },
+              { name: 'All files', extensions: ['*'] },
+            ],
+      });
       if (!path) return;
-      await writeTextFile(path, `${exportPreview}\n`);
+      await writeTextFile(path, isAll ? exportPreview : `${exportPreview}\n`);
       setExportDialog(null);
     } catch {
       /* user cancelled or write failed — keep the dialog open */
@@ -916,15 +1111,30 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                 <Trash2 size={12} />
                 <span>Delete</span>
               </Button>
+              {importUriMenu('import-uri-toolbar-btn', 'h-8 gap-1.5 text-ui-xs')}
               <Button variant="outline" size="sm" className="h-8 gap-1.5 text-ui-xs" data-testid="export-uri-btn" onClick={() => {
                 if (selectedProfile) openExportDialog(selectedProfile.uri, !!selectedProfile.ssh?.enabled);
               }}>
                 <ExternalLink size={12} />
                 <span>Export URI</span>
               </Button>
+              <Button variant="outline" size="sm" className="h-8 gap-1.5 text-ui-xs" data-testid="export-all-uris-btn" onClick={openExportAllDialog}>
+                <ExternalLink size={12} />
+                <span>Export All URIs</span>
+              </Button>
             </>
           )}
         </section>
+
+        {importError && !showEditDialog && (
+          <div
+            className="flex shrink-0 items-center gap-1.5 border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-[11px] text-destructive"
+            data-testid="import-uri-error"
+          >
+            <AlertCircle size={12} />
+            <span>{importError}</span>
+          </div>
+        )}
 
         {/* Content splits */}
         <div className="flex min-h-0 flex-1">
@@ -1966,25 +2176,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                   <RefreshCw size={11} className={testing ? 'animate-spin' : ''} />
                   <span>Test Connection</span>
                 </Button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="outline" size="sm" data-testid="import-uri-btn">
-                      <ClipboardPaste size={11} />
-                      <span>Import URI</span>
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className={NESTED_SELECT_Z}>
-                    <DropdownMenuItem onClick={handleImportFromClipboard} data-testid="import-from-clipboard">
-                      From clipboard
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={handleImportFromFile} data-testid="import-from-file">
-                      From a file…
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={handleImportUri} data-testid="import-paste-manually">
-                      Paste manually…
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                {importUriMenu()}
                 {importError && (
                   <span className="self-center text-ui-2xs text-destructive" data-testid="import-uri-error">
                     {importError}
@@ -2007,11 +2199,22 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       <Dialog open={!!exportDialog} onOpenChange={(o) => !o && setExportDialog(null)}>
         <DialogContent className="max-w-lg" data-testid="export-uri-dialog">
           <DialogHeader>
-            <DialogTitle>Export connection URI</DialogTitle>
+            <DialogTitle>
+              {exportDialog?.mode === 'all' ? 'Export All Connection URIs' : 'Export connection URI'}
+            </DialogTitle>
           </DialogHeader>
           <div className="space-y-3">
+            {exportDialog?.mode === 'all' && (
+              <p className="text-ui-2xs text-muted-foreground">
+                Exporting {profiles.length} saved connection{profiles.length === 1 ? '' : 's'} as JSON
+                (including folder structure). Compatible with MQLens import and Studio 3T-style connection files.
+              </p>
+            )}
             <code
-              className="block break-all rounded-lg border border-border bg-muted/30 px-3 py-2 font-mono text-ui-2xs"
+              className={cn(
+                'block break-all rounded-lg border border-border bg-muted/30 px-3 py-2 font-mono text-ui-2xs',
+                exportDialog?.mode === 'all' && 'max-h-40 overflow-y-auto whitespace-pre-wrap',
+              )}
               data-testid="export-uri-preview"
             >
               {exportPreview}
@@ -2044,7 +2247,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                 data-testid="export-include-settings"
               />
             </div>
-            {exportDialog?.hasSsh && (
+            {exportDialog?.mode === 'single' && exportDialog.hasSsh && (
               <p className="text-ui-2xs text-muted-foreground" data-testid="export-ssh-note">
                 This connection uses an SSH tunnel. Tunnel settings can’t be represented in a
                 MongoDB URI and are not exported.

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -1116,6 +1116,7 @@ describe('URI import and export', () => {
     mockSaveDialog.mockReset();
     mockReadTextFile.mockReset();
     mockWriteTextFile.mockReset();
+    localStorage.clear();
   });
 
   it('imports a URI from the clipboard into the editor form', async () => {
@@ -1203,6 +1204,117 @@ describe('URI import and export', () => {
 
     await waitFor(() => {
       expect(mockWriteTextFile).toHaveBeenCalledWith('/tmp/conn.txt', `${redacted}\n`);
+    });
+  });
+
+  it('exports all saved profile URIs to clipboard as JSON without passwords by default', async () => {
+    const { writeText } = setupClipboard();
+    renderManager([
+      { id: 'p1', name: 'Local', uri: 'mongodb://user:secret@localhost:27017/local', ssh: null, color_tag: null },
+      { id: 'p2', name: 'Prod', uri: 'mongodb://admin:pw@prod.example.com:27017/prod?replicaSet=rs0', ssh: null, color_tag: null },
+    ]);
+
+    fireEvent.click((await screen.findAllByText('Local'))[0]);
+    fireEvent.click(screen.getByTestId('export-all-uris-btn'));
+    await screen.findByTestId('export-uri-preview');
+    fireEvent.click(screen.getByTestId('export-copy-btn'));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        JSON.stringify(
+          {
+            folders: [
+              { name: 'Local resources', connections: [] },
+            ],
+            connections: [
+              { name: 'Local', uri: 'mongodb://user@localhost:27017/local' },
+              { name: 'Prod', uri: 'mongodb://admin@prod.example.com:27017/prod?replicaSet=rs0' },
+            ],
+          },
+          null,
+          2,
+        ),
+      );
+    });
+  });
+
+  it('imports multiple connections from MQLens JSON including folders', async () => {
+    const saved: Array<{ name: string; uri: string }> = [];
+    mockInvoke.mockImplementation((cmd: string, args?: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      if (cmd === 'save_connection_profile') {
+        saved.push({ name: args.profile.name, uri: args.profile.uri });
+        return Promise.resolve();
+      }
+      return Promise.resolve([]);
+    });
+    setupClipboard();
+    mockOpenDialog.mockResolvedValue('/tmp/connections.json');
+    mockReadTextFile.mockResolvedValue(JSON.stringify({
+      folders: [
+        {
+          name: 'Team',
+          connections: [
+            { name: 'Atlas', uri: 'mongodb+srv://user:pw@cluster0.example.net/app' },
+          ],
+        },
+      ],
+      connections: [
+        { name: 'Local', uri: 'mongodb://localhost:27017' },
+      ],
+    }));
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+
+    await openImportMenu();
+    fireEvent.click(await screen.findByTestId('import-from-file'));
+    fireEvent.click(await screen.findByRole('button', { name: /import all/i }));
+
+    await waitFor(() => {
+      expect(saved).toEqual([
+        { name: 'Atlas', uri: 'mongodb+srv://user:pw@cluster0.example.net/app' },
+        { name: 'Local', uri: 'mongodb://localhost:27017' },
+      ]);
+    });
+
+    const storedFolders = JSON.parse(localStorage.getItem('mqlens_folders') || '[]') as Array<{ name: string }>;
+    expect(storedFolders.some((folder) => folder.name === 'Team')).toBe(true);
+    const profileMap = JSON.parse(localStorage.getItem('mqlens_profile_folders') || '{}') as Record<string, string>;
+    expect(Object.keys(profileMap).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('imports multiple URIs from a Studio 3T-style export file', async () => {
+    const saved: Array<{ name: string; uri: string }> = [];
+    mockInvoke.mockImplementation((cmd: string, args?: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      if (cmd === 'save_connection_profile') {
+        saved.push({ name: args.profile.name, uri: args.profile.uri });
+        return Promise.resolve();
+      }
+      return Promise.resolve([]);
+    });
+    setupClipboard();
+    mockOpenDialog.mockResolvedValue('/tmp/studio3t.uri');
+    mockReadTextFile.mockResolvedValue([
+      '# Local',
+      'mongodb://localhost:27017',
+      '',
+      '# Production',
+      'mongodb://user:pw@prod.example.com:27017/app',
+    ].join('\n'));
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+
+    await openImportMenu();
+    fireEvent.click(await screen.findByTestId('import-from-file'));
+    fireEvent.click(await screen.findByRole('button', { name: /import all/i }));
+
+    await waitFor(() => {
+      expect(saved).toEqual([
+        { name: 'Local', uri: 'mongodb://localhost:27017' },
+        { name: 'Production', uri: 'mongodb://user:pw@prod.example.com:27017/app' },
+      ]);
+      expect(screen.queryByTestId('import-uri-success')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/lib/__tests__/connection.test.ts
+++ b/src/lib/__tests__/connection.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { buildExportUri, findMongoUriInText, stripUriSecrets } from '../connection';
+import {
+  buildExportUri,
+  buildExportAllUris,
+  extractMongoUriFromText,
+  findMongoUriInText,
+  maskUriPassword,
+  parseConnectionImportFile,
+  resolveImportUri,
+  stripUriSecrets,
+  validateMongoUri,
+} from '../connection';
 
 describe('stripUriSecrets', () => {
   it('removes the auth password but keeps the username', () => {
@@ -87,5 +97,269 @@ describe('findMongoUriInText', () => {
   it('returns null when no mongodb URI is present', () => {
     expect(findMongoUriInText('postgres://u:p@host/db')).toBeNull();
     expect(findMongoUriInText('')).toBeNull();
+  });
+});
+
+describe('validateMongoUri', () => {
+  it('accepts mongodb and mongodb+srv URIs', () => {
+    expect(validateMongoUri('mongodb://localhost:27017')).toBeNull();
+    expect(validateMongoUri('mongodb+srv://cluster.example.net')).toBeNull();
+  });
+
+  it('rejects empty and non-mongodb strings', () => {
+    expect(validateMongoUri('')).toMatch(/enter a mongodb/i);
+    expect(validateMongoUri('postgres://localhost')).toMatch(/enter a mongodb/i);
+  });
+});
+
+describe('extractMongoUriFromText', () => {
+  it('finds a URI in plain text', () => {
+    expect(extractMongoUriFromText('Use mongodb://user:pw@host/db for dev')).toBe(
+      'mongodb://user:pw@host/db',
+    );
+  });
+
+  it('finds a URI in .env-style content', () => {
+    expect(extractMongoUriFromText('MONGO_URI="mongodb+srv://cluster0.example.net/app"\n')).toBe(
+      'mongodb+srv://cluster0.example.net/app',
+    );
+  });
+
+  it('finds a URI in export-prefixed .env lines', () => {
+    expect(extractMongoUriFromText('export DATABASE_URL=mongodb://user:pw@host:27017/db')).toBe(
+      'mongodb://user:pw@host:27017/db',
+    );
+  });
+
+  it('skips commented .env lines', () => {
+    expect(extractMongoUriFromText('# MONGO_URI=mongodb://old\nMONGO_URI=mongodb://new:27017')).toBe(
+      'mongodb://new:27017',
+    );
+  });
+
+  it('returns null when no URI is present', () => {
+    expect(extractMongoUriFromText('HOST=localhost\nPORT=27017')).toBeNull();
+  });
+});
+
+describe('resolveImportUri', () => {
+  it('accepts a plain mongodb URI', () => {
+    expect(resolveImportUri('mongodb://alice:secret@host:27017/app')).toEqual({
+      ok: true,
+      uri: 'mongodb://alice:secret@host:27017/app',
+    });
+  });
+
+  it('extracts a URI embedded in .env text', () => {
+    expect(resolveImportUri('MONGO_URI=mongodb://host:27017')).toEqual({
+      ok: true,
+      uri: 'mongodb://host:27017',
+    });
+  });
+
+  it('rejects non-mongodb input', () => {
+    expect(resolveImportUri('postgres://localhost')).toEqual({
+      ok: false,
+      error: 'No mongodb:// or mongodb+srv:// URI found in file',
+    });
+  });
+
+  it('rejects empty input', () => {
+    expect(resolveImportUri('   ')).toEqual({
+      ok: false,
+      error: 'File is empty',
+    });
+  });
+});
+
+describe('parseConnectionImportFile', () => {
+  it('parses a Studio 3T single-connection .uri file', () => {
+    const text = 'mongodb://alice:secret@studio3t.example.com:27017/admin?authSource=admin&readPreference=primary';
+    expect(parseConnectionImportFile(text)).toEqual({
+      ok: true,
+      connections: [{
+        name: 'studio3t.example.com',
+        uri: text,
+        folder: null,
+      }],
+    });
+  });
+
+  it('parses multiple labeled URIs like MQLens / NoSQLBooster exports', () => {
+    const text = [
+      '# Local',
+      'mongodb://localhost:27017',
+      '',
+      '# Production',
+      'mongodb://user:pw@prod.example.com:27017/app?replicaSet=rs0',
+    ].join('\n');
+    expect(parseConnectionImportFile(text)).toEqual({
+      ok: true,
+      connections: [
+        { name: 'Local', uri: 'mongodb://localhost:27017', folder: null },
+        { name: 'Production', uri: 'mongodb://user:pw@prod.example.com:27017/app?replicaSet=rs0', folder: null },
+      ],
+    });
+  });
+
+  it('parses folder labels in text exports', () => {
+    const text = [
+      '# folder: Team',
+      '# Atlas',
+      'mongodb+srv://user:pw@cluster0.example.net/app',
+      '# folder: Local',
+      '# Dev',
+      'mongodb://localhost:27017',
+    ].join('\n');
+    expect(parseConnectionImportFile(text)).toEqual({
+      ok: true,
+      connections: [
+        { name: 'Atlas', uri: 'mongodb+srv://user:pw@cluster0.example.net/app', folder: 'Team' },
+        { name: 'Dev', uri: 'mongodb://localhost:27017', folder: 'Local' },
+      ],
+    });
+  });
+
+  it('parses Studio 3T-style JSON connection exports with folders', () => {
+    const text = JSON.stringify({
+      folders: [{
+        name: 'Team',
+        connections: [
+          { name: 'Atlas', uri: 'mongodb+srv://user:pw@cluster0.example.net/app' },
+        ],
+      }],
+      connections: [
+        { connectionName: 'Dev', connectionString: 'mongodb://dev.local:27017' },
+      ],
+    });
+    expect(parseConnectionImportFile(text)).toEqual({
+      ok: true,
+      connections: expect.arrayContaining([
+        { name: 'Atlas', uri: 'mongodb+srv://user:pw@cluster0.example.net/app', folder: 'Team' },
+        { name: 'Dev', uri: 'mongodb://dev.local:27017', folder: null },
+      ]),
+    });
+  });
+
+  it('parses MQLens export JSON with nested folders', () => {
+    const text = JSON.stringify({
+      folders: [
+        {
+          name: 'Local resources',
+          connections: [
+            { name: 'Local', uri: 'mongodb://localhost:27017' },
+          ],
+        },
+      ],
+      connections: [
+        { name: 'Orphan', uri: 'mongodb://orphan:27017' },
+      ],
+    });
+    expect(parseConnectionImportFile(text)).toEqual({
+      ok: true,
+      connections: [
+        { name: 'Local', uri: 'mongodb://localhost:27017', folder: 'Local resources' },
+        { name: 'Orphan', uri: 'mongodb://orphan:27017', folder: null },
+      ],
+    });
+  });
+
+  it('parses multiple plain URIs on separate lines', () => {
+    const text = [
+      'mongodb://localhost:27017',
+      'mongodb://prod.example.com:27017/app',
+    ].join('\n');
+    expect(parseConnectionImportFile(text)).toEqual({
+      ok: true,
+      connections: [
+        { name: 'localhost', uri: 'mongodb://localhost:27017', folder: null },
+        { name: 'prod.example.com', uri: 'mongodb://prod.example.com:27017/app', folder: null },
+      ],
+    });
+  });
+
+  it('deduplicates repeated URIs', () => {
+    const text = [
+      '# One',
+      'mongodb://host:27017/db',
+      '# Two',
+      'mongodb://host:27017/db',
+    ].join('\n');
+    const result = parseConnectionImportFile(text);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.connections).toHaveLength(1);
+  });
+});
+
+describe('maskUriPassword', () => {
+  it('masks the auth password for display', () => {
+    expect(maskUriPassword('mongodb://alice:secret@host/db')).toBe(
+      'mongodb://alice:••••••@host/db',
+    );
+  });
+});
+
+describe('buildExportAllUris', () => {
+  const profiles = [
+    { id: 'p1', name: 'Local', uri: 'mongodb://user:secret@localhost:27017/local?appName=MQLens' },
+    { id: 'p2', name: 'Prod', uri: 'mongodb://admin:pw@prod.example.com:27017/prod?replicaSet=rs0' },
+  ];
+
+  it('formats each connection as JSON', () => {
+    const text = buildExportAllUris(profiles, {
+      includePassword: true,
+      includeSettings: true,
+    });
+    expect(JSON.parse(text)).toEqual({
+      connections: [
+        { name: 'Local', uri: 'mongodb://user:secret@localhost:27017/local?appName=MQLens' },
+        { name: 'Prod', uri: 'mongodb://admin:pw@prod.example.com:27017/prod?replicaSet=rs0' },
+      ],
+    });
+  });
+
+  it('strips secrets from every exported URI by default', () => {
+    const text = buildExportAllUris(profiles, {
+      includePassword: false,
+      includeSettings: true,
+    });
+    const parsed = JSON.parse(text);
+    expect(parsed.connections).toEqual([
+      { name: 'Local', uri: 'mongodb://user@localhost:27017/local?appName=MQLens' },
+      { name: 'Prod', uri: 'mongodb://admin@prod.example.com:27017/prod?replicaSet=rs0' },
+    ]);
+    expect(text).not.toContain('secret');
+    expect(text).not.toContain(':pw@');
+  });
+
+  it('preserves folder structure for transfer between MQLens instances', () => {
+    const text = buildExportAllUris(
+      profiles,
+      { includePassword: false, includeSettings: true },
+      {
+        folders: [
+          { id: 'f1', name: 'Local resources' },
+          { id: 'f2', name: 'Production' },
+        ],
+        profileFolderMap: { p1: 'f1', p2: 'f2' },
+      },
+    );
+    expect(JSON.parse(text)).toEqual({
+      folders: [
+        {
+          name: 'Local resources',
+          connections: [
+            { name: 'Local', uri: 'mongodb://user@localhost:27017/local?appName=MQLens' },
+          ],
+        },
+        {
+          name: 'Production',
+          connections: [
+            { name: 'Prod', uri: 'mongodb://admin@prod.example.com:27017/prod?replicaSet=rs0' },
+          ],
+        },
+      ],
+      connections: [],
+    });
   });
 });

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -19,6 +19,29 @@ export interface ExportUriOptions {
   includeSettings: boolean;
 }
 
+export const MONGO_URI_RE = /^mongodb(\+srv)?:\/\//i;
+export const MONGO_URI_IN_TEXT_RE = /mongodb(\+srv)?:\/\/[^\s'"<>\r\n]+/i;
+
+export type ImportUriResult =
+  | { ok: true; uri: string }
+  | { ok: false; error: string };
+
+export type ImportedConnection = {
+  name: string;
+  uri: string;
+  /** Folder name to place the connection in; omitted/null means root. */
+  folder?: string | null;
+};
+
+export type ParseConnectionsResult =
+  | { ok: true; connections: ImportedConnection[] }
+  | { ok: false; error: string };
+
+export type ExportFolderInfo = {
+  folders: Array<{ id: string; name: string }>;
+  profileFolderMap: Record<string, string>;
+};
+
 // Query params whose values are secrets in their own right.
 const SECRET_PARAM_KEYS = /^(proxyPassword|tlsCertificateKeyFilePassword|sslClientCertificateKeyPassword)$/i;
 
@@ -60,10 +83,280 @@ export const buildExportUri = (uri: string, opts: ExportUriOptions): string => {
   return out;
 };
 
+/** Validation message for import flows; `null` when the string is a MongoDB URI. */
+export function validateMongoUri(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return 'Enter a mongodb:// or mongodb+srv:// URI';
+  if (!MONGO_URI_RE.test(trimmed)) return 'Enter a mongodb:// or mongodb+srv:// URI';
+  return null;
+}
+
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+function deriveNameFromUri(uri: string): string {
+  const match = uri.match(/mongodb(\+srv)?:\/\/(?:[^/@]+@)?([^/?,@]+)/i);
+  const host = match?.[2]?.split(':')[0];
+  return host || 'Imported Connection';
+}
+
+function pickString(obj: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function normalizeUriCandidate(raw: string): string | null {
+  const trimmed = raw.trim().replace(/^["']|["']$/g, '');
+  return MONGO_URI_RE.test(trimmed) ? trimmed : null;
+}
+
+function extractUriFromLine(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  const envMatch = trimmed.match(/^(?:export\s+)?[\w.-]+\s*=\s*(.+)$/i);
+  const candidate = envMatch ? envMatch[1].trim() : trimmed;
+  const unquoted = candidate.replace(/^["']|["']$/g, '');
+
+  const direct = unquoted.match(MONGO_URI_IN_TEXT_RE);
+  return direct ? normalizeUriCandidate(direct[0]) : null;
+}
+
+function parseLabelFromComment(line: string): string | null {
+  const trimmed = line.trim();
+  const match = trimmed.match(/^(?:#|\/\/|;)\s*(.+)$/);
+  if (!match) return null;
+  const label = match[1].trim();
+  if (MONGO_URI_RE.test(label)) return null;
+  return label || null;
+}
+
+function parseTextConnections(text: string, out: ImportedConnection[]): void {
+  let pendingName: string | null = null;
+  let pendingFolder: string | null = null;
+
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    if (trimmed.startsWith('#')) {
+      if (/^#\s*(?:export\s+)?[\w.-]+\s*=\s*.+$/i.test(trimmed)) continue;
+
+      const folderMatch = trimmed.match(/^#\s*(?:folder|group)\s*[:=]\s*(.+)$/i);
+      if (folderMatch) {
+        pendingFolder = folderMatch[1].trim() || null;
+        pendingName = null;
+        continue;
+      }
+
+      const label = parseLabelFromComment(trimmed);
+      if (label) pendingName = label;
+      continue;
+    }
+
+    const label = parseLabelFromComment(trimmed);
+    if (label && !extractUriFromLine(trimmed)) {
+      pendingName = label;
+      continue;
+    }
+
+    const uri = extractUriFromLine(trimmed);
+    if (!uri) continue;
+
+    const name = pendingName || deriveNameFromUri(uri);
+    pendingName = null;
+    out.push({ name, uri, folder: pendingFolder });
+  }
+}
+
+function collectConnectionsFromJson(value: unknown, out: ImportedConnection[], inheritedFolder?: string): void {
+  if (typeof value === 'string') {
+    const uri = normalizeUriCandidate(value);
+    if (uri) {
+      out.push({ name: deriveNameFromUri(uri), uri, folder: inheritedFolder ?? null });
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectConnectionsFromJson(item, out, inheritedFolder));
+    return;
+  }
+
+  if (!value || typeof value !== 'object') return;
+
+  const obj = value as Record<string, unknown>;
+  const name = pickString(obj, ['connectionName', 'name', 'title', 'label']);
+  const folder =
+    pickString(obj, ['folder', 'folderName', 'connectionFolder', 'group', 'groupName'])
+    || inheritedFolder
+    || null;
+  const uri = pickString(obj, ['uri', 'connectionString', 'connectionUri', 'url', 'connection_url']);
+
+  if (uri) {
+    const normalized = normalizeUriCandidate(uri);
+    if (normalized) {
+      out.push({
+        name: name || deriveNameFromUri(normalized),
+        uri: normalized,
+        folder,
+      });
+      return;
+    }
+  }
+
+  // Nested folder node: { name, connections[], folders[] }
+  const isFolderNode =
+    Array.isArray(obj.connections) || Array.isArray(obj.folders) || Array.isArray(obj.items);
+  const folderName = isFolderNode && name && !uri ? name : inheritedFolder;
+
+  if (Array.isArray(obj.folders)) {
+    obj.folders.forEach((nestedFolder) => {
+      collectConnectionsFromJson(nestedFolder, out, folderName || undefined);
+    });
+  }
+
+  for (const key of ['connections', 'items', 'profiles']) {
+    const nested = obj[key];
+    if (Array.isArray(nested)) {
+      nested.forEach((item) => collectConnectionsFromJson(item, out, folderName || undefined));
+    }
+  }
+
+  for (const nested of Object.values(obj)) {
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      const record = nested as Record<string, unknown>;
+      if ('connections' in record || 'folders' in record || 'uri' in record || 'connectionString' in record) {
+        collectConnectionsFromJson(nested, out, folderName || undefined);
+      }
+    }
+  }
+}
+
+/** Parse Studio 3T .uri files, multi-URI lists, .env files, and JSON connection exports. */
+export function parseConnectionImportFile(text: string): ParseConnectionsResult {
+  const normalized = stripBom(text).trim();
+  if (!normalized) {
+    return { ok: false, error: 'File is empty' };
+  }
+
+  const connections: ImportedConnection[] = [];
+
+  if (normalized.startsWith('{') || normalized.startsWith('[')) {
+    try {
+      collectConnectionsFromJson(JSON.parse(normalized), connections);
+    } catch {
+      // Fall back to plain-text parsing below.
+    }
+  }
+
+  if (connections.length === 0) {
+    parseTextConnections(normalized, connections);
+  }
+
+  if (connections.length === 0) {
+    const globalMatches = normalized.matchAll(/mongodb(\+srv)?:\/\/[^\s'"<>\r\n]+/gi);
+    for (const match of globalMatches) {
+      const uri = normalizeUriCandidate(match[0]);
+      if (uri) connections.push({ name: deriveNameFromUri(uri), uri });
+    }
+  }
+
+  const seen = new Set<string>();
+  const unique = connections.filter((connection) => {
+    if (seen.has(connection.uri)) return false;
+    seen.add(connection.uri);
+    return true;
+  });
+
+  if (unique.length === 0) {
+    return { ok: false, error: 'No mongodb:// or mongodb+srv:// URI found in file' };
+  }
+
+  return { ok: true, connections: unique };
+}
+
+/** Find the first mongodb URI in clipboard text or a file (.env, plain text, etc.). */
+export function extractMongoUriFromText(text: string): string | null {
+  const result = parseConnectionImportFile(text);
+  return result.ok ? result.connections[0].uri : null;
+}
+
 /**
  * Find the first mongodb:// / mongodb+srv:// connection string in free-form
  * text (a .env file, a note, a pasted config). Quotes and whitespace end the
  * match so `MONGO_URL="mongodb://…"` yields just the URI.
  */
-export const findMongoUriInText = (text: string): string | null =>
-  text.match(/mongodb(?:\+srv)?:\/\/[^\s"'`;]+/i)?.[0] ?? null;
+export const findMongoUriInText = (text: string): string | null => extractMongoUriFromText(text);
+
+/** Validate and normalize raw clipboard/file/paste input into a MongoDB URI. */
+export function resolveImportUri(raw: string): ImportUriResult {
+  const result = parseConnectionImportFile(raw);
+  if (!result.ok) return result;
+  return { ok: true, uri: result.connections[0].uri };
+}
+
+/** Display mask: replace the auth password with bullets without changing the URI. */
+export function maskUriPassword(uri: string): string {
+  return uri.replace(/(\/\/[^/:@\s]+:)([^@/\s]+)(@)/, (_m, a, _p, c) => `${a}••••••${c}`);
+}
+
+/** Format every saved connection as JSON, preserving folder structure for MQLens / Studio 3T transfer. */
+export function buildExportAllUris(
+  profiles: Array<Pick<ConnectionProfile, 'id' | 'name' | 'uri'> | Pick<ConnectionProfile, 'name' | 'uri'>>,
+  options: ExportUriOptions,
+  folderInfo?: ExportFolderInfo,
+): string {
+  type ExportConnection = { name: string; uri: string };
+  type ExportFolder = { name: string; connections: ExportConnection[] };
+
+  const toExportConnection = (
+    profile: Pick<ConnectionProfile, 'name' | 'uri'>,
+  ): ExportConnection => ({
+    name: profile.name,
+    uri: buildExportUri(profile.uri, options),
+  });
+
+  if (!folderInfo || folderInfo.folders.length === 0) {
+    return JSON.stringify(
+      {
+        connections: profiles.map(toExportConnection),
+      },
+      null,
+      2,
+    );
+  }
+
+  const folderById = new Map(folderInfo.folders.map((folder) => [folder.id, folder.name]));
+  const foldersOut: ExportFolder[] = folderInfo.folders.map((folder) => ({
+    name: folder.name,
+    connections: [],
+  }));
+  const folderIndex = new Map(foldersOut.map((folder, index) => [folder.name, index]));
+  const rootConnections: ExportConnection[] = [];
+
+  for (const profile of profiles) {
+    const exported = toExportConnection(profile);
+    const profileId = 'id' in profile ? profile.id : undefined;
+    const folderId = profileId ? folderInfo.profileFolderMap[profileId] : undefined;
+    const folderName = folderId ? folderById.get(folderId) : undefined;
+    if (folderName && folderIndex.has(folderName)) {
+      foldersOut[folderIndex.get(folderName)!].connections.push(exported);
+    } else {
+      rootConnections.push(exported);
+    }
+  }
+
+  return JSON.stringify(
+    {
+      folders: foldersOut,
+      connections: rootConnections,
+    },
+    null,
+    2,
+  );
+}


### PR DESCRIPTION
## Summary
- Multi-URI import from JSON, Studio 3T `.uri` files, labeled text (`# name` / `# folder: Name`), and `.env` content — bulk saves create profiles and missing folders
- **Export All URIs** exports every saved profile as JSON (with folder structure) for transfer between MQLens instances; single-URI export dialog behavior is unchanged
- Round-trip compatible: MQLens export JSON re-imports with folders preserved; existing `stripUriSecrets` / `buildExportUri` / `findMongoUriInText` APIs and MCP profile fields are unchanged

## Test plan
- [ ] `npx tsc --noEmit`
- [ ] `npm test -- src/lib/__tests__/connection.test.ts src/components/__tests__/ConnectionManager.test.tsx`
- [ ] Import a single URI from clipboard/file → editor fills as before
- [ ] Import a multi-URI JSON / Studio 3T export → confirm → profiles + folders created
- [ ] Export All URIs → JSON on clipboard/file with password/settings toggles
- [ ] Re-import that JSON on a clean profile list and verify folder placement