### PR TITLE
fix(connections): explain a handshake close instead of a bare timeout (#230)

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -217,6 +217,18 @@ export const summarizeConnectionError = (raw: string): { summary: string; hint?:
     return { summary: 'Connection refused.', hint: 'Is the server running and the host/port reachable from this machine?' };
   if (/failed to lookup|name or service not known|no such host|nodename nor servname|dns error/.test(e))
     return { summary: 'Host not found (DNS lookup failed).', hint: 'Check the hostname; for private hosts you may need an SSH tunnel.' };
+  // The server accepted the socket then hung up mid-handshake. Two causes look
+  // identical here, so name both rather than guess: a server older than the
+  // driver supports (pre-3.6 servers don't speak OP_MSG, so they drop the
+  // connection before reporting a version — see #230), or a server that requires
+  // TLS while TLS is off. Must precede the generic server-selection check, since
+  // the driver nests this I/O error inside that timeout.
+  if (/unexpected end of file|end of stream/.test(e))
+    return {
+      summary: 'Server closed the connection during handshake.',
+      hint:
+        'Most often the server predates MongoDB 4.2, the oldest MQLens currently supports — servers before 3.6 don’t speak the wire protocol the driver uses. Otherwise the server may require TLS while TLS is off here.',
+    };
   if (/server selection timeout|no available servers|no suitable servers/.test(e))
     return {
       summary: 'Couldn’t reach any server (selection timed out).',

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -85,6 +85,19 @@ describe('summarizeConnectionError', () => {
 
   it('summarizes a bare server-selection timeout when no deeper cause is present', () => {
     expect(summarizeConnectionError('Server selection timeout: No available servers').summary).toMatch(/selection timed out/i);
+    // #230: a pre-3.6 server drops the connection instead of reporting its
+    // version, so the raw error is an I/O EOF nested in a selection timeout.
+    // That must be named, not swallowed by the generic timeout message.
+    const legacy = summarizeConnectionError(
+      'Kind: Server selection timeout: No available servers. Topology: { Type: Single, Servers: [ { Address: localhost:12220, Type: Unknown, Error: Kind: I/O error: unexpected end of file, Labels: {"SystemOverloadedError"} } ] }',
+    );
+    expect(legacy.summary).toMatch(/closed the connection during handshake/i);
+    expect(legacy.hint).toMatch(/4\.2/);
+    expect(legacy.hint).toMatch(/TLS/i);
+    // A plain selection timeout with no EOF still gets the generic message.
+    expect(
+      summarizeConnectionError('Server selection timeout: No available servers').summary,
+    ).toMatch(/selection timed out/i);
   });
 });
 

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -87,6 +87,12 @@ sudo dpkg -i MQLens_*.deb</code></pre>
         <p>To use the embedded shell you'll also need <a href="https://www.mongodb.com/docs/mongodb-shell/" target="_blank" rel="noopener"><code>mongosh</code></a> on your <code>PATH</code>.</p>
 
         <h2 id="first-connection">Your first connection</h2>
+        <p>
+          <strong>Supported servers:</strong> MongoDB <strong>4.2 or newer</strong>, including Atlas.
+          That's the floor of the official MongoDB Rust driver {SITE.name} is built on. Older servers
+          aren't supported yet — a pre-3.6 server predates the wire protocol the driver speaks, so it
+          closes the connection during the handshake rather than reporting its version.
+        </p>
         <ol>
           <li>Launch {SITE.name} and set a <strong>master password</strong> — this encrypts your saved connection profiles at rest.</li>
           <li>Create a connection: enter a host (standalone or replica set) or paste a full connection string.</li>


### PR DESCRIPTION
Addresses #230 by replacing a dead-end error with an accurate one. Legacy-server support itself is now tracked in **#232**.

## The actual failure here
`summarizeConnectionError` buried the root cause: the driver nests an I/O EOF inside a "server selection timeout", so the user saw only *"Couldn't reach any server"* plus a topology dump — and reasonably went hunting through auth modes for something no auth mode could fix. That's the bug worth fixing today: we gave them nothing to act on.

Now that case is named:

> **Server closed the connection during handshake.**
> Most often the server predates MongoDB 4.2, the oldest MQLens currently supports — servers before 3.6 don't speak the wire protocol the driver uses. Otherwise the server may require TLS while TLS is off here.

**Two causes are indistinguishable at this point** — a too-old server, or a TLS-required server contacted without TLS — so the hint names both rather than guessing. A confidently wrong diagnosis would be worse than a vague one.

The check sits *before* the generic server-selection branch (the EOF is nested inside it) and *after* the specific TLS-certificate branch.

## Why 3.4 fails today (verified in the driver source)
- `mongodb` 3.7 `src/sdam/description/server.rs:16-18` — `DRIVER_MIN_DB_VERSION = "4.2"`, `DRIVER_MIN_WIRE_VERSION = 8`.
- `src/cmap/conn/wire/message.rs:303` — outgoing messages are always `OpCode::Message` (OP_MSG); `OpCode::Query` is only ever parsed, never sent.

OP_MSG arrived in MongoDB 3.6, so a 3.4 server closes the socket before it can report a version.

**This is a driver limitation, not an impossibility** — Studio 3T (Java driver) and NoSQLBooster (bundled older Node drivers) support these servers. Both the error text and the docs therefore say *"not supported yet"*, not *"can't be supported"*, and point at #232.

## Docs
The supported range wasn't written down anywhere — a real gap that contributed to this report. Added to the docs' *Your first connection* section: **MongoDB 4.2+**, with the reason.

## Tests
A test built from the reporter's verbatim error asserts the new summary and that the hint names both 4.2 and TLS, plus a guard that a plain selection timeout still gets the generic message. Verified meaningful — disabling the new branch fails exactly that test.

App build, website build (21 pages), full suite **1159 passing**.
