### PR TITLE
fix(query): address PR #222 review (precision, non-object gating, quoted-key completion, Buffer)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "bson": "^7.2.0",
+        "buffer": "^6.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3573,6 +3574,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.32",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
@@ -3637,6 +3658,30 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4162,6 +4207,26 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/immer": {
       "version": "10.2.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "bson": "^7.2.0",
+    "buffer": "^6.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -4,7 +4,7 @@ import { QueryEditor } from './QueryEditor';
 import { FindQueryBar } from './FindQueryBar';
 import { useCollectionSchema } from '../lib/useCollectionSchema';
 import { collectionRef, type GeneratedQuery } from '../lib/mongoCommand';
-import { parseShellJson } from '../lib/shellDoc';
+import { parseShellJson, parseQueryObject } from '../lib/shellDoc';
 import {
   loadCollectionQueries,
   saveQuery,
@@ -794,11 +794,11 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   // Autocomplete field list = top-level keys seen in the results PLUS the
   // schema analyzer's dotted nested paths (usage.total, usage.featureTypeGroup,
   // …), so nested keys are suggested too. De-duped, order: results first.
-  const fields = (() => {
+  const fields = useMemo(() => {
     const set = new Set<string>(availableFields);
     for (const key of schema.keys()) set.add(key);
     return set.size > 0 ? [...set] : ['_id'];
-  })();
+  }, [availableFields, schema]);
 
   // Validation states
   const [isFilterValid, setIsFilterValid] = useState(true);
@@ -808,7 +808,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   useEffect(() => {
     try {
       if (filterQuery.trim()) {
-        parseShellJson(filterQuery);
+        parseQueryObject(filterQuery);
       }
       setIsFilterValid(true);
     } catch {
@@ -819,7 +819,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   useEffect(() => {
     try {
       if (projectionQuery.trim()) {
-        parseShellJson(projectionQuery);
+        parseQueryObject(projectionQuery);
       }
       setIsProjectionValid(true);
     } catch {
@@ -830,7 +830,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   useEffect(() => {
     try {
       if (sortQuery.trim()) {
-        parseShellJson(sortQuery);
+        parseQueryObject(sortQuery);
       }
       setIsSortValid(true);
     } catch {
@@ -1180,12 +1180,12 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     setError(null);
     try {
       if (queryMode === 'find') {
-        const parsedFilter = filterQuery.trim() ? parseShellJson(filterQuery) : {};
-        const parsedSort = sortQuery.trim() ? parseShellJson(sortQuery) : {};
+        const parsedFilter = filterQuery.trim() ? parseQueryObject(filterQuery) : {};
+        const parsedSort = sortQuery.trim() ? parseQueryObject(sortQuery) : {};
         // Only send a projection when the user has enabled one.
         const parsedProjection =
           isProjectionEnabled && projectionQuery.trim() && projectionQuery.trim() !== '{}'
-            ? parseShellJson(projectionQuery)
+            ? parseQueryObject(projectionQuery)
             : {};
 
         onExecute({
@@ -1274,7 +1274,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     setExplainLoading(true);
     try {
       if (queryMode === 'find') {
-        const parsedFilter = filterQuery.trim() ? parseShellJson(filterQuery) : {};
+        const parsedFilter = filterQuery.trim() ? parseQueryObject(filterQuery) : {};
         await onExplain(JSON.stringify(parsedFilter));
       } else if (onExplainAggregate) {
         // Explain the FULL pipeline (M1), not just a collapsed $match.

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -825,6 +825,16 @@ export const MongoShell: React.FC<MongoShellProps> = ({
               });
               editor.focus();
               registerMongoCompletionProvider(monaco);
+              // mongosh is a REPL, not a linter: like the real shell we don't
+              // statically red-squiggle in-progress JS (errors surface on run).
+              // Explicit here so the behavior is intentional and independent of
+              // whether a query editor (which disables diagnostics globally) has
+              // mounted first.
+              monaco.languages.typescript?.javascriptDefaults?.setDiagnosticsOptions({
+                noSemanticValidation: true,
+                noSyntaxValidation: true,
+                noSuggestionDiagnostics: true,
+              });
               const model = editor.getModel();
               if (model) {
                 const uri = model.uri.toString();

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -58,6 +58,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   const schemaRef = useRef(schema); schemaRef.current = schema;
   const onRunRef = useRef(onRun); onRunRef.current = onRun;
   const stageOperatorRef = useRef(stageOperator); stageOperatorRef.current = stageOperator;
+  const shellSyntaxRef = useRef(shellSyntax); shellSyntaxRef.current = shellSyntax;
   const uriRef = useRef<string | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
   const theme = useMonacoTheme();
@@ -181,7 +182,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
             getFields: () => fieldsRef.current,
             getSchema: () => schemaRef.current,
             getStageOperator: () => stageOperatorRef.current,
-            shellSyntax,
+            getShellSyntax: () => shellSyntaxRef.current,
           });
           ed.onDidDispose(() => { if (uriRef.current) clearModelMeta(uriRef.current); });
         }

--- a/src/lib/__tests__/mongoCompletions.test.ts
+++ b/src/lib/__tests__/mongoCompletions.test.ts
@@ -543,3 +543,16 @@ describe('getCompletions — shell-style projection/sort keys', () => {
     expect(f?.insertText).toBe('"total": ${1|1,0|}');
   });
 });
+
+describe('getCompletions — shell keys respect an already-typed quote (#222 review)', () => {
+  it('filter: closes the quote instead of inserting a bare key when inQuote', () => {
+    const items = getCompletions(base({ surface: 'filter', shellSyntax: true, textBeforeCursor: '{ "', token: '', fields: ['createdTime'], schema: new Map([['createdTime', { type: 'date' }]]) }));
+    const f = items.find((i) => i.label === 'createdTime');
+    expect(f?.insertText).toBe('createdTime": ISODate("${1:2024-01-01T00:00:00Z}")');
+  });
+  it('projection: closes the quote when inQuote', () => {
+    const items = getCompletions(base({ surface: 'projection', shellSyntax: true, textBeforeCursor: '{ "', token: '', fields: ['total'] }));
+    const f = items.find((i) => i.label === 'total');
+    expect(f?.insertText).toBe('total": ${1|1,0|}');
+  });
+});

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ObjectId, Long, Decimal128, Int32 } from 'bson';
-import { docToShell, shellToEjson, parseShellJson } from '../shellDoc';
+import { docToShell, shellToEjson, parseShellJson, parseQueryObject } from '../shellDoc';
 
 describe('docToShell', () => {
   it('renders EJSON-shaped values as shell constructors', () => {
@@ -120,5 +120,28 @@ describe('parseShellJson — relaxed shell-style input (#216)', () => {
     expect(() => parseShellJson('{ _id }')).toThrow();
     expect(() => parseShellJson('type: "DEV", _id')).toThrow();
     expect(() => parseShellJson('{ a: 1, b }')).toThrow();
+  });
+});
+
+describe('parseQueryObject — reject non-object queries (#222 review)', () => {
+  it('accepts a plain object and empty', () => {
+    expect(parseQueryObject('{ a: 1 }')).toEqual({ a: 1 });
+    expect(parseQueryObject('')).toEqual({});
+  });
+  it('rejects bare values, numbers, strings, arrays, expressions', () => {
+    expect(() => parseQueryObject('5')).toThrow();
+    expect(() => parseQueryObject('"active"')).toThrow();
+    expect(() => parseQueryObject('[1,2,3]')).toThrow();
+    expect(() => parseQueryObject('2*3')).toThrow();
+  });
+});
+
+describe('parseShellJson — NumberLong precision (#222 review)', () => {
+  it('preserves a 64-bit NumberLong beyond 2^53 (canonical when a Long is present)', () => {
+    expect(parseShellJson('{ n: NumberLong("9223372036854775807") }'))
+      .toEqual({ n: { $numberLong: '9223372036854775807' } });
+  });
+  it('keeps small numbers in clean relaxed form', () => {
+    expect(parseShellJson('{ a: 1 }')).toEqual({ a: 1 });
   });
 });

--- a/src/lib/monacoMongo.ts
+++ b/src/lib/monacoMongo.ts
@@ -2,7 +2,7 @@ import type { Monaco } from '@monaco-editor/react';
 import { getCompletions, type Surface, type CompletionKind } from './mongoCompletions';
 import type { SchemaMap } from './useCollectionSchema';
 
-interface ModelMeta { surface: Surface; getFields: () => string[]; getSchema: () => SchemaMap | undefined; getCollections?: () => string[]; getStageOperator?: () => string | undefined; shellSyntax?: boolean; }
+interface ModelMeta { surface: Surface; getFields: () => string[]; getSchema: () => SchemaMap | undefined; getCollections?: () => string[]; getStageOperator?: () => string | undefined; getShellSyntax?: () => boolean | undefined; }
 const modelMeta = new Map<string, ModelMeta>();
 let registered = false;
 
@@ -69,7 +69,7 @@ export function registerMongoCompletionProvider(monaco: Monaco) {
       const items = getCompletions({
         surface: meta.surface, textBeforeCursor, textAfterCursor, token,
         fields: meta.getFields(), schema: meta.getSchema(), collections: meta.getCollections?.(),
-        stageOperator: meta.getStageOperator?.(), shellSyntax: meta.shellSyntax,
+        stageOperator: meta.getStageOperator?.(), shellSyntax: meta.getShellSyntax?.(),
       });
       const range = {
         startLineNumber: position.lineNumber, endLineNumber: position.lineNumber,

--- a/src/lib/mongoCompletions.ts
+++ b/src/lib/mongoCompletions.ts
@@ -182,14 +182,17 @@ function isBareIdentifier(s: string): boolean {
 // surfaces (filter/projection/sort/aggStage); in shell style bare identifiers
 // stay unquoted, but dotted/special keys are still quoted.
 function keyInsert(ctx: CompletionCtx, s: string): string {
-  if (isShellStyle(ctx) && isBareIdentifier(s)) return s;
+  // Bare (unquoted) only in shell style AND when the user hasn't already opened
+  // a quote — otherwise `"cre`+accept would insert a bare key after the quote
+  // and corrupt the text. If a quote is open, fall through and close it.
+  if (isShellStyle(ctx) && isBareIdentifier(s) && !inQuote(ctx.textBeforeCursor)) return s;
   return !inQuote(ctx.textBeforeCursor) ? `"${s}"` : s;
 }
 
 // Snippet-escaped key (`\$op`), quoted per surface; reuses keyInsert's rules.
 function snippetKey(ctx: CompletionCtx, key: string): string {
   const esc = key.startsWith('$') ? `\\${key}` : key;
-  if (isShellStyle(ctx)) return esc;
+  if (isShellStyle(ctx) && !inQuote(ctx.textBeforeCursor)) return esc;
   return inQuote(ctx.textBeforeCursor) ? `${esc}"` : `"${esc}"`;
 }
 
@@ -225,7 +228,7 @@ function fieldItems(ctx: CompletionCtx): CompletionItem[] {
 function choiceFieldItems(ctx: CompletionCtx, choices: string): CompletionItem[] {
   return ctx.fields.map((name) => {
     const fs = ctx.schema?.get(name);
-    const bare = isShellStyle(ctx) && isBareIdentifier(name);
+    const bare = isShellStyle(ctx) && isBareIdentifier(name) && !inQuote(ctx.textBeforeCursor);
     const key = bare ? name : inQuote(ctx.textBeforeCursor) ? `${name}"` : `"${name}"`;
     return { label: name, kind: 'field' as const, insertText: `${key}: \${1|${choices}|}`, detail: fs?.type, isSnippet: true };
   });
@@ -274,7 +277,7 @@ function typedFieldItems(ctx: CompletionCtx): CompletionItem[] {
     // Shell style leaves a bare-identifier key unquoted (but still quotes a
     // dotted path); JSON opens a quote unless the user already typed one, and
     // always closes it before the colon.
-    const bare = shell && isBareIdentifier(name);
+    const bare = shell && isBareIdentifier(name) && !inQuote(ctx.textBeforeCursor);
     const key = bare ? name : inQuote(ctx.textBeforeCursor) ? `${name}"` : `"${name}"`;
     return { label: name, kind: 'field' as const, insertText: `${key}: ${shell ? scaffold.shell : scaffold.json}`, detail: fs?.type, isSnippet: true };
   });
@@ -512,7 +515,9 @@ export function getCompletions(ctx: CompletionCtx): CompletionItem[] {
   // enum values, EJSON wrappers + shell constructors (the query bar parses
   // both; the JS shell gets constructors only), operators with value shapes.
   if (atValuePosition(textBeforeCursor)) {
-    const typed = surface === 'shell'
+    // Shell-style surfaces get constructor suggestions only (ISODate(…)); EJSON
+    // wrappers ({"$oid": …}) would just be noisy duplicates there.
+    const typed = isShellStyle(ctx)
       ? snippetItems(SHELL_VALUE_CTORS, 'method')
       : [...ejsonValueItems(ctx), ...snippetItems(SHELL_VALUE_CTORS, 'method')];
     return byPrefix([...enumItemsForLastField(ctx), ...typed, ...opScaffoldItems(ctx, QUERY_OPERATORS, 'query operator', 'value')], token);

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -88,8 +88,22 @@ function ctorToEjson(name: string, arg: string): string {
 // both optional. Malformed input throws, same as before.
 //
 // The parser returns real BSON values; we re-serialize to an EJSON-shaped plain
-// object (via EJSON.serialize) so every caller can keep JSON.stringify-ing the
-// result to the backend — the output contract is unchanged.
+// object so every caller can keep JSON.stringify-ing the result to the backend
+// — the output contract is unchanged.
+//
+// Relaxed EJSON keeps the output clean, but it collapses a 64-bit Long to a JS
+// double, silently corrupting values beyond 2^53 (e.g. a big id/counter). So we
+// serialize canonically ONLY when a Long is actually present, keeping the clean
+// relaxed form for the common case.
+function containsLong(v: any): boolean {
+  if (v == null || typeof v !== 'object') return false;
+  if ((v as { _bsontype?: string })._bsontype === 'Long') return true;
+  if (Array.isArray(v)) return v.some(containsLong);
+  return Object.values(v).some(containsLong);
+}
+function serializeQuery(v: any): any {
+  return EJSON.serialize(v, { relaxed: !containsLong(v) });
+}
 export function parseShellJson(text: string): any {
   const trimmed = text.trim();
   if (!trimmed) return {};
@@ -106,7 +120,7 @@ export function parseShellJson(text: string): any {
     return result;
   };
   try {
-    return EJSON.serialize(attempt(trimmed));
+    return serializeQuery(attempt(trimmed));
   } catch (err) {
     // A braceless field list like `foo: 1` isn't a valid standalone expression;
     // wrap it into an object and retry. Bare values (a `$count` stage body of
@@ -114,13 +128,28 @@ export function parseShellJson(text: string): any {
     // here. Anything still unparseable re-throws the original error.
     if (!/^[{[]/.test(trimmed)) {
       try {
-        return EJSON.serialize(attempt(`{${trimmed}}`));
+        return serializeQuery(attempt(`{${trimmed}}`));
       } catch {
         /* fall through to re-throw the original error */
       }
     }
     throw err;
   }
+}
+
+// A find filter / sort / projection MUST be a document (plain object). The
+// parser otherwise happily accepts a bare value, number, string, array, or
+// expression (e.g. `5`, `"active"`, `[1,2,3]`, `2*3`), which then reaches the
+// backend and fails with a cryptic "got String instead" BSON error. Throwing
+// here lets the live validation flag the field and Run stay disabled. Empty
+// input is a valid empty query ({}). Not for aggregation stage bodies, which
+// can legitimately be non-objects (e.g. a `$count` body of "n").
+export function parseQueryObject(text: string): any {
+  const parsed = parseShellJson(text);
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new SyntaxError('Query must be an object');
+  }
+  return parsed;
 }
 
 // shell-style source text -> Extended JSON string. String literals are copied

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,11 @@
+// The system webview (WKWebView / WebView2 / WebKitGTK) has no Node `Buffer`,
+// which @mongodb-js/shell-bson-parser needs to parse UUID(…) / BinData(…) in the
+// query bar. Provide it before anything that might parse a query loads.
+import { Buffer } from "buffer";
+if (typeof (globalThis as { Buffer?: unknown }).Buffer === "undefined") {
+  (globalThis as { Buffer?: unknown }).Buffer = Buffer;
+}
+
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";


### PR DESCRIPTION
Follow-up to #222 (already merged). An independent multi-lens review of that PR found four real gaps; this fixes them.

## 🔴 Important
- **Non-document queries bypassed gating.** A bare `5`, `"active"`, `[1,2,3]`, or `2*3` parsed as "valid", so Run stayed enabled and the value hit the backend → the cryptic `BSON conversion error: got String instead` the gating was meant to prevent. Added `parseQueryObject` (rejects non-objects) on the filter/sort/projection **validation, Run, and Explain** paths. Aggregation stage bodies still allow non-objects (e.g. a `$count` body of `"n"`).
- **NumberLong precision loss.** Relaxed EJSON collapsed 64-bit `Long` to a JS double — `NumberLong("9223372036854775807")` → `9223372036854776000`. Now serialize **canonically only when a `Long` is present**, keeping clean relaxed output otherwise.
- **Quoted-key completion corruption.** With shell-style keys, accepting a suggestion after the user had typed an opening `"` inserted a bare key → `"createdTime: ISODate(…)` (mismatched quote). Now go bare only when *not* `inQuote`; otherwise close the quote.

## 🟠 Medium
- **`UUID()` / `BinData()` threw "Buffer is not defined"** in the system webview (`shell-bson-parser` uses Node's `Buffer`, no polyfill). Autocomplete offered them and the doc claimed support. Shim `globalThis.Buffer` in `main.tsx` (adds `buffer`).
- **mongosh lost JS squiggles** because the query editor disables Monaco diagnostics globally. Made it **intentional & self-contained** in MongoShell — like the real REPL, mongosh errors on run, not statically. (Monaco's toggle is global, so preserving mongosh squiggles would need a custom language and would cost the query bar's syntax highlighting.)

## ⚪ Minor
- Value-position completions no longer show duplicate EJSON + shell forms with shellSyntax on.
- Memoize the completion field-list merge (was rebuilt every keystroke).
- `shellSyntax` read via a live getter, consistent with the other model-meta getters.

## Verification
Build clean; full suite **1120 passing** (+6 new tests: non-object rejection, NumberLong precision, quoted-key completion). Adds `buffer`.
