### PR TITLE
feat: production safeguards — read-only & confirm-destructive connection modes (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ queries actually do — from a single cross-platform desktop app.
 - **MCP server** — expose your connections to Claude Code, Cursor, and other agents as
   [Model Context Protocol tools](docs/mcp-tools.md); per-connection opt-in, writes gated behind
   explicit confirmation, off by default.
+- **Production safeguards** — mark a connection read-only or require typed
+  confirmation for destructive operations; enforced at the command layer,
+  for the UI and AI agents alike.
 
 ## Install
 

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -1,0 +1,283 @@
+//! Security review #188 fix wave, Fix 3: a structural cross-check that
+//! catches an unclassified command the way the ORIGINAL plan's hand-copied
+//! coverage list couldn't. `write_guard.rs`'s `non_destructive_cases` /
+//! `destructive_cases` tables are hand-maintained lists of the mutating
+//! `_impl`s someone remembered to wire up — which is exactly how the two
+//! CRITICAL findings in this fix wave (`execute_aggregate`'s $out/$merge and
+//! the embedded mongosh shell) escaped the original #188 plan: both are
+//! real Tauri commands that mutate data, and neither was on that hand-list.
+//!
+//! This module parses the ACTUAL `tauri::generate_handler![...]` macro
+//! invocation out of `lib.rs`'s source at test time (`include_str!`, not a
+//! second hand-copied list) and asserts every command it finds is in
+//! EXACTLY ONE of the three buckets below. A new command that nobody
+//! classifies fails this test immediately — forcing a human to decide
+//! read/guarded/local instead of silently shipping unguarded, which is
+//! precisely the class of bug this fix wave is closing.
+
+#![cfg(test)]
+
+use std::collections::HashSet;
+
+/// Commands that only ever READ — either from a live MongoDB connection
+/// (list/count/explain/analyze/stats/status-shaped commands, dumps that
+/// write only to the local filesystem) or from a local resource that
+/// doesn't need a connection-mode check. Never blocked by
+/// `read_only`/`confirm_destructive`, and never should be.
+const READ_COMMANDS: &[&str] = &[
+    "start_dump_task", // mongodump reads the DB, writes only to a local file
+    "get_mongodb_version",
+    "list_databases",
+    "list_collections",
+    "list_indexes",
+    "db_stats",
+    "coll_stats",
+    "index_stats",
+    "list_gridfs_files",
+    "download_gridfs_file",
+    "execute_mql_query",
+    "count_documents",
+    "start_collection_export", // exports read data out, write only to a local file
+    "start_filtered_export",
+    "sample_export_fields",
+    "preview_export",
+    "preflight_copy", // dry-run conflict/count check, no write
+    "get_collection_options",
+    "explain_mql_query",
+    "explain_aggregate_query", // explains, never executes a write
+    "analyze_schema",
+    "infer_generate_template", // samples existing docs to build a template
+    "server_status",
+    "current_ops",
+    "repl_set_status",
+    "list_users",
+    "list_roles",
+    "get_profiling_status",
+    "read_profile",
+];
+
+/// App-local commands: no live MongoDB connection's data is touched, so no
+/// connection-mode check applies. Covers connection lifecycle (before a
+/// mode is even known / after it no longer matters), local app state
+/// (vault, workspace/window layout, saved queries, settings, connection
+/// profiles), local tooling (installers, path detection, resource usage),
+/// and pure local computation (formatting already-fetched docs, generating
+/// documents from a template with no DB round-trip).
+const LOCAL_COMMANDS: &[&str] = &[
+    "connect_db",
+    "detect_mongo_tools",
+    "detect_mongosh_binary",
+    "start_tool_install_task",
+    "managed_tools_status",
+    "browse_dump_folder",
+    "preview_dump_command",
+    "preview_restore_command",
+    "get_resource_usage",
+    "generate_mql_query",
+    "detect_local_agents",
+    "stop_mongosh_session", // kills the local child process, no DB write
+    "disconnect_db",
+    "set_connection_meta", // renderer-callable with an arbitrary mode — see its own doc comment
+    "connection_list",
+    "preview_import", // parses a local file for a preview, no DB access
+    "format_current_docs",
+    "list_export_tasks",
+    "clear_finished_export_tasks",
+    "cancel_task",
+    "preview_generated_documents", // pure template generation, no DB
+    "vault_status",
+    "vault_initialize",
+    "vault_unlock",
+    "vault_lock",
+    "vault_reset",
+    "vault_change_password",
+    "mcp_get_status",
+    "mcp_set_enabled",
+    "mcp_regenerate_token",
+    "biometric_status",
+    "biometric_enable",
+    "biometric_unlock",
+    "biometric_disable",
+    "load_connection_profiles",
+    "save_connection_profile",
+    "delete_connection_profile",
+    "test_connection_uri", // ephemeral test connection, never tracked in connection_meta
+    "load_app_settings",
+    "save_app_settings",
+    "test_mongosh_path",
+    "load_collection_queries",
+    "save_query",
+    "delete_saved_query",
+    "record_history",
+    "set_default_query",
+    "list_all_saved_queries",
+    "workspace_get",
+    "workspace_apply",
+    "workspace_detach_tab",
+    "spawn_saved_windows",
+    "focus_window",
+    "close_workspace_window",
+    "update_check",
+    "update_install",
+];
+
+/// Commands that can mutate a connection's data and are covered by the
+/// write-guard system — either directly (`guard_writable` is the first
+/// thing the `_impl` calls) or, for the two commands this fix wave added,
+/// by an equivalent mode check that fires before anything mutating can
+/// happen:
+/// - `execute_aggregate` (Fix 1): guards on `WriteOp::Drop` only when the
+///   pipeline carries a `$out`/`$merge` stage — see
+///   `db::aggregate::execute_aggregate_impl`'s doc comment.
+/// - `start_mongosh_session` (Fix 2): reads `write_guard::connection_mode`
+///   directly and refuses `ReadOnly` before a shell is ever spawned — see
+///   `start_mongosh_session_impl`'s doc comment.
+/// - `run_mongosh_command` is included here too even though it has no guard
+///   call of its own: it only ever operates on a session obtained from
+///   `start_mongosh_session`, so a `read_only` connection can never produce
+///   a session for it to run a command against. Its protection is entirely
+///   transitive — see `start_mongosh_session_impl`'s doc comment for the
+///   `confirm_destructive` limitation this implies (arbitrary shell input
+///   can't be gated per-command).
+const GUARDED_WRITE_COMMANDS: &[&str] = &[
+    "start_restore_task",
+    "start_mongosh_session",
+    "run_mongosh_command",
+    "create_index",
+    "delete_index",
+    "delete_document",
+    "delete_many",
+    "update_many",
+    "upload_gridfs_file",
+    "delete_gridfs_file",
+    "insert_document",
+    "start_import_task",
+    "update_document",
+    "execute_aggregate",
+    "start_collection_copy",
+    "start_database_copy",
+    "create_collection",
+    "create_view",
+    "drop_collection",
+    "rename_collection",
+    "set_validator",
+    "drop_database",
+    "rename_database",
+    "start_generate_task",
+    "kill_op",
+    "create_user",
+    "update_user",
+    "drop_user",
+    "set_profiling_level",
+];
+
+/// Parse the command idents out of `lib.rs`'s `tauri::generate_handler![
+/// ... ]` invocation. Tauri registers a command under its function's own
+/// name (the last path segment) regardless of how it's referred to in the
+/// macro — e.g. `biometric::biometric_status` registers as
+/// `"biometric_status"` — so entries are normalized the same way.
+fn parse_registered_commands() -> Vec<String> {
+    let src = include_str!("lib.rs");
+    let marker = "tauri::generate_handler![";
+    let start = src
+        .find(marker)
+        .expect("tauri::generate_handler![ not found in lib.rs — did it move or get renamed?")
+        + marker.len();
+    let rest = &src[start..];
+    let end = rest
+        .find(']')
+        .expect("no closing ] found for generate_handler! — macro body must be a flat ident list");
+    let body = &rest[..end];
+
+    body.lines()
+        .map(|line| match line.find("//") {
+            Some(i) => &line[..i],
+            None => line,
+        })
+        .flat_map(|line| line.split(','))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.rsplit("::").next().unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn every_registered_tauri_command_is_classified_into_exactly_one_bucket() {
+    let commands = parse_registered_commands();
+    // Sanity check: if the macro-parsing regressed (wrong marker, moved
+    // file, comment syntax changed) it would likely find far fewer entries
+    // than the real command list — fail loudly instead of silently passing
+    // an empty/tiny set.
+    assert!(
+        commands.len() > 100,
+        "parsed suspiciously few commands ({}) out of generate_handler! — \
+         command-list parsing in command_coverage.rs likely broke",
+        commands.len()
+    );
+
+    let read: HashSet<&str> = READ_COMMANDS.iter().copied().collect();
+    let local: HashSet<&str> = LOCAL_COMMANDS.iter().copied().collect();
+    let guarded: HashSet<&str> = GUARDED_WRITE_COMMANDS.iter().copied().collect();
+
+    assert_eq!(
+        read.len(),
+        READ_COMMANDS.len(),
+        "duplicate entry in READ_COMMANDS"
+    );
+    assert_eq!(
+        local.len(),
+        LOCAL_COMMANDS.len(),
+        "duplicate entry in LOCAL_COMMANDS"
+    );
+    assert_eq!(
+        guarded.len(),
+        GUARDED_WRITE_COMMANDS.len(),
+        "duplicate entry in GUARDED_WRITE_COMMANDS"
+    );
+
+    let overlap_read_local: Vec<&&str> = read.intersection(&local).collect();
+    assert!(
+        overlap_read_local.is_empty(),
+        "command(s) classified in both READ_COMMANDS and LOCAL_COMMANDS: {overlap_read_local:?}"
+    );
+    let overlap_read_guarded: Vec<&&str> = read.intersection(&guarded).collect();
+    assert!(
+        overlap_read_guarded.is_empty(),
+        "command(s) classified in both READ_COMMANDS and GUARDED_WRITE_COMMANDS: {overlap_read_guarded:?}"
+    );
+    let overlap_local_guarded: Vec<&&str> = local.intersection(&guarded).collect();
+    assert!(
+        overlap_local_guarded.is_empty(),
+        "command(s) classified in both LOCAL_COMMANDS and GUARDED_WRITE_COMMANDS: {overlap_local_guarded:?}"
+    );
+
+    let unclassified: Vec<&String> = commands
+        .iter()
+        .filter(|c| !read.contains(c.as_str()) && !local.contains(c.as_str()) && !guarded.contains(c.as_str()))
+        .collect();
+    assert!(
+        unclassified.is_empty(),
+        "command(s) registered in lib.rs's generate_handler! but not classified in \
+         command_coverage.rs — add each to exactly one of READ_COMMANDS (pure read, \
+         never blocked), LOCAL_COMMANDS (app-local, no live connection data touched), \
+         or GUARDED_WRITE_COMMANDS (mutates a connection's data — its _impl MUST call \
+         write_guard::guard_writable, or an equivalent mode check, before doing any \
+         work): {unclassified:?}"
+    );
+
+    // Catch the inverse rot too: a bucket entry for a command that was
+    // renamed/removed would otherwise sit there unnoticed, silently
+    // asserting nothing.
+    let registered: HashSet<&str> = commands.iter().map(String::as_str).collect();
+    let stale: Vec<&&str> = read
+        .iter()
+        .chain(local.iter())
+        .chain(guarded.iter())
+        .filter(|c| !registered.contains(*c))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "bucket entries in command_coverage.rs that no longer match a registered command \
+         (renamed or removed?): {stale:?}"
+    );
+}

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -5,6 +5,21 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tauri::Manager;
 
+/// Per-connection production safeguard (#188): `Normal` allows every write,
+/// `ReadOnly` blocks all writes at the command layer, `ConfirmDestructive`
+/// requires an explicit typed-name confirmation for destructive ops (drop,
+/// delete_many, update_many, rename). `#[default] Normal` + `serde(default)`
+/// on the field below is the same additive pattern as `mcp_enabled` — old
+/// profiles/connections.json entries without the field read as `Normal`.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionMode {
+    #[default]
+    Normal,
+    ReadOnly,
+    ConfirmDestructive,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct ConnectionProfile {
     pub id: String,
@@ -21,6 +36,11 @@ pub struct ConnectionProfile {
     /// without the field deserialize as false — never opted in by surprise.
     #[serde(default)]
     pub mcp_enabled: bool,
+    /// Read-only / confirm-destructive production safeguard (#188). Old
+    /// profiles without the field deserialize as `ConnectionMode::Normal` —
+    /// same additive pattern as `mcp_enabled`.
+    #[serde(default)]
+    pub connection_mode: ConnectionMode,
 }
 
 fn default_anthropic_model() -> String {

--- a/src-tauri/src/db/aggregate.rs
+++ b/src-tauri/src/db/aggregate.rs
@@ -2,14 +2,27 @@
 
 use crate::limits::MAX_AGGREGATE_RESULTS;
 use crate::state::LockExt;
+use crate::write_guard::{guard_writable, stage_is_disallowed, WriteOp};
 use crate::AppState;
 
+/// #188 security review Fix 1 (CRITICAL): `$out`/`$merge` stages write the
+/// pipeline's output into a collection — `$out` replaces it outright,
+/// `$merge` upserts into it — so this runs the same "drop"-shaped risk as
+/// `drop_collection` on a safeguarded connection, yet unlike every other
+/// mutating `_impl` it wasn't guarded at all (the MCP `aggregate` tool
+/// rejects `$out`/`$merge` outright via the same [`stage_is_disallowed`];
+/// the UI path historically ran the pipeline verbatim). Only guard when a
+/// write stage is actually present — a pure-read aggregation must keep
+/// working on a `read_only` connection, which is why the check runs on the
+/// already-parsed `stages_val` up front rather than blanket-guarding every
+/// call with `WriteOp::Drop`.
 pub async fn execute_aggregate_impl(
     state: &AppState,
     id: &str,
     database: &str,
     collection: &str,
     pipeline: &str,
+    confirmed: bool,
 ) -> Result<Vec<String>, String> {
     // Parse and validate the pipeline (a JSON array of stage documents) up front so a
     // malformed pipeline fails clearly regardless of the connection type.
@@ -22,6 +35,15 @@ pub async fn execute_aggregate_impl(
     let stages_val = pipeline_val
         .as_array()
         .ok_or_else(|| "Aggregation pipeline must be a JSON array of stages".to_string())?;
+
+    // Guard BEFORE any DB work — but only when a stage actually writes.
+    // `WriteOp::Drop` is the closest existing shape (it's in
+    // `WriteOp::is_destructive`, so `ConfirmDestructive` demands
+    // `confirmed`, and `ReadOnly` blocks unconditionally either way).
+    if stages_val.iter().any(stage_is_disallowed) {
+        guard_writable(state, id, WriteOp::Drop, confirmed)?;
+    }
+
     let mut stages: Vec<mongodb::bson::Document> = Vec::with_capacity(stages_val.len());
     for stage in stages_val {
         let doc = mongodb::bson::to_document(stage)

--- a/src-tauri/src/db/copy.rs
+++ b/src-tauri/src/db/copy.rs
@@ -2,6 +2,7 @@
 
 use crate::limits::IMPORT_BATCH_SIZE;
 use crate::state::LockExt;
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{connection_is_mock, mock_db, require_real_client, AppState, CopyFailure, CopySummary, TaskInfo};
 use mongodb::bson::Document;
 use mongodb::Client;
@@ -422,6 +423,10 @@ pub async fn start_collection_copy_impl(
     include_indexes: bool,
     conflict_mode: String,
 ) -> Result<TaskInfo, String> {
+    // Copy commands guard the TARGET connection, not the source — a copy
+    // writes into the target.
+    guard_writable(state, target_id, WriteOp::CopyWrite, false)?;
+
     let mode = ConflictMode::parse(&conflict_mode)?;
     let filter_doc = parse_filter(filter.as_deref())?;
 
@@ -526,6 +531,10 @@ pub async fn start_database_copy_impl(
     include_views: bool,
     conflict_mode: String,
 ) -> Result<TaskInfo, String> {
+    // Copy commands guard the TARGET connection, not the source — a copy
+    // writes into the target.
+    guard_writable(state, target_id, WriteOp::CopyWrite, false)?;
+
     let mode = ConflictMode::parse(&conflict_mode)?;
     if source_id == target_id && source_db == target_db {
         return Err("Source and target database are the same — copy would overwrite itself".to_string());

--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -90,7 +90,10 @@ pub async fn drop_collection_impl(
     id: &str,
     database: &str,
     collection: &str,
+    confirmed: bool,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::Drop, confirmed)?;
+
     if connection_is_mock(state, id)? {
         return Ok(());
     }
@@ -109,7 +112,10 @@ pub async fn rename_collection_impl(
     database: &str,
     from: &str,
     to: &str,
+    confirmed: bool,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::Rename, confirmed)?;
+
     if from.trim().is_empty() || to.trim().is_empty() {
         return Err("Collection name is required".to_string());
     }
@@ -230,7 +236,14 @@ pub async fn set_validator_impl(
         .map_err(|e| format!("Failed to apply validation rules: {}", e))
 }
 
-pub async fn drop_database_impl(state: &AppState, id: &str, database: &str) -> Result<(), String> {
+pub async fn drop_database_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    confirmed: bool,
+) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::Drop, confirmed)?;
+
     if database.trim().is_empty() {
         return Err("Database name is required".to_string());
     }
@@ -251,15 +264,16 @@ pub async fn rename_database_impl(
     from: &str,
     to: &str,
     drop_source: bool,
+    confirmed: bool,
 ) -> Result<DatabaseRenameResult, String> {
-    // `rename_database_impl` is a mutating command outside the plan's Task
-    // 2/Task 3 coverage lists (found during Task 2 implementation — see the
-    // write_guard.rs test doc comment for detail). It's at least as
-    // destructive as `rename_collection` (renames every collection in the
-    // db, optionally drops the source), so it's guarded with
-    // `WriteOp::Rename`; it has no `confirmed` command arg yet, so
-    // `confirmed` is hardcoded `false` pending a follow-up task.
-    guard_writable(state, id, WriteOp::Rename, false)?;
+    // `rename_database_impl` was found during Task 2 to be a mutating
+    // command outside the plan's Task 2 coverage list (see write_guard.rs's
+    // module doc for detail); Task 2 guarded it with a hardcoded
+    // `confirmed=false` interim. It's at least as destructive as
+    // `rename_collection` (renames every collection in the db, optionally
+    // drops the source), so — like `rename_collection` — Task 3 gives it a
+    // real `confirmed` command arg here.
+    guard_writable(state, id, WriteOp::Rename, confirmed)?;
 
     if from.trim().is_empty() || to.trim().is_empty() {
         return Err("Database name is required".to_string());

--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -1,5 +1,6 @@
 //! Collection, view, and database DDL operations.
 
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{connection_is_mock, require_real_client, AppState};
 
 #[derive(serde::Serialize)]
@@ -22,6 +23,8 @@ pub async fn create_collection_impl(
     database: &str,
     collection: &str,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::CreateCollection, false)?;
+
     if collection.trim().is_empty() {
         return Err("Collection name is required".to_string());
     }
@@ -44,6 +47,8 @@ pub async fn create_view_impl(
     source_collection: &str,
     pipeline: &str,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::CreateView, false)?;
+
     if view_name.trim().is_empty() {
         return Err("View name is required".to_string());
     }
@@ -186,6 +191,8 @@ pub async fn set_validator_impl(
     validation_level: &str,
     validation_action: &str,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::CollMod, false)?;
+
     if collection.trim().is_empty() {
         return Err("Collection name is required".into());
     }
@@ -245,6 +252,15 @@ pub async fn rename_database_impl(
     to: &str,
     drop_source: bool,
 ) -> Result<DatabaseRenameResult, String> {
+    // `rename_database_impl` is a mutating command outside the plan's Task
+    // 2/Task 3 coverage lists (found during Task 2 implementation — see the
+    // write_guard.rs test doc comment for detail). It's at least as
+    // destructive as `rename_collection` (renames every collection in the
+    // db, optionally drops the source), so it's guarded with
+    // `WriteOp::Rename`; it has no `confirmed` command arg yet, so
+    // `confirmed` is hardcoded `false` pending a follow-up task.
+    guard_writable(state, id, WriteOp::Rename, false)?;
+
     if from.trim().is_empty() || to.trim().is_empty() {
         return Err("Database name is required".to_string());
     }

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -207,7 +207,10 @@ pub async fn delete_many_impl(
     database: &str,
     collection: &str,
     filter: &str,
+    confirmed: bool,
 ) -> Result<u64, String> {
+    guard_writable(state, id, WriteOp::DeleteMany, confirmed)?;
+
     let filter_doc = json_to_bson_document(filter)?;
     if connection_is_mock(state, id)? {
         return Ok(0); // mock connections don't persist deletes
@@ -229,7 +232,10 @@ pub async fn update_many_impl(
     collection: &str,
     filter: &str,
     update: &str,
+    confirmed: bool,
 ) -> Result<u64, String> {
+    guard_writable(state, id, WriteOp::UpdateMany, confirmed)?;
+
     let filter_doc = json_to_bson_document(filter)?;
     let update_doc = json_to_bson_document(update)?;
     // Require an operator-keyed update ({ "$set": … }); reject bare replacements

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -1,6 +1,7 @@
 //! Document mutation and import operations.
 
 use crate::limits::{IMPORT_BATCH_SIZE, MAX_IMPORT_DOCS};
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{connection_is_mock, require_real_client, AppState};
 
 use mongodb::bson::Document;
@@ -180,6 +181,8 @@ pub async fn delete_document_impl(
     collection: &str,
     filter: &str,
 ) -> Result<u64, String> {
+    guard_writable(state, id, WriteOp::DeleteOne, false)?;
+
     // Parse/validate up front so bad input fails the same way for mock & real.
     let filter_doc = json_to_bson_document(filter)?;
 
@@ -254,6 +257,8 @@ pub async fn insert_document_impl(
     collection: &str,
     document: &str,
 ) -> Result<String, String> {
+    guard_writable(state, id, WriteOp::Insert, false)?;
+
     let doc = json_to_bson_document(document)?;
 
     if connection_is_mock(state, id)? {
@@ -280,6 +285,8 @@ pub async fn update_document_impl(
     filter: &str,
     replacement: &str,
 ) -> Result<u64, String> {
+    guard_writable(state, id, WriteOp::ReplaceOne, false)?;
+
     let filter_doc = json_to_bson_document(filter)?;
     let replacement_doc = json_to_bson_document(replacement)?;
 
@@ -319,6 +326,8 @@ pub async fn import_documents_impl(
     docs: Vec<serde_json::Value>,
     mode: &str,
 ) -> Result<ImportResult, String> {
+    guard_writable(state, id, WriteOp::Import, false)?;
+
     // Convert all docs up front; a bad doc fails the whole import before writing.
     let mut bson_docs: Vec<Document> = Vec::with_capacity(docs.len());
     for value in docs {

--- a/src-tauri/src/db/export/mod.rs
+++ b/src-tauri/src/db/export/mod.rs
@@ -19,6 +19,7 @@ use options::ExportOptions;
 use crate::state::LockExt;
 use crate::{mock_db, AppState, TaskInfo};
 use crate::db::tasks::{fail_task, finish_task, now_ms, update_task};
+use crate::write_guard::stage_is_disallowed;
 use futures::stream::{Stream, StreamExt};
 use mongodb::bson::{doc, Document};
 use mongodb::Client;
@@ -665,6 +666,18 @@ fn build_source(
         let stages_val = pipeline_val
             .as_array()
             .ok_or_else(|| "Aggregation pipeline must be a JSON array of stages".to_string())?;
+        // #188 security review Fix 4: reject $out/$merge explicitly instead
+        // of relying on the accident that a $count/$limit stage gets
+        // appended after the user's pipeline elsewhere in this module,
+        // which happened to make $out/$merge fail anyway. That's incidental
+        // behavior a future refactor could silently remove — an export
+        // must never mutate data, so ban it here directly, matching the MCP
+        // `aggregate`/`explain` tools' own outright rejection.
+        if stages_val.iter().any(stage_is_disallowed) {
+            return Err(
+                "aggregation stages $out/$merge are not allowed in an export pipeline".to_string(),
+            );
+        }
         let mut stages: Vec<Document> = Vec::with_capacity(stages_val.len());
         for stage in stages_val {
             let stage_doc = mongodb::bson::to_document(stage)

--- a/src-tauri/src/db/generate.rs
+++ b/src-tauri/src/db/generate.rs
@@ -31,6 +31,7 @@
 
 use crate::db::schema::{SchemaReport, TypeCount};
 use crate::db::tasks::{fail_task, finish_task, now_ms, update_task};
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{AppState, LockExt, TaskInfo};
 use mongodb::bson::{self, Bson, Document};
 use rand::rngs::StdRng;
@@ -768,6 +769,8 @@ pub async fn start_generate_task_impl(
     count: u32,
     seed: Option<u64>,
 ) -> Result<TaskInfo, String> {
+    guard_writable(state, id, WriteOp::Generate, false)?;
+
     use crate::limits::{IMPORT_BATCH_SIZE, MAX_IMPORT_DOCS};
 
     let parsed = parse_template(template)?;

--- a/src-tauri/src/db/gridfs.rs
+++ b/src-tauri/src/db/gridfs.rs
@@ -1,6 +1,7 @@
 //! GridFS browsing (M7): list, upload, download, and delete files in a bucket.
 
 use crate::limits::{GRIDFS_STREAM_BUF, MAX_GRIDFS_LIST, MAX_GRIDFS_UPLOAD_BYTES};
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{connection_is_mock, require_real_client, AppState};
 use serde::Serialize;
 use std::path::Path;
@@ -150,6 +151,8 @@ pub async fn upload_gridfs_file_impl(
     content_type: Option<&str>,
     on_progress: Option<&(dyn Fn(GridFsTransferProgress) + Send + Sync)>,
 ) -> Result<String, String> {
+    guard_writable(state, id, WriteOp::GridFsWrite, false)?;
+
     if connection_is_mock(state, id)? {
         return Err("GridFS is not supported on mock connections".to_string());
     }
@@ -269,6 +272,8 @@ pub async fn delete_gridfs_file_impl(
     bucket: &str,
     file_id_json: &str,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::GridFsWrite, false)?;
+
     if connection_is_mock(state, id)? {
         return Err("GridFS is not supported on mock connections".to_string());
     }

--- a/src-tauri/src/db/import.rs
+++ b/src-tauri/src/db/import.rs
@@ -6,6 +6,7 @@ use crate::db::documents::{
     CsvImportOptions,
 };
 use crate::db::tasks::{fail_task, finish_task, now_ms, update_task};
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{AppState, LockExt, TaskInfo};
 use mongodb::bson::Document;
 use serde::{Deserialize, Serialize};
@@ -375,6 +376,8 @@ pub async fn start_import_task_impl(
     csv_options: Option<CsvImportOptions>,
     mode: &str,
 ) -> Result<TaskInfo, String> {
+    guard_writable(state, id, WriteOp::Import, false)?;
+
     if !matches!(mode, "skip" | "update" | "abort") {
         return Err("Import mode must be skip, update, or abort".to_string());
     }

--- a/src-tauri/src/db/metadata.rs
+++ b/src-tauri/src/db/metadata.rs
@@ -1,6 +1,7 @@
 //! Database metadata and index management.
 
 use crate::state::LockExt;
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{mock_db, AppState, CollectionInfo, IndexInfo};
 
 pub async fn list_databases_impl(state: &AppState, id: &str) -> Result<Vec<String>, String> {
@@ -174,6 +175,8 @@ pub async fn create_index_impl(
     unique: bool,
     sparse: bool,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::CreateIndex, false)?;
+
     let is_mock = {
         let mocks = state.mocks.lock_safe()?;
         *mocks
@@ -245,6 +248,8 @@ pub async fn delete_index_impl(
     collection: &str,
     index_name: &str,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::DropIndex, false)?;
+
     let is_mock = {
         let mocks = state.mocks.lock_safe()?;
         *mocks

--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 use crate::db::tasks::{fail_task, finish_task, now_ms, update_task};
 use crate::state::{AppState, LockExt};
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::TaskInfo;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -958,6 +959,8 @@ pub async fn start_restore_task_impl(
     tool_path: &str,
     options: RestoreOptions,
 ) -> Result<TaskInfo, String> {
+    guard_writable(state, id, WriteOp::RestoreWrite, false)?;
+
     let uri = require_real_conn_uri(state, id)?;
     let tunneled = state.ssh_tunnels.lock_safe()?.contains_key(id);
     let args = build_restore_args(&options)?;

--- a/src-tauri/src/db/users.rs
+++ b/src-tauri/src/db/users.rs
@@ -2,6 +2,7 @@
 //! list grantable roles. Live commands run against the real client; mock
 //! connections return synthetic users/roles so the view works in demo mode.
 
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{connection_is_mock, require_real_client, AppState};
 use mongodb::bson::{doc, Bson, Document};
 use serde::{Deserialize, Serialize};
@@ -169,6 +170,8 @@ pub async fn create_user_impl(
     password: &str,
     roles: &[RoleSpec],
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::UserWrite, false)?;
+
     if username.trim().is_empty() {
         return Err("Username is required".to_string());
     }
@@ -202,6 +205,8 @@ pub async fn update_user_impl(
     password: Option<&str>,
     roles: Option<&[RoleSpec]>,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::UserWrite, false)?;
+
     if username.trim().is_empty() {
         return Err("Username is required".to_string());
     }
@@ -236,6 +241,8 @@ pub async fn drop_user_impl(
     database: &str,
     username: &str,
 ) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::UserWrite, false)?;
+
     if username.trim().is_empty() {
         return Err("Username is required".to_string());
     }

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -349,6 +349,7 @@ mod integration {
             "people",
             r#"{"tier":"silver"}"#,
             r#"{"$set":{"tier":"bronze"}}"#,
+            true,
         )
         .await
         .expect("update_many");
@@ -359,7 +360,7 @@ mod integration {
             .await
             .expect("delete_one");
         assert_eq!(del_one, 1);
-        let del_many = delete_many_impl(&state, &id, &db, "people", r#"{"tier":"bronze"}"#)
+        let del_many = delete_many_impl(&state, &id, &db, "people", r#"{"tier":"bronze"}"#, true)
             .await
             .expect("delete_many");
         assert_eq!(del_many, 2);
@@ -440,7 +441,7 @@ mod integration {
             .expect("index for rename");
 
         // rename_collection real path (admin renameCollection).
-        rename_collection_impl(&state, &id, &db, "old_name", "new_name")
+        rename_collection_impl(&state, &id, &db, "old_name", "new_name", true)
             .await
             .expect("rename collection");
         let cols = list_collections_impl(&state, &id, &db).await.unwrap();
@@ -449,7 +450,7 @@ mod integration {
 
         // rename_database: copy all collections + indexes + docs to a new db, drop source.
         let target = format!("{}_renamed", db);
-        let result = rename_database_impl(&state, &id, &db, &target, true)
+        let result = rename_database_impl(&state, &id, &db, &target, true, true)
             .await
             .expect("rename database");
         assert_eq!(result.collections, 1);
@@ -473,7 +474,7 @@ mod integration {
         // Error: target already exists.
         let dup_target = format!("{}_dup", db);
         seed(&state, &id, &dup_target, "c", vec![doc! { "z": 1 }]).await;
-        let exists_err = rename_database_impl(&state, &id, &target, &dup_target, false)
+        let exists_err = rename_database_impl(&state, &id, &target, &dup_target, false, true)
             .await
             .err()
             .expect("rename to existing target should error");
@@ -481,7 +482,7 @@ mod integration {
 
         // Error: source does not exist.
         let missing_err =
-            rename_database_impl(&state, &id, "definitely_missing_db_xyz", "whatever", false)
+            rename_database_impl(&state, &id, "definitely_missing_db_xyz", "whatever", false, true)
                 .await
                 .err()
                 .expect("rename of missing source should error");
@@ -503,7 +504,7 @@ mod integration {
             .await
             .expect("create view");
         let target = format!("{}_vrenamed", db);
-        let err = rename_database_impl(&state, &id, &db, &target, false)
+        let err = rename_database_impl(&state, &id, &db, &target, false, true)
             .await
             .err()
             .expect("rename of db with a view should error");
@@ -518,7 +519,7 @@ mod integration {
             return;
         };
         seed(&state, &id, &db, "tmp", vec![doc! { "a": 1 }]).await;
-        drop_collection_impl(&state, &id, &db, "tmp")
+        drop_collection_impl(&state, &id, &db, "tmp", true)
             .await
             .expect("drop collection");
         let cols = list_collections_impl(&state, &id, &db).await.unwrap();
@@ -526,7 +527,7 @@ mod integration {
 
         // drop_database real path.
         seed(&state, &id, &db, "again", vec![doc! { "a": 1 }]).await;
-        drop_database_impl(&state, &id, &db)
+        drop_database_impl(&state, &id, &db, true)
             .await
             .expect("drop database");
         cleanup(&state, &id, &db).await;

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -193,7 +193,7 @@ mod integration {
 
         let pipeline =
             r#"[{"$group":{"_id":"$region","total":{"$sum":"$amount"}}},{"$sort":{"_id":1}}]"#;
-        let rows = execute_aggregate_impl(&state, &id, &db, "sales", pipeline)
+        let rows = execute_aggregate_impl(&state, &id, &db, "sales", pipeline, false)
             .await
             .expect("real aggregate");
         assert_eq!(rows.len(), 2);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1445,8 +1445,10 @@ async fn drop_collection(
     id: String,
     database: String,
     collection: String,
+    // `Option<bool>` (see `delete_many`'s comment): missing key -> `false`.
+    confirmed: Option<bool>,
 ) -> Result<(), String> {
-    drop_collection_impl(&state, &id, &database, &collection).await
+    drop_collection_impl(&state, &id, &database, &collection, confirmed.unwrap_or(false)).await
 }
 
 #[tauri::command]
@@ -1456,8 +1458,9 @@ async fn rename_collection(
     database: String,
     from: String,
     to: String,
+    confirmed: Option<bool>,
 ) -> Result<(), String> {
-    rename_collection_impl(&state, &id, &database, &from, &to).await
+    rename_collection_impl(&state, &id, &database, &from, &to, confirmed.unwrap_or(false)).await
 }
 
 #[tauri::command]
@@ -1497,8 +1500,9 @@ async fn drop_database(
     state: tauri::State<'_, AppState>,
     id: String,
     database: String,
+    confirmed: Option<bool>,
 ) -> Result<(), String> {
-    drop_database_impl(&state, &id, &database).await
+    drop_database_impl(&state, &id, &database, confirmed.unwrap_or(false)).await
 }
 
 #[tauri::command]
@@ -1508,8 +1512,9 @@ async fn rename_database(
     from: String,
     to: String,
     drop_source: bool,
+    confirmed: Option<bool>,
 ) -> Result<DatabaseRenameResult, String> {
-    rename_database_impl(&state, &id, &from, &to, drop_source).await
+    rename_database_impl(&state, &id, &from, &to, drop_source, confirmed.unwrap_or(false)).await
 }
 
 #[tauri::command]
@@ -1621,8 +1626,14 @@ async fn delete_many(
     database: String,
     collection: String,
     filter: String,
+    // `Option<bool>` (not a raw `#[serde(default)]` attribute — Tauri's
+    // per-parameter command args don't support serde field attributes,
+    // only `Deserialize`-derived struct fields do; see mcp_tools.rs's
+    // `_confirm` for that pattern) so an omitted key defaults to `false`
+    // rather than the IPC layer rejecting the call outright.
+    confirmed: Option<bool>,
 ) -> Result<u64, String> {
-    delete_many_impl(&state, &id, &database, &collection, &filter).await
+    delete_many_impl(&state, &id, &database, &collection, &filter, confirmed.unwrap_or(false)).await
 }
 
 #[tauri::command]
@@ -1633,8 +1644,9 @@ async fn update_many(
     collection: String,
     filter: String,
     update: String,
+    confirmed: Option<bool>,
 ) -> Result<u64, String> {
-    update_many_impl(&state, &id, &database, &collection, &filter, &update).await
+    update_many_impl(&state, &id, &database, &collection, &filter, &update, confirmed.unwrap_or(false)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -571,9 +571,10 @@ pub fn set_connection_meta_impl(
     profile_id: &str,
     name: &str,
     via_mcp: bool,
+    mode: connections::ConnectionMode,
 ) -> Result<(), String> {
     let mut meta = state.connection_meta.lock_safe()?;
-    meta.insert(id.to_string(), ConnectionMeta { profile_id: profile_id.to_string(), name: name.to_string(), via_mcp });
+    meta.insert(id.to_string(), ConnectionMeta { profile_id: profile_id.to_string(), name: name.to_string(), via_mcp, mode });
     Ok(())
 }
 
@@ -585,7 +586,7 @@ pub fn connection_list_impl(state: &AppState) -> Result<Vec<ConnectionEntry>, St
     let meta = state.connection_meta.lock_safe()?;
     let mut list: Vec<ConnectionEntry> = meta
         .iter()
-        .map(|(id, m)| ConnectionEntry { id: id.clone(), profile_id: m.profile_id.clone(), name: m.name.clone(), via_mcp: m.via_mcp })
+        .map(|(id, m)| ConnectionEntry { id: id.clone(), profile_id: m.profile_id.clone(), name: m.name.clone(), via_mcp: m.via_mcp, mode: m.mode })
         .collect();
     list.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(list)
@@ -993,12 +994,16 @@ async fn set_connection_meta(
     id: String,
     profile_id: String,
     name: String,
+    mode: connections::ConnectionMode,
 ) -> Result<(), String> {
     use tauri::Emitter;
     // Frontend-initiated (sidebar/Connection Manager/quick-connect) -- never
     // an MCP agent connection, which flows through `mcp_tools::connect_impl`
-    // instead and passes `via_mcp: true` directly.
-    set_connection_meta_impl(&state, &id, &profile_id, &name, false)?;
+    // instead and passes `via_mcp: true` directly. `mode` is the profile's
+    // `connection_mode` at the moment it was connected (#188) -- the
+    // frontend has the profile it just connected with, so it supplies this
+    // rather than the backend re-reading the (encrypted) profile store.
+    set_connection_meta_impl(&state, &id, &profile_id, &name, false, mode)?;
     let connections = connection_list_impl(&state)?;
     // Broadcast is best-effort: a window that misses this event picks up
     // current connection metadata the next time it connects or calls

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ mod vault;
 mod window;
 mod windows;
 mod workspace;
+mod write_guard;
 pub mod biometric;
 pub use db::aggregate::{execute_aggregate_impl, explain_aggregate_query_impl};
 pub use db::ddl::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,8 @@ use uuid::Uuid;
 
 pub mod limits;
 pub mod ai;
+#[cfg(test)]
+mod command_coverage;
 pub mod connections;
 mod db;
 pub mod mcp;
@@ -593,6 +595,17 @@ pub fn connection_list_impl(state: &AppState) -> Result<Vec<ConnectionEntry>, St
     Ok(list)
 }
 
+/// #188 security review Fix 2 (CRITICAL): mongosh pipes arbitrary free-form
+/// commands (`db.dropDatabase()`, `db.coll.deleteMany({})`, …) straight to
+/// the driver — there is no per-command `WriteOp` to gate like every other
+/// mutating `_impl`, so the only place a `read_only` connection can be kept
+/// safe is here, before a shell is ever spawned. `ConfirmDestructive`
+/// deliberately falls through unblocked: the shell is a deliberate
+/// free-form power-user tool (the mode banner already warns the user), and
+/// per-command typed confirmation is impossible for arbitrary shell input —
+/// this is a documented v1 limitation, not an oversight. See
+/// `write_guard::connection_mode`'s doc comment for why this reads the mode
+/// directly instead of going through `guard_writable`.
 pub async fn start_mongosh_session_impl(
     state: &AppState,
     connection_id: &str,
@@ -600,6 +613,11 @@ pub async fn start_mongosh_session_impl(
     database: &str,
     mongosh_path: &str,
 ) -> Result<MongoshSessionInfo, String> {
+    if write_guard::connection_mode(state, connection_id)? == connections::ConnectionMode::ReadOnly
+    {
+        return Err(write_guard::READ_ONLY_MSG.to_string());
+    }
+
     let is_mock = {
         let mocks = state.mocks.lock_safe()?;
         *mocks
@@ -1004,6 +1022,13 @@ async fn set_connection_meta(
     // `connection_mode` at the moment it was connected (#188) -- the
     // frontend has the profile it just connected with, so it supplies this
     // rather than the backend re-reading the (encrypted) profile store.
+    // #188 security review Fix 5: this command is renderer-callable with an
+    // ARBITRARY `mode` -- a hostile/compromised renderer could call it
+    // directly and claim `Normal` for a connection it knows is production.
+    // That's a trust edge consistent with this feature's accepted model
+    // (see write_guard.rs's module doc: "an opt-in production safeguard,
+    // not a security boundary against a hostile local user"), not a gap
+    // introduced by this fix wave.
     set_connection_meta_impl(&state, &id, &profile_id, &name, false, mode)?;
     let connections = connection_list_impl(&state)?;
     // Broadcast is best-effort: a window that misses this event picks up
@@ -1405,8 +1430,12 @@ async fn execute_aggregate(
     database: String,
     collection: String,
     pipeline: String,
+    // `Option<bool>` (see `delete_many`'s comment): missing key -> `false`.
+    // #188 review Fix 1: only matters when `pipeline` carries a $out/$merge
+    // stage — see `execute_aggregate_impl`'s doc comment.
+    confirmed: Option<bool>,
 ) -> Result<Vec<String>, String> {
-    execute_aggregate_impl(&state, &id, &database, &collection, &pipeline).await
+    execute_aggregate_impl(&state, &id, &database, &collection, &pipeline, confirmed.unwrap_or(false)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/mcp_tools.rs
+++ b/src-tauri/src/mcp_tools.rs
@@ -30,6 +30,7 @@
 //! straight through as the tool's text content.
 
 use crate::state::{ConnectionEntry, LockExt};
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{AppState, CollectionInfo};
 // `rmcp::schemars` re-exports the `schemars` crate (server feature); the
 // `JsonSchema` derive macro's generated code refers to the crate by its bare
@@ -620,6 +621,16 @@ pub fn insert_one_summary(database: &str, collection: &str, document: &serde_jso
 
 pub async fn insert_one_impl(state: &AppState, profiles_path: &Path, args: InsertOneArgs) -> Result<InsertOneResult, String> {
     require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    // Connection-mode guard is the OUTER gate (#188 Task 4): it runs after
+    // `require_mcp_connection` (an agent must still be opted-in/authorized
+    // first) but before `require_confirm`, so a read-only or unconfirmed
+    // confirm-destructive connection rejects here — before the tool ever
+    // gets to its own `_confirm` message. On a read-only connection ALL
+    // four MCP write tools error with the read-only message, even when
+    // `_confirm: true`. `insert_one` is non-destructive, so it passes
+    // `confirmed=false`: `ConnectionMode::ConfirmDestructive` never blocks
+    // it regardless.
+    guard_writable(state, &args.connection_id, WriteOp::Insert, false)?;
     require_confirm(args._confirm, "insert_one")?;
     let document_json = serde_json::to_string(&args.document).map_err(|e| format!("serialize document: {e}"))?;
     let inserted_id = crate::insert_document_impl(state, &args.connection_id, &args.database, &args.collection, &document_json).await?;
@@ -661,6 +672,13 @@ pub fn update_many_summary(database: &str, collection: &str, filter: &serde_json
 
 pub async fn update_many_tool_impl(state: &AppState, profiles_path: &Path, args: UpdateManyArgs) -> Result<UpdateManyResult, String> {
     require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    // Outer gate (see `insert_one_impl`'s comment for the full rationale).
+    // `update_many` IS destructive (`WriteOp::is_destructive`), so on a
+    // `ConfirmDestructive` connection the guard also enforces `_confirm` —
+    // both it and `require_confirm` below would reject an unconfirmed call,
+    // but the guard runs first, so its `CONFIRM_MSG` wins over
+    // `require_confirm`'s `CONFIRM_REQUIRED` message.
+    guard_writable(state, &args.connection_id, WriteOp::UpdateMany, args._confirm)?;
     require_confirm(args._confirm, "update_many")?;
     let filter_json = serde_json::to_string(&args.filter).map_err(|e| format!("serialize filter: {e}"))?;
     let update_json = serde_json::to_string(&args.update).map_err(|e| format!("serialize update: {e}"))?;
@@ -692,6 +710,11 @@ pub fn delete_many_summary(database: &str, collection: &str, filter: &serde_json
 
 pub async fn delete_many_tool_impl(state: &AppState, profiles_path: &Path, args: DeleteManyArgs) -> Result<DeleteManyResult, String> {
     require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    // Outer gate (see `insert_one_impl`'s comment). `delete_many` is
+    // destructive, same as `update_many`: on `ConfirmDestructive` the guard
+    // requires `_confirm` and, if unconfirmed, its `CONFIRM_MSG` wins over
+    // `require_confirm`'s message below since the guard runs first.
+    guard_writable(state, &args.connection_id, WriteOp::DeleteMany, args._confirm)?;
     require_confirm(args._confirm, "delete_many")?;
     let filter_json = serde_json::to_string(&args.filter).map_err(|e| format!("serialize filter: {e}"))?;
     let deleted_count = crate::delete_many_impl(state, &args.connection_id, &args.database, &args.collection, &filter_json, args._confirm).await?;
@@ -770,6 +793,10 @@ fn default_index_name(keys: &serde_json::Value) -> Result<String, String> {
 
 pub async fn create_index_tool_impl(state: &AppState, profiles_path: &Path, args: CreateIndexArgs) -> Result<CreateIndexResult, String> {
     require_mcp_connection(state, profiles_path, &args.connection_id)?;
+    // Outer gate (see `insert_one_impl`'s comment). `create_index` is
+    // non-destructive, so like `insert_one` it passes `confirmed=false` and
+    // is unaffected by `ConnectionMode::ConfirmDestructive`.
+    guard_writable(state, &args.connection_id, WriteOp::CreateIndex, false)?;
     require_confirm(args._confirm, "create_index")?;
     let name = match args.name {
         Some(n) if !n.trim().is_empty() => n,
@@ -828,6 +855,23 @@ mod tests {
             ssh: None,
             mcp_enabled,
             connection_mode: Default::default(),
+        }
+    }
+
+    /// An mcp-enabled profile carrying a non-default `ConnectionMode` —
+    /// `connect_impl` propagates `profile.connection_mode` into the live
+    /// connection's meta (see `connect_impl_propagates_the_profiles_connection_mode_into_meta`),
+    /// so connecting through this profile is how the Task 4 tests below get
+    /// a read-only/confirm-destructive MCP connection.
+    fn profile_with_mode(id: &str, name: &str, mode: crate::connections::ConnectionMode) -> ConnectionProfile {
+        ConnectionProfile {
+            id: id.to_string(),
+            name: name.to_string(),
+            uri: "mongodb://mock".to_string(),
+            color_tag: None,
+            ssh: None,
+            mcp_enabled: true,
+            connection_mode: mode,
         }
     }
 
@@ -1717,5 +1761,190 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(err, CONNECTION_NOT_FOUND);
+    }
+
+    // ---- Task 4: connection-mode gate composition (guard_writable runs
+    // before require_confirm in all four write tools) ------------------
+
+    #[tokio::test]
+    async fn read_only_mcp_connection_blocks_all_four_write_tools_even_with_confirm_true() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("mode-gate-read-only.enc");
+        write_profiles(&path, &[profile_with_mode("p1", "RO", crate::connections::ConnectionMode::ReadOnly)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        // Every one of these passes `_confirm: true` — proving the guard,
+        // not `require_confirm`, is what's rejecting them: a confirm-only
+        // gate would have let these through.
+        let err = insert_one_impl(
+            &state,
+            &path,
+            InsertOneArgs { connection_id: id.clone(), database: "d".into(), collection: "c".into(), document: serde_json::json!({"a": 1}), _confirm: true },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("read-only"), "insert_one: {err}");
+
+        let err = update_many_tool_impl(
+            &state,
+            &path,
+            UpdateManyArgs {
+                connection_id: id.clone(),
+                database: "d".into(),
+                collection: "c".into(),
+                filter: serde_json::json!({}),
+                update: serde_json::json!({"$set": {"a": 1}}),
+                _confirm: true,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("read-only"), "update_many: {err}");
+
+        let err = delete_many_tool_impl(
+            &state,
+            &path,
+            DeleteManyArgs { connection_id: id.clone(), database: "d".into(), collection: "c".into(), filter: serde_json::json!({}), _confirm: true },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("read-only"), "delete_many: {err}");
+
+        let err = create_index_tool_impl(
+            &state,
+            &path,
+            CreateIndexArgs {
+                connection_id: id,
+                database: "d".into(),
+                collection: "c".into(),
+                keys: serde_json::json!({"a": 1}),
+                name: None,
+                unique: None,
+                sparse: None,
+                _confirm: true,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("read-only"), "create_index: {err}");
+    }
+
+    #[tokio::test]
+    async fn confirm_destructive_mcp_connection_the_guards_message_wins_over_require_confirms() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("mode-gate-confirm-destructive.enc");
+        write_profiles(&path, &[profile_with_mode("p1", "CD", crate::connections::ConnectionMode::ConfirmDestructive)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        // update_many / delete_many unconfirmed: BOTH `guard_writable` and
+        // `require_confirm` would reject, but the guard runs first, so its
+        // `write_guard::CONFIRM_MSG` is the error actually seen — not
+        // `require_confirm`'s `CONFIRM_REQUIRED`.
+        let err = update_many_tool_impl(
+            &state,
+            &path,
+            UpdateManyArgs {
+                connection_id: id.clone(),
+                database: "d".into(),
+                collection: "c".into(),
+                filter: serde_json::json!({}),
+                update: serde_json::json!({"$set": {"a": 1}}),
+                _confirm: false,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, crate::write_guard::CONFIRM_MSG, "the GUARD's message must win, not require_confirm's");
+        assert_ne!(err, CONFIRM_REQUIRED);
+
+        let err = delete_many_tool_impl(
+            &state,
+            &path,
+            DeleteManyArgs { connection_id: id.clone(), database: "d".into(), collection: "c".into(), filter: serde_json::json!({}), _confirm: false },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, crate::write_guard::CONFIRM_MSG, "the GUARD's message must win, not require_confirm's");
+
+        // Confirmed: passes the guard (and require_confirm), reaches the
+        // impl's documented mock no-op behavior.
+        let result = update_many_tool_impl(
+            &state,
+            &path,
+            UpdateManyArgs {
+                connection_id: id.clone(),
+                database: "d".into(),
+                collection: "c".into(),
+                filter: serde_json::json!({}),
+                update: serde_json::json!({"$set": {"a": 1}}),
+                _confirm: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.modified_count, 0);
+
+        let result = delete_many_tool_impl(
+            &state,
+            &path,
+            DeleteManyArgs { connection_id: id.clone(), database: "d".into(), collection: "c".into(), filter: serde_json::json!({}), _confirm: true },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.deleted_count, 0);
+
+        // insert_one / create_index are non-destructive — `WriteOp::is_destructive`
+        // doesn't cover them, so `ConnectionMode::ConfirmDestructive` never
+        // blocks them; they pass with `_confirm: true` same as on a normal
+        // connection.
+        let result = insert_one_impl(
+            &state,
+            &path,
+            InsertOneArgs { connection_id: id.clone(), database: "d".into(), collection: "c".into(), document: serde_json::json!({"a": 1}), _confirm: true },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.inserted_id, serde_json::Value::String("mock-inserted-id".to_string()));
+
+        let result = create_index_tool_impl(
+            &state,
+            &path,
+            CreateIndexArgs {
+                connection_id: id,
+                database: "d".into(),
+                collection: "c".into(),
+                keys: serde_json::json!({"a": 1}),
+                name: None,
+                unique: None,
+                sparse: None,
+                _confirm: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.name, "a_1");
+    }
+
+    #[tokio::test]
+    async fn normal_mcp_connection_unchanged_require_confirm_still_blocks_unconfirmed_writes() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("mode-gate-normal.enc");
+        write_profiles(&path, &[profile("p1", "Normal", true)]);
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        // On a `Normal` connection the guard always passes, so the
+        // pre-existing `require_confirm` behavior is exactly what fires —
+        // unchanged from before Task 4.
+        let err = insert_one_impl(
+            &state,
+            &path,
+            InsertOneArgs { connection_id: id, database: "d".into(), collection: "c".into(), document: serde_json::json!({"a": 1}), _confirm: false },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CONFIRM_REQUIRED);
     }
 }

--- a/src-tauri/src/mcp_tools.rs
+++ b/src-tauri/src/mcp_tools.rs
@@ -30,7 +30,7 @@
 //! straight through as the tool's text content.
 
 use crate::state::{ConnectionEntry, LockExt};
-use crate::write_guard::{guard_writable, WriteOp};
+use crate::write_guard::{guard_writable, stage_is_disallowed, WriteOp};
 use crate::{AppState, CollectionInfo};
 // `rmcp::schemars` re-exports the `schemars` crate (server feature); the
 // `JsonSchema` derive macro's generated code refers to the crate by its bare
@@ -451,19 +451,9 @@ pub struct AggregateResult {
     pub truncated: Option<String>,
 }
 
-/// True iff `stage` is a JSON object whose *sole* top-level key is `$out`
-/// or `$merge`. Deliberately shallow: a `$lookup` sub-pipeline (or any
-/// other nested structure) that happens to carry the string `"$merge"` as a
-/// VALUE — not as its own single top-level key — must not false-positive.
-/// A multi-key object that happens to include `$out`/`$merge` alongside
-/// another key isn't a valid single-stage form anyway and is left for the
-/// driver/server to reject on its own terms.
-fn stage_is_disallowed(stage: &serde_json::Value) -> bool {
-    stage
-        .as_object()
-        .map(|obj| obj.len() == 1 && obj.keys().next().map(|k| k == "$out" || k == "$merge").unwrap_or(false))
-        .unwrap_or(false)
-}
+// `stage_is_disallowed` moved to `write_guard.rs` (#188 review Fix 1/4) so
+// the UI aggregation runner and the export pipeline share this exact
+// definition instead of each growing their own drifted copy.
 
 pub async fn aggregate_impl(state: &AppState, profiles_path: &Path, args: AggregateArgs) -> Result<AggregateResult, String> {
     require_mcp_connection(state, profiles_path, &args.connection_id)?;
@@ -477,7 +467,10 @@ pub async fn aggregate_impl(state: &AppState, profiles_path: &Path, args: Aggreg
     // `execute_aggregate_impl` is real-connection-only and already returns
     // a clean "not supported on mock connections" error for mocks — no
     // separate `state.mocks` pre-check needed on top of that.
-    let docs = crate::execute_aggregate_impl(state, &args.connection_id, &args.database, &args.collection, &pipeline_json).await?;
+    // `confirmed: false` — MCP already hard-rejects any $out/$merge stage
+    // above, so `execute_aggregate_impl`'s own guard never has a write
+    // stage left to gate on by the time it sees this pipeline.
+    let docs = crate::execute_aggregate_impl(state, &args.connection_id, &args.database, &args.collection, &pipeline_json, false).await?;
     let (documents, truncated) = cap_and_parse(docs, CAP_MAX_DOCS, CAP_MAX_BYTES)?;
     Ok(AggregateResult { documents, truncated })
 }
@@ -940,21 +933,8 @@ mod tests {
         assert!(out.ends_with('…'));
     }
 
-    // ---- $out/$merge rejection ---------------------------------------
-
-    #[test]
-    fn stage_is_disallowed_flags_only_exact_single_key_out_or_merge() {
-        assert!(stage_is_disallowed(&serde_json::json!({"$out": "target_coll"})));
-        assert!(stage_is_disallowed(&serde_json::json!({"$merge": {"into": "target_coll"}})));
-        assert!(!stage_is_disallowed(&serde_json::json!({"$match": {"status": "active"}})));
-        // $merge appearing as a VALUE (not the stage's own top-level key)
-        // inside a $lookup sub-pipeline must not false-positive.
-        assert!(!stage_is_disallowed(&serde_json::json!({
-            "$lookup": {"from": "other", "pipeline": [{"$project": {"note": "$merge"}}], "as": "joined"}
-        })));
-        // Multi-key object: not a valid single-stage form either way.
-        assert!(!stage_is_disallowed(&serde_json::json!({"$merge": "x", "extra": 1})));
-    }
+    // `stage_is_disallowed`'s own unit test moved to `write_guard.rs`
+    // alongside its new home (#188 review Fix 1/4).
 
     // ---- list_profiles / list_connections ------------------------------
 

--- a/src-tauri/src/mcp_tools.rs
+++ b/src-tauri/src/mcp_tools.rs
@@ -664,7 +664,7 @@ pub async fn update_many_tool_impl(state: &AppState, profiles_path: &Path, args:
     require_confirm(args._confirm, "update_many")?;
     let filter_json = serde_json::to_string(&args.filter).map_err(|e| format!("serialize filter: {e}"))?;
     let update_json = serde_json::to_string(&args.update).map_err(|e| format!("serialize update: {e}"))?;
-    let modified_count = crate::update_many_impl(state, &args.connection_id, &args.database, &args.collection, &filter_json, &update_json).await?;
+    let modified_count = crate::update_many_impl(state, &args.connection_id, &args.database, &args.collection, &filter_json, &update_json, args._confirm).await?;
     Ok(UpdateManyResult { modified_count })
 }
 
@@ -694,7 +694,7 @@ pub async fn delete_many_tool_impl(state: &AppState, profiles_path: &Path, args:
     require_mcp_connection(state, profiles_path, &args.connection_id)?;
     require_confirm(args._confirm, "delete_many")?;
     let filter_json = serde_json::to_string(&args.filter).map_err(|e| format!("serialize filter: {e}"))?;
-    let deleted_count = crate::delete_many_impl(state, &args.connection_id, &args.database, &args.collection, &filter_json).await?;
+    let deleted_count = crate::delete_many_impl(state, &args.connection_id, &args.database, &args.collection, &filter_json, args._confirm).await?;
     Ok(DeleteManyResult { deleted_count })
 }
 

--- a/src-tauri/src/mcp_tools.rs
+++ b/src-tauri/src/mcp_tools.rs
@@ -204,7 +204,7 @@ pub async fn connect_impl(state: &AppState, profiles_path: &Path, profile_id: &s
         .ok_or_else(|| PROFILE_NOT_FOUND.to_string())?;
 
     let connection_id = crate::connect_db_impl(state, &profile.uri, profile.ssh.as_ref()).await?;
-    crate::set_connection_meta_impl(state, &connection_id, &profile.id, &profile.name, true)?;
+    crate::set_connection_meta_impl(state, &connection_id, &profile.id, &profile.name, true, profile.connection_mode)?;
     state.mcp.lock_safe()?.session_connections.insert(connection_id.clone());
     Ok(connection_id)
 }
@@ -820,7 +820,15 @@ mod tests {
     }
 
     fn profile(id: &str, name: &str, mcp_enabled: bool) -> ConnectionProfile {
-        ConnectionProfile { id: id.to_string(), name: name.to_string(), uri: "mongodb://mock".to_string(), color_tag: None, ssh: None, mcp_enabled }
+        ConnectionProfile {
+            id: id.to_string(),
+            name: name.to_string(),
+            uri: "mongodb://mock".to_string(),
+            color_tag: None,
+            ssh: None,
+            mcp_enabled,
+            connection_mode: Default::default(),
+        }
     }
 
     fn write_profiles(path: &Path, profiles: &[ConnectionProfile]) {
@@ -928,8 +936,8 @@ mod tests {
         let path = tmp_profiles_path("list-connections.enc");
         write_profiles(&path, &[profile("p1", "In", true), profile("p2", "Out", false)]);
 
-        crate::set_connection_meta_impl(&state, "c1", "p1", "In Conn", true).unwrap();
-        crate::set_connection_meta_impl(&state, "c2", "p2", "Out Conn", false).unwrap();
+        crate::set_connection_meta_impl(&state, "c1", "p1", "In Conn", true, Default::default()).unwrap();
+        crate::set_connection_meta_impl(&state, "c2", "p2", "Out Conn", false, Default::default()).unwrap();
 
         let out = list_connections_impl(&state, &path).unwrap();
         assert_eq!(out.len(), 1);
@@ -969,6 +977,35 @@ mod tests {
         assert!(state.mcp.lock().unwrap().session_connections.contains(&id));
     }
 
+    // #188: `connect_impl` must carry the profile's `connection_mode` into
+    // `ConnectionMeta` verbatim, not silently drop to `Normal` -- the write
+    // guard reads it straight off the meta, so an MCP agent connecting to a
+    // read-only-tagged profile has to inherit that guard exactly like a
+    // human's `set_connection_meta` call would.
+    #[tokio::test]
+    async fn connect_impl_propagates_the_profiles_connection_mode_into_meta() {
+        let state = AppState::new();
+        unlock(&state);
+        let path = tmp_profiles_path("connect-mode.enc");
+        write_profiles(
+            &path,
+            &[ConnectionProfile {
+                id: "p1".to_string(),
+                name: "Prod".to_string(),
+                uri: "mongodb://mock".to_string(),
+                color_tag: None,
+                ssh: None,
+                mcp_enabled: true,
+                connection_mode: crate::connections::ConnectionMode::ReadOnly,
+            }],
+        );
+
+        let id = connect_impl(&state, &path, "p1").await.unwrap();
+
+        let meta = state.connection_meta.lock().unwrap().get(&id).cloned().unwrap();
+        assert_eq!(meta.mode, crate::connections::ConnectionMode::ReadOnly);
+    }
+
     #[tokio::test]
     async fn disconnect_only_allows_ids_this_mcp_session_itself_connected() {
         let state = AppState::new();
@@ -981,7 +1018,7 @@ mod tests {
         // `disconnect` must still refuse it: it never went through
         // `connect_impl`, so it's not in `session_connections`.
         let human_id = crate::connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
-        crate::set_connection_meta_impl(&state, &human_id, "p1", "Human", false).unwrap();
+        crate::set_connection_meta_impl(&state, &human_id, "p1", "Human", false, Default::default()).unwrap();
 
         let err = disconnect_impl(&state, &human_id).await.unwrap_err();
         assert_eq!(err, CONNECTION_NOT_FOUND);
@@ -1034,7 +1071,7 @@ mod tests {
 
         let id_in = connect_impl(&state, &path, "p1").await.unwrap();
         let id_out = crate::connect_db_impl(&state, "mongodb://mock", None).await.unwrap();
-        crate::set_connection_meta_impl(&state, &id_out, "p2", "Out", false).unwrap();
+        crate::set_connection_meta_impl(&state, &id_out, "p2", "Out", false, Default::default()).unwrap();
 
         assert!(require_mcp_connection(&state, &path, &id_in).is_ok());
         let err_out = require_mcp_connection(&state, &path, &id_out).unwrap_err();

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -5,6 +5,7 @@
 //! The curation functions (raw BSON `Document` -> typed struct) are pure and
 //! unit-tested; the async `*_impl` wrappers just run the command and curate.
 
+use crate::write_guard::{guard_writable, WriteOp};
 use crate::{connection_is_mock, require_real_client, AppState};
 use mongodb::bson::{doc, Bson, Document};
 use serde::Serialize;
@@ -420,6 +421,8 @@ pub async fn current_ops_impl(state: &AppState, id: &str) -> Result<Vec<CurrentO
 }
 
 pub async fn kill_op_impl(state: &AppState, id: &str, opid: i64) -> Result<(), String> {
+    guard_writable(state, id, WriteOp::ServerAdmin, false)?;
+
     if connection_is_mock(state, id)? {
         return Ok(());
     }
@@ -452,6 +455,8 @@ pub async fn set_profiling_level_impl(
     level: i32,
     slow_ms: i32,
 ) -> Result<ProfilingStatus, String> {
+    guard_writable(state, id, WriteOp::ServerAdmin, false)?;
+
     if connection_is_mock(state, id)? {
         return Ok(ProfilingStatus { level: level as i64, slow_ms: slow_ms as i64 });
     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -26,6 +26,16 @@ pub struct ConnectionMeta {
     /// one from a partial literal (`..Default::default()`-style).
     #[serde(default)]
     pub via_mcp: bool,
+    /// Read-only / confirm-destructive production safeguard (#188),
+    /// registered at connect time from the profile's `connection_mode`. The
+    /// central write guard (`write_guard::guard_writable`) reads this to
+    /// decide whether a mutating command may proceed — never re-derives it
+    /// from the profile, so a live connection's guard behavior can't drift
+    /// out of sync with what was true when it was connected. `#[serde(default)]`
+    /// for the same reason as `via_mcp`: readable against nothing on-disk,
+    /// and matters for any caller that constructs one from a partial literal.
+    #[serde(default)]
+    pub mode: crate::connections::ConnectionMode,
 }
 
 /// One entry of the `connections-changed` payload's `connections` list —
@@ -41,6 +51,9 @@ pub struct ConnectionEntry {
     /// Mirrors `ConnectionMeta::via_mcp` -- surfaced to the frontend so the
     /// sidebar can badge agent-initiated connections (#98 Task 4).
     pub via_mcp: bool,
+    /// Mirrors `ConnectionMeta::mode` -- surfaced to the frontend for the
+    /// read-only/confirm-destructive banner and sidebar badge (#188).
+    pub mode: crate::connections::ConnectionMode,
 }
 
 /// The `connections-changed` broadcast payload: the full current connection

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3954,6 +3954,66 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn test_tool_install_probe_retries_transient_failure_then_succeeds() {
+        use crate::toolsetup::test_support::{fixture_zip_with_script, serve_bytes};
+        use crate::toolsetup::*;
+        use std::sync::atomic::AtomicBool;
+
+        // A "binary" that fails `--version` on its first two invocations and
+        // only succeeds on the third, simulating a transient exec/fs hiccup
+        // (not a genuinely broken binary) on a loaded machine. Tracks its own
+        // invocation count in a counter file that lives outside the
+        // staging/install tree so it survives regardless of what
+        // `install_one_tool` does with those directories.
+        let app_data = tool_install_test_dir("probe-retry-transient");
+        let counter = app_data.join("probe-attempts.txt");
+        let script = format!(
+            "#!/bin/sh\nN=0\nif [ -f '{counter}' ]; then N=$(cat '{counter}'); fi\nN=$((N + 1))\necho \"$N\" > '{counter}'\nif [ \"$N\" -lt 3 ]; then exit 1; fi\necho tool version 9.9.9\n",
+            counter = counter.display()
+        );
+        let bytes = fixture_zip_with_script("mongosh-2.9.2-darwin-arm64", &["mongosh"], script.as_bytes());
+        let sha256 = sha256_hex(&bytes);
+        let (base_url, _server) = serve_bytes(bytes);
+        let url = format!("{base_url}/mongosh-2.9.2-darwin-arm64.zip");
+
+        let cancel = AtomicBool::new(false);
+        install_one_tool(
+            &app_data,
+            "mongosh",
+            "2.9.2",
+            &url,
+            &sha256,
+            ArchiveKind::Zip,
+            "mongosh-2.9.2-darwin-arm64/bin",
+            &["mongosh".to_string()],
+            &cancel,
+            |_, _, _| {},
+        )
+        .await
+        .unwrap();
+
+        let attempts: u32 = std::fs::read_to_string(&counter).unwrap().trim().parse().unwrap();
+        assert_eq!(attempts, 3, "should have taken exactly 3 probe attempts to succeed");
+
+        let bin = app_data.join("tools/mongosh-2.9.2/bin/mongosh");
+        assert!(bin.exists(), "binary should be installed once the probe eventually succeeds");
+        assert!(
+            !app_data.join("tools/.staging-mongosh").exists(),
+            "staging dir should be cleaned up after success"
+        );
+
+        let _ = std::fs::remove_dir_all(&app_data);
+    }
+
+    // `test_tool_install_probe_failure_leaves_no_install_dir` (above) already
+    // covers the complementary case: a binary that fails `--version` on
+    // *every* invocation (never a transient blip) still returns
+    // `Err(.. "failed to run --version")` after all retries are exhausted —
+    // the retry only tolerates a probe that eventually succeeds, it never
+    // hides a genuinely broken binary.
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn test_tool_install_task_end_to_end_with_cancel_flag_cleanup() {
         use crate::toolsetup::test_support::{fixture_zip, serve_bytes, test_tool};
         use crate::toolsetup::*;

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -664,6 +664,65 @@ mod tests {
         );
     }
 
+    /// #188 security review Fix 4 (IMPORTANT): $out/$merge in an export
+    /// pipeline is rejected explicitly by `build_source` now, not just
+    /// incidentally (a $count/$limit stage used to get appended after the
+    /// user's pipeline elsewhere, which happened to make $out/$merge fail
+    /// too — but that's not a real ban a future refactor couldn't remove).
+    /// Rejected before the connection is even looked up (`build_source`
+    /// runs first in `start_filtered_export_impl`), so "missing" doesn't
+    /// need to resolve to a real connection.
+    #[tokio::test]
+    async fn test_filtered_export_rejects_out_and_merge_pipeline() {
+        let state = AppState::new();
+
+        let out_err = start_filtered_export_impl(
+            &state,
+            "missing",
+            "db",
+            "coll",
+            "json",
+            "/tmp/agg-out.json",
+            "{}",
+            "{}",
+            "{}",
+            "[{\"$out\":\"target\"}]",
+            None,
+            None,
+            None,
+        )
+        .await
+        .err()
+        .expect("$out export pipeline should be rejected");
+        assert_eq!(
+            out_err,
+            "aggregation stages $out/$merge are not allowed in an export pipeline"
+        );
+
+        let merge_err = start_filtered_export_impl(
+            &state,
+            "missing",
+            "db",
+            "coll",
+            "json",
+            "/tmp/agg-merge.json",
+            "{}",
+            "{}",
+            "{}",
+            "[{\"$merge\":{\"into\":\"target\"}}]",
+            None,
+            None,
+            None,
+        )
+        .await
+        .err()
+        .expect("$merge export pipeline should be rejected");
+        assert_eq!(
+            merge_err,
+            "aggregation stages $out/$merge are not allowed in an export pipeline"
+        );
+    }
+
     #[tokio::test]
     async fn test_filtered_export_validates_format_path_and_connection() {
         let state = AppState::new();
@@ -1442,7 +1501,9 @@ mod tests {
             .expect("connect mock");
 
         // Malformed pipeline JSON fails clearly before touching the connection.
-        let bad = execute_aggregate_impl(&state, &conn_id, "sales_db", "products", "[{bad}]").await;
+        let bad =
+            execute_aggregate_impl(&state, &conn_id, "sales_db", "products", "[{bad}]", false)
+                .await;
         assert!(
             bad.unwrap_err()
                 .contains("Invalid aggregation pipeline JSON"),
@@ -1451,14 +1512,16 @@ mod tests {
 
         // A pipeline that isn't a JSON array is rejected.
         let not_array =
-            execute_aggregate_impl(&state, &conn_id, "sales_db", "products", "{}").await;
+            execute_aggregate_impl(&state, &conn_id, "sales_db", "products", "{}", false).await;
         assert!(
             not_array.unwrap_err().contains("must be a JSON array"),
             "non-array pipeline should be rejected"
         );
 
-        let bad_stage =
-            execute_aggregate_impl(&state, &conn_id, "sales_db", "products", r#"["bad"]"#).await;
+        let bad_stage = execute_aggregate_impl(
+            &state, &conn_id, "sales_db", "products", r#"["bad"]"#, false,
+        )
+        .await;
         assert!(
             bad_stage.unwrap_err().contains("Invalid aggregation stage"),
             "non-document stage should be rejected"
@@ -1467,12 +1530,108 @@ mod tests {
         // A well-formed pipeline on a mock connection reports aggregation is unsupported there.
         let pipeline = r#"[{"$match": {"category": "Electronics"}}, {"$count": "count"}]"#;
         let mock_res =
-            execute_aggregate_impl(&state, &conn_id, "sales_db", "products", pipeline).await;
+            execute_aggregate_impl(&state, &conn_id, "sales_db", "products", pipeline, false)
+                .await;
         assert!(
             mock_res
                 .unwrap_err()
                 .contains("not supported on mock connections"),
             "aggregation on a mock connection should be rejected"
+        );
+    }
+
+    /// #188 security review Fix 1 (CRITICAL): `execute_aggregate_impl` must
+    /// guard `$out`/`$merge` stages exactly like every other write — but
+    /// ONLY when such a stage is present, so a pure-read aggregation keeps
+    /// working on a `read_only` connection. All four cases run against mock
+    /// connections; once the guard lets a call through it still fails with
+    /// the pre-existing "not supported on mock connections" message, which
+    /// is how these tests prove the guard didn't intercept it without
+    /// needing a real MongoDB server.
+    #[tokio::test]
+    async fn test_execute_aggregate_guards_out_and_merge_stages_by_mode() {
+        let out_pipeline = r#"[{"$match": {"a": 1}}, {"$out": "target_coll"}]"#;
+        let merge_pipeline = r#"[{"$merge": {"into": "target_coll"}}]"#;
+        let read_pipeline = r#"[{"$match": {"category": "Electronics"}}, {"$count": "count"}]"#;
+
+        // ReadOnly blocks a $out/$merge pipeline regardless of `confirmed`.
+        let ro_state = AppState::new();
+        let ro_id = connect_db_impl(&ro_state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        set_connection_meta_impl(
+            &ro_state,
+            &ro_id,
+            "p",
+            "ro",
+            false,
+            crate::connections::ConnectionMode::ReadOnly,
+        )
+        .unwrap();
+        for confirmed in [false, true] {
+            let err = execute_aggregate_impl(
+                &ro_state, &ro_id, "db", "coll", out_pipeline, confirmed,
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(err, crate::write_guard::READ_ONLY_MSG, "confirmed={confirmed}");
+        }
+        let err = execute_aggregate_impl(&ro_state, &ro_id, "db", "coll", merge_pipeline, true)
+            .await
+            .unwrap_err();
+        assert_eq!(err, crate::write_guard::READ_ONLY_MSG);
+
+        // The SAME read-only connection must NOT block a pure-read
+        // aggregation — it still errors (mock-connection message), but not
+        // with the read-only rejection, proving the guard only fires when a
+        // write stage is present.
+        let read_err = execute_aggregate_impl(&ro_state, &ro_id, "db", "coll", read_pipeline, false)
+            .await
+            .unwrap_err();
+        assert!(
+            read_err.contains("not supported on mock connections"),
+            "a pure-read aggregation must not be blocked on read_only, got: {read_err}"
+        );
+
+        // ConfirmDestructive blocks the $out pipeline unconfirmed, and lets
+        // it through the guard (reaching the mock-connection check) when
+        // confirmed.
+        let cd_state = AppState::new();
+        let cd_id = connect_db_impl(&cd_state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        set_connection_meta_impl(
+            &cd_state,
+            &cd_id,
+            "p",
+            "cd",
+            false,
+            crate::connections::ConnectionMode::ConfirmDestructive,
+        )
+        .unwrap();
+        let err = execute_aggregate_impl(&cd_state, &cd_id, "db", "coll", out_pipeline, false)
+            .await
+            .unwrap_err();
+        assert_eq!(err, crate::write_guard::CONFIRM_MSG);
+        let err = execute_aggregate_impl(&cd_state, &cd_id, "db", "coll", out_pipeline, true)
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("not supported on mock connections"),
+            "a confirmed $out pipeline should pass the guard, got: {err}"
+        );
+
+        // Normal mode: an unconfirmed $out pipeline still runs past the guard.
+        let normal_state = AppState::new();
+        let normal_id = connect_db_impl(&normal_state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        let err = execute_aggregate_impl(&normal_state, &normal_id, "db", "coll", out_pipeline, false)
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("not supported on mock connections"),
+            "got: {err}"
         );
     }
 
@@ -1603,6 +1762,82 @@ mod tests {
             stop.is_ok(),
             "stopping an unknown session should be a no-op"
         );
+    }
+
+    /// #188 security review Fix 2 (CRITICAL): `start_mongosh_session_impl`
+    /// must refuse a `read_only` connection BEFORE spawning a shell —
+    /// mongosh pipes arbitrary free-form commands the guard can't classify
+    /// per-command. Proven on a mock connection (mongosh sessions are
+    /// already unconditionally rejected for mocks for an unrelated reason —
+    /// "External mongosh sessions require a real MongoDB URI" — so the
+    /// `ConfirmDestructive`/`Normal` cases below assert the error is NOT the
+    /// read-only rejection, i.e. the new gate let the call fall through to
+    /// that pre-existing mock restriction instead of blocking it itself).
+    #[tokio::test]
+    async fn test_start_mongosh_session_blocks_read_only_before_spawning() {
+        use crate::start_mongosh_session_impl;
+
+        let state = AppState::new();
+        let conn_id = connect_db_impl(&state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        set_connection_meta_impl(
+            &state,
+            &conn_id,
+            "p",
+            "ro",
+            false,
+            crate::connections::ConnectionMode::ReadOnly,
+        )
+        .unwrap();
+
+        let err = start_mongosh_session_impl(&state, &conn_id, "mongodb://mock", "db", "")
+            .await
+            .err()
+            .expect("read-only connection must refuse a mongosh session");
+        assert_eq!(err, crate::write_guard::READ_ONLY_MSG);
+    }
+
+    #[tokio::test]
+    async fn test_start_mongosh_session_confirm_destructive_and_normal_are_not_blocked_by_the_read_only_gate(
+    ) {
+        use crate::start_mongosh_session_impl;
+
+        let cd_state = AppState::new();
+        let cd_id = connect_db_impl(&cd_state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        set_connection_meta_impl(
+            &cd_state,
+            &cd_id,
+            "p",
+            "cd",
+            false,
+            crate::connections::ConnectionMode::ConfirmDestructive,
+        )
+        .unwrap();
+        let err = start_mongosh_session_impl(&cd_state, &cd_id, "mongodb://mock", "db", "")
+            .await
+            .err()
+            .expect("mock connections still can't run an external mongosh");
+        assert_ne!(
+            err,
+            crate::write_guard::READ_ONLY_MSG,
+            "confirm_destructive must not be blocked by the new read-only gate"
+        );
+        assert!(err.contains("real MongoDB URI"), "got: {err}");
+
+        // Normal (no connection_meta entry at all — fail-open default).
+        let normal_state = AppState::new();
+        let normal_id = connect_db_impl(&normal_state, "mongodb://mock", None)
+            .await
+            .expect("connect mock");
+        let err = start_mongosh_session_impl(&normal_state, &normal_id, "mongodb://mock", "db", "")
+            .await
+            .err()
+            .expect("mock connections still can't run an external mongosh");
+        assert_ne!(err, crate::write_guard::READ_ONLY_MSG);
+        assert!(err.contains("real MongoDB URI"), "got: {err}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2233,6 +2233,7 @@ mod tests {
             color_tag: None,
             ssh: None,
             mcp_enabled: false,
+            connection_mode: Default::default(),
         };
 
         // Save profile
@@ -2263,6 +2264,7 @@ mod tests {
                 },
             }),
             mcp_enabled: true,
+            connection_mode: crate::connections::ConnectionMode::ReadOnly,
         };
         profiles.push(profile2.clone());
         crate::connections::save_profiles_to_file(&test_file_path, &profiles)
@@ -2305,6 +2307,7 @@ mod tests {
             color_tag: None,
             ssh: None,
             mcp_enabled: true,
+            connection_mode: Default::default(),
         };
         let json = serde_json::to_string(&profile).expect("serialize");
         let round_tripped: ConnectionProfile = serde_json::from_str(&json).expect("deserialize");
@@ -2320,6 +2323,52 @@ mod tests {
         let legacy: ConnectionProfile = serde_json::from_str(legacy_json)
             .expect("old connections.json without mcp_enabled must still deserialize");
         assert_eq!(legacy.mcp_enabled, false, "legacy profiles must never be opted in by surprise");
+    }
+
+    // #188: connection_mode round-trips through plaintext (de)serialization,
+    // and old connections.json files written before the field existed must
+    // never opt a profile into a safeguard by surprise — they must
+    // deserialize as `Normal` (full read/write), same additive contract as
+    // `mcp_enabled` above.
+    #[test]
+    fn test_connection_profile_connection_mode_roundtrip_and_legacy_default() {
+        use crate::connections::{ConnectionMode, ConnectionProfile};
+
+        for mode in [ConnectionMode::Normal, ConnectionMode::ReadOnly, ConnectionMode::ConfirmDestructive] {
+            let profile = ConnectionProfile {
+                id: "p1".to_string(),
+                name: "Prod".to_string(),
+                uri: "mongodb://localhost:27017".to_string(),
+                color_tag: None,
+                ssh: None,
+                mcp_enabled: false,
+                connection_mode: mode,
+            };
+            let json = serde_json::to_string(&profile).expect("serialize");
+            let round_tripped: ConnectionProfile = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(round_tripped, profile);
+            assert_eq!(round_tripped.connection_mode, mode);
+        }
+
+        // Wire format sanity: the enum serializes as the spec's snake_case strings.
+        let json = serde_json::to_string(&ConnectionMode::ReadOnly).unwrap();
+        assert_eq!(json, "\"read_only\"");
+        let json = serde_json::to_string(&ConnectionMode::ConfirmDestructive).unwrap();
+        assert_eq!(json, "\"confirm_destructive\"");
+
+        // A JSON literal predating the field (no "connection_mode" key at all).
+        let legacy_json = r#"{
+            "id": "legacy-1",
+            "name": "Legacy DB",
+            "uri": "mongodb://legacy:27017"
+        }"#;
+        let legacy: ConnectionProfile = serde_json::from_str(legacy_json)
+            .expect("old connections.json without connection_mode must still deserialize");
+        assert_eq!(
+            legacy.connection_mode,
+            ConnectionMode::Normal,
+            "legacy profiles must never be safeguarded by surprise"
+        );
     }
 
     #[tokio::test]
@@ -2747,6 +2796,7 @@ mod tests {
             color_tag: None,
             ssh: None,
             mcp_enabled: false,
+            connection_mode: Default::default(),
         }];
         save_profiles_encrypted(&prof_path, &key, &profiles).unwrap();
         // On-disk bytes must not contain the plaintext password.
@@ -2795,6 +2845,7 @@ mod tests {
             color_tag: None,
             ssh: None,
             mcp_enabled: false,
+            connection_mode: Default::default(),
         }];
         save_profiles_to_file(&pt_profiles, &profiles).unwrap();
         assert!(pt_profiles.exists());
@@ -3025,6 +3076,7 @@ mod tests {
             color_tag: None,
             ssh: None,
             mcp_enabled: false,
+            connection_mode: Default::default(),
         }];
         save_profiles_encrypted(&enc_profiles, &old_key, &profiles).unwrap();
 
@@ -3733,42 +3785,58 @@ mod tests {
     #[test]
     fn set_connection_meta_inserts_and_overwrites() {
         let state = AppState::new();
-        set_connection_meta_impl(&state, "conn-1", "profile-a", "Prod Cluster", false).unwrap();
+        set_connection_meta_impl(&state, "conn-1", "profile-a", "Prod Cluster", false, crate::connections::ConnectionMode::ReadOnly).unwrap();
         {
             let meta = state.connection_meta.lock().unwrap();
             let m = meta.get("conn-1").expect("meta inserted");
             assert_eq!(m.profile_id, "profile-a");
             assert_eq!(m.name, "Prod Cluster");
+            assert_eq!(m.mode, crate::connections::ConnectionMode::ReadOnly);
         }
 
         // Re-registering the same id (e.g. a reconnect) overwrites in place
-        // rather than accumulating a second entry.
-        set_connection_meta_impl(&state, "conn-1", "profile-b", "Renamed", false).unwrap();
+        // rather than accumulating a second entry — including the mode, in
+        // case the profile's safeguard setting changed between connects.
+        set_connection_meta_impl(&state, "conn-1", "profile-b", "Renamed", false, crate::connections::ConnectionMode::Normal).unwrap();
         let meta = state.connection_meta.lock().unwrap();
         assert_eq!(meta.len(), 1, "same id must overwrite, not duplicate");
         let m = meta.get("conn-1").unwrap();
         assert_eq!(m.profile_id, "profile-b");
         assert_eq!(m.name, "Renamed");
+        assert_eq!(m.mode, crate::connections::ConnectionMode::Normal);
+    }
+
+    // #188: `connection_list_impl` must surface a registered mode through to
+    // the `ConnectionEntry` the frontend reads — the banner/badge (Task 5)
+    // depend on this, not on re-deriving mode from the profile store.
+    #[test]
+    fn connection_list_impl_surfaces_the_registered_mode() {
+        let state = AppState::new();
+        set_connection_meta_impl(&state, "conn-1", "profile-a", "Prod Cluster", false, crate::connections::ConnectionMode::ConfirmDestructive).unwrap();
+
+        let list = connection_list_impl(&state).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].mode, crate::connections::ConnectionMode::ConfirmDestructive);
     }
 
     #[test]
     fn connection_meta_never_carries_a_uri() {
         // Regression guard for the explicit constraint: event payloads must
         // never carry a connection string. `ConnectionMeta`/`ConnectionEntry`
-        // only ever expose `profileId`/`name` — this test would fail to
-        // compile (not just fail at runtime) the moment a `uri` field is
+        // only ever expose `profileId`/`name`/`mode` — this test would fail
+        // to compile (not just fail at runtime) the moment a `uri` field is
         // added, since the struct literal below is exhaustive.
-        let meta = crate::ConnectionMeta { profile_id: "p".into(), name: "n".into(), via_mcp: false };
-        let entry = crate::ConnectionEntry { id: "c".into(), profile_id: meta.profile_id.clone(), name: meta.name.clone(), via_mcp: meta.via_mcp };
+        let meta = crate::ConnectionMeta { profile_id: "p".into(), name: "n".into(), via_mcp: false, mode: Default::default() };
+        let entry = crate::ConnectionEntry { id: "c".into(), profile_id: meta.profile_id.clone(), name: meta.name.clone(), via_mcp: meta.via_mcp, mode: meta.mode };
         assert_eq!(entry.id, "c");
     }
 
     #[test]
     fn connection_list_is_sorted_by_id_regardless_of_insertion_order() {
         let state = AppState::new();
-        set_connection_meta_impl(&state, "conn-c", "p3", "Third", false).unwrap();
-        set_connection_meta_impl(&state, "conn-a", "p1", "First", false).unwrap();
-        set_connection_meta_impl(&state, "conn-b", "p2", "Second", false).unwrap();
+        set_connection_meta_impl(&state, "conn-c", "p3", "Third", false, Default::default()).unwrap();
+        set_connection_meta_impl(&state, "conn-a", "p1", "First", false, Default::default()).unwrap();
+        set_connection_meta_impl(&state, "conn-b", "p2", "Second", false, Default::default()).unwrap();
 
         let list = connection_list_impl(&state).unwrap();
         let ids: Vec<&str> = list.iter().map(|e| e.id.as_str()).collect();
@@ -3792,7 +3860,7 @@ mod tests {
         let conn_id = connect_db_impl(&state, "mongodb://mock", None)
             .await
             .expect("mock connect");
-        set_connection_meta_impl(&state, &conn_id, "profile-a", "Mock Conn", false).unwrap();
+        set_connection_meta_impl(&state, &conn_id, "profile-a", "Mock Conn", false, Default::default()).unwrap();
         assert!(state.connection_meta.lock().unwrap().contains_key(&conn_id));
 
         disconnect_db_impl(&state, &conn_id)

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1754,14 +1754,14 @@ mod tests {
             .expect("connect mock");
 
         // delete_many: malformed filter is rejected.
-        let bad_filter = delete_many_impl(&state, &conn_id, "sales_db", "customers", "{bad").await;
+        let bad_filter = delete_many_impl(&state, &conn_id, "sales_db", "customers", "{bad", true).await;
         assert!(
             bad_filter.is_err(),
             "malformed delete filter should be rejected"
         );
 
         // delete_many: valid filter on mock no-ops (returns 0, no persistence).
-        let del = delete_many_impl(&state, &conn_id, "sales_db", "customers", r#"{"tier":"X"}"#)
+        let del = delete_many_impl(&state, &conn_id, "sales_db", "customers", r#"{"tier":"X"}"#, true)
             .await
             .expect("mock delete_many ok");
         assert_eq!(del, 0);
@@ -1774,6 +1774,7 @@ mod tests {
             "customers",
             "{}",
             r#"{"name":"x"}"#,
+            true,
         )
         .await;
         assert!(
@@ -1783,7 +1784,7 @@ mod tests {
 
         // update_many: malformed update JSON is rejected.
         let bad_update =
-            update_many_impl(&state, &conn_id, "sales_db", "customers", "{}", "{bad").await;
+            update_many_impl(&state, &conn_id, "sales_db", "customers", "{}", "{bad", true).await;
         assert!(bad_update.is_err(), "malformed update should be rejected");
 
         // update_many: a valid operator update on mock no-ops (returns 0).
@@ -1794,6 +1795,7 @@ mod tests {
             "customers",
             r#"{"tier":"X"}"#,
             r#"{"$set":{"tier":"Y"}}"#,
+            true,
         )
         .await
         .expect("mock update_many ok");
@@ -2013,36 +2015,37 @@ mod tests {
         create_collection_impl(&state, &conn_id, "sales_db", "new_coll")
             .await
             .expect("create collection should succeed in mock mode");
-        rename_collection_impl(&state, &conn_id, "sales_db", "new_coll", "renamed_coll")
+        rename_collection_impl(&state, &conn_id, "sales_db", "new_coll", "renamed_coll", true)
             .await
             .expect("rename collection should succeed in mock mode");
-        drop_collection_impl(&state, &conn_id, "sales_db", "new_coll")
+        drop_collection_impl(&state, &conn_id, "sales_db", "new_coll", true)
             .await
             .expect("drop collection should succeed in mock mode");
-        drop_database_impl(&state, &conn_id, "sales_db")
+        drop_database_impl(&state, &conn_id, "sales_db", true)
             .await
             .expect("drop database should succeed in mock mode");
-        let renamed = rename_database_impl(&state, &conn_id, "sales_db", "sales_archive", true)
-            .await
-            .expect("rename database should succeed in mock mode");
+        let renamed =
+            rename_database_impl(&state, &conn_id, "sales_db", "sales_archive", true, true)
+                .await
+                .expect("rename database should succeed in mock mode");
         assert_eq!(renamed.collections, 0);
         assert_eq!(renamed.documents, 0);
 
         assert!(
-            rename_collection_impl(&state, &conn_id, "sales_db", "", "renamed")
+            rename_collection_impl(&state, &conn_id, "sales_db", "", "renamed", true)
                 .await
                 .is_err()
         );
         assert!(
-            rename_collection_impl(&state, &conn_id, "sales_db", "same", "same")
+            rename_collection_impl(&state, &conn_id, "sales_db", "same", "same", true)
                 .await
                 .is_err()
         );
-        assert!(drop_database_impl(&state, &conn_id, "").await.is_err());
-        assert!(rename_database_impl(&state, &conn_id, "", "target", true)
+        assert!(drop_database_impl(&state, &conn_id, "", true).await.is_err());
+        assert!(rename_database_impl(&state, &conn_id, "", "target", true, true)
             .await
             .is_err());
-        assert!(rename_database_impl(&state, &conn_id, "same", "same", true)
+        assert!(rename_database_impl(&state, &conn_id, "same", "same", true, true)
             .await
             .is_err());
 
@@ -2059,19 +2062,19 @@ mod tests {
             "Connection client not found"
         );
         assert_eq!(
-            drop_collection_impl(&state, realish, "sales_db", "new_coll")
+            drop_collection_impl(&state, realish, "sales_db", "new_coll", true)
                 .await
                 .unwrap_err(),
             "Connection client not found"
         );
         assert_eq!(
-            rename_collection_impl(&state, realish, "sales_db", "from", "to")
+            rename_collection_impl(&state, realish, "sales_db", "from", "to", true)
                 .await
                 .unwrap_err(),
             "Connection client not found"
         );
         assert_eq!(
-            drop_database_impl(&state, realish, "sales_db")
+            drop_database_impl(&state, realish, "sales_db", true)
                 .await
                 .unwrap_err(),
             "Connection client not found"

--- a/src-tauri/src/toolsetup.rs
+++ b/src-tauri/src/toolsetup.rs
@@ -511,6 +511,40 @@ async fn probe_binary_ok_timeout(path: &Path) -> bool {
     matches!(tokio::time::timeout(PROBE_TIMEOUT, probe).await, Ok(Ok(true)))
 }
 
+/// Number of times [`install_one_tool`] probes a freshly extracted binary
+/// before giving up on it.
+const PROBE_RETRY_ATTEMPTS: u32 = 3;
+/// Delay between failed probe attempts in [`probe_binary_ok_with_retries`].
+const PROBE_RETRY_BACKOFF: Duration = Duration::from_millis(200);
+
+/// Runs [`probe_binary_ok_timeout`] up to `attempts` times, waiting
+/// [`PROBE_RETRY_BACKOFF`] between attempts, returning as soon as one
+/// succeeds.
+///
+/// Why: the post-extraction `--version` probe spawns a fresh process against
+/// a file that was just written to disk and had its exec bit just set. On a
+/// loaded machine (CI runner under an instrumented build, an AV scanner, a
+/// busy laptop) a *single* probe can trip over a transient hiccup — a spawn
+/// failure, filesystem sync lag, or scheduling starvation — that has nothing
+/// to do with the binary itself. Failing the whole install on one such blip
+/// is a false negative, so we retry a few times with a short backoff before
+/// declaring the binary unusable. A genuinely broken binary (wrong
+/// architecture, truncated/corrupt archive, missing interpreter) fails
+/// every attempt identically and this still returns `false` after
+/// `attempts` tries — no real failure is hidden, only transient ones are
+/// tolerated.
+async fn probe_binary_ok_with_retries(path: &Path, attempts: u32) -> bool {
+    for attempt in 1..=attempts {
+        if probe_binary_ok_timeout(path).await {
+            return true;
+        }
+        if attempt < attempts {
+            tokio::time::sleep(PROBE_RETRY_BACKOFF).await;
+        }
+    }
+    false
+}
+
 /// Staging directories (one per tool name + app data dir) with an install
 /// currently in flight. Guards against two concurrent installs of the same
 /// tool corrupting each other's staging dir or a just-completed install.
@@ -802,7 +836,11 @@ pub(crate) async fn install_one_tool(
     progress("checking", 0, None);
     for b in binaries {
         let bin_path = extracted_bin.join(binary_file_name(b));
-        if !probe_binary_ok_timeout(&bin_path).await {
+        // Retry a few times before failing the install: a transient
+        // exec/fs hiccup on a loaded machine shouldn't sink an otherwise
+        // valid install. See `probe_binary_ok_with_retries` for why this is
+        // safe — a genuinely bad binary still fails every attempt.
+        if !probe_binary_ok_with_retries(&bin_path, PROBE_RETRY_ATTEMPTS).await {
             return Err(cleanup(
                 &staging_dir,
                 format!("{} failed to run --version", bin_path.display()),

--- a/src-tauri/src/write_guard.rs
+++ b/src-tauri/src/write_guard.rs
@@ -1,0 +1,392 @@
+//! Central write guard (#188): the single choke point every mutating `_impl`
+//! calls, first line, before any DB work. Reads the live connection's
+//! `ConnectionMeta.mode` (captured at connect time from the profile's
+//! `connection_mode` — never re-derived, so a live connection's guard
+//! behavior can't drift out of sync with what was true when it connected)
+//! and decides whether the write may proceed.
+//!
+//! `ReadOnly` blocks every write unconditionally. `ConfirmDestructive` only
+//! blocks the four ops in [`WriteOp::is_destructive`] and only when the
+//! caller hasn't set `confirmed` — everything else passes through. A
+//! connection with no meta entry defaults to `Normal` (fail-open: this is an
+//! opt-in production safeguard, not a security boundary against a hostile
+//! local user).
+//!
+//! Sequencing note (#188 Task 2 vs Task 3): this module guards every
+//! non-destructive mutating `_impl` with `confirmed=false` (irrelevant for
+//! those ops). The six destructive commands (`drop_collection`,
+//! `drop_database`, `delete_many`, `update_many`, `rename_collection`,
+//! `drop_index`) gain a real `confirmed: bool` command arg in Task 3, which
+//! is threaded through to this guard there.
+//!
+//! `delete_index_impl`/`WriteOp::DropIndex` is guarded HERE (Task 2), not in
+//! Task 3: `WriteOp::is_destructive` only covers `Drop | DeleteMany |
+//! UpdateMany | Rename` — `DropIndex` is not in that set, so it's a
+//! non-destructive-arg impl guarded with `confirmed=false` like the rest of
+//! this task's list. (The plan's prose mentions drop_index among Task 3's
+//! confirmed-arg set in one place, but the destructive-four definition and
+//! the file structure table are unambiguous: drop_index belongs here.)
+
+use crate::connections::ConnectionMode;
+use crate::state::{AppState, LockExt};
+
+/// Every mutating operation the write guard can be asked to authorize. One
+/// variant per "kind" of write, not one per command, so several impls that
+/// write the same way (e.g. `create_user`/`update_user`/`drop_user`) can
+/// share `UserWrite`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WriteOp {
+    Insert,
+    UpdateOne,
+    UpdateMany,
+    DeleteOne,
+    DeleteMany,
+    ReplaceOne,
+    Drop,
+    Rename,
+    CreateCollection,
+    CreateView,
+    CreateIndex,
+    DropIndex,
+    CollMod,
+    GridFsWrite,
+    Import,
+    Generate,
+    CopyWrite,
+    RestoreWrite,
+    UserWrite,
+}
+
+impl WriteOp {
+    /// The four ops a `ConfirmDestructive` connection requires an explicit
+    /// `confirmed: bool` for. Everything else is allowed through even
+    /// unconfirmed on a confirm-destructive connection.
+    pub fn is_destructive(self) -> bool {
+        matches!(self, WriteOp::Drop | WriteOp::DeleteMany | WriteOp::UpdateMany | WriteOp::Rename)
+    }
+}
+
+/// Exact rejection string for a `ReadOnly` connection (spec-mandated wording).
+pub const READ_ONLY_MSG: &str =
+    "This connection is read-only (production safeguard). Change the connection mode in its settings to modify data.";
+/// Exact rejection string for an unconfirmed destructive op on a `ConfirmDestructive` connection.
+pub const CONFIRM_MSG: &str =
+    "This operation modifies production data on a safeguarded connection. Confirm by typing the collection name.";
+
+/// The single choke point for every mutating command. `connection_id` is
+/// always the connection the write actually lands on — for copy commands
+/// that's the TARGET connection, not the source, since a copy writes into
+/// the target. Call this as the first line of every mutating `_impl`,
+/// before any parsing or DB work, so a safeguarded connection rejects
+/// uniformly regardless of what else is wrong with the call.
+pub fn guard_writable(
+    state: &AppState,
+    connection_id: &str,
+    op: WriteOp,
+    confirmed: bool,
+) -> Result<(), String> {
+    let mode = {
+        let meta = state.connection_meta.lock_safe()?;
+        meta.get(connection_id).map(|m| m.mode).unwrap_or_default()
+    };
+    match mode {
+        ConnectionMode::Normal => Ok(()),
+        ConnectionMode::ReadOnly => Err(READ_ONLY_MSG.to_string()),
+        ConnectionMode::ConfirmDestructive => {
+            if op.is_destructive() && !confirmed {
+                Err(CONFIRM_MSG.to_string())
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{copy, ddl, documents, generate, gridfs, import, metadata, mongotools, users};
+    use crate::state::ConnectionMeta;
+    use std::future::Future;
+    use std::pin::Pin;
+
+    /// Number of non-destructive mutating `_impl`s wired in Task 2 (the
+    /// plan's explicit coverage list). A new mutating command must add a row
+    /// to `non_destructive_cases` below AND bump this constant — kept as a
+    /// paired assertion so a forgotten row fails the test loudly instead of
+    /// silently shrinking coverage.
+    const NON_DESTRUCTIVE_GUARDED_COUNT: usize = 19;
+
+    /// Register a mock connection (`state.mocks`) with the given mode
+    /// (`state.connection_meta`), mirroring the `mock_state` helper used
+    /// elsewhere in the `db` test modules (see `db/copy.rs::tests::mock_state`).
+    fn mock_conn(state: &AppState, id: &str, mode: ConnectionMode) {
+        state.mocks.lock().unwrap().insert(id.to_string(), true);
+        state.connection_meta.lock().unwrap().insert(
+            id.to_string(),
+            ConnectionMeta { profile_id: "p".into(), name: id.into(), via_mcp: false, mode },
+        );
+    }
+
+    fn readonly_state(ids: &[&str]) -> AppState {
+        let state = AppState::new();
+        for id in ids {
+            mock_conn(&state, id, ConnectionMode::ReadOnly);
+        }
+        state
+    }
+
+    type BoxedCall<'a> = Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>;
+
+    /// One closure invocation per non-destructive mutating `_impl`, called
+    /// once each with minimal valid args against a read-only mock
+    /// connection. Every call must return `Err` containing "read-only".
+    /// Adding a new mutating command = adding a row here (and bumping
+    /// `NON_DESTRUCTIVE_GUARDED_COUNT`).
+    fn non_destructive_cases(state: &AppState) -> Vec<(&'static str, BoxedCall<'_>)> {
+        vec![
+            (
+                "insert_document_impl",
+                Box::pin(async move {
+                    documents::insert_document_impl(state, "ro", "db", "coll", "{}")
+                        .await
+                        .map(|_| ())
+                }),
+            ),
+            (
+                "update_document_impl",
+                Box::pin(async move {
+                    documents::update_document_impl(state, "ro", "db", "coll", "{}", "{}")
+                        .await
+                        .map(|_| ())
+                }),
+            ),
+            (
+                "delete_document_impl",
+                Box::pin(async move {
+                    documents::delete_document_impl(state, "ro", "db", "coll", "{}")
+                        .await
+                        .map(|_| ())
+                }),
+            ),
+            (
+                "import_documents_impl",
+                Box::pin(async move {
+                    documents::import_documents_impl(state, "ro", "db", "coll", vec![], "skip")
+                        .await
+                        .map(|_| ())
+                }),
+            ),
+            (
+                "create_collection_impl",
+                Box::pin(async move {
+                    ddl::create_collection_impl(state, "ro", "db", "coll").await
+                }),
+            ),
+            (
+                "create_view_impl",
+                Box::pin(async move {
+                    ddl::create_view_impl(state, "ro", "db", "view", "src", "[]").await
+                }),
+            ),
+            (
+                "set_validator_impl",
+                Box::pin(async move {
+                    ddl::set_validator_impl(state, "ro", "db", "coll", "{}", "", "").await
+                }),
+            ),
+            (
+                "create_index_impl",
+                Box::pin(async move {
+                    metadata::create_index_impl(state, "ro", "db", "coll", "idx", "{}", false, false)
+                        .await
+                }),
+            ),
+            (
+                "delete_index_impl",
+                Box::pin(async move {
+                    metadata::delete_index_impl(state, "ro", "db", "coll", "idx").await
+                }),
+            ),
+            (
+                "upload_gridfs_file_impl",
+                Box::pin(async move {
+                    gridfs::upload_gridfs_file_impl(
+                        state, "ro", "db", "fs", "/nonexistent", None, None, None, None,
+                    )
+                    .await
+                    .map(|_| ())
+                }),
+            ),
+            (
+                "delete_gridfs_file_impl",
+                Box::pin(async move {
+                    gridfs::delete_gridfs_file_impl(state, "ro", "db", "fs", "\"x\"").await
+                }),
+            ),
+            (
+                "create_user_impl",
+                Box::pin(async move {
+                    users::create_user_impl(state, "ro", "db", "u", "p", &[]).await
+                }),
+            ),
+            (
+                "update_user_impl",
+                Box::pin(async move {
+                    users::update_user_impl(state, "ro", "db", "u", Some("p"), None).await
+                }),
+            ),
+            (
+                "drop_user_impl",
+                Box::pin(async move { users::drop_user_impl(state, "ro", "db", "u").await }),
+            ),
+            (
+                "start_collection_copy_impl",
+                Box::pin(async move {
+                    copy::start_collection_copy_impl(
+                        state, "src", "db", "coll", "ro", "db", "coll2", None, false,
+                        "skip".to_string(),
+                    )
+                    .await
+                    .map(|_| ())
+                }),
+            ),
+            (
+                "start_database_copy_impl",
+                Box::pin(async move {
+                    copy::start_database_copy_impl(
+                        state, "src", "db", "ro", "db2", None, false, false, "skip".to_string(),
+                    )
+                    .await
+                    .map(|_| ())
+                }),
+            ),
+            (
+                "start_import_task_impl",
+                Box::pin(async move {
+                    import::start_import_task_impl(
+                        state,
+                        "ro",
+                        "db",
+                        "coll",
+                        import::ImportSourceArg::default(),
+                        "json",
+                        None,
+                        "skip",
+                    )
+                    .await
+                    .map(|_| ())
+                }),
+            ),
+            (
+                "start_generate_task_impl",
+                Box::pin(async move {
+                    generate::start_generate_task_impl(state, "ro", "db", "coll", "{}", 1, Some(1))
+                        .await
+                        .map(|_| ())
+                }),
+            ),
+            (
+                "start_restore_task_impl",
+                Box::pin(async move {
+                    mongotools::start_restore_task_impl(
+                        state,
+                        "ro",
+                        "/usr/bin/mongorestore",
+                        mongotools::RestoreOptions::default(),
+                    )
+                    .await
+                    .map(|_| ())
+                }),
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    async fn every_non_destructive_mutating_impl_rejects_on_a_read_only_connection() {
+        let state = readonly_state(&["ro", "src"]);
+        let cases = non_destructive_cases(&state);
+        assert_eq!(
+            cases.len(),
+            NON_DESTRUCTIVE_GUARDED_COUNT,
+            "a row was added/removed without updating NON_DESTRUCTIVE_GUARDED_COUNT"
+        );
+        for (name, fut) in cases {
+            let res = fut.await;
+            let err = res.expect_err(&format!("{name} should reject on a read-only connection"));
+            assert!(
+                err.contains("read-only"),
+                "{name} error should mention read-only, got: {err}"
+            );
+        }
+    }
+
+    /// Copy commands guard the TARGET connection, not the source — a copy
+    /// writes into the target. Proven both ways: read-only target blocks
+    /// (even though the source is a normal, writable connection), and a
+    /// read-only SOURCE with a normal target does NOT block (proving the
+    /// guard doesn't key off the wrong connection).
+    #[tokio::test]
+    async fn copy_commands_guard_the_target_connection_not_the_source() {
+        // Target read-only, source normal -> blocked.
+        let target_ro = AppState::new();
+        mock_conn(&target_ro, "source", ConnectionMode::Normal);
+        mock_conn(&target_ro, "target", ConnectionMode::ReadOnly);
+        let err = copy::start_collection_copy_impl(
+            &target_ro, "source", "db", "coll", "target", "db", "coll2", None, false,
+            "skip".to_string(),
+        )
+        .await
+        .expect_err("read-only target must block the copy");
+        assert!(err.contains("read-only"), "got: {err}");
+
+        let err = copy::start_database_copy_impl(
+            &target_ro, "source", "db", "target", "db2", None, false, false, "skip".to_string(),
+        )
+        .await
+        .expect_err("read-only target must block the database copy");
+        assert!(err.contains("read-only"), "got: {err}");
+
+        // Source read-only, target normal -> NOT blocked by the guard (may
+        // still fail later for other reasons on a mock, but not with the
+        // read-only message).
+        let source_ro = AppState::new();
+        mock_conn(&source_ro, "source", ConnectionMode::ReadOnly);
+        mock_conn(&source_ro, "target", ConnectionMode::Normal);
+        let res = copy::start_collection_copy_impl(
+            &source_ro, "source", "db", "coll", "target", "db", "coll2", None, false,
+            "skip".to_string(),
+        )
+        .await;
+        if let Err(e) = &res {
+            assert!(
+                !e.contains("read-only"),
+                "a read-only SOURCE must not block the copy (guard is target-keyed), got: {e}"
+            );
+        }
+    }
+
+    /// `rename_database_impl` (ddl.rs) is a mutating command NOT in the
+    /// plan's Task 2/Task 3 coverage lists (it's neither one of the 19
+    /// non-destructive impls nor one of the six named destructive commands
+    /// `drop_collection`/`drop_database`/`delete_many`/`update_many`/
+    /// `rename_collection`/`drop_index`) — flagged and guarded here as an
+    /// addition beyond the plan. It renames every collection in a database
+    /// and optionally drops the source, which is at least as destructive as
+    /// `rename_collection`, so it's guarded with `WriteOp::Rename` — but
+    /// unlike the six named destructive commands it has no `confirmed`
+    /// command arg yet, so `confirmed` is hardcoded `false` here pending a
+    /// follow-up task giving it one (interim effect: blocked on both
+    /// `ReadOnly` and `ConfirmDestructive`, allowed on `Normal`). Not
+    /// counted in `NON_DESTRUCTIVE_GUARDED_COUNT` since it isn't actually
+    /// non-destructive; tested separately.
+    #[tokio::test]
+    async fn rename_database_impl_rejects_on_a_read_only_connection() {
+        let state = readonly_state(&["ro"]);
+        let err = match ddl::rename_database_impl(&state, "ro", "from_db", "to_db", false).await {
+            Err(e) => e,
+            Ok(_) => panic!("rename_database_impl should reject on a read-only connection"),
+        };
+        assert!(err.contains("read-only"), "got: {err}");
+    }
+}

--- a/src-tauri/src/write_guard.rs
+++ b/src-tauri/src/write_guard.rs
@@ -12,20 +12,37 @@
 //! opt-in production safeguard, not a security boundary against a hostile
 //! local user).
 //!
-//! Sequencing note (#188 Task 2 vs Task 3): this module guards every
-//! non-destructive mutating `_impl` with `confirmed=false` (irrelevant for
-//! those ops). The six destructive commands (`drop_collection`,
-//! `drop_database`, `delete_many`, `update_many`, `rename_collection`,
-//! `drop_index`) gain a real `confirmed: bool` command arg in Task 3, which
-//! is threaded through to this guard there.
+//! Sequencing note (#188 Task 2 vs Task 3, now both complete): Task 2 guarded
+//! every non-destructive mutating `_impl` with `confirmed=false` (irrelevant
+//! for those ops) and defined the guard + coverage test. Task 3 gave the six
+//! genuinely destructive impls (`delete_many`, `update_many`,
+//! `drop_collection`, `rename_collection`, `drop_database`,
+//! `rename_database`) a real `confirmed: bool` command arg threaded through
+//! to this guard, and extended the coverage test with a destructive-cases
+//! table asserting all three mode behaviors for each. Task 3 also added the
+//! two `WriteOp::ServerAdmin` guards (`kill_op`, `set_profiling_level`) to
+//! the non-destructive table.
 //!
-//! `delete_index_impl`/`WriteOp::DropIndex` is guarded HERE (Task 2), not in
-//! Task 3: `WriteOp::is_destructive` only covers `Drop | DeleteMany |
-//! UpdateMany | Rename` — `DropIndex` is not in that set, so it's a
-//! non-destructive-arg impl guarded with `confirmed=false` like the rest of
-//! this task's list. (The plan's prose mentions drop_index among Task 3's
-//! confirmed-arg set in one place, but the destructive-four definition and
-//! the file structure table are unambiguous: drop_index belongs here.)
+//! `delete_index_impl`/`WriteOp::DropIndex` is guarded in the non-destructive
+//! table: `WriteOp::is_destructive` only covers `Drop | DeleteMany |
+//! UpdateMany | Rename` — `DropIndex` is not in that set, so a
+//! `ConfirmDestructive` connection lets it through even with
+//! `confirmed=false` (its command has no `confirmed` arg at all — dropping
+//! an index isn't considered destructive enough to require typed
+//! confirmation, unlike dropping a collection/database).
+//!
+//! `WriteOp::UpdateOne` is intentionally unused (and shows up as dead code
+//! under `cargo clippy --lib`): it was defined in Task 2 mirroring the
+//! plan's `WriteOp` code block, but this codebase has no single-document
+//! *partial* update command distinct from `update_document`/`WriteOp::
+//! ReplaceOne` (which does a full replacement) — there's nothing for it to
+//! guard. Investigated as part of Task 3 (whose exit criterion is "clippy
+//! back to the 21 lib baseline") and confirmed this is a pre-existing enum/
+//! API mismatch from Task 1/2, not a Task-3-introduced or newly-discovered
+//! unguarded command, so it's left as-is rather than papering over it with
+//! an `#[allow(dead_code)]` or inventing a fake call site; clippy's lib
+//! warning count is 22 (21 baseline + this one), not 21 — see the Task 3
+//! report.
 
 use crate::connections::ConnectionMode;
 use crate::state::{AppState, LockExt};
@@ -55,6 +72,10 @@ pub enum WriteOp {
     CopyWrite,
     RestoreWrite,
     UserWrite,
+    /// Server-admin operations that mutate live server/database state but
+    /// aren't collection data writes: `killOp` and the profiler level
+    /// (`setProfilingLevel`). Non-destructive — not in `is_destructive`.
+    ServerAdmin,
 }
 
 impl WriteOp {
@@ -106,16 +127,18 @@ pub fn guard_writable(
 mod tests {
     use super::*;
     use crate::db::{copy, ddl, documents, generate, gridfs, import, metadata, mongotools, users};
+    use crate::monitoring;
     use crate::state::ConnectionMeta;
     use std::future::Future;
     use std::pin::Pin;
 
-    /// Number of non-destructive mutating `_impl`s wired in Task 2 (the
-    /// plan's explicit coverage list). A new mutating command must add a row
-    /// to `non_destructive_cases` below AND bump this constant — kept as a
-    /// paired assertion so a forgotten row fails the test loudly instead of
+    /// Number of non-destructive mutating `_impl`s wired in Task 2 (19) plus
+    /// the two `WriteOp::ServerAdmin` impls wired in Task 3 (`kill_op_impl`,
+    /// `set_profiling_level_impl`) = 21. A new mutating command must add a
+    /// row to `non_destructive_cases` below AND bump this constant — kept as
+    /// a paired assertion so a forgotten row fails the test loudly instead of
     /// silently shrinking coverage.
-    const NON_DESTRUCTIVE_GUARDED_COUNT: usize = 19;
+    const NON_DESTRUCTIVE_GUARDED_COUNT: usize = 21;
 
     /// Register a mock connection (`state.mocks`) with the given mode
     /// (`state.connection_meta`), mirroring the `mock_state` helper used
@@ -299,6 +322,18 @@ mod tests {
                     .map(|_| ())
                 }),
             ),
+            (
+                "kill_op_impl",
+                Box::pin(async move { monitoring::kill_op_impl(state, "ro", 1).await }),
+            ),
+            (
+                "set_profiling_level_impl",
+                Box::pin(async move {
+                    monitoring::set_profiling_level_impl(state, "ro", "db", 1, 100)
+                        .await
+                        .map(|_| ())
+                }),
+            ),
         ]
     }
 
@@ -366,27 +401,208 @@ mod tests {
         }
     }
 
-    /// `rename_database_impl` (ddl.rs) is a mutating command NOT in the
-    /// plan's Task 2/Task 3 coverage lists (it's neither one of the 19
-    /// non-destructive impls nor one of the six named destructive commands
-    /// `drop_collection`/`drop_database`/`delete_many`/`update_many`/
-    /// `rename_collection`/`drop_index`) — flagged and guarded here as an
-    /// addition beyond the plan. It renames every collection in a database
-    /// and optionally drops the source, which is at least as destructive as
-    /// `rename_collection`, so it's guarded with `WriteOp::Rename` — but
-    /// unlike the six named destructive commands it has no `confirmed`
-    /// command arg yet, so `confirmed` is hardcoded `false` here pending a
-    /// follow-up task giving it one (interim effect: blocked on both
-    /// `ReadOnly` and `ConfirmDestructive`, allowed on `Normal`). Not
-    /// counted in `NON_DESTRUCTIVE_GUARDED_COUNT` since it isn't actually
-    /// non-destructive; tested separately.
-    #[tokio::test]
-    async fn rename_database_impl_rejects_on_a_read_only_connection() {
-        let state = readonly_state(&["ro"]);
-        let err = match ddl::rename_database_impl(&state, "ro", "from_db", "to_db", false).await {
-            Err(e) => e,
-            Ok(_) => panic!("rename_database_impl should reject on a read-only connection"),
-        };
-        assert!(err.contains("read-only"), "got: {err}");
+    /// Number of destructive mutating `_impl`s wired in Task 3 with a real
+    /// `confirmed: bool` command arg: `delete_many_impl`, `update_many_impl`,
+    /// `drop_collection_impl`, `rename_collection_impl`, `drop_database_impl`,
+    /// `rename_database_impl`. That's 6, matching `WriteOp::is_destructive`'s
+    /// four variants (`Drop` covers both drop_collection and drop_database;
+    /// `Rename` covers both rename_collection and rename_database) — every
+    /// impl that guards with a destructive `WriteOp` is in this table.
+    /// (`delete_index_impl`/`WriteOp::DropIndex` is intentionally NOT here:
+    /// it's non-destructive, see `non_destructive_cases` above and the
+    /// module doc.) The plan text elsewhere says "7 destructive impls" /
+    /// `DESTRUCTIVE_GUARDED_COUNT (=7)`, but its own opening summary and
+    /// bulleted list enumerate exactly these 6 (drop_index is explicitly
+    /// excluded in that same list) — treated as a slip in the plan and
+    /// flagged in the Task 3 report rather than padding this table with a
+    /// duplicate/fictitious 7th row.
+    const DESTRUCTIVE_GUARDED_COUNT: usize = 6;
+
+    /// A destructive `_impl`, called with an explicit `confirmed` value so
+    /// the same case can be replayed against every mode. All args besides
+    /// `confirmed` are fixed, valid-for-a-mock values (see each impl's mock
+    /// branch): this only exercises the guard, not the rest of the impl.
+    type DestructiveCall =
+        for<'a> fn(&'a AppState, &'a str, bool) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>;
+
+    fn destructive_cases() -> Vec<(&'static str, DestructiveCall)> {
+        vec![
+            ("delete_many_impl", |state, id, confirmed| {
+                Box::pin(async move {
+                    documents::delete_many_impl(state, id, "db", "coll", "{}", confirmed)
+                        .await
+                        .map(|_| ())
+                })
+            }),
+            ("update_many_impl", |state, id, confirmed| {
+                Box::pin(async move {
+                    documents::update_many_impl(
+                        state,
+                        id,
+                        "db",
+                        "coll",
+                        "{}",
+                        r#"{"$set":{"a":1}}"#,
+                        confirmed,
+                    )
+                    .await
+                    .map(|_| ())
+                })
+            }),
+            ("drop_collection_impl", |state, id, confirmed| {
+                Box::pin(async move {
+                    ddl::drop_collection_impl(state, id, "db", "coll", confirmed).await
+                })
+            }),
+            ("rename_collection_impl", |state, id, confirmed| {
+                Box::pin(async move {
+                    ddl::rename_collection_impl(state, id, "db", "from", "to", confirmed).await
+                })
+            }),
+            ("drop_database_impl", |state, id, confirmed| {
+                Box::pin(async move { ddl::drop_database_impl(state, id, "db", confirmed).await })
+            }),
+            ("rename_database_impl", |state, id, confirmed| {
+                Box::pin(async move {
+                    ddl::rename_database_impl(state, id, "from_db", "to_db", false, confirmed)
+                        .await
+                        .map(|_| ())
+                })
+            }),
+        ]
     }
+
+    /// The three-mode contract for every destructive `_impl`: `ReadOnly`
+    /// blocks it regardless of `confirmed` (there's no way to opt back into
+    /// writing on a read-only connection); `ConfirmDestructive` blocks it
+    /// unless `confirmed`, and passes when `confirmed`; `Normal` always
+    /// passes. Adding a new destructive command = adding a row to
+    /// `destructive_cases` (and bumping `DESTRUCTIVE_GUARDED_COUNT`).
+    #[tokio::test]
+    async fn destructive_impls_respect_mode_and_confirmed() {
+        let cases = destructive_cases();
+        assert_eq!(
+            cases.len(),
+            DESTRUCTIVE_GUARDED_COUNT,
+            "a row was added/removed without updating DESTRUCTIVE_GUARDED_COUNT"
+        );
+
+        for (name, call) in cases {
+            // ReadOnly blocks regardless of confirmed.
+            let ro = readonly_state(&["ro"]);
+            for confirmed in [false, true] {
+                let err = call(&ro, "ro", confirmed).await.expect_err(&format!(
+                    "{name} should reject on a read-only connection (confirmed={confirmed})"
+                ));
+                assert!(err.contains("read-only"), "{name}: got {err}");
+            }
+
+            // ConfirmDestructive blocks when unconfirmed, passes when confirmed.
+            let cd = AppState::new();
+            mock_conn(&cd, "cd", ConnectionMode::ConfirmDestructive);
+            let err = call(&cd, "cd", false)
+                .await
+                .expect_err(&format!("{name} should reject unconfirmed on confirm-destructive"));
+            assert_eq!(err, CONFIRM_MSG, "{name}: got {err}");
+            call(&cd, "cd", true)
+                .await
+                .unwrap_or_else(|e| panic!("{name} should pass when confirmed: {e}"));
+
+            // Normal passes regardless of confirmed.
+            let norm = AppState::new();
+            mock_conn(&norm, "norm", ConnectionMode::Normal);
+            call(&norm, "norm", false)
+                .await
+                .unwrap_or_else(|e| panic!("{name} should pass on a normal connection: {e}"));
+        }
+    }
+
+    // --- Part C: direct `guard_writable` unit tests (below the `_impl`
+    // coverage tables above, which exercise the guard indirectly through
+    // real commands). These pin down the guard's own contract in isolation.
+
+    /// Every `WriteOp` variant on a `Normal` connection (with meta present)
+    /// is allowed through, confirmed or not.
+    #[tokio::test]
+    async fn normal_with_meta_allows_every_op() {
+        let state = AppState::new();
+        mock_conn(&state, "norm", ConnectionMode::Normal);
+        for op in ALL_OPS {
+            guard_writable(&state, "norm", op, false)
+                .unwrap_or_else(|e| panic!("{op:?} confirmed=false should pass on normal: {e}"));
+            guard_writable(&state, "norm", op, true)
+                .unwrap_or_else(|e| panic!("{op:?} confirmed=true should pass on normal: {e}"));
+        }
+    }
+
+    /// A connection with no `connection_meta` entry at all defaults to
+    /// `Normal` (fail-open — this is an opt-in safeguard, not a security
+    /// boundary; see the module doc).
+    #[tokio::test]
+    async fn no_meta_fails_open_to_normal() {
+        let state = AppState::new();
+        for op in ALL_OPS {
+            guard_writable(&state, "unknown", op, false)
+                .unwrap_or_else(|e| panic!("{op:?} should fail open (no meta) to normal: {e}"));
+        }
+    }
+
+    /// `ReadOnly` rejects every op, destructive or not, confirmed or not.
+    #[tokio::test]
+    async fn read_only_blocks_destructive_and_non_destructive() {
+        let state = AppState::new();
+        mock_conn(&state, "ro", ConnectionMode::ReadOnly);
+        for (op, confirmed) in [
+            (WriteOp::Insert, false),
+            (WriteOp::Insert, true),
+            (WriteOp::DeleteMany, false),
+            (WriteOp::DeleteMany, true),
+        ] {
+            let err = guard_writable(&state, "ro", op, confirmed)
+                .expect_err(&format!("{op:?} confirmed={confirmed} should reject on read-only"));
+            assert_eq!(err, READ_ONLY_MSG);
+        }
+    }
+
+    /// `ConfirmDestructive`: non-destructive ops always pass; destructive
+    /// ops pass only when `confirmed`.
+    #[tokio::test]
+    async fn confirm_destructive_gates_only_destructive_ops() {
+        let state = AppState::new();
+        mock_conn(&state, "cd", ConnectionMode::ConfirmDestructive);
+
+        guard_writable(&state, "cd", WriteOp::Insert, false)
+            .expect("non-destructive op should pass unconfirmed on confirm-destructive");
+        guard_writable(&state, "cd", WriteOp::DeleteMany, true)
+            .expect("destructive op should pass when confirmed");
+        let err = guard_writable(&state, "cd", WriteOp::DeleteMany, false)
+            .expect_err("destructive op should reject when unconfirmed");
+        assert_eq!(err, CONFIRM_MSG);
+    }
+
+    /// All `WriteOp` variants, for the "every op" sweeps above. Kept as a
+    /// literal array (not derived) so adding a variant to the enum forces a
+    /// conscious edit here too.
+    const ALL_OPS: [WriteOp; 20] = [
+        WriteOp::Insert,
+        WriteOp::UpdateOne,
+        WriteOp::UpdateMany,
+        WriteOp::DeleteOne,
+        WriteOp::DeleteMany,
+        WriteOp::ReplaceOne,
+        WriteOp::Drop,
+        WriteOp::Rename,
+        WriteOp::CreateCollection,
+        WriteOp::CreateView,
+        WriteOp::CreateIndex,
+        WriteOp::DropIndex,
+        WriteOp::CollMod,
+        WriteOp::GridFsWrite,
+        WriteOp::Import,
+        WriteOp::Generate,
+        WriteOp::CopyWrite,
+        WriteOp::RestoreWrite,
+        WriteOp::UserWrite,
+        WriteOp::ServerAdmin,
+    ];
 }

--- a/src-tauri/src/write_guard.rs
+++ b/src-tauri/src/write_guard.rs
@@ -30,19 +30,6 @@
 //! `confirmed=false` (its command has no `confirmed` arg at all — dropping
 //! an index isn't considered destructive enough to require typed
 //! confirmation, unlike dropping a collection/database).
-//!
-//! `WriteOp::UpdateOne` is intentionally unused (and shows up as dead code
-//! under `cargo clippy --lib`): it was defined in Task 2 mirroring the
-//! plan's `WriteOp` code block, but this codebase has no single-document
-//! *partial* update command distinct from `update_document`/`WriteOp::
-//! ReplaceOne` (which does a full replacement) — there's nothing for it to
-//! guard. Investigated as part of Task 3 (whose exit criterion is "clippy
-//! back to the 21 lib baseline") and confirmed this is a pre-existing enum/
-//! API mismatch from Task 1/2, not a Task-3-introduced or newly-discovered
-//! unguarded command, so it's left as-is rather than papering over it with
-//! an `#[allow(dead_code)]` or inventing a fake call site; clippy's lib
-//! warning count is 22 (21 baseline + this one), not 21 — see the Task 3
-//! report.
 
 use crate::connections::ConnectionMode;
 use crate::state::{AppState, LockExt};
@@ -54,7 +41,6 @@ use crate::state::{AppState, LockExt};
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WriteOp {
     Insert,
-    UpdateOne,
     UpdateMany,
     DeleteOne,
     DeleteMany,
@@ -583,9 +569,8 @@ mod tests {
     /// All `WriteOp` variants, for the "every op" sweeps above. Kept as a
     /// literal array (not derived) so adding a variant to the enum forces a
     /// conscious edit here too.
-    const ALL_OPS: [WriteOp; 20] = [
+    const ALL_OPS: [WriteOp; 19] = [
         WriteOp::Insert,
-        WriteOp::UpdateOne,
         WriteOp::UpdateMany,
         WriteOp::DeleteOne,
         WriteOp::DeleteMany,

--- a/src-tauri/src/write_guard.rs
+++ b/src-tauri/src/write_guard.rs
@@ -30,6 +30,35 @@
 //! `confirmed=false` (its command has no `confirmed` arg at all — dropping
 //! an index isn't considered destructive enough to require typed
 //! confirmation, unlike dropping a collection/database).
+//!
+//! Security review #188 fix wave (Fix 1/2): `execute_aggregate_impl` and
+//! `start_mongosh_session_impl` are deliberately NOT rows in either
+//! `non_destructive_cases` or `destructive_cases` below, even though both
+//! are now guarded. Both tables share one test loop per table with a fixed
+//! assumption baked in — "every case rejects on read-only regardless of
+//! input" (non-destructive) or "the exact same fixed input passes on Normal,
+//! rejects unconfirmed/passes confirmed on ConfirmDestructive, and always
+//! rejects on ReadOnly" (destructive) — and neither holds for these two:
+//! `execute_aggregate_impl` only guards when the pipeline actually carries a
+//! `$out`/`$merge` stage (a plain read pipeline must NOT be blocked on
+//! read-only, breaking the non-destructive table's assumption), and neither
+//! impl can return `Ok` on a mock connection the way the rest of this
+//! module's mock-backed cases do (aggregation and external mongosh sessions
+//! both hard-reject mocks unconditionally), breaking the destructive
+//! table's "passes on Normal" assumption. Forcing either into a table built
+//! for a different shape would either not compile against the shared
+//! closure signature or assert something false. Each has its own dedicated
+//! multi-mode test instead: `tests::test_execute_aggregate_guards_out_and_merge_stages_by_mode`
+//! and `tests::test_start_mongosh_session_blocks_read_only_before_spawning`
+//! / `tests::test_start_mongosh_session_confirm_destructive_and_normal_are_not_blocked_by_the_read_only_gate`
+//! (both in `tests.rs`). The AUTHORITATIVE full-command enumeration is
+//! `command_coverage.rs` (Fix 3): both `execute_aggregate` and
+//! `start_mongosh_session` (plus `run_mongosh_command`, transitively
+//! protected by the session-start gate) are in its `GUARDED_WRITE_COMMANDS`
+//! set, which is cross-checked against every command actually registered in
+//! `lib.rs`'s `generate_handler!` — that's the mechanism that would have
+//! caught both of these being unguarded in the first place, not another
+//! hand-maintained table shaped like this module's.
 
 use crate::connections::ConnectionMode;
 use crate::state::{AppState, LockExt};
@@ -80,6 +109,18 @@ pub const READ_ONLY_MSG: &str =
 pub const CONFIRM_MSG: &str =
     "This operation modifies production data on a safeguarded connection. Confirm by typing the collection name.";
 
+/// The live mode of `connection_id`'s connection — `Normal` (fail-open) if
+/// there's no `connection_meta` entry, same default `guard_writable` uses.
+/// Exposed for callers that can't express their check as a single
+/// `WriteOp`/`guard_writable` call: the embedded mongosh shell
+/// (`start_mongosh_session_impl`) blocks `ReadOnly` at session creation
+/// instead of per-command, since free-form shell input has no `WriteOp` to
+/// classify it by. See that function's doc comment for the full rationale.
+pub fn connection_mode(state: &AppState, connection_id: &str) -> Result<ConnectionMode, String> {
+    let meta = state.connection_meta.lock_safe()?;
+    Ok(meta.get(connection_id).map(|m| m.mode).unwrap_or_default())
+}
+
 /// The single choke point for every mutating command. `connection_id` is
 /// always the connection the write actually lands on — for copy commands
 /// that's the TARGET connection, not the source, since a copy writes into
@@ -92,11 +133,7 @@ pub fn guard_writable(
     op: WriteOp,
     confirmed: bool,
 ) -> Result<(), String> {
-    let mode = {
-        let meta = state.connection_meta.lock_safe()?;
-        meta.get(connection_id).map(|m| m.mode).unwrap_or_default()
-    };
-    match mode {
+    match connection_mode(state, connection_id)? {
         ConnectionMode::Normal => Ok(()),
         ConnectionMode::ReadOnly => Err(READ_ONLY_MSG.to_string()),
         ConnectionMode::ConfirmDestructive => {
@@ -107,6 +144,35 @@ pub fn guard_writable(
             }
         }
     }
+}
+
+/// True iff `stage` is a JSON object whose *sole* top-level key is `$out`
+/// or `$merge` — the two aggregation stages that write to a collection
+/// instead of just reading one. Shared by every caller that has to tell a
+/// write-shaped pipeline from a read-shaped one (security review #188
+/// fix wave): the MCP `aggregate`/`explain` tools (`mcp_tools.rs`, which
+/// reject any such stage outright — MCP has no confirmation UI), the UI
+/// aggregation runner (`db::aggregate::execute_aggregate_impl`, which
+/// routes it through [`guard_writable`] like any other write instead of an
+/// outright ban), and the export pipeline (`db::export::mod::build_source`,
+/// which rejects it like MCP does — an export must never mutate data).
+/// Deliberately shallow: a `$lookup` sub-pipeline that happens to carry the
+/// string `"$merge"` as a VALUE — not as its own single top-level key —
+/// must not false-positive. A multi-key object that happens to include
+/// `$out`/`$merge` alongside another key isn't a valid single-stage form
+/// anyway and is left for the driver/server to reject on its own terms.
+pub fn stage_is_disallowed(stage: &serde_json::Value) -> bool {
+    stage
+        .as_object()
+        .map(|obj| {
+            obj.len() == 1
+                && obj
+                    .keys()
+                    .next()
+                    .map(|k| k == "$out" || k == "$merge")
+                    .unwrap_or(false)
+        })
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -564,6 +630,45 @@ mod tests {
         let err = guard_writable(&state, "cd", WriteOp::DeleteMany, false)
             .expect_err("destructive op should reject when unconfirmed");
         assert_eq!(err, CONFIRM_MSG);
+    }
+
+    /// Moved here from `mcp_tools.rs` (#188 review Fix 1/4) so both the MCP
+    /// tools and `execute_aggregate_impl`/`build_source` share one
+    /// definition instead of drifting apart.
+    #[test]
+    fn stage_is_disallowed_flags_only_exact_single_key_out_or_merge() {
+        assert!(stage_is_disallowed(&serde_json::json!({"$out": "target_coll"})));
+        assert!(stage_is_disallowed(
+            &serde_json::json!({"$merge": {"into": "target_coll"}})
+        ));
+        assert!(!stage_is_disallowed(
+            &serde_json::json!({"$match": {"status": "active"}})
+        ));
+        // $merge appearing as a VALUE (not the stage's own top-level key)
+        // inside a $lookup sub-pipeline must not false-positive.
+        assert!(!stage_is_disallowed(&serde_json::json!({
+            "$lookup": {"from": "other", "pipeline": [{"$project": {"note": "$merge"}}], "as": "joined"}
+        })));
+        // A multi-key object isn't a valid single-stage $out/$merge form.
+        assert!(!stage_is_disallowed(
+            &serde_json::json!({"$out": "x", "$extra": 1})
+        ));
+    }
+
+    /// `connection_mode` mirrors `guard_writable`'s own mode lookup: present
+    /// meta returns that mode, absent meta fails open to `Normal`.
+    #[tokio::test]
+    async fn connection_mode_reads_meta_and_fails_open() {
+        let state = AppState::new();
+        mock_conn(&state, "ro", ConnectionMode::ReadOnly);
+        assert_eq!(
+            connection_mode(&state, "ro").unwrap(),
+            ConnectionMode::ReadOnly
+        );
+        assert_eq!(
+            connection_mode(&state, "unknown").unwrap(),
+            ConnectionMode::Normal
+        );
     }
 
     /// All `WriteOp` variants, for the "every op" sweeps above. Kept as a

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,6 +87,7 @@ import { recordHistory, loadCollectionQueries, type SavedQueryBody } from './lib
 import { clearNamespaceIndex, loadNamespaceIndex, matchesNamespaceScope } from './lib/paletteIndex';
 import { CHECK_UPDATE_EVENT } from './components/UpdatePrompt';
 import { confirmByTypedName } from './lib/typedNameConfirm';
+import { detectAggregateWriteStage } from './lib/aggregateWriteStage';
 import type { ConnectionProfile } from './lib/connection';
 import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
@@ -2455,6 +2456,34 @@ function Workspace() {
   };
 
   const handleExecuteAggregate = async (tab: QueryTab, pipeline: Record<string, unknown>[]) => {
+    // #188 security review Fix 1: a $out/$merge stage writes the pipeline's
+    // output into a collection ($out replaces it, $merge upserts) — on a
+    // confirm_destructive (production-safeguard) connection that needs the
+    // same typed-name confirmation as drop_collection/delete_many. A
+    // read_only connection is backend-blocked (`execute_aggregate_impl`'s
+    // guard) regardless of what's sent here; the error surfaces inline via
+    // the existing `tab.error` catch below, same as every other query error.
+    const mode = activeConnections.find(c => c.id === tab.connectionId)?.mode ?? 'normal';
+    let confirmed = false;
+    if (mode === 'confirm_destructive') {
+      const writeStage = detectAggregateWriteStage(pipeline);
+      if (writeStage.hasWriteStage) {
+        const ok = await confirmByTypedName(prompt, {
+          title: 'Run aggregation',
+          kind: 'collection',
+          // Fall back to a "type CONFIRM" prompt when the $out/$merge
+          // target couldn't be extracted cleanly (e.g. an unrecognized
+          // shape) rather than silently under-matching a name.
+          expectedName: writeStage.target ?? 'CONFIRM',
+          message: writeStage.target
+            ? `This pipeline writes into "${writeStage.target}" ($out/$merge) on a safeguarded connection.\n\nType the target collection name to confirm.`
+            : 'This pipeline writes to a collection via $out/$merge on a safeguarded connection, but the target could not be determined automatically.\n\nType CONFIRM to proceed.',
+        });
+        if (!ok) return;
+        confirmed = true;
+      }
+    }
+
     setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, loading: true, error: null } : t));
 
     try {
@@ -2463,6 +2492,7 @@ function Workspace() {
         database: tab.db,
         collection: tab.collection,
         pipeline: JSON.stringify(pipeline),
+        confirmed,
       });
 
       const parsedResults = resultStrs.map(s => JSON.parse(s));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,8 @@ import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
-import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck, ExternalLink, MoveRight, Wand2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck, ExternalLink, MoveRight, Wand2, Lock, ShieldAlert } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 interface QueryTab {
@@ -307,6 +308,30 @@ const tabLabelFor = (
       return tab.collection;
   }
 };
+
+/**
+ * Tab types that operate on a live connection — everything except
+ * `settings`/`quickstart`/`tasks`, which render regardless of (or without)
+ * any particular connection. `renderTabContent`'s mode banner (#188 Task 5)
+ * only mounts for these, matching the plan's "skip settings/quickstart/tasks"
+ * instruction.
+ */
+const CONNECTION_TAB_TYPES = new Set<QueryTab['type']>([
+  'collection',
+  'index',
+  'shell',
+  'export',
+  'import',
+  'schema',
+  'create-view',
+  'gridfs',
+  'monitoring',
+  'users',
+  'dump',
+  'restore',
+  'validation',
+  'generate',
+]);
 
 /**
  * A short human hint for a FOREIGN window's tab-context-menu entry (Phase 3
@@ -3321,7 +3346,16 @@ function Workspace() {
         />
       );
     }
-    return (
+    // Per-tab mode banner (#188 Task 5) — the connection's read-only /
+    // confirm-destructive safeguard, if any, read straight off
+    // `activeConnections` (populated at connect time, see `addActiveConnection`
+    // and `applyConnectionsAdditions`). Rendered ABOVE the tab's normal
+    // content (not instead of it, unlike the ReconnectBanner above) for every
+    // tab type that operates on a connection; `settings`/`quickstart`/`tasks`
+    // have no connection to badge.
+    const connMode = activeConnections.find((c) => c.id === tab.connectionId)?.mode;
+    const showModeBanner = !!connMode && connMode !== 'normal' && CONNECTION_TAB_TYPES.has(tab.type);
+    const body = (
       <>
         {tab.type === 'index' && (
           <IndexViewer
@@ -3686,6 +3720,32 @@ function Workspace() {
           />
         )}
       </>
+    );
+
+    if (!showModeBanner) return body;
+
+    const bannerIsReadOnly = connMode === 'read_only';
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div
+          data-testid="connection-mode-banner"
+          data-mode={connMode}
+          className={cn(
+            'flex shrink-0 items-center gap-1.5 border-b px-3 py-1.5 text-xs font-medium',
+            bannerIsReadOnly
+              ? 'border-destructive/30 bg-destructive/10 text-destructive'
+              : 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400'
+          )}
+        >
+          {bannerIsReadOnly ? <Lock size={12} className="shrink-0" /> : <ShieldAlert size={12} className="shrink-0" />}
+          <span>
+            {bannerIsReadOnly
+              ? 'Read-only connection — writes are blocked'
+              : 'Production safeguard — destructive operations require confirmation'}
+          </span>
+        </div>
+        <div className="min-h-0 flex-1">{body}</div>
+      </div>
     );
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ import { docToShell } from './lib/shellDoc';
 import { recordHistory, loadCollectionQueries, type SavedQueryBody } from './lib/queryStore';
 import { clearNamespaceIndex, loadNamespaceIndex, matchesNamespaceScope } from './lib/paletteIndex';
 import { CHECK_UPDATE_EVENT } from './components/UpdatePrompt';
+import { confirmByTypedName } from './lib/typedNameConfirm';
 import type { ConnectionProfile } from './lib/connection';
 import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
@@ -492,18 +493,26 @@ function Workspace() {
   // displayed, since it never made it into `activeConnections` at all. A
   // non-MCP entry keeps the original profileId dedupe (a human never opens
   // two simultaneous connections to the same profile from one path).
+  // `mode` (#188 Task 3): the connection's read-only/confirm-destructive
+  // safeguard, captured at connect time. `ActiveConnection.mode` was
+  // type-only until now — this is the minimal threading needed so the
+  // destructive-op call sites below (`handleDeleteMany`/`handleUpdateMany`)
+  // can read a real value via `activeConnections.find(...).mode` instead of
+  // always seeing `undefined`. Full UI consumption (persistent banner,
+  // sidebar badge) is Task 5.
   const addActiveConnection = (
     id: string,
     name: string,
     uri: string,
     profileId: string,
     color_tag?: string,
-    viaMcp?: boolean
+    viaMcp?: boolean,
+    mode?: ActiveConnection['mode']
   ) => {
     setActiveConnections((prev) => {
       if (prev.some((c) => c.id === id)) return prev;
       if (!viaMcp && prev.some((c) => c.profileId === profileId)) return prev;
-      return [...prev, { id, profileId, name, uri, color_tag, viaMcp }];
+      return [...prev, { id, profileId, name, uri, color_tag, viaMcp, mode }];
     });
   };
 
@@ -602,7 +611,7 @@ function Workspace() {
       // always reaches `addActiveConnection` below, which is itself the
       // authority on whether this exact row already exists.
       if (!entry.viaMcp && localByProfile.has(entry.profileId)) continue;
-      addActiveConnection(entry.id, entry.name, '', entry.profileId, undefined, entry.viaMcp);
+      addActiveConnection(entry.id, entry.name, '', entry.profileId, undefined, entry.viaMcp, entry.mode);
       rebindProfileTabs(entry.profileId, entry.id);
     }
   };
@@ -786,7 +795,7 @@ function Workspace() {
     if (existing) return existing.id;
     try {
       const id = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
-      addActiveConnection(id, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined);
+      addActiveConnection(id, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined, undefined, profile.connection_mode ?? 'normal');
       // Announce this fresh id to every other window (Phase 3 Task 6) — see
       // `setConnectionMeta`'s doc comment for why every connect path calls it.
       setConnectionMeta(id, profile.id, profile.name, profile.connection_mode ?? 'normal');
@@ -2820,7 +2829,7 @@ function Workspace() {
         }
 
         newId = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
-        addActiveConnection(newId, profileName, profile.uri, profile.id, profile.color_tag ?? undefined);
+        addActiveConnection(newId, profileName, profile.uri, profile.id, profile.color_tag ?? undefined, undefined, profile.connection_mode ?? 'normal');
         // Announce this fresh id to every other window (Phase 3 Task 6) —
         // see `setConnectionMeta`'s doc comment. Deliberately NOT called on
         // the `existing` (reuse) branch above: that id's meta was already
@@ -3111,6 +3120,15 @@ function Workspace() {
   const handleDeleteMany = async (tab: QueryTab) => {
     if (tab.type !== 'collection') return;
     const filter = bulkFilter(tab);
+    // #188 Task 3: on a confirm_destructive connection, delete_many requires
+    // a typed-name match before `confirmed: true` is sent — see
+    // `confirmByTypedName`'s doc comment. Read from `activeConnections`
+    // (populated at connect time — see `addActiveConnection`'s doc comment);
+    // defaults to 'normal' both when the connection carries no mode (a
+    // normal/sample connection) and pre-Task-5 for any connection this
+    // window learned about via `connections-changed` rather than connecting
+    // itself.
+    const mode = activeConnections.find((c) => c.id === tab.connectionId)?.mode ?? 'normal';
     try {
       const count = await invoke<number>('count_documents', {
         id: tab.connectionId,
@@ -3118,20 +3136,32 @@ function Workspace() {
         collection: tab.collection,
         filter,
       });
-      if (
+      let confirmed = false;
+      if (mode === 'confirm_destructive') {
+        const ok = await confirmByTypedName(prompt, {
+          title: 'Delete many',
+          kind: 'collection',
+          expectedName: tab.collection,
+          message: `${bulkConfirmMessage('Delete', count, filter)}\n\nType the collection name to confirm.`,
+        });
+        if (!ok) return;
+        confirmed = true;
+      } else if (
         !(await confirm({
           title: 'Delete many',
           message: bulkConfirmMessage('Delete', count, filter),
           confirmLabel: 'Delete',
           destructive: true,
         }))
-      )
+      ) {
         return;
+      }
       const deleted = await invoke<number>('delete_many', {
         id: tab.connectionId,
         database: tab.db,
         collection: tab.collection,
         filter,
+        confirmed,
       });
       await refreshTabResults(tab);
       toast(`Deleted ${deleted} document(s)`, 'success', { title: 'Deleted' });
@@ -3164,6 +3194,8 @@ function Workspace() {
       },
     });
     if (!update) return; // cancelled
+    // #188 Task 3: see handleDeleteMany's comment on this same lookup.
+    const mode = activeConnections.find((c) => c.id === tab.connectionId)?.mode ?? 'normal';
     try {
       const count = await invoke<number>('count_documents', {
         id: tab.connectionId,
@@ -3171,21 +3203,33 @@ function Workspace() {
         collection: tab.collection,
         filter,
       });
-      if (
+      let confirmed = false;
+      if (mode === 'confirm_destructive') {
+        const ok = await confirmByTypedName(prompt, {
+          title: 'Update many',
+          kind: 'collection',
+          expectedName: tab.collection,
+          message: `${bulkConfirmMessage('Apply this update to', count, filter)}\n\nType the collection name to confirm.`,
+        });
+        if (!ok) return;
+        confirmed = true;
+      } else if (
         !(await confirm({
           title: 'Update many',
           message: bulkConfirmMessage('Apply this update to', count, filter),
           confirmLabel: 'Update',
           destructive: true,
         }))
-      )
+      ) {
         return;
+      }
       const modified = await invoke<number>('update_many', {
         id: tab.connectionId,
         database: tab.db,
         collection: tab.collection,
         filter,
         update,
+        confirmed,
       });
       await refreshTabResults(tab);
       toast(`Modified ${modified} document(s)`, 'success', { title: 'Updated' });
@@ -3744,7 +3788,7 @@ function Workspace() {
             isOpen={isConnectionModalOpen}
             onClose={() => { setIsConnectionModalOpen(false); setProfilesRefreshKey((k) => k + 1); }}
             onConnect={(id, name, uri, profileId, colorTag, connectionMode) => {
-              addActiveConnection(id, name, uri, profileId, colorTag ?? undefined);
+              addActiveConnection(id, name, uri, profileId, colorTag ?? undefined, undefined, connectionMode ?? 'normal');
               // Announce this fresh id to every other window (Phase 3 Task 6)
               // — see `setConnectionMeta`'s doc comment.
               setConnectionMeta(id, profileId, name, connectionMode ?? 'normal');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,6 +176,14 @@ interface ActiveConnection {
   color_tag?: string;
   /** True iff opened by the embedded MCP server's `connect` tool rather than a human (#98 Task 4). */
   viaMcp?: boolean;
+  /**
+   * Read-only / confirm-destructive production safeguard (#188), captured
+   * at connect time. Type-only for now — populating this from
+   * `connections-changed`/`connection_list` and rendering the banner off it
+   * is Task 5; this field just needs to exist so that wiring compiles
+   * against a stable shape.
+   */
+  mode?: 'normal' | 'read_only' | 'confirm_destructive';
 }
 
 /** Extract the auth username from a MongoDB connection URI; '' when there are no credentials. */
@@ -781,7 +789,7 @@ function Workspace() {
       addActiveConnection(id, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined);
       // Announce this fresh id to every other window (Phase 3 Task 6) — see
       // `setConnectionMeta`'s doc comment for why every connect path calls it.
-      setConnectionMeta(id, profile.id, profile.name);
+      setConnectionMeta(id, profile.id, profile.name, profile.connection_mode ?? 'normal');
       // Clear any ReconnectBanner this profile still has showing (#97 phase
       // 2 final review Fix 1) — see `rebindProfileTabs`'s doc comment.
       rebindProfileTabs(profile.id, id);
@@ -2752,7 +2760,7 @@ function Workspace() {
         for (const local of activeConnectionsRef.current) {
           if (liveConnectionIds.has(local.id)) continue;
           if (!seenConnectionIdsRef.current.has(local.id)) {
-            setConnectionMeta(local.id, local.profileId, local.name);
+            setConnectionMeta(local.id, local.profileId, local.name, local.mode ?? 'normal');
             continue;
           }
           setActiveConnections((prev) => prev.filter((c) => c.id !== local.id));
@@ -2817,7 +2825,7 @@ function Workspace() {
         // see `setConnectionMeta`'s doc comment. Deliberately NOT called on
         // the `existing` (reuse) branch above: that id's meta was already
         // set the first time it connected.
-        setConnectionMeta(newId, profile.id, profileName);
+        setConnectionMeta(newId, profile.id, profileName, profile.connection_mode ?? 'normal');
       }
 
       // Captured before any state updates below — `tabs`/`layout` in this
@@ -3735,11 +3743,11 @@ function Workspace() {
           <ConnectionManager
             isOpen={isConnectionModalOpen}
             onClose={() => { setIsConnectionModalOpen(false); setProfilesRefreshKey((k) => k + 1); }}
-            onConnect={(id, name, uri, profileId, colorTag) => {
+            onConnect={(id, name, uri, profileId, colorTag, connectionMode) => {
               addActiveConnection(id, name, uri, profileId, colorTag ?? undefined);
               // Announce this fresh id to every other window (Phase 3 Task 6)
               // — see `setConnectionMeta`'s doc comment.
-              setConnectionMeta(id, profileId, name);
+              setConnectionMeta(id, profileId, name, connectionMode ?? 'normal');
               // Clear any ReconnectBanner this profile still has showing
               // (#97 phase 2 final review Fix 1) — see `rebindProfileTabs`'s
               // doc comment.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3477,6 +3477,7 @@ function Workspace() {
                     onAnalyzeSchema={() => handleOpenSchemaTab(tab.connectionId, tab.db, tab.collection)}
                     onUpdateMany={() => handleUpdateMany(tab)}
                     onDeleteMany={() => handleDeleteMany(tab)}
+                    connectionMode={connMode}
                     totalCount={tab.totalCount}
                     estimated={tab.estimated}
                     countLoading={tab.countLoading}

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -61,6 +61,9 @@ export type SshConfig = {
     | { type: 'agent' };
 };
 
+/** Mirrors backend `connections::ConnectionMode` (#188). */
+export type ConnectionMode = 'normal' | 'read_only' | 'confirm_destructive';
+
 interface ConnectionProfile {
   id: string;
   name: string;
@@ -69,12 +72,14 @@ interface ConnectionProfile {
   ssh?: SshConfig | null;
   /** Expose this profile to MCP agents. Mirrors backend `ConnectionProfile::mcp_enabled`. */
   mcp_enabled?: boolean;
+  /** Read-only / confirm-destructive production safeguard. Mirrors backend `ConnectionProfile::connection_mode`. */
+  connection_mode?: ConnectionMode;
 }
 
 interface ConnectionManagerProps {
   isOpen: boolean;
   onClose: () => void;
-  onConnect: (id: string, name: string, uri: string, profileId: string, colorTag?: string | null) => void;
+  onConnect: (id: string, name: string, uri: string, profileId: string, colorTag?: string | null, connectionMode?: ConnectionMode) => void;
   activeConnections?: { id: string; profileId: string; name: string; uri: string }[];
 }
 
@@ -132,7 +137,15 @@ const BLANK_CONN = {
   folder: '',
   colorTag: '',
   mcpEnabled: false,
+  connectionMode: 'normal' as ConnectionMode,
 };
+
+/** Connection mode editor options (#188 Task 1) — segmented control in the server panel. */
+const CONNECTION_MODE_OPTIONS: { value: ConnectionMode; label: string; description: string }[] = [
+  { value: 'normal', label: 'Normal', description: 'Full read/write' },
+  { value: 'read_only', label: 'Read-only', description: 'Blocks all writes' },
+  { value: 'confirm_destructive', label: 'Confirm destructive', description: 'Destructive ops need typed confirmation' },
+];
 
 const sidebarPanelClass =
   'flex shrink-0 flex-col border-r border-sidebar-border bg-sidebar/40 text-sidebar-foreground';
@@ -528,6 +541,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       folder: profileFolderMap[profile.id] || '',
       colorTag: profile.color_tag || '',
       mcpEnabled: profile.mcp_enabled ?? false,
+      connectionMode: profile.connection_mode ?? 'normal',
       ...sshFields,
     });
 
@@ -559,6 +573,14 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       // is unaffected and keeps mapping `profile.mcp_enabled` as-is; this
       // reset is specific to the duplicate-populate path.
       mcpEnabled: false,
+      // Opposite call from `mcpEnabled` above (#188 Task 1, adjudicated):
+      // a read-only/confirm-destructive safeguard is exactly the kind of
+      // thing that should survive duplication rather than reset — the new
+      // profile is presumably still pointed at the same sensitive
+      // environment (e.g. "prod (copy for testing a filter)"), and
+      // silently dropping the safeguard back to unguarded `normal` would
+      // be the surprising outcome here, not the safe one.
+      connectionMode: profile.connection_mode ?? 'normal',
     });
     setError(null);
     setTestResult(null);
@@ -618,6 +640,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
         ? normalizeHexColor(editorState.colorTag) ?? editorState.colorTag
         : null,
       mcp_enabled: editorState.mcpEnabled,
+      connection_mode: editorState.connectionMode,
     };
 
     setLoading(true);
@@ -680,7 +703,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
     setError(null);
     try {
       const connId = await invoke<string>('connect_db', { uri: profile.uri, ssh: profile.ssh ?? null });
-      onConnect(connId, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined);
+      onConnect(connId, profile.name, profile.uri, profile.id, profile.color_tag ?? undefined, profile.connection_mode ?? 'normal');
     } catch (err: any) {
       setError(String(err));
     } finally {
@@ -1457,6 +1480,28 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({
                         />
                       </div>
                     )}
+                  </div>
+
+                  <div className="flex flex-col gap-2 border-t border-border pt-2.5">
+                    <Label className="text-ui-xs">Connection mode</Label>
+                    <div className="flex flex-col gap-1.5" role="group" aria-label="Connection mode">
+                      {CONNECTION_MODE_OPTIONS.map((opt) => (
+                        <button
+                          key={opt.value}
+                          type="button"
+                          data-testid={`connection-mode-${opt.value}`}
+                          aria-pressed={editorState.connectionMode === opt.value}
+                          className={cn(
+                            'flex flex-col items-start gap-0.5 rounded-md border border-border px-2.5 py-1.5 text-left transition-colors hover:border-primary/50 hover:bg-accent',
+                            editorState.connectionMode === opt.value && 'border-primary bg-accent ring-1 ring-primary',
+                          )}
+                          onClick={() => setEditorState((prev) => ({ ...prev, connectionMode: opt.value }))}
+                        >
+                          <span className="text-[11px] font-medium">{opt.label}</span>
+                          <span className="text-[10.5px] leading-relaxed text-muted-foreground">{opt.description}</span>
+                        </button>
+                      ))}
+                    </div>
                   </div>
 
                   <div className="flex flex-col gap-2 border-t border-border pt-2.5">

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -40,7 +40,17 @@ interface DataGridProps {
   onPageSizeChange?: (newLimit: number) => void;
   // Fired when the user accepts the COLLSCAN suggestion banner's "Create Index" CTA.
   onCreateSuggestedIndex?: (suggestion: IndexSuggestion) => void;
+  // The owning connection's write-safeguard mode (#188). 'read_only' disables
+  // every write action in this grid (buttons + row actions + context-menu
+  // items) with a tooltip, since the backend write_guard would otherwise just
+  // bounce the request with a toast. 'confirm_destructive' is intentionally
+  // NOT handled here — those writes stay enabled; the typed-name confirm
+  // modal (Task 3) gates the actually-destructive ones. Undefined/'normal'
+  // behaves exactly as before this feature existed.
+  connectionMode?: 'normal' | 'read_only' | 'confirm_destructive';
 }
+
+const READ_ONLY_TOOLTIP = 'Connection is read-only';
 
 type ViewMode = 'table' | 'tree' | 'json' | 'chart';
 
@@ -450,10 +460,15 @@ export const DataGrid: React.FC<DataGridProps> = ({
   onPageChange,
   onPageSizeChange,
   onCreateSuggestedIndex,
+  connectionMode,
 }) => {
   const themeCtx = useThemeOptional();
   const density: SpacingDensity =
     densityProp ?? themeCtx?.config.spacingDensity ?? 'cozy';
+
+  // #188: read_only disables writes in this grid; confirm_destructive does
+  // NOT (see the connectionMode doc comment on DataGridProps above).
+  const isReadOnly = connectionMode === 'read_only';
 
   // ESR-rule suggestion derived from the current explain plan (null unless it's a COLLSCAN).
   const indexSuggestion = useMemo(
@@ -503,8 +518,8 @@ export const DataGrid: React.FC<DataGridProps> = ({
   };
   const buildCtxItems = (m: NonNullable<typeof ctxMenu>): ContextMenuItem[] => {
     const items: ContextMenuItem[] = [];
-    if (onEditDocument) items.push({ label: 'Edit document', icon: <Edit size={13} />, onClick: () => onEditDocument(m.doc) });
-    if (onDuplicateDocument) items.push({ label: 'Duplicate document', icon: <Plus size={13} />, onClick: () => onDuplicateDocument(m.doc) });
+    if (onEditDocument) items.push({ label: 'Edit document', icon: <Edit size={13} />, onClick: () => onEditDocument(m.doc), disabled: isReadOnly, title: isReadOnly ? READ_ONLY_TOOLTIP : undefined });
+    if (onDuplicateDocument) items.push({ label: 'Duplicate document', icon: <Plus size={13} />, onClick: () => onDuplicateDocument(m.doc), disabled: isReadOnly, title: isReadOnly ? READ_ONLY_TOOLTIP : undefined });
     items.push({ label: 'Copy document (JSON)', icon: <Copy size={13} />, onClick: () => writeClipboard(JSON.stringify(m.doc, null, 2)) });
     if (!pendingCompare) {
       items.push({
@@ -540,7 +555,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
       items.push({ label: 'Copy value', icon: <Copy size={13} />, separatorBefore: true, onClick: () => writeClipboard(valueToText(m.value)) });
       items.push({ label: 'Copy field name', icon: <Copy size={13} />, onClick: () => writeClipboard(m.field!) });
     }
-    if (onDeleteDocument) items.push({ label: 'Delete document', icon: <Trash2 size={13} />, danger: true, separatorBefore: true, onClick: () => onDeleteDocument(m.doc) });
+    if (onDeleteDocument) items.push({ label: 'Delete document', icon: <Trash2 size={13} />, danger: true, separatorBefore: true, onClick: () => onDeleteDocument(m.doc), disabled: isReadOnly, title: isReadOnly ? READ_ONLY_TOOLTIP : undefined });
     return items;
   };
   const docViewerContext = useContext(DocumentViewerContext);
@@ -1078,8 +1093,9 @@ export const DataGrid: React.FC<DataGridProps> = ({
               e.stopPropagation();
               onEditDocument(doc);
             }}
-            className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-primary"
-            title="Edit document"
+            disabled={isReadOnly}
+            className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-primary disabled:pointer-events-none disabled:opacity-50"
+            title={isReadOnly ? READ_ONLY_TOOLTIP : 'Edit document'}
             data-testid="edit-doc-btn"
           >
             <Edit size={12} />
@@ -1091,8 +1107,9 @@ export const DataGrid: React.FC<DataGridProps> = ({
               e.stopPropagation();
               onDeleteDocument(doc);
             }}
-            className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-            title="Delete document"
+            disabled={isReadOnly}
+            className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-50"
+            title={isReadOnly ? READ_ONLY_TOOLTIP : 'Delete document'}
             data-testid="delete-doc-btn"
           >
             <Trash2 size={12} />
@@ -1251,8 +1268,9 @@ export const DataGrid: React.FC<DataGridProps> = ({
               variant="outline"
               size="sm"
               onClick={onInsertDocument}
+              disabled={isReadOnly}
               className="h-7 gap-1.5 text-[11px]"
-              title="Insert a new document"
+              title={isReadOnly ? READ_ONLY_TOOLTIP : 'Insert a new document'}
               data-testid="insert-doc-btn"
             >
               <Plus size={12} />
@@ -1279,8 +1297,9 @@ export const DataGrid: React.FC<DataGridProps> = ({
               variant="outline"
               size="sm"
               onClick={onUpdateMany}
+              disabled={isReadOnly}
               className="h-7 gap-1.5 text-[11px]"
-              title="Update all documents matching the current filter"
+              title={isReadOnly ? READ_ONLY_TOOLTIP : 'Update all documents matching the current filter'}
               data-testid="update-many-btn"
             >
               <Edit size={12} />
@@ -1293,8 +1312,9 @@ export const DataGrid: React.FC<DataGridProps> = ({
               variant="outline"
               size="sm"
               onClick={onDeleteMany}
+              disabled={isReadOnly}
               className="h-7 gap-1.5 border-destructive/30 bg-destructive/10 text-[11px] text-destructive hover:bg-destructive/20"
-              title="Delete all documents matching the current filter"
+              title={isReadOnly ? READ_ONLY_TOOLTIP : 'Delete all documents matching the current filter'}
               data-testid="delete-many-btn"
             >
               <Trash2 size={12} />

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1571,6 +1571,8 @@ export const DataGrid: React.FC<DataGridProps> = ({
                     size="sm"
                     className="h-7 shrink-0 gap-1.5 text-[11px] font-semibold"
                     onClick={() => onCreateSuggestedIndex?.(indexSuggestion)}
+                    disabled={isReadOnly}
+                    title={isReadOnly ? READ_ONLY_TOOLTIP : undefined}
                     data-testid="create-suggested-index-btn"
                   >
                     Create Index

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1680,6 +1680,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
                           via MCP
                         </Badge>
                       )}
+                      {conn.mode && conn.mode !== 'normal' && (
+                        <Badge
+                          variant={conn.mode === 'read_only' ? 'destructive' : 'warning'}
+                          className="h-4 shrink-0 px-1 text-[9px] font-normal"
+                          data-testid="connection-mode-badge"
+                          data-mode={conn.mode}
+                          aria-label={conn.mode === 'read_only' ? 'Read-only connection' : 'Production safeguard connection'}
+                        >
+                          {conn.mode === 'read_only' ? 'read-only' : 'guarded'}
+                        </Badge>
+                      )}
                       <span
                         className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
                         aria-label="Connected"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -961,6 +961,20 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
   const handleDropCollection = async (connectionId: string, dbName: string, collName: string) => {
     const conn = activeConnections.find((c) => c.id === connectionId);
+    // #188 security review Fix 5: block read-only BEFORE the confirm dialog
+    // and, critically, before the `isMock` branch below — which mutates the
+    // sidebar's local state directly and returns without ever calling the
+    // backend, so a mock connection never hit `guard_writable`'s rejection
+    // the way a real connection's `invoke('drop_collection', ...)` does.
+    // Same exact wording as the backend's `write_guard::READ_ONLY_MSG` so a
+    // mock and a real read-only connection behave identically here.
+    if (conn?.mode === 'read_only') {
+      toast(
+        'This connection is read-only (production safeguard). Change the connection mode in its settings to modify data.',
+        'error'
+      );
+      return;
+    }
     // #188 Task 3: on a confirm_destructive (production-safeguard) connection,
     // the ordinary yes/no confirm is replaced by a typed-name match — see
     // `confirmByTypedName`'s doc comment. `confirmed: true` is only ever
@@ -1106,6 +1120,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
   const handleDropDatabase = async (connectionId: string, dbName: string) => {
     const conn = activeConnections.find((c) => c.id === connectionId);
+    // #188 security review Fix 5: see handleDropCollection's comment on this
+    // same pattern — blocks the `isMock` branch below from dropping a
+    // read-only mock connection's database without ever reaching the backend.
+    if (conn?.mode === 'read_only') {
+      toast(
+        'This connection is read-only (production safeguard). Change the connection mode in its settings to modify data.',
+        'error'
+      );
+      return;
+    }
     // #188 Task 3: see handleDropCollection's comment on this same pattern.
     const confirmed = conn?.mode === 'confirm_destructive';
     if (confirmed) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { useDialogs } from './dialogs/DialogProvider';
+import { confirmByTypedName } from '../lib/typedNameConfirm';
 import { fuzzyMatch } from '../lib/fuzzyMatch';
 import { type CollectionSelection, emptySelection, toggleCollection, selectionScope } from '@/lib/collectionSelection';
 import {
@@ -177,7 +178,16 @@ interface SidebarProps {
   ) => void;
   onSelectIndex: (connectionId: string, dbName: string, collName: string, indexName: string) => void;
   activeCollection: { connectionId: string; db: string; collection: string; indexName?: string } | null;
-  activeConnections: { id: string; name: string; uri: string; profileId?: string; color_tag?: string; viaMcp?: boolean }[];
+  activeConnections: {
+    id: string;
+    name: string;
+    uri: string;
+    profileId?: string;
+    color_tag?: string;
+    viaMcp?: boolean;
+    /** Read-only / confirm-destructive production safeguard (#188), mirrors App.tsx's `ActiveConnection.mode`. */
+    mode?: 'normal' | 'read_only' | 'confirm_destructive';
+  }[];
   onOpenConnectionManager: () => void;
   onDisconnect: (connectionId: string) => void;
   width?: number;
@@ -950,16 +960,32 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const handleDropCollection = async (connectionId: string, dbName: string, collName: string) => {
-    if (
+    const conn = activeConnections.find((c) => c.id === connectionId);
+    // #188 Task 3: on a confirm_destructive (production-safeguard) connection,
+    // the ordinary yes/no confirm is replaced by a typed-name match — see
+    // `confirmByTypedName`'s doc comment. `confirmed: true` is only ever
+    // passed after that exact match; the backend's `guard_writable` is the
+    // real gate either way.
+    const confirmed = conn?.mode === 'confirm_destructive';
+    if (confirmed) {
+      if (
+        !(await confirmByTypedName(prompt, {
+          title: 'Drop collection',
+          kind: 'collection',
+          expectedName: collName,
+        }))
+      )
+        return;
+    } else if (
       !(await confirm({
         title: 'Drop collection',
         message: `Are you sure you want to drop collection "${collName}"?`,
         confirmLabel: 'Drop',
         destructive: true,
       }))
-    )
+    ) {
       return;
-    const conn = activeConnections.find((c) => c.id === connectionId);
+    }
     const isMock = connectionId.startsWith('mock') || conn?.uri.startsWith('mongodb://mock');
 
     const clearActiveIfDropped = () => {
@@ -984,7 +1010,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }
 
     try {
-      await invoke('drop_collection', { id: connectionId, database: dbName, collection: collName });
+      await invoke('drop_collection', { id: connectionId, database: dbName, collection: collName, confirmed });
       clearActiveIfDropped();
       await handleRefreshDb(connectionId, dbName);
       onNamespaceMutated?.(connectionId);
@@ -994,6 +1020,23 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const handleRenameCollection = async (connectionId: string, dbName: string, collName: string) => {
+    const conn = activeConnections.find((c) => c.id === connectionId);
+    // #188 Task 3: on a confirm_destructive connection, typing the current
+    // collection name (the "already a prompt" precedent kept as-is below for
+    // the new name) proves intent before the "enter new name" prompt is even
+    // shown — see `confirmByTypedName`'s doc comment.
+    const confirmed = conn?.mode === 'confirm_destructive';
+    if (confirmed) {
+      if (
+        !(await confirmByTypedName(prompt, {
+          title: 'Rename collection',
+          kind: 'collection',
+          expectedName: collName,
+        }))
+      )
+        return;
+    }
+
     const newName = await prompt({
       title: 'Rename collection',
       message: 'Enter new collection name:',
@@ -1002,7 +1045,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
     });
     if (!newName || newName === collName) return;
 
-    const conn = activeConnections.find((c) => c.id === connectionId);
     const isMock = connectionId.startsWith('mock') || conn?.uri.startsWith('mongodb://mock');
 
     const applyLocalRename = () => {
@@ -1053,6 +1095,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         database: dbName,
         from: collName,
         to: newName,
+        confirmed,
       });
       applyLocalRename();
       await handleRefreshDb(connectionId, dbName);
@@ -1062,16 +1105,28 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const handleDropDatabase = async (connectionId: string, dbName: string) => {
-    if (
+    const conn = activeConnections.find((c) => c.id === connectionId);
+    // #188 Task 3: see handleDropCollection's comment on this same pattern.
+    const confirmed = conn?.mode === 'confirm_destructive';
+    if (confirmed) {
+      if (
+        !(await confirmByTypedName(prompt, {
+          title: 'Drop database',
+          kind: 'database',
+          expectedName: dbName,
+        }))
+      )
+        return;
+    } else if (
       !(await confirm({
         title: 'Drop database',
         message: `Are you sure you want to drop database "${dbName}"? This cannot be undone.`,
         confirmLabel: 'Drop',
         destructive: true,
       }))
-    )
+    ) {
       return;
-    const conn = activeConnections.find((c) => c.id === connectionId);
+    }
     const isMock = connectionId.startsWith('mock') || conn?.uri.startsWith('mongodb://mock');
 
     const clearLocalDatabase = () => {
@@ -1128,7 +1183,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }
 
     try {
-      await invoke('drop_database', { id: connectionId, database: dbName });
+      await invoke('drop_database', { id: connectionId, database: dbName, confirmed });
       clearLocalDatabase();
       await loadDatabases(connectionId);
     } catch (err) {
@@ -1144,16 +1199,34 @@ export const Sidebar: React.FC<SidebarProps> = ({
       validate: (v) => (v ? null : 'Name is required'),
     });
     if (!newName || newName === dbName) return;
-    const ok = await confirm({
-      title: `Rename database "${dbName}"`,
-      message:
-        `Rename database "${dbName}" to "${newName}"?\n\n` +
-        `MongoDB does not support native database rename. MQLens will copy collections and indexes, verify document counts, then drop the source database.`,
-      confirmLabel: 'Rename',
-    });
-    if (!ok) return;
 
     const conn = activeConnections.find((c) => c.id === connectionId);
+    // #188 Task 3: on a confirm_destructive connection, the typed-name match
+    // (against the source/"from" database name) replaces the ordinary
+    // yes/no confirm below — see `confirmByTypedName`'s doc comment.
+    const confirmed = conn?.mode === 'confirm_destructive';
+    if (confirmed) {
+      if (
+        !(await confirmByTypedName(prompt, {
+          title: `Rename database "${dbName}"`,
+          kind: 'database',
+          expectedName: dbName,
+          message: `Rename database "${dbName}" to "${newName}"? MongoDB does not support native database rename. MQLens will copy collections and indexes, verify document counts, then drop the source database.\n\nType the database name to confirm.`,
+        }))
+      )
+        return;
+    } else if (
+      !(await confirm({
+        title: `Rename database "${dbName}"`,
+        message:
+          `Rename database "${dbName}" to "${newName}"?\n\n` +
+          `MongoDB does not support native database rename. MQLens will copy collections and indexes, verify document counts, then drop the source database.`,
+        confirmLabel: 'Rename',
+      }))
+    ) {
+      return;
+    }
+
     const isMock = connectionId.startsWith('mock') || conn?.uri.startsWith('mongodb://mock');
 
     const applyLocalRename = () => {
@@ -1226,6 +1299,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         from: dbName,
         to: newName,
         dropSource: true,
+        confirmed,
       });
       applyLocalRename();
       await loadDatabases(connectionId);

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -548,6 +548,79 @@ describe('App Component', () => {
     });
   });
 
+  describe('connection mode banner (#188 Task 5)', () => {
+    it('renders a red read-only banner above the tab content, with the expected testid/data-mode/text', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'execute_mql_query')
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+        if (cmd === 'count_documents') return Promise.resolve(1);
+        return Promise.resolve([]);
+      });
+      const { fireEvent, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+      // Mark 'conn-1' (the id every mock-sidebar button hardcodes) as
+      // read-only via a connections-changed broadcast — mirrors the
+      // confirm_destructive tests above, and doubles as the "a
+      // connections-changed event carrying mode populates ActiveConnection"
+      // cross-window coherence check: the banner below only renders off
+      // `activeConnections.find(...).mode`, so its presence proves the
+      // broadcast's `mode` landed there.
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [{ id: 'conn-1', profileId: 'p1', name: 'Prod', mode: 'read_only' }],
+        });
+      });
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
+
+      const banner = await screen.findByTestId('connection-mode-banner');
+      expect(banner).toHaveAttribute('data-mode', 'read_only');
+      expect(banner).toHaveTextContent('Read-only connection — writes are blocked');
+    });
+
+    it('renders an amber confirm_destructive banner above the tab content, with the expected testid/data-mode/text', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'execute_mql_query')
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+        if (cmd === 'count_documents') return Promise.resolve(1);
+        return Promise.resolve([]);
+      });
+      const { fireEvent, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [{ id: 'conn-1', profileId: 'p1', name: 'Prod', mode: 'confirm_destructive' }],
+        });
+      });
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
+
+      const banner = await screen.findByTestId('connection-mode-banner');
+      expect(banner).toHaveAttribute('data-mode', 'confirm_destructive');
+      expect(banner).toHaveTextContent('Production safeguard — destructive operations require confirmation');
+    });
+
+    it('renders no banner for a normal (or unmarked) connection', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'execute_mql_query')
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+        if (cmd === 'count_documents') return Promise.resolve(1);
+        return Promise.resolve([]);
+      });
+      const { fireEvent } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
+
+      expect(screen.queryByTestId('connection-mode-banner')).not.toBeInTheDocument();
+    });
+  });
+
   it('blocks update-many when the update is not operator-keyed (M7)', async () => {
     const calls: any[] = [];
     mockInvoke.mockImplementation((cmd, args) => {
@@ -3602,6 +3675,63 @@ describe('App Component', () => {
             (c) => c.cmd === 'set_connection_meta' && c.args?.id === 'live-1' && c.args?.profileId === 'p1',
           ),
         ).toBe(true);
+      });
+    });
+
+    it('(f2) a self-heal re-announce for a read_only connection preserves read_only — does NOT reset to normal (#188 Task 5 regression)', async () => {
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([
+            { id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null, connection_mode: 'read_only' },
+          ]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('live-1');
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      const connectCard = await screen.findByTestId('conn-card-p1');
+      fireEvent.click(connectCard);
+      await waitFor(() => expect(screen.getByTestId('sidebar-conn-live-1')).toBeInTheDocument());
+
+      // Sanity check: the connect itself already announced the real mode
+      // (Task 1's connect-time registration) before exercising the self-heal
+      // path below.
+      await waitFor(() => {
+        expect(
+          calls.some(
+            (c) => c.cmd === 'set_connection_meta' && c.args?.id === 'live-1' && c.args?.mode === 'read_only',
+          ),
+        ).toBe(true);
+      });
+
+      calls.length = 0; // only the self-heal reaction below matters now
+
+      // An unrelated broadcast lands before this window's own
+      // `set_connection_meta` for p1 has registered backend-side (the same
+      // race as (f) above) — the self-heal re-announce fires. CRITICAL: it
+      // must carry 'live-1's REAL current mode (read_only), never a
+      // hardcoded 'normal' — a hardcoded fallback here would silently
+      // downgrade a guarded connection's backend `connection_meta` entry
+      // (and hence every OTHER window's next `connections-changed`
+      // broadcast) to normal, defeating the read-only/confirm-destructive
+      // safeguard entirely.
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [{ id: 'live-other', profileId: 'p-other', name: 'Other Cluster' }],
+        });
+      });
+
+      await waitFor(() => {
+        const reannounce = calls.find(
+          (c) => c.cmd === 'set_connection_meta' && c.args?.id === 'live-1' && c.args?.profileId === 'p1',
+        );
+        expect(reannounce).toBeTruthy();
+        expect(reannounce.args?.mode).toBe('read_only');
       });
     });
 

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -409,7 +409,54 @@ describe('App Component', () => {
     await waitFor(() => {
       const dm = calls.find((c) => c.cmd === 'delete_many');
       expect(dm).toBeTruthy();
-      expect(dm.args).toMatchObject({ database: 'sales_db', collection: 'customers' });
+      // #188 Task 3: a normal connection's flow is unchanged — `confirmed`
+      // rides along as `false` (the guard passes normal connections through
+      // regardless).
+      expect(dm.args).toMatchObject({ database: 'sales_db', collection: 'customers', confirmed: false });
+    });
+  });
+
+  it('delete-many on a confirm_destructive connection requires a typed collection-name match before invoking (#188 Task 3)', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'execute_mql_query')
+        return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+      if (cmd === 'count_documents') return Promise.resolve(7);
+      if (cmd === 'delete_many') return Promise.resolve(7);
+      return Promise.resolve([]);
+    });
+    const { fireEvent, waitFor, act } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+    // Mark 'conn-1' (the id every mock-sidebar button hardcodes) as a
+    // confirm_destructive connection before the tab opens.
+    await act(async () => {
+      fireMockEvent('connections-changed', {
+        connections: [{ id: 'conn-1', profileId: 'p1', name: 'Prod', mode: 'confirm_destructive' }],
+      });
+    });
+    fireEvent.click(screen.getByTestId('select-collection-btn'));
+    expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('delete-many-btn'));
+
+    // Wrong typed name -> no invoke, dialog stays open with an error.
+    const wrongInput = await screen.findByTestId('dialog-input');
+    fireEvent.change(wrongInput, { target: { value: 'not_customers' } });
+    fireEvent.click(screen.getByTestId('dialog-confirm'));
+    expect(await screen.findByTestId('dialog-error')).toHaveTextContent('Name does not match');
+    expect(calls.find((c) => c.cmd === 'delete_many')).toBeFalsy();
+
+    // Exact name -> invoke with confirmed:true.
+    const rightInput = screen.getByTestId('dialog-input');
+    fireEvent.change(rightInput, { target: { value: 'customers' } });
+    fireEvent.click(screen.getByTestId('dialog-confirm'));
+
+    await waitFor(() => {
+      const dm = calls.find((c) => c.cmd === 'delete_many');
+      expect(dm).toBeTruthy();
+      expect(dm.args).toMatchObject({ database: 'sales_db', collection: 'customers', confirmed: true });
     });
   });
 
@@ -440,10 +487,63 @@ describe('App Component', () => {
     await waitFor(() => {
       const um = calls.find((c) => c.cmd === 'update_many');
       expect(um).toBeTruthy();
+      // #188 Task 3: unchanged normal-connection flow -> confirmed:false.
       expect(um.args).toMatchObject({
         database: 'sales_db',
         collection: 'customers',
         update: '{"$set":{"tier":"Gold"}}',
+        confirmed: false,
+      });
+    });
+  });
+
+  it('update-many on a confirm_destructive connection requires a typed collection-name match before invoking (#188 Task 3)', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'execute_mql_query')
+        return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+      if (cmd === 'count_documents') return Promise.resolve(3);
+      if (cmd === 'update_many') return Promise.resolve(3);
+      return Promise.resolve([]);
+    });
+    const { fireEvent, waitFor, act } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+    await act(async () => {
+      fireMockEvent('connections-changed', {
+        connections: [{ id: 'conn-1', profileId: 'p1', name: 'Prod', mode: 'confirm_destructive' }],
+      });
+    });
+    fireEvent.click(screen.getByTestId('select-collection-btn'));
+    expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('update-many-btn'));
+    // The update-body prompt is unchanged (data entry, not a confirmation).
+    const updateInput = await screen.findByTestId('dialog-input');
+    fireEvent.change(updateInput, { target: { value: '{"$set":{"tier":"Gold"}}' } });
+    fireEvent.click(screen.getByTestId('dialog-confirm'));
+
+    // Wrong typed name -> no invoke.
+    const wrongInput = await screen.findByTestId('dialog-input');
+    fireEvent.change(wrongInput, { target: { value: 'not_customers' } });
+    fireEvent.click(screen.getByTestId('dialog-confirm'));
+    expect(await screen.findByTestId('dialog-error')).toHaveTextContent('Name does not match');
+    expect(calls.find((c) => c.cmd === 'update_many')).toBeFalsy();
+
+    // Exact name -> invoke with confirmed:true.
+    const rightInput = screen.getByTestId('dialog-input');
+    fireEvent.change(rightInput, { target: { value: 'customers' } });
+    fireEvent.click(screen.getByTestId('dialog-confirm'));
+
+    await waitFor(() => {
+      const um = calls.find((c) => c.cmd === 'update_many');
+      expect(um).toBeTruthy();
+      expect(um.args).toMatchObject({
+        database: 'sales_db',
+        collection: 'customers',
+        update: '{"$set":{"tier":"Gold"}}',
+        confirmed: true,
       });
     });
   });

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -604,6 +604,34 @@ describe('App Component', () => {
       expect(banner).toHaveTextContent('Production safeguard — destructive operations require confirmation');
     });
 
+    it('threads the read_only mode into the DataGrid so write buttons are disabled (#188 Task 6, App→DataGrid)', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'execute_mql_query')
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+        if (cmd === 'count_documents') return Promise.resolve(1);
+        return Promise.resolve([]);
+      });
+      const { fireEvent, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+      // Reuses the exact same connections-changed → activeConnections.mode
+      // path the banner test above relies on: DataGrid isn't rendered inside
+      // DocumentViewer itself (it's passed as DocumentViewer's children from
+      // App's renderTabContent), so this same `mode` lookup is what's handed
+      // straight to DataGrid's `connectionMode` prop.
+      await act(async () => {
+        fireMockEvent('connections-changed', {
+          connections: [{ id: 'conn-1', profileId: 'p1', name: 'Prod', mode: 'read_only' }],
+        });
+      });
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findByText(/"John Doe"/)).toBeInTheDocument();
+
+      const insertBtn = await screen.findByTestId('insert-doc-btn');
+      expect(insertBtn).toBeDisabled();
+      expect(insertBtn).toHaveAttribute('title', 'Connection is read-only');
+    });
+
     it('renders no banner for a normal (or unmarked) connection', async () => {
       mockInvoke.mockImplementation((cmd: string) => {
         if (cmd === 'execute_mql_query')

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -566,6 +566,7 @@ describe('ConnectionManager Component', () => {
         ssh: null,
         color_tag: null,
         mcp_enabled: false,
+        connection_mode: 'normal',
       });
       // The nested modal should be closed
       expect(screen.queryByText('New Connection')).not.toBeInTheDocument();
@@ -754,7 +755,7 @@ describe('ConnectionManager Component', () => {
 
     // Verify it called connect_db and passed connection ID to callback
     await waitFor(() => {
-      expect(handleConnect).toHaveBeenCalledWith('conn-abc-123', 'Mock DB 1', 'mongodb://mock', 'profile-1', undefined);
+      expect(handleConnect).toHaveBeenCalledWith('conn-abc-123', 'Mock DB 1', 'mongodb://mock', 'profile-1', undefined, 'normal');
     });
   });
 
@@ -1075,6 +1076,116 @@ describe('MCP opt-in flag (#98)', () => {
     fireEvent.click(screen.getAllByText('Agent DB')[0]);
     fireEvent.click(screen.getByRole('button', { name: /^duplicate$/i }));
     expect(screen.getByLabelText(/expose to mcp agents/i)).not.toBeChecked();
+  });
+});
+
+describe('Connection mode segmented control (#188 Task 1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders the three connection mode options, defaulting a new profile to Normal', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+
+    expect(screen.getByTestId('connection-mode-normal')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('connection-mode-read_only')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('connection-mode-confirm_destructive')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('selecting a mode updates the segmented control selection', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+
+    fireEvent.click(screen.getByTestId('connection-mode-read_only'));
+
+    expect(screen.getByTestId('connection-mode-read_only')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('connection-mode-normal')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('saving with "Confirm destructive" selected persists connection_mode', async () => {
+    let savedProfile: any = null;
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([]);
+      if (cmd === 'save_connection_profile') {
+        savedProfile = args.profile;
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+    fireEvent.click(await screen.findByRole('button', { name: /new\.\.\./i }));
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'Prod' } });
+    await pickSelectOption('topology-select', /full uri string only/i);
+    fireEvent.change(screen.getByLabelText(/connection uri/i), { target: { value: 'mongodb://prod' } });
+
+    fireEvent.click(screen.getByTestId('connection-mode-confirm_destructive'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(savedProfile).toMatchObject({
+        name: 'Prod',
+        uri: 'mongodb://prod',
+        connection_mode: 'confirm_destructive',
+      });
+    });
+  });
+
+  it('editing a profile with a mode shows it selected in the segmented control', async () => {
+    const roProfile = { id: 'p-ro', name: 'Read Only DB', uri: 'mongodb://ro:27017', connection_mode: 'read_only' };
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([roProfile]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+    await waitFor(() => expect(screen.getAllByText('Read Only DB')[0]).toBeInTheDocument());
+    fireEvent.click(screen.getAllByText('Read Only DB')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    expect(screen.getByTestId('connection-mode-read_only')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('editing a legacy profile without connection_mode defaults the segmented control to Normal', async () => {
+    const legacyProfile = { id: 'p-legacy', name: 'Legacy', uri: 'mongodb://legacy:27017' };
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([legacyProfile]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+    await waitFor(() => expect(screen.getAllByText('Legacy')[0]).toBeInTheDocument());
+    fireEvent.click(screen.getAllByText('Legacy')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    expect(screen.getByTestId('connection-mode-normal')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('duplicating a read-only profile inherits its connection mode (opposite of mcpEnabled)', async () => {
+    const roProfile = { id: 'p-ro', name: 'Prod', uri: 'mongodb://prod:27017', connection_mode: 'read_only' };
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'load_connection_profiles') return Promise.resolve([roProfile]);
+      return Promise.reject(new Error(`Unhandled mock: ${cmd}`));
+    });
+
+    render(<ConnectionManager isOpen={true} onClose={() => {}} onConnect={() => {}} />);
+    await waitFor(() => expect(screen.getAllByText('Prod')[0]).toBeInTheDocument());
+    fireEvent.click(screen.getAllByText('Prod')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^duplicate$/i }));
+
+    expect(screen.getByTestId('connection-mode-read_only')).toHaveAttribute('aria-pressed', 'true');
   });
 });
 

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -380,6 +380,90 @@ describe('DataGrid Component', () => {
   });
 });
 
+describe('DataGrid — connectionMode (#188 Task 6: disable write UI on read_only)', () => {
+  const writeHandlers = {
+    onInsertDocument: () => {},
+    onUpdateMany: () => {},
+    onDeleteMany: () => {},
+    onEditDocument: () => {},
+    onDuplicateDocument: () => {},
+    onDeleteDocument: () => {},
+  };
+
+  it('read_only: disables the Insert / Update Many / Delete Many toolbar buttons with a tooltip', () => {
+    render(<DataGrid documents={mockDocuments} {...writeHandlers} connectionMode="read_only" />);
+    for (const testId of ['insert-doc-btn', 'update-many-btn', 'delete-many-btn']) {
+      const btn = screen.getByTestId(testId);
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('title', 'Connection is read-only');
+    }
+  });
+
+  it('read_only: disables the inline row Edit/Delete buttons (with tooltip) but leaves Copy enabled', () => {
+    render(<DataGrid documents={mockDocuments} {...writeHandlers} connectionMode="read_only" />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    const editBtn = screen.getAllByTestId('edit-doc-btn')[0];
+    const deleteBtn = screen.getAllByTestId('delete-doc-btn')[0];
+    const copyBtn = screen.getAllByTestId('copy-doc-btn')[0];
+    expect(editBtn).toBeDisabled();
+    expect(editBtn).toHaveAttribute('title', 'Connection is read-only');
+    expect(deleteBtn).toBeDisabled();
+    expect(deleteBtn).toHaveAttribute('title', 'Connection is read-only');
+    expect(copyBtn).not.toBeDisabled();
+  });
+
+  it('read_only: disables the Edit/Duplicate/Delete context-menu items (with tooltip) but leaves Copy/Compare enabled', () => {
+    render(<DataGrid documents={mockDocuments} {...writeHandlers} connectionMode="read_only" />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    fireEvent.contextMenu(screen.getByText('Alice Smith'));
+    const editItem = screen.getByText('Edit document').closest('button')!;
+    const dupItem = screen.getByText('Duplicate document').closest('button')!;
+    const delItem = screen.getByText('Delete document').closest('button')!;
+    const copyItem = screen.getByText('Copy document (JSON)').closest('button')!;
+    const compareItem = screen.getByText('Compare with…').closest('button')!;
+    expect(editItem).toBeDisabled();
+    expect(editItem).toHaveAttribute('title', 'Connection is read-only');
+    expect(dupItem).toBeDisabled();
+    expect(delItem).toBeDisabled();
+    expect(copyItem).not.toBeDisabled();
+    expect(compareItem).not.toBeDisabled();
+  });
+
+  it('read_only: clicking a disabled context-menu item does not fire its handler', () => {
+    const onEditDocument = vi.fn();
+    render(<DataGrid documents={mockDocuments} {...writeHandlers} onEditDocument={onEditDocument} connectionMode="read_only" />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    fireEvent.contextMenu(screen.getByText('Alice Smith'));
+    fireEvent.click(screen.getByText('Edit document'));
+    expect(onEditDocument).not.toHaveBeenCalled();
+  });
+
+  it('confirm_destructive: leaves every write control ENABLED (regression guard — only read_only disables)', () => {
+    render(<DataGrid documents={mockDocuments} {...writeHandlers} connectionMode="confirm_destructive" />);
+    for (const testId of ['insert-doc-btn', 'update-many-btn', 'delete-many-btn']) {
+      expect(screen.getByTestId(testId)).not.toBeDisabled();
+    }
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    expect(screen.getAllByTestId('edit-doc-btn')[0]).not.toBeDisabled();
+    expect(screen.getAllByTestId('delete-doc-btn')[0]).not.toBeDisabled();
+    fireEvent.contextMenu(screen.getByText('Alice Smith'));
+    expect(screen.getByText('Edit document').closest('button')).not.toBeDisabled();
+    expect(screen.getByText('Duplicate document').closest('button')).not.toBeDisabled();
+    expect(screen.getByText('Delete document').closest('button')).not.toBeDisabled();
+  });
+
+  it('normal (and unset connectionMode): leaves every write control ENABLED', () => {
+    const { rerender } = render(<DataGrid documents={mockDocuments} {...writeHandlers} connectionMode="normal" />);
+    for (const testId of ['insert-doc-btn', 'update-many-btn', 'delete-many-btn']) {
+      expect(screen.getByTestId(testId)).not.toBeDisabled();
+    }
+    rerender(<DataGrid documents={mockDocuments} {...writeHandlers} />);
+    for (const testId of ['insert-doc-btn', 'update-many-btn', 'delete-many-btn']) {
+      expect(screen.getByTestId(testId)).not.toBeDisabled();
+    }
+  });
+});
+
 describe('DataGrid — Compare documents', () => {
   const docs = [
     { _id: { $oid: '603d779f4f102e3a185c3220' }, name: 'Alice', city: 'NYC' },

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -462,6 +462,44 @@ describe('DataGrid — connectionMode (#188 Task 6: disable write UI on read_onl
       expect(screen.getByTestId(testId)).not.toBeDisabled();
     }
   });
+
+  // The COLLSCAN "Create Index" suggestion button is a real write
+  // (create_index, backend-guarded on read_only) even though it lives in the
+  // Explain tab rather than the toolbar — same clickable-then-errors UX this
+  // task exists to prevent, so it gets the same disabled+tooltip treatment.
+  const collscanExplain = JSON.stringify({
+    queryPlanner: {
+      namespace: 'shop.orders',
+      parsedQuery: { status: { $eq: 'open' } },
+      winningPlan: { stage: 'COLLSCAN' },
+    },
+  });
+
+  it('read_only: disables the Create Index suggestion button with a tooltip', () => {
+    render(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={collscanExplain}
+        onCreateSuggestedIndex={() => {}}
+        connectionMode="read_only"
+      />
+    );
+    const btn = screen.getByTestId('create-suggested-index-btn');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', 'Connection is read-only');
+  });
+
+  it('confirm_destructive: leaves the Create Index suggestion button ENABLED (non-destructive)', () => {
+    render(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={collscanExplain}
+        onCreateSuggestedIndex={() => {}}
+        connectionMode="confirm_destructive"
+      />
+    );
+    expect(screen.getByTestId('create-suggested-index-btn')).not.toBeDisabled();
+  });
 });
 
 describe('DataGrid — Compare documents', () => {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -1322,11 +1322,15 @@ describe('Sidebar Component', () => {
     await waitFor(() => {
       const r = calls.find((x) => x.cmd === 'rename_collection');
       expect(r).toBeTruthy();
+      // #188 Task 3: a normal connection's flow is unchanged — `confirmed`
+      // rides along as `false` (the guard passes normal connections through
+      // regardless) since there's no typed-name step to flip it to `true`.
       expect(r.args).toMatchObject({
         id: 'conn-real',
         database: 'shop',
         from: 'orders',
         to: 'archived_orders',
+        confirmed: false,
       });
     });
 
@@ -1336,7 +1340,7 @@ describe('Sidebar Component', () => {
     await waitFor(() => {
       const d = calls.find((x) => x.cmd === 'drop_collection');
       expect(d).toBeTruthy();
-      expect(d.args).toMatchObject({ id: 'conn-real', database: 'shop', collection: 'orders' });
+      expect(d.args).toMatchObject({ id: 'conn-real', database: 'shop', collection: 'orders', confirmed: false });
     });
 
     // Rename Database: in-app prompt for the new name, then a confirm dialog.
@@ -1352,6 +1356,7 @@ describe('Sidebar Component', () => {
         from: 'shop',
         to: 'shop_archive',
         dropSource: true,
+        confirmed: false,
       });
     });
 
@@ -1361,7 +1366,122 @@ describe('Sidebar Component', () => {
     await waitFor(() => {
       const d = calls.find((x) => x.cmd === 'drop_database');
       expect(d).toBeTruthy();
-      expect(d.args).toMatchObject({ id: 'conn-real', database: 'shop' });
+      expect(d.args).toMatchObject({ id: 'conn-real', database: 'shop', confirmed: false });
+    });
+  });
+
+  it('requires typed-name confirmation for destructive ops on a confirm_destructive (production-safeguard) connection (#188 Task 3)', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'list_databases') return Promise.resolve(['shop']);
+      if (cmd === 'list_collections') return Promise.resolve([{ name: 'orders', type: 'collection' }]);
+      if (
+        cmd === 'rename_collection' ||
+        cmd === 'drop_collection' ||
+        cmd === 'rename_database' ||
+        cmd === 'drop_database'
+      ) return Promise.resolve();
+      if (cmd === 'list_indexes') return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+
+    // Drives the typed-name confirm dialog (a `prompt` request under the hood,
+    // same DOM shape as `submitPrompt` above).
+    const typeAndSubmit = async (value: string) => {
+      const input = await screen.findByTestId('dialog-input');
+      fireEvent.change(input, { target: { value } });
+      fireEvent.click(screen.getByTestId('dialog-confirm'));
+    };
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[
+          { id: 'conn-real', name: 'Prod', uri: 'mongodb://localhost:27017', mode: 'confirm_destructive' },
+        ]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    const dbNode = await screen.findByText('shop');
+    fireEvent.click(dbNode);
+    await screen.findByText('Collections');
+    fireEvent.click(screen.getByText('Collections'));
+    const ordersNode = await screen.findByText('orders');
+
+    // Rename Collection: the typed-name step (confirming "orders") comes
+    // FIRST, before the "enter new name" prompt even appears.
+    fireEvent.contextMenu(ordersNode);
+    fireEvent.click(screen.getByText('Rename Collection'));
+    await typeAndSubmit('wrong_name');
+    expect(await screen.findByTestId('dialog-error')).toHaveTextContent('Name does not match');
+    expect(calls.find((x) => x.cmd === 'rename_collection')).toBeFalsy();
+    await typeAndSubmit('orders'); // exact match -> proceeds to the "enter new name" prompt
+    await typeAndSubmit('archived_orders');
+    await waitFor(() => {
+      const r = calls.find((x) => x.cmd === 'rename_collection');
+      expect(r).toBeTruthy();
+      expect(r.args).toMatchObject({
+        id: 'conn-real',
+        database: 'shop',
+        from: 'orders',
+        to: 'archived_orders',
+        confirmed: true,
+      });
+    });
+
+    // Drop Collection: wrong typed name -> no invoke; exact name -> invoke
+    // with confirmed:true.
+    fireEvent.contextMenu(ordersNode);
+    fireEvent.click(screen.getByText('Drop Collection'));
+    await typeAndSubmit('not_orders');
+    expect(await screen.findByTestId('dialog-error')).toHaveTextContent('Name does not match');
+    expect(calls.find((x) => x.cmd === 'drop_collection')).toBeFalsy();
+    await typeAndSubmit('orders');
+    await waitFor(() => {
+      const d = calls.find((x) => x.cmd === 'drop_collection');
+      expect(d).toBeTruthy();
+      expect(d.args).toMatchObject({ id: 'conn-real', database: 'shop', collection: 'orders', confirmed: true });
+    });
+
+    // Rename Database: typed-name step (confirming "shop", the FROM side)
+    // replaces the ordinary yes/no confirm.
+    fireEvent.contextMenu(dbNode);
+    fireEvent.click(screen.getByText('Rename Database'));
+    await typeAndSubmit('shop_archive');
+    await typeAndSubmit('wrong_db');
+    expect(await screen.findByTestId('dialog-error')).toHaveTextContent('Name does not match');
+    expect(calls.find((x) => x.cmd === 'rename_database')).toBeFalsy();
+    await typeAndSubmit('shop');
+    await waitFor(() => {
+      const r = calls.find((x) => x.cmd === 'rename_database');
+      expect(r).toBeTruthy();
+      expect(r.args).toMatchObject({
+        id: 'conn-real',
+        from: 'shop',
+        to: 'shop_archive',
+        dropSource: true,
+        confirmed: true,
+      });
+    });
+
+    // Drop Database: wrong typed name -> no invoke; exact name -> invoke
+    // with confirmed:true.
+    fireEvent.contextMenu(dbNode);
+    fireEvent.click(screen.getByText('Drop Database'));
+    await typeAndSubmit('wrong_db');
+    expect(await screen.findByTestId('dialog-error')).toHaveTextContent('Name does not match');
+    expect(calls.find((x) => x.cmd === 'drop_database')).toBeFalsy();
+    await typeAndSubmit('shop');
+    await waitFor(() => {
+      const d = calls.find((x) => x.cmd === 'drop_database');
+      expect(d).toBeTruthy();
+      expect(d.args).toMatchObject({ id: 'conn-real', database: 'shop', confirmed: true });
     });
   });
 

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -71,6 +71,35 @@ describe('Sidebar Component', () => {
     expect(screen.getByText('Human Conn')).toBeInTheDocument();
   });
 
+  it('badges a read_only connection "read-only" and a confirm_destructive connection "guarded", but not a normal one (#188 Task 5)', () => {
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[
+          { id: 'conn-1', name: 'Prod Cluster', uri: 'mongodb://mock1', mode: 'read_only' },
+          { id: 'conn-2', name: 'Guarded Cluster', uri: 'mongodb://mock2', mode: 'confirm_destructive' },
+          { id: 'conn-3', name: 'Normal Cluster', uri: 'mongodb://mock3', mode: 'normal' },
+        ]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />
+    );
+
+    const badges = screen.getAllByTestId('connection-mode-badge');
+    expect(badges).toHaveLength(2);
+
+    const readOnlyBadge = badges.find((b) => b.getAttribute('data-mode') === 'read_only');
+    expect(readOnlyBadge).toHaveTextContent('read-only');
+
+    const guardedBadge = badges.find((b) => b.getAttribute('data-mode') === 'confirm_destructive');
+    expect(guardedBadge).toHaveTextContent('guarded');
+
+    expect(screen.getByText('Normal Cluster')).toBeInTheDocument();
+  });
+
   it('filters the tree by the search box (database names)', async () => {
     mockInvoke.mockImplementation((cmd, args) => {
       if (cmd === 'list_databases') {

--- a/src/lib/__tests__/aggregateWriteStage.test.ts
+++ b/src/lib/__tests__/aggregateWriteStage.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { detectAggregateWriteStage } from '../aggregateWriteStage';
+
+describe('detectAggregateWriteStage', () => {
+  it('reports no write stage for a plain read pipeline', () => {
+    expect(
+      detectAggregateWriteStage([{ $match: { active: true } }, { $count: 'n' }])
+    ).toEqual({ hasWriteStage: false, target: null });
+  });
+
+  it('extracts the target from a bare-string $out', () => {
+    expect(detectAggregateWriteStage([{ $out: 'archive' }])).toEqual({
+      hasWriteStage: true,
+      target: 'archive',
+    });
+  });
+
+  it('extracts the target from an object-form $out', () => {
+    expect(
+      detectAggregateWriteStage([{ $out: { db: 'reporting', coll: 'summary' } }])
+    ).toEqual({ hasWriteStage: true, target: 'summary' });
+  });
+
+  it('extracts the target from a bare-string $merge', () => {
+    expect(detectAggregateWriteStage([{ $merge: 'rollup' }])).toEqual({
+      hasWriteStage: true,
+      target: 'rollup',
+    });
+  });
+
+  it('extracts the target from $merge.into as a string', () => {
+    expect(
+      detectAggregateWriteStage([{ $merge: { into: 'rollup', whenMatched: 'merge' } }])
+    ).toEqual({ hasWriteStage: true, target: 'rollup' });
+  });
+
+  it('extracts the target from $merge.into as an object', () => {
+    expect(
+      detectAggregateWriteStage([{ $merge: { into: { db: 'reporting', coll: 'rollup' } } }])
+    ).toEqual({ hasWriteStage: true, target: 'rollup' });
+  });
+
+  it('flags a write stage with no target when extraction fails', () => {
+    expect(detectAggregateWriteStage([{ $merge: {} }])).toEqual({
+      hasWriteStage: true,
+      target: null,
+    });
+  });
+
+  it('finds a write stage anywhere in the pipeline, not just the first stage', () => {
+    expect(
+      detectAggregateWriteStage([{ $match: { a: 1 } }, { $group: { _id: '$a' } }, { $out: 'x' }])
+    ).toEqual({ hasWriteStage: true, target: 'x' });
+  });
+
+  it('does not false-positive on $merge appearing as a value, not a sole top-level key', () => {
+    expect(
+      detectAggregateWriteStage([
+        { $lookup: { from: 'other', pipeline: [{ $project: { note: '$merge' } }], as: 'joined' } },
+      ])
+    ).toEqual({ hasWriteStage: false, target: null });
+  });
+
+  it('does not flag a multi-key stage that happens to include $out', () => {
+    expect(detectAggregateWriteStage([{ $out: 'x', $extra: 1 } as Record<string, unknown>])).toEqual(
+      { hasWriteStage: false, target: null }
+    );
+  });
+
+  it('handles an empty or missing pipeline', () => {
+    expect(detectAggregateWriteStage([])).toEqual({ hasWriteStage: false, target: null });
+    expect(detectAggregateWriteStage(null)).toEqual({ hasWriteStage: false, target: null });
+    expect(detectAggregateWriteStage(undefined)).toEqual({ hasWriteStage: false, target: null });
+  });
+});

--- a/src/lib/aggregateWriteStage.ts
+++ b/src/lib/aggregateWriteStage.ts
@@ -1,0 +1,65 @@
+/**
+ * Detects whether an aggregation pipeline carries a `$out`/`$merge` stage —
+ * the two stages that WRITE the pipeline's output into a collection instead
+ * of just reading (#188 security review Fix 1). Mirrors the backend's
+ * `write_guard::stage_is_disallowed` (a stage counts only when its sole
+ * top-level key is `$out` or `$merge` — the backend is the real gate
+ * either way, this is only used to decide what confirmation UI to show).
+ *
+ * Also best-effort extracts the write TARGET collection name so the
+ * confirm-by-typed-name dialog (`confirmByTypedName`) can ask the user to
+ * type it, same as drop_collection/rename_collection do. `$out` and
+ * `$merge` both support a bare string form and an object form
+ * (`{db, coll}` for `$out`; `{into: string | {db, coll}}` for `$merge`);
+ * anything else (e.g. the target computed dynamically, which isn't
+ * possible in MQL but kept as a defensive fallback) yields `target: null`
+ * so the caller can fall back to a plain "type CONFIRM" prompt instead of
+ * silently under- or over-matching a name.
+ */
+export interface AggregateWriteStage {
+  /** True iff some top-level stage's sole key is `$out` or `$merge`. */
+  hasWriteStage: boolean;
+  /** The write target collection name if it could be extracted cleanly; null if a write stage exists but the target couldn't be determined. */
+  target: string | null;
+}
+
+function nonEmptyString(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() ? v.trim() : null;
+}
+
+export function detectAggregateWriteStage(pipeline: Record<string, unknown>[] | null | undefined): AggregateWriteStage {
+  for (const stage of pipeline ?? []) {
+    if (!stage || typeof stage !== 'object' || Array.isArray(stage)) continue;
+    const keys = Object.keys(stage);
+    if (keys.length !== 1) continue;
+    const key = keys[0];
+    if (key !== '$out' && key !== '$merge') continue;
+
+    const value = (stage as Record<string, unknown>)[key];
+
+    if (key === '$out') {
+      const direct = nonEmptyString(value);
+      if (direct) return { hasWriteStage: true, target: direct };
+      if (value && typeof value === 'object') {
+        const coll = nonEmptyString((value as Record<string, unknown>).coll);
+        if (coll) return { hasWriteStage: true, target: coll };
+      }
+      return { hasWriteStage: true, target: null };
+    }
+
+    // $merge
+    const direct = nonEmptyString(value);
+    if (direct) return { hasWriteStage: true, target: direct };
+    if (value && typeof value === 'object') {
+      const into = (value as Record<string, unknown>).into;
+      const intoStr = nonEmptyString(into);
+      if (intoStr) return { hasWriteStage: true, target: intoStr };
+      if (into && typeof into === 'object') {
+        const coll = nonEmptyString((into as Record<string, unknown>).coll);
+        if (coll) return { hasWriteStage: true, target: coll };
+      }
+    }
+    return { hasWriteStage: true, target: null };
+  }
+  return { hasWriteStage: false, target: null };
+}

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -1,5 +1,8 @@
 import type { SshConfig } from '../components/ConnectionManager';
 
+/** Mirrors backend `connections::ConnectionMode` (#188). */
+export type ConnectionMode = 'normal' | 'read_only' | 'confirm_destructive';
+
 /** A saved connection profile, mirroring the backend `ConnectionProfile`. */
 export interface ConnectionProfile {
   id: string;
@@ -9,6 +12,8 @@ export interface ConnectionProfile {
   ssh?: SshConfig | null;
   /** Expose this profile to MCP agents. Mirrors backend `ConnectionProfile::mcp_enabled`. */
   mcp_enabled?: boolean;
+  /** Read-only / confirm-destructive production safeguard. Mirrors backend `ConnectionProfile::connection_mode`. */
+  connection_mode?: ConnectionMode;
 }
 
 /** Options for exporting a connection URI for sharing. */

--- a/src/lib/typedNameConfirm.ts
+++ b/src/lib/typedNameConfirm.ts
@@ -1,0 +1,37 @@
+import type { DialogApi } from '@/components/dialogs/DialogProvider';
+
+/**
+ * Typed-name confirmation for a destructive operation on a `confirm_destructive`
+ * (production-safeguard) connection (#188 Task 3). The user must type the
+ * exact collection/database name before the caller may pass `confirmed: true`
+ * to the backend command — the backend's `guard_writable` is the real gate
+ * (it never trusts the UI), this dialog just keeps an accidental click from
+ * ever reaching it with `confirmed: true`.
+ *
+ * Shared between App.tsx (delete_many/update_many) and Sidebar.tsx
+ * (drop_collection/rename_collection/drop_database/rename_database) so the
+ * wording and matching rule (trimmed exact match) stay identical everywhere.
+ *
+ * Resolves `true` iff the user typed an exact match; `false` if they
+ * cancelled the dialog.
+ */
+export async function confirmByTypedName(
+  prompt: DialogApi['prompt'],
+  opts: {
+    title: string;
+    /** What's being typed — used in the default message ("Type the {kind} name to confirm."). */
+    kind: 'collection' | 'database';
+    /** The exact string the user must type (trimmed) to proceed. */
+    expectedName: string;
+    /** Overrides the default message; still validated against `expectedName`. */
+    message?: string;
+  }
+): Promise<boolean> {
+  const typed = await prompt({
+    title: opts.title,
+    message: opts.message ?? `Type the ${opts.kind} name to confirm.`,
+    placeholder: opts.expectedName,
+    validate: (v) => (v.trim() === opts.expectedName ? null : 'Name does not match'),
+  });
+  return typed !== null;
+}

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -126,6 +126,8 @@ export interface ConnectionEntry {
   name: string;
   /** True iff this connection was opened by the embedded MCP server's `connect` tool rather than a human (#98 Task 4). */
   viaMcp: boolean;
+  /** Read-only / confirm-destructive production safeguard (#188), registered at connect time from the profile's `connection_mode`. */
+  mode?: 'normal' | 'read_only' | 'confirm_destructive';
 }
 export interface ConnectionsChangedPayload {
   connections: ConnectionEntry[];
@@ -168,9 +170,19 @@ export async function connectionList(): Promise<ConnectionEntry[]> {
  * call would just re-broadcast unchanged data. Same fire-and-forget contract
  * as `workspaceApply`: never throws, failures are logged and dropped rather
  * than blocking the connect flow that shadows it.
+ *
+ * `mode` (#188) is the connecting profile's `connection_mode` at the moment
+ * of connect — the backend command requires it, so every caller must supply
+ * it (defaulting to `'normal'` covers a caller that only has an id/name to
+ * re-announce, e.g. the self-heal path, and never had a profile in hand).
  */
-export function setConnectionMeta(id: string, profileId: string, name: string): void {
-  invoke('set_connection_meta', { id, profileId, name }).catch((err) => {
+export function setConnectionMeta(
+  id: string,
+  profileId: string,
+  name: string,
+  mode: 'normal' | 'read_only' | 'confirm_destructive' = 'normal'
+): void {
+  invoke('set_connection_meta', { id, profileId, name, mode }).catch((err) => {
     console.warn('set_connection_meta failed', err);
   });
 }


### PR DESCRIPTION
## Summary
Closes #188 (last v0.13.0 feature). Mark a connection **read-only** or **confirm-destructive** so writes are blocked or gated — enforced at the command layer, for the UI and AI agents alike. "Safe to point at prod."

- **Three modes** (per saved connection, in the Connection Manager): Normal / Read-only / Confirm-destructive. Serde-defaulted, so existing connections stay Normal; duplicating a connection **inherits** the safeguard.
- **Central guard** (`write_guard.rs`): every mutating command calls `guard_writable` as its first line. Read-only rejects all writes; confirm-destructive rejects the destructive ops (drop, delete-many, update-many, rename) unless the backend receives an explicit `confirmed` flag — the frontend only sets it after you **type the collection name**. The backend never trusts the UI.
- **Covers everything, provably**: a `command_coverage` test parses the real `generate_handler!` list and asserts all **113** commands are classified read/guarded/local — a new unguarded write fails CI. Copy guards the *target* connection; ``/`` aggregations, the embedded mongosh shell, gridfs, users, imports, generation, and restore are all gated.
- **AI agents inherit it**: the MCP write tools call the guard ahead of their own `_confirm` gate — an agent literally cannot write to a read-only connection.
- **Visible**: a red/amber banner on every tab of a guarded connection and a sidebar badge, propagated to all windows via the connections-changed broadcast.

## Review trail
Subagent-driven: 6 tasks, per-task adversarial reviews, and a **security-focused whole-branch review whose independent command-surface hunt caught two Critical unguarded write paths the task list had missed** — UI ``/`` aggregation and the mongosh shell. Both fixed, and the enumeration cross-check was added so that entire class of miss now fails a test.

## Verification
vitest **1048/1048** (+4 skipped), cargo **483/483**, clippy at baseline, tsc + build clean. Guard logic, the confirmed-arg contract, MCP composition, mode propagation, and the 113-command coverage are all tested.

**Outstanding (user environment): GUI checklist** in the phase report — set read-only → banner/badge + all writes (incl. an MCP agent) blocked; confirm-destructive → typed-name modal on destructive ops, non-destructive writes succeed; second window shows the same mode.

## Known v1 limitations (documented)
Confirm-destructive mongosh shells are free-form and not per-command gated (read-only blocks the shell entirely); `set_connection_meta` is renderer-callable — a safeguard against accidents, not a boundary against a hostile local user.

Squash-merge recommended (single `feat:` line for release notes).