### PR TITLE
fix(grid): keep table header aligned with the body when columns overflow (#219)

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -560,6 +560,30 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // column set changes per collection); the tree view's key column persists.
   const [colWidths, setColWidths] = useState<Record<string, number>>({});
   const colWidth = (col: string) => colWidths[col] ?? 180;
+  // The table header and the virtualized body are separate boxes: only the body
+  // scrolls. Once resized columns overflow the viewport the header would stay
+  // put and its cells would sit at a different x-offset than the rows, so mirror
+  // the body's horizontal scroll onto the header.
+  const tableHeaderRef = React.useRef<HTMLDivElement>(null);
+  const tableBodyRef = React.useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const body = tableBodyRef.current;
+    if (!body) return;
+    // Scroll events don't bubble, but they DO propagate during the capture
+    // phase — and the virtualized List renders its own overflow:auto scroller,
+    // so the element that actually scrolls sideways may be this wrapper or that
+    // inner div. Listening in capture catches either. Only the box that can
+    // actually scroll horizontally drives the header, so the vertical scroller
+    // doesn't reset it to 0.
+    const onScroll = (e: Event) => {
+      const target = e.target as HTMLElement | null;
+      const header = tableHeaderRef.current;
+      if (!header || !target || !(target instanceof HTMLElement)) return;
+      if (target.scrollWidth > target.clientWidth) header.scrollLeft = target.scrollLeft;
+    };
+    body.addEventListener('scroll', onScroll, true);
+    return () => body.removeEventListener('scroll', onScroll, true);
+  }, [viewMode]);
   const [treeKeyWidth, setTreeKeyWidth] = useState<number>(() => {
     const saved = Number(localStorage.getItem('mqlens-treekey-width'));
     return saved >= 140 && saved <= 800 ? saved : 320;
@@ -1471,7 +1495,16 @@ export const DataGrid: React.FC<DataGridProps> = ({
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             {viewMode === 'table' && (
               /* Table Headers */
-              <div className="flex h-6 shrink-0 select-none items-center border-b border-border bg-sidebar text-ui-2xs font-bold uppercase tracking-wider text-muted-foreground">
+              <div
+                ref={tableHeaderRef}
+                data-testid="table-header"
+                // overflow-hidden makes this a scroll container so its scrollLeft
+                // can be driven by the body; scrollbar-gutter keeps its usable
+                // width equal to the body's, so the two stay aligned at the far
+                // right too (where the body's vertical scrollbar eats space).
+                className="flex h-6 shrink-0 select-none items-center overflow-hidden border-b border-border bg-sidebar text-ui-2xs font-bold uppercase tracking-wider text-muted-foreground"
+                style={{ scrollbarGutter: 'stable' }}
+              >
                 <div className="flex items-center justify-center border-r border-border w-12 flex-shrink-0">
                   #
                 </div>
@@ -1494,7 +1527,12 @@ export const DataGrid: React.FC<DataGridProps> = ({
             )}
 
             {/* Virtualized list */}
-            <div className="min-h-0 flex-1 min-w-0 overflow-auto">
+            <div
+              ref={tableBodyRef}
+              data-testid="table-body-scroll"
+              className="min-h-0 flex-1 min-w-0 overflow-auto"
+              style={{ scrollbarGutter: 'stable' }}
+            >
               <List<{}>
                 rowCount={documents.length}
                 rowHeight={getRowHeight()}

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -612,6 +612,72 @@ describe('DataGrid — Compare documents', () => {
   });
 });
 
+describe('DataGrid table header/body scroll sync (#219)', () => {
+  it('keeps the header aligned by mirroring the body\'s horizontal scroll', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    const header = screen.getByTestId('table-header');
+    const body = screen.getByTestId('table-body-scroll');
+
+    // jsdom has no layout: fake the overflow that makes a box scrollable, since
+    // only a horizontally-scrollable element is allowed to drive the header.
+    const overflowing = (el: HTMLElement) => {
+      Object.defineProperty(el, 'clientWidth', { value: 500, configurable: true });
+      Object.defineProperty(el, 'scrollWidth', { value: 1400, configurable: true });
+    };
+    overflowing(body);
+
+    body.scrollLeft = 240;
+    fireEvent.scroll(body);
+    expect(header.scrollLeft).toBe(240);
+
+    body.scrollLeft = 0;
+    fireEvent.scroll(body);
+    expect(header.scrollLeft).toBe(0);
+  });
+
+  it('syncs from the virtualized list\'s inner scroller too (scroll does not bubble)', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    const header = screen.getByTestId('table-header');
+    const body = screen.getByTestId('table-body-scroll');
+    // react-window renders its own overflow:auto element inside the wrapper; a
+    // scroll there must still reach the header, which only works via capture.
+    const inner = body.firstElementChild as HTMLElement;
+    expect(inner).toBeTruthy();
+    Object.defineProperty(inner, 'clientWidth', { value: 500, configurable: true });
+    Object.defineProperty(inner, 'scrollWidth', { value: 1400, configurable: true });
+
+    inner.scrollLeft = 310;
+    fireEvent.scroll(inner);
+    expect(header.scrollLeft).toBe(310);
+  });
+
+  it('ignores a purely vertical scroller so it cannot reset the header', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    const header = screen.getByTestId('table-header');
+    const body = screen.getByTestId('table-body-scroll');
+    Object.defineProperty(body, 'clientWidth', { value: 500, configurable: true });
+    Object.defineProperty(body, 'scrollWidth', { value: 1400, configurable: true });
+    body.scrollLeft = 200;
+    fireEvent.scroll(body);
+    expect(header.scrollLeft).toBe(200);
+
+    // A sibling box that only scrolls vertically (scrollWidth == clientWidth)
+    // must not drag the header back to 0.
+    const inner = body.firstElementChild as HTMLElement;
+    Object.defineProperty(inner, 'clientWidth', { value: 500, configurable: true });
+    Object.defineProperty(inner, 'scrollWidth', { value: 500, configurable: true });
+    inner.scrollLeft = 0;
+    fireEvent.scroll(inner);
+    expect(header.scrollLeft).toBe(200);
+  });
+});
+
 describe('DataGrid column resize', () => {
   it('renders a resize handle per table column and resizes with the keyboard', () => {
     render(<DataGrid documents={mockDocuments} />);


### PR DESCRIPTION
Closes #219 (part of #215 item 3).

## Root cause
Not a width bug — header and body cells are geometrically identical (same `px-3`, same `border-r`, same `colWidth`, both `flexShrink: 0`). It's **scroll position**: the header was a plain flex row with **no `overflow-x`** inside an `overflow-hidden` parent, so it *clipped* instead of scrolling while the body scrolled. Labels ended up off by exactly the scroll offset.

That also explains the "sometimes": it only appears once total column width exceeds the viewport.

## Why the first attempt didn't fix it
My initial fix put a React `onScroll` on the body wrapper. That was the wrong element: **react-window v2's `List` renders its own `overflow: auto` scroller inside the wrapper**, and since scroll events **don't bubble**, the handler never fired in the real app. The test passed only because it dispatched the event directly on the wrapper — a green test over a broken fix.

## The actual fix
- Header becomes a scroll container (`overflow-hidden`) whose `scrollLeft` is driven programmatically.
- The listener is attached in the **capture phase** (`addEventListener('scroll', fn, true)`). Scroll doesn't bubble, but it *does* propagate during capture — so this catches the scroll whether it happens on the wrapper or on react-window's inner scroller, without depending on library internals.
- Guarded on `scrollWidth > clientWidth`, so only a box that can actually scroll horizontally drives the header — the vertical scroller can't yank it back to 0.
- Both boxes get `scrollbar-gutter: stable` so their usable widths match and they stay aligned at the far-right extreme, where the body's vertical scrollbar would otherwise consume space the header doesn't (visible on Windows/Chromium; a no-op with macOS overlay scrollbars).

## Tests (3 new)
1. Header follows the wrapper's horizontal scroll (and back to 0).
2. **Header follows react-window's inner scroller** — the real-world case. Verified this test genuinely catches the bug: flipping the listener to the bubble phase makes it fail, and only it.
3. A purely vertical scroller (`scrollWidth == clientWidth`) does **not** reset the header.

jsdom has no layout, so the tests fake `clientWidth`/`scrollWidth` to model real overflow rather than asserting on pixels.

Build clean, full suite **1129 passing**.
