### PR TITLE
fix(query): parse the query bar like Compass (shell syntax, braceless, expressions)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mqlens",
-  "version": "0.9.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mqlens",
-      "version": "0.9.1",
+      "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
@@ -38,6 +38,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "lucide-react": "^1.18.0",
+        "mongodb-query-parser": "^4.7.15",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-resizable-panels": "^4.11.2",
@@ -1113,6 +1114,18 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mongodb-js/shell-bson-parser": {
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/shell-bson-parser/-/shell-bson-parser-1.5.14.tgz",
+      "integrity": "sha512-yHOzGhawr1Pvrux62CgdfGYZz9vmCD1ZJT3dsNAJTYfxyIFVZPlxYYVHu4wCU3CWsatUO9GQteUazNjJTlFjEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.16.0"
+      },
+      "peerDependencies": {
+        "bson": "^4.6.3 || ^5 || ^6.10.3 || ^7.0.0"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3472,6 +3485,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3856,7 +3881,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4214,6 +4238,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/javascript-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.1.0.tgz",
+      "integrity": "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -4568,6 +4598,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4689,11 +4725,25 @@
         "marked": "14.0.0"
       }
     },
+    "node_modules/mongodb-query-parser": {
+      "version": "4.7.15",
+      "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-4.7.15.tgz",
+      "integrity": "sha512-rCkAXmL0WEcraRXedMYzjarrb2fq7jG347P8vION6ibUulqMALl+gTwOcC+MNr3DQgxZ3rlFSj1vtN09knpyrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/shell-bson-parser": "^1.5.14",
+        "debug": "^4.4.0",
+        "javascript-stringify": "^2.1.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "bson": "^4.6.3 || ^5 || ^6.10.3 || ^7.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^1.18.0",
+    "mongodb-query-parser": "^4.7.15",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-resizable-panels": "^4.11.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,6 +124,20 @@ interface QueryTab {
 
 const DEFAULT_QUERY = { filter: '{}', sort: '{}', projection: '{}', limit: 50, skip: 0 };
 
+// A cached/restored builder state may carry "{}" in the query/sort/projection
+// fields (from workspaces saved before empties were blanked); normalize it to
+// blank on read so those fields never display "{}". Passthrough for undefined.
+function blankEmptyQueryFields(s: BuilderState | undefined): BuilderState | undefined {
+  if (!s) return s;
+  const blank = (v: string) => (v?.trim() === '{}' ? '' : v);
+  return {
+    ...s,
+    filterQuery: blank(s.filterQuery),
+    sortQuery: blank(s.sortQuery),
+    projectionQuery: blank(s.projectionQuery),
+  };
+}
+
 const isEmptyFilter = (s: string): boolean => {
   const t = (s || '').trim();
   return t === '' || t === '{}';
@@ -3510,7 +3524,7 @@ function Workspace() {
               databaseName={tab.db}
               collectionName={tab.collection}
               initialBuilderState={
-                tabBuilderStateCache.current.get(tab.id)
+                blankEmptyQueryFields(tabBuilderStateCache.current.get(tab.id))
                 ?? builderStateFromQueryTab(tab.lastQuery, tab.lastAggregate)
               }
               onBuilderStateChange={(state) => handleBuilderStateChange(tab.id, state)}

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -110,9 +110,11 @@ export interface BuilderState {
 
 export const DEFAULT_BUILDER_STATE: BuilderState = {
   queryMode: 'find',
-  filterQuery: '{}',
-  sortQuery: '{}',
-  projectionQuery: '{}',
+  // The query/sort/projection fields start empty (not "{}") — an empty field
+  // means "no filter", which handleRun treats as {}. Keeps the bar uncluttered.
+  filterQuery: '',
+  sortQuery: '',
+  projectionQuery: '',
   limit: '50',
   skip: '0',
   stages: [{ id: 'stage-1', operator: '$match', content: '{\n  \n}' }],
@@ -142,12 +144,14 @@ export function builderStateFromQueryTab(
     };
   }
   if (lastQuery) {
+    // A stored "{}" is the canonical empty query; show it as a blank field.
+    const blankIfEmpty = (s: string) => (s.trim() === '{}' ? '' : s);
     return {
       ...DEFAULT_BUILDER_STATE,
       queryMode: 'find',
-      filterQuery: lastQuery.filter,
-      sortQuery: lastQuery.sort,
-      projectionQuery: lastQuery.projection,
+      filterQuery: blankIfEmpty(lastQuery.filter),
+      sortQuery: blankIfEmpty(lastQuery.sort),
+      projectionQuery: blankIfEmpty(lastQuery.projection),
       limit: String(lastQuery.limit),
       skip: String(lastQuery.skip),
     };
@@ -310,7 +314,7 @@ const parseValue = (val: string): any => {
 };
 
 const compileRulesToQuery = (rules: VisualRule[], matchType: 'and' | 'or'): string => {
-  if (rules.length === 0) return '{}';
+  if (rules.length === 0) return '';
   
   const ruleObjects = rules.map(rule => {
     if (!rule.field || rule.field === '__custom__') return null;
@@ -327,7 +331,7 @@ const compileRulesToQuery = (rules: VisualRule[], matchType: 'and' | 'or'): stri
     return ruleObj;
   }).filter(Boolean) as Record<string, any>[];
   
-  if (ruleObjects.length === 0) return '{}';
+  if (ruleObjects.length === 0) return '';
   
   if (matchType === 'or') {
     return JSON.stringify({ $or: ruleObjects }, null, 2);
@@ -353,7 +357,7 @@ const compileRulesToQuery = (rules: VisualRule[], matchType: 'and' | 'or'): stri
 };
 
 const compileProjectionRules = (rules: ProjectionRule[]): string => {
-  if (rules.length === 0) return '{}';
+  if (rules.length === 0) return '';
   const projObj: Record<string, number> = {};
   rules.forEach(r => {
     if (r.field && r.field !== '__custom__') {
@@ -364,7 +368,7 @@ const compileProjectionRules = (rules: ProjectionRule[]): string => {
 };
 
 const compileSortRules = (rules: SortRule[]): string => {
-  if (rules.length === 0) return '{}';
+  if (rules.length === 0) return '';
   const sortObj: Record<string, number> = {};
   rules.forEach(r => {
     if (r.field && r.field !== '__custom__') {
@@ -720,10 +724,15 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       setQueryMode('aggregate');
       toast('Aggregation pipeline applied', 'success');
     } else {
-      setFilterQuery(JSON.stringify(query.filter ?? {}, null, 2));
-      setSortQuery(JSON.stringify(query.sort ?? {}, null, 2));
+      // Empty parts show as a blank field (not "{}"), matching the default.
+      const jsonOrBlank = (v: unknown) => {
+        const s = JSON.stringify(v ?? {}, null, 2);
+        return s === '{}' ? '' : s;
+      };
+      setFilterQuery(jsonOrBlank(query.filter));
+      setSortQuery(jsonOrBlank(query.sort));
       if (query.projection !== undefined) {
-        setProjectionQuery(JSON.stringify(query.projection ?? {}, null, 2));
+        setProjectionQuery(jsonOrBlank(query.projection));
       }
       setQueryMode('find');
       toast('Query applied to editor', 'success');
@@ -782,7 +791,14 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   projectionRulesRef.current = projectionRules;
   sortRulesRef.current = sortRules;
 
-  const fields = availableFields.length > 0 ? availableFields : ['_id'];
+  // Autocomplete field list = top-level keys seen in the results PLUS the
+  // schema analyzer's dotted nested paths (usage.total, usage.featureTypeGroup,
+  // …), so nested keys are suggested too. De-duped, order: results first.
+  const fields = (() => {
+    const set = new Set<string>(availableFields);
+    for (const key of schema.keys()) set.add(key);
+    return set.size > 0 ? [...set] : ['_id'];
+  })();
 
   // Validation states
   const [isFilterValid, setIsFilterValid] = useState(true);
@@ -843,7 +859,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         setRules(synced.rules);
         setQueryMatchType(synced.matchType);
         setIsQueryEnabled(true);
-      } else if (json.trim() === '{}') {
+      } else if ((json.trim() === '{}' || !json.trim())) {
         rulesRef.current = [];
         setRules([]);
         setIsQueryEnabled(false);
@@ -860,7 +876,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         projectionRulesRef.current = synced;
         setProjectionRules(synced);
         setIsProjectionEnabled(true);
-      } else if (json.trim() === '{}') {
+      } else if ((json.trim() === '{}' || !json.trim())) {
         projectionRulesRef.current = [];
         setProjectionRules([]);
         setIsProjectionEnabled(false);
@@ -877,7 +893,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         sortRulesRef.current = synced;
         setSortRules(synced);
         setIsSortEnabled(true);
-      } else if (json.trim() === '{}') {
+      } else if ((json.trim() === '{}' || !json.trim())) {
         sortRulesRef.current = [];
         setSortRules([]);
         setIsSortEnabled(false);
@@ -947,7 +963,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   const clearAllRules = () => {
     rulesRef.current = [];
     setRules([]);
-    setFilterQuery('{}');
+    setFilterQuery('');
   };
 
   // Projection CRUD Handlers
@@ -992,7 +1008,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   const clearAllProjectionRules = () => {
     projectionRulesRef.current = [];
     setProjectionRules([]);
-    setProjectionQuery('{}');
+    setProjectionQuery('');
   };
 
   // Sort CRUD Handlers
@@ -1037,7 +1053,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   const clearAllSortRules = () => {
     sortRulesRef.current = [];
     setSortRules([]);
-    setSortQuery('{}');
+    setSortQuery('');
   };
 
   // Section Toggle Handlers
@@ -1046,7 +1062,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       setIsQueryEnabled(true);
       setFilterQuery(compileRulesToQuery(rulesRef.current, queryMatchTypeRef.current));
     } else {
-      setFilterQuery('{}');
+      setFilterQuery('');
       setIsQueryEnabled(false);
     }
   };
@@ -1056,7 +1072,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       setIsProjectionEnabled(true);
       setProjectionQuery(compileProjectionRules(projectionRulesRef.current));
     } else {
-      setProjectionQuery('{}');
+      setProjectionQuery('');
       setIsProjectionEnabled(false);
     }
   };
@@ -1066,7 +1082,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       setIsSortEnabled(true);
       setSortQuery(compileSortRules(sortRulesRef.current));
     } else {
-      setSortQuery('{}');
+      setSortQuery('');
       setIsSortEnabled(false);
     }
   };
@@ -1151,7 +1167,16 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       .filter(stage => !stage.disabled && stage.content.trim())
       .map(stage => ({ [stage.operator]: parseShellJson(stage.content) }));
 
+  // In find mode, block Run/Enter while any active field is invalid so a
+  // half-typed query never reaches the backend (which would surface a cryptic
+  // BSON error). Aggregate stages are validated inside handleRun's try/catch.
+  const canRun =
+    queryMode === 'aggregate'
+      ? true
+      : isFilterValid && isSortValid && (!isProjectionEnabled || isProjectionValid);
+
   const handleRun = () => {
+    if (!canRun) return;
     setError(null);
     try {
       if (queryMode === 'find') {
@@ -1277,9 +1302,9 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   };
 
   const handleClearField = (field: 'filter' | 'projection' | 'sort') => {
-    if (field === 'filter') setFilterQuery('{}');
-    if (field === 'projection') setProjectionQuery('{}');
-    if (field === 'sort') setSortQuery('{}');
+    if (field === 'filter') setFilterQuery('');
+    if (field === 'projection') setProjectionQuery('');
+    if (field === 'sort') setSortQuery('');
     notify(`Cleared ${field} parameters`);
   };
 
@@ -1341,10 +1366,10 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
           <div className="flex overflow-hidden rounded-md shadow-sm">
             <Button
               onClick={handleRun}
-              disabled={loading || explainLoading}
+              disabled={loading || explainLoading || !canRun}
               size="sm"
               className="h-7 rounded-r-none px-2.5 text-[11px]"
-              title={`Execute query (${formatShortcut(shortcutById('run-query')!)})`}
+              title={!canRun ? 'Fix the query syntax to run' : `Execute query (${formatShortcut(shortcutById('run-query')!)})`}
             >
               <Play size={11} fill="currentColor" />
               Run
@@ -1660,6 +1685,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
           {queryMode === 'find' ? (
             <div className="shrink-0">
               <FindQueryBar
+                shellSyntax
                 filter={filterQuery}
                 projection={projectionQuery}
                 sort={sortQuery}
@@ -1801,6 +1827,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                         {!stage.collapsed && (
                           <QueryEditor
                             surface="aggStage"
+                            shellSyntax
                             stageOperator={stage.operator}
                             onRun={handleRun}
                             value={stage.content}
@@ -2204,7 +2231,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
             </ScrollArea>
 
             <div className="flex shrink-0 justify-end border-t border-border bg-card p-2">
-              <Button onClick={handleRun} disabled={loading} size="sm" className="h-7 text-[11px]">
+              <Button onClick={handleRun} disabled={loading || !canRun} size="sm" className="h-7 text-[11px]">
                 Apply
               </Button>
             </div>

--- a/src/components/FindQueryBar.tsx
+++ b/src/components/FindQueryBar.tsx
@@ -19,6 +19,9 @@ export interface FindQueryBarProps {
   sortInvalid?: boolean;
   fields: string[];
   schema?: SchemaMap;
+  /** Emit mongosh-style completions (bare keys + ISODate()/ObjectId()) instead
+   *  of EJSON — set by editors that parse shell syntax (the main query bar). */
+  shellSyntax?: boolean;
   /** Run handler (⌘/Ctrl+Enter in the editors, Enter in skip/limit). */
   onRun?: () => void;
   /** Clear handlers — default to resetting the field to '{}' when omitted. */
@@ -67,6 +70,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
   sortInvalid = false,
   fields,
   schema,
+  shellSyntax,
   onRun,
   onClearFilter,
   onClearProjection,
@@ -86,14 +90,14 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
     }
   };
 
-  const clearFilter = onClearFilter ?? (() => onFilterChange('{}'));
-  const clearProjection = onClearProjection ?? (() => onProjectionChange('{}'));
-  const clearSort = onClearSort ?? (() => onSortChange('{}'));
+  const clearFilter = onClearFilter ?? (() => onFilterChange(''));
+  const clearProjection = onClearProjection ?? (() => onProjectionChange(''));
+  const clearSort = onClearSort ?? (() => onSortChange(''));
 
   const cycleSort = () => {
-    if (sort === '{}') onSortChange('{"_id": -1}');
+    if (sort === '{}' || sort.trim() === '') onSortChange('{"_id": -1}');
     else if (sort === '{"_id": -1}') onSortChange('{"_id": 1}');
-    else onSortChange('{}');
+    else onSortChange('');
   };
 
   return (
@@ -104,6 +108,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
           <QueryEditor
             singleLine
             surface="filter"
+            shellSyntax={shellSyntax}
             onRun={onRun}
             value={filter}
             onChange={onFilterChange}
@@ -130,6 +135,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
           <QueryEditor
             singleLine
             surface="projection"
+            shellSyntax={shellSyntax}
             onRun={onRun}
             value={projection}
             onChange={onProjectionChange}
@@ -154,6 +160,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
           <QueryEditor
             singleLine
             surface="sort"
+            shellSyntax={shellSyntax}
             onRun={onRun}
             value={sort}
             onChange={onSortChange}

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -34,6 +34,9 @@ interface QueryEditorProps {
   className?: string;
   onRun?: () => void;
   stageOperator?: string;
+  /** Emit mongosh-style completions (bare keys + ISODate()/ObjectId()) instead
+   *  of EJSON. Set by the main query bar, which parses shell syntax. */
+  shellSyntax?: boolean;
   'data-testid'?: string;
 }
 
@@ -48,6 +51,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   className,
   onRun,
   stageOperator,
+  shellSyntax,
   'data-testid': testid,
 }) => {
   const fieldsRef = useRef(fields); fieldsRef.current = fields;
@@ -115,11 +119,28 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   const editor = (
     <Editor
       height={editorHeight}
-      defaultLanguage="json"
+      defaultLanguage="javascript"
+      language="javascript"
       theme={theme}
       value={value}
       onChange={(v) => onChange(v ?? '')}
       wrapperProps={testid ? { 'data-testid': testid } : undefined}
+      beforeMount={(monaco: Monaco) => {
+        // Query text is mongosh-style, not strict JSON: unquoted keys, single
+        // quotes, ObjectId(…)/ISODate(…), and braceless field lists are all
+        // valid input (see parseShellJson). Turn off Monaco's built-in language
+        // diagnostics so it stops red-squiggling that valid input — the app's
+        // own parseShellJson validation drives the real error state. This MUST
+        // run in beforeMount (not onMount): by the time onMount fires the JS
+        // worker has already validated the model, and updating the options then
+        // doesn't clear the markers.
+        monaco.languages?.typescript?.javascriptDefaults?.setDiagnosticsOptions({
+          noSemanticValidation: true,
+          noSyntaxValidation: true,
+          noSuggestionDiagnostics: true,
+        });
+        monaco.languages?.json?.jsonDefaults?.setDiagnosticsOptions({ validate: false });
+      }}
       onMount={(ed, monaco: Monaco) => {
         monacoRef.current = monaco;
         registerMqlensMonacoThemes(monaco);
@@ -160,6 +181,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
             getFields: () => fieldsRef.current,
             getSchema: () => schemaRef.current,
             getStageOperator: () => stageOperatorRef.current,
+            shellSyntax,
           });
           ed.onDidDispose(() => { if (uriRef.current) clearModelMeta(uriRef.current); });
         }
@@ -172,7 +194,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
     return (
       <div
         className={cn(
-          'flex h-7 min-w-0 flex-1 items-center bg-input',
+          'flex h-7 min-w-0 flex-1 items-center bg-input pl-2',
           '[&_.monaco-editor]:bg-transparent [&_.monaco-editor-background]:bg-transparent',
           '[&_.margin]:bg-transparent [&_.monaco-scrollable-element]:bg-transparent',
           className

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -2330,12 +2330,12 @@ describe('App Component', () => {
     fireEvent.change(filterInput, { target: { value: '{"status":"active"}' } });
     expect(filterInput.value).toContain('"status"');
 
-    // Switch to orders — editor must reset to default {}, not carry over the filter.
+    // Switch to orders — editor must reset to the default empty filter, not carry over.
     fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
     await screen.findByText(/"Sample"/);
     fireEvent.click(screen.getByTestId('toggle-query-builder'));
     const ordersFilter = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
-    expect(ordersFilter.value).toBe('{}');
+    expect(ordersFilter.value).toBe('');
 
     // Type a different filter on orders.
     fireEvent.change(ordersFilter, { target: { value: '{"shipped":true}' } });

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -229,7 +229,7 @@ describe('DocumentViewer Component', () => {
     const clearBtn = screen.getByTitle('Clear Filter');
     fireEvent.click(clearBtn);
 
-    expect(filterInput).toHaveValue('{}');
+    expect(filterInput).toHaveValue('');
     expect(screen.getByText('Cleared filter parameters')).toBeInTheDocument();
   });
 
@@ -518,12 +518,12 @@ describe('DocumentViewer Component', () => {
     // Uncheck projection
     fireEvent.click(projectionCheckbox);
     expect(projectionCheckbox.checked).toBe(false);
-    expect(projectionInput.value).toBe('{}');
+    expect(projectionInput.value).toBe('');
 
     // Uncheck sort
     fireEvent.click(sortCheckbox);
     expect(sortCheckbox.checked).toBe(false);
-    expect(sortInput.value).toBe('{}');
+    expect(sortInput.value).toBe('');
 
     // Check projection back
     fireEvent.click(projectionCheckbox);

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -477,3 +477,69 @@ describe('getCompletions — per-stage body editor (stageOperator)', () => {
     expect(items.find((i) => i.label === '$region')!.insertText).toBe('"$region"');
   });
 });
+
+describe('getCompletions — shell-style suggestions (shellSyntax)', () => {
+  const dateSchema = new Map([['createdTime', { type: 'date' }]]);
+  const oidSchema = new Map([['_id', { type: 'objectId' }]]);
+
+  it('inserts a date field as an unquoted key with ISODate() when shellSyntax is on', () => {
+    const items = getCompletions(base({ surface: 'filter', shellSyntax: true, textBeforeCursor: '{ ', token: '', fields: ['createdTime'], schema: dateSchema }));
+    const f = items.find((i) => i.label === 'createdTime');
+    expect(f?.insertText).toBe('createdTime: ISODate("${1:2024-01-01T00:00:00Z}")');
+  });
+
+  it('inserts an objectId field with ObjectId() when shellSyntax is on', () => {
+    const items = getCompletions(base({ surface: 'filter', shellSyntax: true, textBeforeCursor: '{ ', token: '', fields: ['_id'], schema: oidSchema }));
+    const f = items.find((i) => i.label === '_id');
+    expect(f?.insertText).toBe('_id: ObjectId("${1:objectId}")');
+  });
+
+  it('quotes a dotted field key even in shell style', () => {
+    const schema = new Map([['mongo.ssl', { type: 'bool' }]]);
+    const items = getCompletions(base({ surface: 'filter', shellSyntax: true, textBeforeCursor: '{ ', token: '', fields: ['mongo.ssl'], schema }));
+    const f = items.find((i) => i.label === 'mongo.ssl');
+    expect(f?.insertText).toBe('"mongo.ssl": ${1:true}');
+  });
+
+  it('keeps EJSON/quoted style when shellSyntax is off (default)', () => {
+    const items = getCompletions(base({ surface: 'filter', textBeforeCursor: '{ ', token: '', fields: ['createdTime'], schema: dateSchema }));
+    const f = items.find((i) => i.label === 'createdTime');
+    expect(f?.insertText).toBe('"createdTime": {"\\$date": "${1:2024-01-01T00:00:00Z}"}');
+  });
+});
+
+describe('getCompletions — nested field paths', () => {
+  it('suggests a nested dotted path matching the typed dotted token', () => {
+    const items = getCompletions(base({
+      surface: 'filter',
+      textBeforeCursor: '{ "usage.to',
+      token: 'usage.to',
+      fields: ['_id', 'usage', 'usage.total', 'usage.featureTypeGroup'],
+    }));
+    expect(labels(items)).toContain('usage.total');
+    expect(labels(items)).not.toContain('usage.featureTypeGroup');
+  });
+});
+
+describe('getCompletions — shell-style projection/sort keys', () => {
+  it('projection field key is unquoted in shell style', () => {
+    const items = getCompletions(base({ surface: 'projection', shellSyntax: true, textBeforeCursor: '{ ', token: '', fields: ['total'] }));
+    const f = items.find((i) => i.label === 'total');
+    expect(f?.insertText).toBe('total: ${1|1,0|}');
+  });
+  it('sort field key is unquoted in shell style', () => {
+    const items = getCompletions(base({ surface: 'sort', shellSyntax: true, textBeforeCursor: '{ ', token: '', fields: ['createdAt'] }));
+    const f = items.find((i) => i.label === 'createdAt');
+    expect(f?.insertText).toBe('createdAt: ${1|1,-1|}');
+  });
+  it('projection dotted key stays quoted in shell style', () => {
+    const items = getCompletions(base({ surface: 'projection', shellSyntax: true, textBeforeCursor: '{ ', token: '', fields: ['usage.total'] }));
+    const f = items.find((i) => i.label === 'usage.total');
+    expect(f?.insertText).toBe('"usage.total": ${1|1,0|}');
+  });
+  it('projection field key stays quoted when shellSyntax is off', () => {
+    const items = getCompletions(base({ surface: 'projection', textBeforeCursor: '{ ', token: '', fields: ['total'] }));
+    const f = items.find((i) => i.label === 'total');
+    expect(f?.insertText).toBe('"total": ${1|1,0|}');
+  });
+});

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -66,8 +66,9 @@ describe('parseShellJson', () => {
   it('parses shell constructors into EJSON shapes', () => {
     expect(parseShellJson('{"_id": ObjectId("507f1f77bcf86cd799439011")}'))
       .toEqual({ _id: { $oid: '507f1f77bcf86cd799439011' } });
+    // EJSON.serialize normalizes the date string (same instant); .000 is dropped.
     expect(parseShellJson('{"when": {"$gte": ISODate("2025-01-04T00:00:00.000Z")}}'))
-      .toEqual({ when: { $gte: { $date: '2025-01-04T00:00:00.000Z' } } });
+      .toEqual({ when: { $gte: { $date: '2025-01-04T00:00:00Z' } } });
   });
   it('leaves EJSON wrappers untouched', () => {
     expect(parseShellJson('{"_id": {"$oid": "507f1f77bcf86cd799439011"}}'))
@@ -78,5 +79,46 @@ describe('parseShellJson', () => {
   });
   it('throws on invalid input', () => {
     expect(() => parseShellJson('{nope')).toThrow();
+  });
+});
+
+describe('parseShellJson — relaxed shell-style input (#216)', () => {
+  it('accepts unquoted keys', () => {
+    expect(parseShellJson('{ createdAt: 1 }')).toEqual({ createdAt: 1 });
+  });
+  it('accepts single-quoted keys and string values', () => {
+    expect(parseShellJson("{ 'name': 'Ada' }")).toEqual({ name: 'Ada' });
+  });
+  it('accepts a trailing comma', () => {
+    expect(parseShellJson('{ status: "active", }')).toEqual({ status: 'active' });
+  });
+  it('accepts unquoted operator keys', () => {
+    expect(parseShellJson('{ age: { $gte: 18 } }')).toEqual({ age: { $gte: 18 } });
+  });
+  it('combines unquoted keys with shell constructors', () => {
+    expect(parseShellJson('{ _id: ObjectId("507f1f77bcf86cd799439011") }'))
+      .toEqual({ _id: { $oid: '507f1f77bcf86cd799439011' } });
+  });
+  it('still supports quoted keys for dotted paths', () => {
+    expect(parseShellJson('{ "user.age": { $gt: 21 } }')).toEqual({ 'user.age': { $gt: 21 } });
+  });
+  it('still throws on genuinely malformed input', () => {
+    expect(() => parseShellJson('{ oops ')).toThrow();
+  });
+  it('accepts braceless field:value input (auto-wrapped)', () => {
+    expect(parseShellJson('datacenterId: "METROPOLITAN_DC"')).toEqual({ datacenterId: 'METROPOLITAN_DC' });
+  });
+  it('accepts a braceless multi-field filter', () => {
+    expect(parseShellJson('a: 1, b: 2')).toEqual({ a: 1, b: 2 });
+  });
+  it('evaluates safe arithmetic expressions (Compass loose mode)', () => {
+    expect(parseShellJson('{ limit: 2 * 3 }')).toEqual({ limit: 6 });
+  });
+  it('throws on an incomplete query (parser returns its empty-string sentinel)', () => {
+    // mongodb-query-parser returns '' for unparseable input instead of throwing;
+    // parseShellJson must surface that as an error so validation/Run reject it.
+    expect(() => parseShellJson('{ _id }')).toThrow();
+    expect(() => parseShellJson('type: "DEV", _id')).toThrow();
+    expect(() => parseShellJson('{ a: 1, b }')).toThrow();
   });
 });

--- a/src/lib/monacoMongo.ts
+++ b/src/lib/monacoMongo.ts
@@ -2,7 +2,7 @@ import type { Monaco } from '@monaco-editor/react';
 import { getCompletions, type Surface, type CompletionKind } from './mongoCompletions';
 import type { SchemaMap } from './useCollectionSchema';
 
-interface ModelMeta { surface: Surface; getFields: () => string[]; getSchema: () => SchemaMap | undefined; getCollections?: () => string[]; getStageOperator?: () => string | undefined; }
+interface ModelMeta { surface: Surface; getFields: () => string[]; getSchema: () => SchemaMap | undefined; getCollections?: () => string[]; getStageOperator?: () => string | undefined; shellSyntax?: boolean; }
 const modelMeta = new Map<string, ModelMeta>();
 let registered = false;
 
@@ -35,9 +35,10 @@ export function registerMongoCompletionProvider(monaco: Monaco) {
     d.setCompilerOptions({ ...d.getCompilerOptions(), lib: ['es2020'], allowNonTsExtensions: true });
   }
 
-  // Disable the built-in JSON language completions ($schema, etc.) so only our
-  // Mongo provider contributes in the filter/projection/sort/aggregation editors.
-  // Keep diagnostics/validation on.
+  // Belt-and-braces: also disable the built-in JSON language completions
+  // ($schema, etc.) in case any editor still uses JSON mode. The query editors
+  // themselves now run in JavaScript mode with diagnostics turned off (see
+  // QueryEditor), since query text is mongosh-style, not strict JSON.
   const json = (monaco.languages as unknown as { json?: any }).json;
   if (json?.jsonDefaults) {
     const jd = json.jsonDefaults;
@@ -61,11 +62,14 @@ export function registerMongoCompletionProvider(monaco: Monaco) {
         startLineNumber: position.lineNumber, startColumn: position.column,
         endLineNumber: position.lineNumber, endColumn: model.getLineMaxColumn(position.lineNumber),
       });
-      const token = textBeforeCursor.match(/[\w$]*$/)?.[0] ?? '';
+      // In the query surfaces a dotted field path (usage.total) is ONE token, so
+      // a half-typed nested key like "usage.to" matches and replaces the whole
+      // path. The shell surface keeps db.coll.method segmented (dot-free token).
+      const token = textBeforeCursor.match(meta.surface === 'shell' ? /[\w$]*$/ : /[\w$.]*$/)?.[0] ?? '';
       const items = getCompletions({
         surface: meta.surface, textBeforeCursor, textAfterCursor, token,
         fields: meta.getFields(), schema: meta.getSchema(), collections: meta.getCollections?.(),
-        stageOperator: meta.getStageOperator?.(),
+        stageOperator: meta.getStageOperator?.(), shellSyntax: meta.shellSyntax,
       });
       const range = {
         startLineNumber: position.lineNumber, endLineNumber: position.lineNumber,

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -15,6 +15,12 @@ export interface CompletionCtx {
   // OPERATOR'S BODY (e.g. the object after "$group":), so completions are
   // driven by the operator instead of guessing from the text.
   stageOperator?: string;
+  // When true, emit mongosh-style suggestions (bare keys + shell constructors
+  // like ISODate(…)) instead of EJSON (quoted keys + {"$date": …}). The main
+  // query bar sets this now that it parses shell syntax; JSON-only surfaces
+  // (mongodump --query, $jsonSchema validation) leave it off. Independent of
+  // `surface`, which still selects WHICH completions appear.
+  shellSyntax?: boolean;
 }
 
 export interface CompletionItem {
@@ -159,17 +165,31 @@ function inQuote(text: string): boolean {
   return /"[\w$.]*$/.test(text);
 }
 
-// Object keys (field names and $operators/$stages) must be quoted in the JSON
-// surfaces (filter/projection/sort/aggStage); the mongosh surface is JS, where
-// bare keys/identifiers are fine.
+// Whether to emit mongosh-style output (bare keys + shell constructors): the
+// dedicated shell surface, or any surface the caller marked shellSyntax (the
+// main query bar). `surface` still decides WHICH completions appear.
+function isShellStyle(ctx: CompletionCtx): boolean {
+  return ctx.surface === 'shell' || !!ctx.shellSyntax;
+}
+
+// A key safe to leave unquoted in shell style. Dotted paths ("mongo.ssl") and
+// other non-identifier keys still need quotes even in mongosh.
+function isBareIdentifier(s: string): boolean {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(s);
+}
+
+// Object keys (field names and $operators/$stages) are quoted in the JSON
+// surfaces (filter/projection/sort/aggStage); in shell style bare identifiers
+// stay unquoted, but dotted/special keys are still quoted.
 function keyInsert(ctx: CompletionCtx, s: string): string {
-  return ctx.surface !== 'shell' && !inQuote(ctx.textBeforeCursor) ? `"${s}"` : s;
+  if (isShellStyle(ctx) && isBareIdentifier(s)) return s;
+  return !inQuote(ctx.textBeforeCursor) ? `"${s}"` : s;
 }
 
 // Snippet-escaped key (`\$op`), quoted per surface; reuses keyInsert's rules.
 function snippetKey(ctx: CompletionCtx, key: string): string {
   const esc = key.startsWith('$') ? `\\${key}` : key;
-  if (ctx.surface === 'shell') return esc;
+  if (isShellStyle(ctx)) return esc;
   return inQuote(ctx.textBeforeCursor) ? `${esc}"` : `"${esc}"`;
 }
 
@@ -182,7 +202,7 @@ function opScaffoldItems(
   ctx: CompletionCtx, ops: string[], detail: string, mode: 'key' | 'value',
   table: Record<string, string> = OPERATOR_VALUE_SCAFFOLDS, kind: CompletionKind = 'operator',
 ): CompletionItem[] {
-  const shell = ctx.surface === 'shell';
+  const shell = isShellStyle(ctx);
   const fieldKey = mode === 'value' ? lastFieldKey(ctx.textBeforeCursor) : parentKeyOfOpenObject(ctx.textBeforeCursor);
   const ftype = fieldKey && !fieldKey.startsWith('$') ? ctx.schema?.get(fieldKey)?.type : undefined;
   const typed = ftype ? TYPE_VALUE_SCAFFOLDS[ftype] : undefined;
@@ -205,7 +225,8 @@ function fieldItems(ctx: CompletionCtx): CompletionItem[] {
 function choiceFieldItems(ctx: CompletionCtx, choices: string): CompletionItem[] {
   return ctx.fields.map((name) => {
     const fs = ctx.schema?.get(name);
-    const key = inQuote(ctx.textBeforeCursor) ? `${name}"` : `"${name}"`;
+    const bare = isShellStyle(ctx) && isBareIdentifier(name);
+    const key = bare ? name : inQuote(ctx.textBeforeCursor) ? `${name}"` : `"${name}"`;
     return { label: name, kind: 'field' as const, insertText: `${key}: \${1|${choices}|}`, detail: fs?.type, isSnippet: true };
   });
 }
@@ -245,14 +266,16 @@ export const TYPE_VALUE_SCAFFOLDS: Record<string, { json: string; shell: string 
 function typedFieldItems(ctx: CompletionCtx): CompletionItem[] {
   return ctx.fields.map((name) => {
     const fs = ctx.schema?.get(name);
-    const shell = ctx.surface === 'shell';
+    const shell = isShellStyle(ctx);
     const scaffold = fs?.type ? TYPE_VALUE_SCAFFOLDS[fs.type] : undefined;
     if (!scaffold) {
       return { label: name, kind: 'field' as const, insertText: keyInsert(ctx, name), detail: fs?.type };
     }
-    // keyInsert semantics inline: shell keys are bare; in JSON we open a quote
-    // unless the user already typed one, and always close it before the colon.
-    const key = shell ? name : inQuote(ctx.textBeforeCursor) ? `${name}"` : `"${name}"`;
+    // Shell style leaves a bare-identifier key unquoted (but still quotes a
+    // dotted path); JSON opens a quote unless the user already typed one, and
+    // always closes it before the colon.
+    const bare = shell && isBareIdentifier(name);
+    const key = bare ? name : inQuote(ctx.textBeforeCursor) ? `${name}"` : `"${name}"`;
     return { label: name, kind: 'field' as const, insertText: `${key}: ${shell ? scaffold.shell : scaffold.json}`, detail: fs?.type, isSnippet: true };
   });
 }

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -3,7 +3,8 @@
 // to Extended JSON for the backend on save. The display accepts both BSON
 // instances and EJSON-shaped plain objects; the save path is string-tokenized so
 // constructor-looking text inside string values is left untouched.
-import { ObjectId, Long, Decimal128, Int32, Double } from 'bson';
+import { ObjectId, Long, Decimal128, Int32, Double, EJSON } from 'bson';
+import { parseFilter } from 'mongodb-query-parser';
 
 const isPlainObject = (v: any): boolean => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -77,10 +78,49 @@ function ctorToEjson(name: string, arg: string): string {
   }
 }
 
-// Parse user query text that may mix JSON, EJSON wrappers, and shell
-// constructors (ObjectId(…), ISODate(…)) — the query bar accepts all three.
+// Parse query-bar text the way MongoDB Compass does — via mongodb-query-parser
+// (backed by @mongodb-js/shell-bson-parser in Loose mode). That accepts the full
+// mongosh query style: unquoted keys, single quotes, trailing commas, BSON
+// constructors (ObjectId(…), ISODate(…), NumberLong(…), UUID(…), …) and safe
+// expressions (e.g. `2 * 3`, `Math.max(…)`), with AST-validated, sandboxed
+// evaluation (no arbitrary code execution). A braceless field list like
+// `foo: 1` is wrapped into an object first, so double quotes and braces are
+// both optional. Malformed input throws, same as before.
+//
+// The parser returns real BSON values; we re-serialize to an EJSON-shaped plain
+// object (via EJSON.serialize) so every caller can keep JSON.stringify-ing the
+// result to the backend — the output contract is unchanged.
 export function parseShellJson(text: string): any {
-  return JSON.parse(shellToEjson(text));
+  const trimmed = text.trim();
+  if (!trimmed) return {};
+  // parseFilter signals "unparseable / not a valid query" by returning an empty
+  // string rather than throwing (e.g. `{ _id }`, a half-typed field). Surface
+  // that as an error so callers (live validation + Run) reject it instead of
+  // shipping `""` to the backend. A user who literally typed `""`/`''` (a rare
+  // empty-string stage body) is left alone.
+  const attempt = (s: string) => {
+    const result = parseFilter(s);
+    if (result === '' && !/^(['"])\1$/.test(s.trim())) {
+      throw new SyntaxError('Invalid query');
+    }
+    return result;
+  };
+  try {
+    return EJSON.serialize(attempt(trimmed));
+  } catch (err) {
+    // A braceless field list like `foo: 1` isn't a valid standalone expression;
+    // wrap it into an object and retry. Bare values (a `$count` stage body of
+    // `"n"`, a number, an array) parse on the first try, so they never reach
+    // here. Anything still unparseable re-throws the original error.
+    if (!/^[{[]/.test(trimmed)) {
+      try {
+        return EJSON.serialize(attempt(`{${trimmed}}`));
+      } catch {
+        /* fall through to re-throw the original error */
+      }
+    }
+    throw err;
+  }
 }
 
 // shell-style source text -> Extended JSON string. String literals are copied


### PR DESCRIPTION
Closes #216 (part of #215 item 1a).

## Problem
The query bar required strict JSON, rejecting normal mongosh-style input — unquoted keys (`{ createdAt: 1 }`), single quotes, trailing commas, and a **braceless** field list like `type: "DC"`.

## Fix
Parse the query bar **the way MongoDB Compass does** — via `mongodb-query-parser` (backed by `@mongodb-js/shell-bson-parser` in **Loose** mode). `parseShellJson` (`src/lib/shellDoc.ts`) now accepts the full mongosh query style:

- unquoted keys, single quotes, trailing commas
- BSON constructors: `ObjectId()`, `ISODate()`, `NumberLong()`, `UUID()`, `BinData()`, …
- safe expressions: `2 * 3`, `Math.max(…)`
- a **braceless** field list (`foo: 1`) — auto-wrapped into `{ foo: 1 }`

Parsing is **AST-validated and sandboxed** (no arbitrary code execution) — the same approach Compass relies on for untrusted input.

### Why not the simpler JSON5 swap
An earlier revision of this PR relaxed the final parse to JSON5. It handled unquoted keys/quotes/commas but **not** braceless input (your screenshot: `JSON5: invalid character 'd'`), expressions, or the full BSON constructor set. Compass's parser covers all of it — this is the right long-term choice.

## Integration / contract
`parseShellJson` returns real BSON from the parser but **re-serializes to an EJSON-shaped plain object** (`EJSON.serialize`), so the ~13 call sites keep `JSON.stringify`-ing to the backend with **zero changes**. `shellToEjson` (the document-editor save path, used by `DocumentEditModal`) is untouched. Braceless wrapping only triggers when the raw value fails to parse, so bare stage bodies — a `$count` body of `"n"`, numbers, arrays — are preserved (this was a real bug caught by the suite and fixed).

## Safety (impact was HIGH — 13 callers)
- **Full suite green: 78 files, 1104 passing**; production build clean. That exercises the aggregate builder, save-query/set-default, explain, and DataGrid paths.
- One existing test updated: an EJSON date string normalizes `…00:00:00.000Z` → `…00:00:00Z` (same instant).

## Please verify locally (I have no mongod here)
1. A **date** query still returns results (the EJSON date string is now `…Z` without `.000`; bson's own EJSON emitter uses this form, so it should round-trip — worth a quick check).
2. Braceless input like `datacenterId: "…"` runs and clears the live-validation error.

## Dependency
Replaces `json5` with `mongodb-query-parser@^4.7.15` (Compass's parser; pulls in `@mongodb-js/shell-bson-parser` + acorn). Heavier than json5 but purpose-built and battle-tested. Ships its own types.
