### PR TITLE
fix(grid): copy ObjectId as hex and Date as ISO, not the EJSON wrapper (#220)

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -10,6 +10,7 @@ import { generateQueryCode, CODE_LANGUAGES, CODE_LANGUAGE_MONACO_IDS, type CodeL
 import { suggestESRIndex, type IndexSuggestion } from '../lib/indexSuggestions';
 import { useMonacoTheme } from '../lib/useMonacoTheme';
 import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
+import { copyValueToText } from '../lib/copyValue';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useThemeOptional } from '@/hooks/use-theme';
@@ -498,13 +499,6 @@ export const DataGrid: React.FC<DataGridProps> = ({
   const writeClipboard = (text: string) => {
     try { navigator.clipboard?.writeText(text); } catch { /* clipboard unavailable */ }
   };
-  const valueToText = (v: any): string => {
-    if (v === null || v === undefined) return '';
-    if (typeof v === 'object') {
-      try { return EJSON.stringify(v); } catch { return JSON.stringify(v); }
-    }
-    return String(v);
-  };
   const openCtxMenu = (
     e: React.MouseEvent,
     doc: Record<string, any> | undefined,
@@ -552,7 +546,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
       });
     }
     if (m.field) {
-      items.push({ label: 'Copy value', icon: <Copy size={13} />, separatorBefore: true, onClick: () => writeClipboard(valueToText(m.value)) });
+      items.push({ label: 'Copy value', icon: <Copy size={13} />, separatorBefore: true, onClick: () => writeClipboard(copyValueToText(m.value)) });
       items.push({ label: 'Copy field name', icon: <Copy size={13} />, onClick: () => writeClipboard(m.field!) });
     }
     if (onDeleteDocument) items.push({ label: 'Delete document', icon: <Trash2 size={13} />, danger: true, separatorBefore: true, onClick: () => onDeleteDocument(m.doc), disabled: isReadOnly, title: isReadOnly ? READ_ONLY_TOOLTIP : undefined });

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -354,6 +354,17 @@ describe('DataGrid Component', () => {
     expect(writeText).toHaveBeenCalledWith('Alice Smith');
   });
 
+  it('copies an ObjectId cell as the raw hex, not the EJSON wrapper (#220)', () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    render(<DataGrid documents={mockDocuments} onEditDocument={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    // The _id cell renders as the bare hex string; right-click it and copy.
+    fireEvent.contextMenu(screen.getByText('603d779f4f102e3a185c3220'));
+    fireEvent.click(screen.getByText('Copy value'));
+    expect(writeText).toHaveBeenCalledWith('603d779f4f102e3a185c3220');
+  });
+
   it('shows the same context menu in the JSON view', () => {
     render(<DataGrid documents={mockDocuments} onEditDocument={() => {}} onDeleteDocument={() => {}} />);
     fireEvent.click(screen.getByRole('button', { name: /json/i }));

--- a/src/lib/__tests__/copyValue.test.ts
+++ b/src/lib/__tests__/copyValue.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { ObjectId, Long, Decimal128 } from 'bson';
+import { copyValueToText } from '../copyValue';
+
+describe('copyValueToText', () => {
+  it('copies an ObjectId as its hex string', () => {
+    expect(copyValueToText(new ObjectId('507f1f77bcf86cd799439011'))).toBe('507f1f77bcf86cd799439011');
+    expect(copyValueToText({ $oid: '507f1f77bcf86cd799439011' })).toBe('507f1f77bcf86cd799439011');
+  });
+
+  it('copies a Date as an ISO-8601 string', () => {
+    expect(copyValueToText(new Date('2026-06-02T03:45:55.902Z'))).toBe('2026-06-02T03:45:55.902Z');
+    expect(copyValueToText({ $date: '2026-06-02T03:45:55.902Z' })).toBe('2026-06-02T03:45:55.902Z');
+    expect(copyValueToText({ $date: { $numberLong: '1780371955902' } })).toBe('2026-06-02T03:45:55.902Z');
+  });
+
+  it('copies numeric BSON wrappers as their plain number', () => {
+    expect(copyValueToText(Long.fromString('9007199254740993'))).toBe('9007199254740993');
+    expect(copyValueToText({ $numberLong: '9007199254740993' })).toBe('9007199254740993');
+    expect(copyValueToText(Decimal128.fromString('12.50'))).toBe('12.50');
+    expect(copyValueToText({ $numberDecimal: '12.50' })).toBe('12.50');
+  });
+
+  it('passes plain scalars through as strings', () => {
+    expect(copyValueToText('Alice')).toBe('Alice');
+    expect(copyValueToText(42)).toBe('42');
+    expect(copyValueToText(true)).toBe('true');
+    expect(copyValueToText(null)).toBe('');
+    expect(copyValueToText(undefined)).toBe('');
+  });
+
+  it('falls back to EJSON for nested objects/arrays', () => {
+    expect(copyValueToText({ a: 1, b: [1, 2] })).toContain('"a"');
+    expect(copyValueToText([1, 2, 3])).toBe('[1,2,3]');
+  });
+});

--- a/src/lib/copyValue.ts
+++ b/src/lib/copyValue.ts
@@ -1,0 +1,38 @@
+import { EJSON, ObjectId, Long, Decimal128, Int32, Double } from 'bson';
+
+// Text placed on the clipboard by the grid's "Copy value" action. ObjectId and
+// Date (and the numeric BSON types) copy as their raw scalar — the hex string,
+// an ISO-8601 date, a plain number — instead of the EJSON wrapper
+// ({"$oid":…} / {"$date":{"$numberLong":…}}), so the value pastes cleanly into a
+// query or document. Mirrors renderColoredCell so "copy" matches what's shown,
+// and handles both real BSON instances (tree / JSON views) and the canonical
+// plain shapes the backend sends (table view). Nested objects/arrays fall back
+// to EJSON.
+export function copyValueToText(v: any): string {
+  if (v === null || v === undefined) return '';
+  if (typeof v !== 'object') return String(v);
+
+  // Real BSON instances (tree / JSON views parse documents into these).
+  if (v instanceof ObjectId) return v.toString();
+  if (v instanceof Date) return v.toISOString();
+  if (v instanceof Long || v instanceof Decimal128 || v instanceof Int32 || v instanceof Double) {
+    return v.toString();
+  }
+
+  // Canonical extended-JSON shapes (table view uses the raw backend documents).
+  if (typeof v.$oid === 'string') return v.$oid;
+  if (v.$date !== undefined) {
+    if (typeof v.$date === 'string') return v.$date;
+    if (v.$date?.$numberLong) return new Date(Number(v.$date.$numberLong)).toISOString();
+  }
+  if (v.$numberLong !== undefined) return String(v.$numberLong);
+  if (v.$numberDecimal !== undefined) return String(v.$numberDecimal);
+  if (v.$numberInt !== undefined) return String(v.$numberInt);
+  if (v.$numberDouble !== undefined) return String(v.$numberDouble);
+
+  try {
+    return EJSON.stringify(v);
+  } catch {
+    return JSON.stringify(v);
+  }
+}


### PR DESCRIPTION
Closes #220 (part of #215 item 4).

## Problem
'Copy value' on an ObjectId copied `{"$oid":"6a1e...498d"}` and a Date copied `{"$date":{"$numberLong":"..."}}` — unusable when pasting into a query or document.

## Fix
Extracted the clipboard text into a pure `copyValueToText` (src/lib/copyValue.ts) that unwraps:
- **ObjectId → hex** (`6a1e...498d`)
- **Date → ISO-8601** (`2026-06-02T03:45:55.902Z`)
- numeric BSON types → their plain number

…handling both real BSON instances (tree/JSON views) and the canonical `{$oid}`/`{$date}` shapes the backend sends (table view), so **copy matches what's displayed**. Nested objects/arrays still fall back to EJSON. One function, shared by all three views.

## Tests
- New unit tests for `copyValueToText` (ObjectId, Date incl. `$numberLong`, numeric wrappers, scalars, nested fallback).
- Integration test: copying an `_id` cell yields the raw hex, not the wrapper.
- Full suite 1126 passing.