### PR TITLE
fix: keep AI helper replies and panel width across tab switches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Sidebar } from './components/Sidebar';
 import { CommandPalette, type PaletteAction } from './components/CommandPalette';
 import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import type { ChatMessage } from './components/AIChatPanel';
+import { clearChatRequest, renameChatRequest, resetChatRequests } from './lib/aiChatRequest';
 import { DataGrid } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
 import { SettingsView, type SettingsTabId, MONGO_TOOLS_DIR_KEY } from './components/SettingsModal';
@@ -631,6 +632,9 @@ function Workspace() {
         tabChatCache.current.set(newId, chat);
         tabChatCache.current.delete(oldId);
       }
+      // The in-flight request follows the tab; dropping it here would lose a
+      // reply that is already on its way.
+      renameChatRequest(oldId, newId);
     }
 
     // Dispatched straight to the layout reducer via `dispatchLayout`,
@@ -774,6 +778,7 @@ function Workspace() {
             // pre-restore entries so a Quick Start tab id can't inherit a
             // stale transcript after hydrate reuses ids.
             tabChatCache.current.clear();
+            resetChatRequests();
             const windowTabIds = new Set(snapshot.tabs.map((t) => t.id));
             const profileNames = new Map<string, string>();
             for (const t of ws.tabs) {
@@ -2157,6 +2162,7 @@ function Workspace() {
     if (action.type === 'close_tab') {
       tabBuilderStateCache.current.delete(action.tabId);
       tabChatCache.current.delete(action.tabId);
+      clearChatRequest(action.tabId);
       // #91: forget this tab's generate-task tracking on close (running or
       // finished) — otherwise reopening "Generate Data…" on the same
       // namespace reuses the same deterministic tab id and the fresh view
@@ -2182,6 +2188,7 @@ function Workspace() {
       action.tabIds.forEach((id) => {
         generateTaskIdsRef.current.delete(id);
         tabChatCache.current.delete(id);
+        clearChatRequest(id);
       });
     }
     dispatchLayout(action);
@@ -2756,6 +2763,7 @@ function Workspace() {
           setTabs([]);
           tabBuilderStateCache.current.clear();
           tabChatCache.current.clear();
+          resetChatRequests();
           dispatchLayout({ type: 'hydrate', layout: createInitialLayout([], null) });
           return;
         }
@@ -2822,6 +2830,7 @@ function Workspace() {
           leavingIds.forEach((id) => {
             tabBuilderStateCache.current.delete(id);
             tabChatCache.current.delete(id);
+            clearChatRequest(id);
             unmirroredTabIdsRef.current.delete(id);
           });
           setTabs((prev) => prev.filter((t) => !leavingIds.has(t.id)));
@@ -2963,6 +2972,7 @@ function Workspace() {
           removedIds.forEach((id) => {
             tabBuilderStateCache.current.delete(id);
             tabChatCache.current.delete(id);
+            clearChatRequest(id);
             unmirroredTabIdsRef.current.delete(id);
           });
           setTabs((prev) => prev.filter((t) => !removedIds.has(t.id)));
@@ -3559,6 +3569,7 @@ function Workspace() {
                 ?? builderStateFromQueryTab(tab.lastQuery, tab.lastAggregate)
               }
               onBuilderStateChange={(state) => handleBuilderStateChange(tab.id, state)}
+              chatSessionKey={tab.id}
               initialChatMessages={tabChatCache.current.get(tab.id)?.messages ?? []}
               onChatMessagesChange={(messages) => handleChatMessagesChange(tab.id, messages)}
               initialAIHelperOpen={tabChatCache.current.get(tab.id)?.isOpen ?? false}

--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -4,6 +4,12 @@ import { Sparkles, User, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { buildRunnableCommand, type GeneratedQuery } from '../lib/mongoCommand';
+import {
+  getPendingChatRequest,
+  startChatRequest,
+  takeSettledChatRequest,
+  type PendingChatReply,
+} from '../lib/aiChatRequest';
 
 export type { GeneratedQuery };
 
@@ -30,6 +36,10 @@ interface AIChatPanelProps {
   /** Restored when remounting this tab's chat (see App tabChatCache). */
   initialMessages?: ChatMessage[];
   onMessagesChange?: (messages: ChatMessage[]) => void;
+  /** Identifies this chat across unmounts so an in-flight request can be
+   *  re-attached on remount (see lib/aiChatRequest). Without it a request
+   *  started here is still lost when the tab is switched away. */
+  sessionKey?: string;
 }
 
 /** Highest numeric suffix among `mN` message ids, or -1 if none. */
@@ -41,6 +51,8 @@ const maxChatIdNum = (messages: ChatMessage[]): number => {
   }
   return max;
 };
+
+const AI_HELPER_WIDTH_KEY = 'mqlens-ai-helper-width';
 
 const composerClassName = cn(
   'min-h-[52px] w-full resize-y rounded-md border border-input bg-background px-2 py-1.5 text-xs shadow-sm transition-colors',
@@ -58,14 +70,29 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
   embedded = false,
   initialMessages = [],
   onMessagesChange,
+  sessionKey,
 }) => {
   const [chatInput, setChatInput] = useState('');
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(initialMessages);
   const [isChatLoading, setIsChatLoading] = useState(false);
-  const [aiHelperWidth, setAIHelperWidth] = useState(340);
+  // Persisted, not per-tab: a panel width is a UI preference, and remounting
+  // on every tab switch used to snap it back to the default. Mirrors
+  // DataGrid's `mqlens-treekey-width`. Range matches the resizer clamp below.
+  const [aiHelperWidth, setAIHelperWidth] = useState<number>(() => {
+    const saved = Number(localStorage.getItem(AI_HELPER_WIDTH_KEY));
+    return saved >= 240 && saved <= 600 ? saved : 340;
+  });
+  useEffect(() => {
+    localStorage.setItem(AI_HELPER_WIDTH_KEY, String(aiHelperWidth));
+  }, [aiHelperWidth]);
   const [isResizingAIHelper, setIsResizingAIHelper] = useState(false);
   const chatScrollRef = React.useRef<HTMLDivElement>(null);
   const chatIdRef = React.useRef(maxChatIdNum(initialMessages) + 1);
+  // A promise continuation is not cancelled by unmount, so the instance that
+  // started a request still resumes after the tab is switched away. It must not
+  // consume the settled reply in that case — the next mount needs to find it.
+  const mountedRef = React.useRef(true);
+  useEffect(() => () => { mountedRef.current = false; }, []);
   const nextChatId = () => `m${chatIdRef.current++}`;
 
   useEffect(() => {
@@ -94,6 +121,49 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     };
   }, [isResizingAIHelper]);
 
+  /** Append an assistant reply, assigning its id here because the id counter
+   *  is panel-local and the reply may have been produced while unmounted. */
+  const appendReply = (reply: PendingChatReply) => {
+    setChatMessages((prev) => [
+      ...prev,
+      {
+        id: nextChatId(),
+        role: 'assistant',
+        text: reply.text,
+        ...(reply.error ? { error: true } : { query: reply.query as GeneratedQuery | undefined }),
+      },
+    ]);
+  };
+
+  // Re-attach to a request that was started before this panel last unmounted:
+  // either it already settled while we were away, or it is still running and we
+  // show the spinner and wait for it. Without this the reply is lost whenever
+  // the user switches tabs mid-request.
+  useEffect(() => {
+    if (!sessionKey) return;
+    const settled = takeSettledChatRequest(sessionKey);
+    if (settled) {
+      appendReply(settled);
+      return;
+    }
+    const inFlight = getPendingChatRequest(sessionKey);
+    if (!inFlight) return;
+    let active = true;
+    setIsChatLoading(true);
+    void inFlight.then((reply) => {
+      if (!active) return;
+      takeSettledChatRequest(sessionKey);
+      appendReply(reply);
+      setIsChatLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+    // Runs once per mount for this session; appendReply is stable enough here
+    // because it only closes over setState functions and the id ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionKey]);
+
   const handleSendChat = async () => {
     const text = chatInput.trim();
     if (!text || isChatLoading) return;
@@ -111,7 +181,7 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     setChatInput('');
     setIsChatLoading(true);
 
-    try {
+    const run = async (): Promise<PendingChatReply> => {
       const raw = await invoke<string>('generate_mql_query', {
         prompt: text,
         collection: collectionName,
@@ -142,20 +212,21 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
         pipeline: Array.isArray(parsed.pipeline) ? parsed.pipeline : [],
         script: typeof parsed.script === 'string' ? parsed.script : '',
       };
-      setChatMessages((prev) => [
-        ...prev,
-        {
-          id: nextChatId(),
-          role: 'assistant',
-          text: parsed.explanation ?? 'Here is a query.',
-          query,
-        },
-      ]);
-    } catch (err) {
-      setChatMessages((prev) => [
-        ...prev,
-        { id: nextChatId(), role: 'assistant', text: String(err), error: true },
-      ]);
+      return { text: parsed.explanation ?? 'Here is a query.', query };
+    };
+
+    try {
+      // Held outside the tree so switching tabs mid-request does not discard
+      // the answer; `startChatRequest` also turns a rejection into an
+      // `error: true` reply, so there is a single completion path.
+      const reply = sessionKey
+        ? await startChatRequest(sessionKey, run)
+        : await run().catch((err): PendingChatReply => ({ text: String(err), error: true }));
+      // Unmounted mid-request: leave the reply in the registry so the panel
+      // picks it up when the user comes back to this tab.
+      if (!mountedRef.current) return;
+      if (sessionKey) takeSettledChatRequest(sessionKey);
+      appendReply(reply)
     } finally {
       setIsChatLoading(false);
     }

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -209,6 +209,9 @@ interface DocumentViewerProps {
   /** Restored when remounting this tab's viewer (see App tab cache). */
   initialBuilderState?: BuilderState;
   onBuilderStateChange?: (state: BuilderState) => void;
+  /** Identifies this tab's chat so an in-flight AI request survives the
+   *  unmount that happens when the user switches tabs. */
+  chatSessionKey?: string;
   /** Restored when remounting this tab's AI helper (see App tabChatCache). */
   initialChatMessages?: ChatMessage[];
   onChatMessagesChange?: (messages: ChatMessage[]) => void;
@@ -525,6 +528,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   availableFields = [],
   initialBuilderState = DEFAULT_BUILDER_STATE,
   onBuilderStateChange,
+  chatSessionKey,
   initialChatMessages = [],
   onChatMessagesChange,
   initialAIHelperOpen = false,
@@ -2267,6 +2271,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
             <ResizableHandle withHandle data-testid="ai-helper-resizer" />
             <ResizablePanel id="ai-helper" minSize="18%" maxSize="50%" className="flex min-h-0 flex-col">
               <AIChatPanel
+                sessionKey={chatSessionKey}
                 variant="editor"
                 embedded
                 databaseName={databaseName}

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -36,7 +36,7 @@ import {
   ResizablePanel,
   ResizableHandle,
 } from '@/components/ui/resizable';
-import type { Layout } from 'react-resizable-panels';
+import { useDefaultLayout, type Layout } from 'react-resizable-panels';
 import { cn } from '@/lib/utils';
 import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 import {
@@ -1347,6 +1347,24 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     return { 'document-main': 100 };
   }, [workspaceRightPanel]);
 
+  // Switching tabs unmounts this view, so without persistence the group fell
+  // back to the fixed 70/30 above every time and the user's drag was lost.
+  // `panelIds` keys the saved layout by which right-hand panel is open, so the
+  // query builder and the AI helper remember their own widths instead of
+  // fighting over one entry.
+  const workspacePanelIds = useMemo(() => {
+    if (workspaceRightPanel === 'query-builder') return ['document-main', 'query-builder'];
+    if (workspaceRightPanel === 'ai-helper') return ['document-main', 'ai-helper'];
+    return ['document-main'];
+  }, [workspaceRightPanel]);
+
+  const { defaultLayout: savedWorkspaceLayout, onLayoutChanged: saveWorkspaceLayout } =
+    useDefaultLayout({
+      id: 'document-viewer-workspace',
+      panelIds: workspacePanelIds,
+      storage: typeof localStorage === 'undefined' ? undefined : localStorage,
+    });
+
   return (
     <div className="relative flex h-full min-h-0 flex-col min-w-0">
       
@@ -1675,7 +1693,8 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       <ResizablePanelGroup
         id="document-viewer-workspace"
         orientation="horizontal"
-        defaultLayout={workspaceDefaultLayout}
+        defaultLayout={savedWorkspaceLayout ?? workspaceDefaultLayout}
+        onLayoutChanged={saveWorkspaceLayout}
         className="min-h-0 min-w-0 flex-1"
       >
         <ResizablePanel id="document-main" minSize="30%" className="flex min-h-0 flex-col">

--- a/src/components/__tests__/AIChatPanel.test.tsx
+++ b/src/components/__tests__/AIChatPanel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AIChatPanel } from '../AIChatPanel';
+import { resetChatRequests } from '../../lib/aiChatRequest';
 
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
@@ -26,6 +27,8 @@ describe('AIChatPanel', () => {
     );
 
   beforeEach(() => {
+    resetChatRequests();
+    localStorage.clear();
     invokeMock.mockReset();
     onInsertQuery.mockReset();
     onInsertAndRunQuery.mockReset();
@@ -197,5 +200,76 @@ describe('AIChatPanel', () => {
     // Ids continue past the restored m0/m1 range.
     expect(lastCall[2].id).toBe('m2');
     expect(lastCall[3].id).toBe('m3');
+  });
+
+  it('keeps an in-flight reply when the tab is switched away mid-request (#221 follow-up)', async () => {
+    // Switching tabs unmounts the panel (PaneView renders only the active tab).
+    // The request used to die with it: the user's question was cached, the
+    // assistant's answer was silently dropped, and the tab came back showing a
+    // question with no reply, no spinner and no error.
+    let resolveInvoke: (v: string) => void = () => {};
+    invokeMock.mockImplementation(() => new Promise<string>((res) => { resolveInvoke = res; }));
+
+    const first = render(
+      <AIChatPanel
+        connectionId="c1" databaseName="test-db" collectionName="users" fields={[]}
+        variant="editor" isOpen sessionKey="tab-1"
+        onClose={onClose} onInsertQuery={onInsertQuery} onInsertAndRunQuery={onInsertAndRunQuery}
+      />
+    );
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'adults please' } });
+    fireEvent.click(screen.getByTestId('chat-send-btn'));
+    await waitFor(() => expect(screen.getByTestId('chat-thinking')).toBeInTheDocument());
+
+    first.unmount();                                   // user switches tab
+    resolveInvoke(JSON.stringify({ explanation: 'Finds adults.', queryType: 'find', filter: {} }));
+    await new Promise((r) => setTimeout(r, 0));
+
+    render(                                            // user switches back
+      <AIChatPanel
+        connectionId="c1" databaseName="test-db" collectionName="users" fields={[]}
+        variant="editor" isOpen sessionKey="tab-1"
+        initialMessages={[{ id: 'm0', role: 'user', text: 'adults please' }]}
+        onClose={onClose} onInsertQuery={onInsertQuery} onInsertAndRunQuery={onInsertAndRunQuery}
+      />
+    );
+    expect(await screen.findByText('Finds adults.')).toBeInTheDocument();
+  });
+
+  it('shows the spinner again when returning while the request is still running', async () => {
+    let resolveInvoke: (v: string) => void = () => {};
+    invokeMock.mockImplementation(() => new Promise<string>((res) => { resolveInvoke = res; }));
+
+    const first = render(
+      <AIChatPanel
+        connectionId="c1" databaseName="test-db" collectionName="users" fields={[]}
+        variant="editor" isOpen sessionKey="tab-2"
+        onClose={onClose} onInsertQuery={onInsertQuery} onInsertAndRunQuery={onInsertAndRunQuery}
+      />
+    );
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'still running' } });
+    fireEvent.click(screen.getByTestId('chat-send-btn'));
+    await waitFor(() => expect(screen.getByTestId('chat-thinking')).toBeInTheDocument());
+    first.unmount();
+
+    render(                                            // back while still pending
+      <AIChatPanel
+        connectionId="c1" databaseName="test-db" collectionName="users" fields={[]}
+        variant="editor" isOpen sessionKey="tab-2"
+        initialMessages={[{ id: 'm0', role: 'user', text: 'still running' }]}
+        onClose={onClose} onInsertQuery={onInsertQuery} onInsertAndRunQuery={onInsertAndRunQuery}
+      />
+    );
+    expect(screen.getByTestId('chat-thinking')).toBeInTheDocument();
+
+    resolveInvoke(JSON.stringify({ explanation: 'Late but delivered.', queryType: 'find', filter: {} }));
+    expect(await screen.findByText('Late but delivered.')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByTestId('chat-thinking')).not.toBeInTheDocument());
+  });
+
+  it('remembers the panel width across remounts', async () => {
+    localStorage.setItem('mqlens-ai-helper-width', '420');
+    renderPanel('editor');
+    expect(screen.getByTestId('ai-helper-panel')).toHaveStyle({ width: '420px' });
   });
 });

--- a/src/components/__tests__/workspaceLayoutPersistence.test.tsx
+++ b/src/components/__tests__/workspaceLayoutPersistence.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { useDefaultLayout, type Layout } from 'react-resizable-panels';
+
+/**
+ * Guards the layout-persistence contract DocumentViewer relies on.
+ *
+ * Switching tabs unmounts DocumentViewer, so the ResizablePanelGroup used to
+ * fall back to its fixed 70/30 default every time and the user's drag was lost
+ * — the AI helper panel snapped back to its default width on every tab switch.
+ *
+ * Note the id and panelIds below MUST match DocumentViewer's. The two open
+ * right-hand panels are keyed separately on purpose: the query builder and the
+ * AI helper each remember their own width rather than sharing one entry.
+ *
+ * This covers the persistence round trip. Whether DocumentViewer actually wires
+ * `onLayoutChanged` onto the Group is NOT covered here — its own suite replaces
+ * `@/components/ui/resizable` with plain divs, which drops those props.
+ */
+const GROUP_ID = 'document-viewer-workspace';
+const AI_PANELS = ['document-main', 'ai-helper'];
+const BUILDER_PANELS = ['document-main', 'query-builder'];
+
+function Probe({ panelIds, save }: { panelIds: string[]; save?: Layout }) {
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: GROUP_ID,
+    panelIds,
+    storage: localStorage,
+  });
+  if (save) onLayoutChanged(save);
+  return <span data-testid="layout">{JSON.stringify(defaultLayout ?? null)}</span>;
+}
+
+// Scoped to this render's own container — repeated render() calls share
+// document.body, so a global query would match every probe mounted so far.
+const readBack = (panelIds: string[]) => {
+  const { container } = render(<Probe panelIds={panelIds} />);
+  const text = container.querySelector('[data-testid="layout"]')?.textContent;
+  return JSON.parse(text || 'null') as Layout | null;
+};
+
+describe('workspace layout persistence', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('restores a dragged layout on the next mount', () => {
+    expect(readBack(AI_PANELS)).toBeNull();
+
+    render(<Probe panelIds={AI_PANELS} save={{ 'document-main': 55, 'ai-helper': 45 }} />);
+
+    expect(readBack(AI_PANELS)).toEqual({ 'document-main': 55, 'ai-helper': 45 });
+  });
+
+  it('keeps the query builder and the AI helper widths separate', () => {
+    render(<Probe panelIds={AI_PANELS} save={{ 'document-main': 55, 'ai-helper': 45 }} />);
+    render(
+      <Probe panelIds={BUILDER_PANELS} save={{ 'document-main': 80, 'query-builder': 20 }} />,
+    );
+
+    expect(readBack(AI_PANELS)).toEqual({ 'document-main': 55, 'ai-helper': 45 });
+    expect(readBack(BUILDER_PANELS)).toEqual({ 'document-main': 80, 'query-builder': 20 });
+  });
+});

--- a/src/lib/aiChatRequest.ts
+++ b/src/lib/aiChatRequest.ts
@@ -1,0 +1,93 @@
+/**
+ * In-flight AI Helper requests, held outside the React tree.
+ *
+ * Inactive tabs are unmounted (PaneView renders only `pane.activeTabId`), so a
+ * request started in AIChatPanel used to die with the component: the awaited
+ * `invoke` still completed, but `setChatMessages` on an unmounted component is
+ * a silent no-op and the effect that mirrors messages into App's tab cache
+ * never fired. The user's question was cached, the assistant's reply was
+ * discarded, and the tab came back showing a question with no answer, no
+ * spinner and no error — with the API call already paid for.
+ *
+ * Keeping the promise here instead means the request outlives the unmount. The
+ * panel re-attaches to it on remount, or picks up an already-settled reply that
+ * landed while it was gone.
+ *
+ * Session-local by design: this mirrors App's `tabChatCache`, which is also not
+ * part of the persisted workspace snapshot.
+ */
+
+/** An assistant reply, minus its id — the id is assigned by the panel when it
+ *  appends the message, because the id counter is panel-local. */
+export interface PendingChatReply {
+  text: string;
+  query?: unknown;
+  error?: boolean;
+}
+
+interface PendingChat {
+  promise: Promise<PendingChatReply>;
+  /** Set once the promise settles; cleared when a panel consumes it. */
+  settled?: PendingChatReply;
+}
+
+const pending = new Map<string, PendingChat>();
+
+/**
+ * Run `task` as the pending request for `key`. The returned promise never
+ * rejects — a failure is delivered as a reply with `error: true`, so callers
+ * have a single path and an unconsumed rejection can never become an unhandled
+ * rejection while no panel is mounted.
+ */
+export function startChatRequest(
+  key: string,
+  task: () => Promise<PendingChatReply>,
+): Promise<PendingChatReply> {
+  const promise = task().catch((err): PendingChatReply => ({
+    text: String(err),
+    error: true,
+  }));
+  const entry: PendingChat = { promise };
+  pending.set(key, entry);
+  void promise.then((reply) => {
+    // Only record it if this entry is still the current one for the key; a
+    // newer request must not be overwritten by an older one settling late.
+    if (pending.get(key) === entry) entry.settled = reply;
+  });
+  return promise;
+}
+
+/** The live promise for `key` while it is still running, else undefined. */
+export function getPendingChatRequest(key: string): Promise<PendingChatReply> | undefined {
+  const entry = pending.get(key);
+  return entry && entry.settled === undefined ? entry.promise : undefined;
+}
+
+/** A reply that settled while no panel was mounted. Removes it — a reply is
+ *  consumed exactly once, so remounting twice cannot duplicate a message. */
+export function takeSettledChatRequest(key: string): PendingChatReply | undefined {
+  const entry = pending.get(key);
+  if (!entry?.settled) return undefined;
+  pending.delete(key);
+  return entry.settled;
+}
+
+/** Follow a tab that was rebound to a new id (App's rebindProfileTabs), so an
+ *  in-flight reply is not orphaned by the rename — dropping it here would
+ *  reintroduce exactly the loss this module exists to prevent. */
+export function renameChatRequest(oldKey: string, newKey: string): void {
+  const entry = pending.get(oldKey);
+  if (!entry) return;
+  pending.delete(oldKey);
+  pending.set(newKey, entry);
+}
+
+/** Drop any request state for `key` — used when its tab closes. */
+export function clearChatRequest(key: string): void {
+  pending.delete(key);
+}
+
+/** Test seam: forget everything. */
+export function resetChatRequests(): void {
+  pending.clear();
+}


### PR DESCRIPTION
Targets `feat/preserve-ai-chat-history-per-tab-221` (#233), not `dev` — merge this into that branch and #233 carries both.

Two issues found while testing #233. Neither is caused by it: both were always true, but while a tab switch wiped the whole chat there was nothing left to notice them on. Making the transcript survive is what makes them visible.

## 1. An in-flight reply was lost, not paused

Inactive tabs are unmounted (`PaneView` renders only `pane.activeTabId`). `handleSendChat` awaits `invoke('generate_mql_query', …)` and then calls `setChatMessages`, so switching tabs mid-request meant:

- `setChatMessages` on an unmounted component is a silent no-op in React 18
- the effect mirroring messages into `tabChatCache` never fired

The user's question **was** cached — it is written before the `await` — but the assistant's answer was discarded. You came back to a tab showing your question with no reply, no spinner and no error, with the API call already paid for.

The request now lives in a module-level registry (`src/lib/aiChatRequest.ts`) keyed by tab id, so it outlives the unmount. The panel re-attaches on remount: spinner if it is still running, or appending a reply that landed while the tab was away.

Three details worth a look in review:

- **A promise continuation is not cancelled by unmount.** The instance that started the request still resumes after the tab is gone, and my first attempt had it *consume* the settled reply before the remount could read it — the new test caught this. A mounted flag now makes an unmounted instance leave the reply behind.
- **Reply ids are assigned when the message is appended**, not when it is produced, because the id counter is panel-local and the reply may be produced while nothing is mounted. This works with `maxChatIdNum` rather than around it.
- **Tab rebind moves the request rather than dropping it.** #233 migrates its cache entry old-id → new-id; dropping the pending request there would reintroduce exactly this bug. All seven cache-drop sites now mirror onto the registry.

## 2. Panel width reset on every tab switch

`aiHelperWidth` was local state seeded with a constant, so each remount snapped back to 340px.

Width is a UI preference rather than per-tab state, so it is deliberately **not** in `tabChatCache` — it persists to `localStorage` as `mqlens-ai-helper-width`, following `DataGrid`'s `mqlens-treekey-width`, and now survives restart too.

## Tests

Three regression tests, each verified to fail against the pre-fix component and pass after:

- reply survives an unmount mid-request
- spinner resumes when returning while the request is still running
- width restored on remount

## Verification

```
npx tsc --noEmit  → 0 errors
npm run build     → clean
npx vitest run    → 82 files, 1163 passed, 4 skipped
```

## Note on `dev`

This branch is based on #233's head, so the diff stays small and reviewable. #233 itself still predates the merge of #236 (German localization) and needs a rebase before it can land on `dev` — I have that rebase verified locally (one trivial import conflict in `DocumentViewer.tsx`, resolved by keeping both sides) and can supply it separately. One thing it will need after rebasing: the `'Here is a query.'` fallback here becomes `t('aiChatPanel.fallbackExplanation')`, which is what the conflict in this cherry-pick was.
