### PR TITLE
fix(deps): patch 8 Dependabot advisories (undici, postcss, russh)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3407,6 +3407,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
@@ -5997,9 +6057,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -6193,9 +6253,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6212,7 +6272,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6967,9 +7027,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -80,9 +80,9 @@
   },
   "overrides": {
     "dompurify": "3.4.12",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "@babel/core": "7.29.6",
     "esbuild": "0.28.1",
-    "postcss": "8.5.18"
+    "postcss": "8.5.23"
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5301,9 +5301,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.4"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
+checksum = "da7c230e0ed9cbeb92fbad6c8848985d6df2a1464c0dc247a021abd666e9005e"
 dependencies = [
  "aes 0.9.1",
  "aws-lc-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ mongodb = { version = "3.0.0", features = ["aws-auth", "gssapi-auth"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 uuid = { version = "1", features = ["v4", "serde"] }
-russh = "0.62.4"
+russh = "0.62.5"
 sysinfo = "0.38.4"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 argon2 = "0.5"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2898,9 +2898,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -3341,9 +3341,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -3546,9 +3546,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3565,7 +3565,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Clears every open alert on https://github.com/mqlens/mqlens-mongodb/security/dependabot — 8 alerts, 1 high and 7 moderate.

## What's patched

| Package | Manifest | From → To | Advisories |
|---|---|---|---|
| `undici` | `package-lock.json` | 7.28.0 → **7.29.0** | 5 (**1 high**) |
| `postcss` | `package-lock.json` | 8.5.18 → **8.5.23** | 1 |
| `postcss` | `website/package-lock.json` | 8.5.21 → **8.5.26** | 1 |
| `russh` | `src-tauri/Cargo.lock` | 0.62.4 → **0.62.5** | 1 |

**undici** — CVE-2026-13697 (*high*): cross-user information disclosure and a parse-time crash via degenerate private cache directives. Plus CVE-2026-14643 (cross-user disclosure via whitespace around equals in `Cache-Control`), CVE-2026-15157 (CRLF injection via a blob-like body `type`), CVE-2026-16728 (downstream response desynchronization in the retry interceptor), CVE-2026-16729 (cookie attribute injection via unsanitized domain and unparsed `setCookie` fields).

**postcss** — CVE-2026-69153, an incomplete fix of GHSA-6g55-p6wh-862q: an attacker-controlled `sourceMappingURL` can read arbitrary `.map` files when `from` is unset.

**russh** — CVE-2026-68930: channel-scoped server callbacks reachable without an open channel. We use russh as an SSH tunnel *client* rather than a server, so exposure looks limited — but it is a point release, so there is no reason not to take it. This follows #227, which moved us 0.61 → 0.62.4 for an earlier set of SSH advisories.

## One thing worth knowing

`undici` and `postcss` are pinned in the root `overrides` block. Bumping only the lockfile would have looked fine and then been silently reverted by the next `npm install` — the pins move too, which is why `package.json` is in this diff.

## Beyond the Dependabot list

Also bumps **js-yaml 4.3.0 → 4.3.1** in the website. `npm audit` flags it high (CVE-2026-59870, quadratic CPU consumption in `!!omap` resolution) but Dependabot has not raised it yet. It sits in a lockfile this change already touches and the fix was available, so leaving a known high behind seemed worse than the small scope increase. Say the word if you would rather it went separately.

## Lockfile noise

The only movement not listed above is `nanoid` (a postcss dependency) and npm re-materialising the optional `@tailwindcss/oxide-wasm32-wasi` bundled deps. No other resolved version changed — I diffed the lockfiles package-by-package rather than eyeballing the hunks.

## Verification

```
npm audit (root)     → 0 vulnerabilities
npm audit (website)  → 0 vulnerabilities

npx tsc --noEmit     → 0 errors
npm run i18n:check   → clean (exit 0)
npm run build        → clean
npx vitest run       → 90 files, 1219 passed, 4 skipped

cargo check --all-targets → clean
cargo test                → 484 passed, 0 failed

website: npm run build    → 21 pages built
```

The frontend suite matters more than usual here: `undici` backs `jsdom`, so a bad bump would surface as test failures rather than staying invisible until runtime.
