### PR TITLE
feat(query): persist results view mode and page size per tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { CommandPalette, type PaletteAction } from './components/CommandPalette'
 import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import type { ChatMessage } from './components/AIChatPanel';
 import { clearChatRequest, renameChatRequest, resetChatRequests } from './lib/aiChatRequest';
-import { DataGrid } from './components/DataGrid';
+import { DataGrid, type ViewMode } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
 import { SettingsView, type SettingsTabId, MONGO_TOOLS_DIR_KEY } from './components/SettingsModal';
 import { IndexViewer } from './components/IndexViewer';
@@ -120,6 +120,9 @@ export interface QueryTab {
   lastQuery?: { filter: string; sort: string; projection: string; limit: number; skip: number };
   // Last executed aggregation pipeline, so an aggregate view refreshes as an aggregate.
   lastAggregate?: Record<string, unknown>[];
+  // Results view mode, kept on the tab so it survives the grid remounting on
+  // every run and the tab being switched away (#218).
+  viewMode?: ViewMode;
   // Pagination count state.
   totalCount?: number;
   countLoading?: boolean;
@@ -537,6 +540,9 @@ function Workspace() {
     tabBuilderStateCache.current.set(tabId, state);
     mirrorUpdateTabState(tabId, activeConnectionsRef.current, { builderState: state });
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const handleViewModeChange = useCallback((tabId: string, mode: ViewMode) => {
+    setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, viewMode: mode } : t)));
   }, []);
   const handleChatMessagesChange = useCallback((tabId: string, messages: ChatMessage[]) => {
     const prev = tabChatCache.current.get(tabId);
@@ -3600,6 +3606,8 @@ function Workspace() {
                 ?? builderStateFromQueryTab(tab.lastQuery, tab.lastAggregate)
               }
               onBuilderStateChange={(state) => handleBuilderStateChange(tab.id, state)}
+              executedLimit={tab.lastQuery?.limit}
+              executedSkip={tab.lastQuery?.skip}
               chatSessionKey={tab.id}
               initialChatMessages={tabChatCache.current.get(tab.id)?.messages ?? []}
               onChatMessagesChange={(messages) => handleChatMessagesChange(tab.id, messages)}
@@ -3657,6 +3665,8 @@ function Workspace() {
                     countLoading={tab.countLoading}
                     skip={tab.lastQuery?.skip ?? 0}
                     limit={tab.lastQuery?.limit ?? 50}
+                    viewMode={tab.viewMode ?? 'json'}
+                    onViewModeChange={(mode) => handleViewModeChange(tab.id, mode)}
                     onCreateSuggestedIndex={s => handleCreateSuggestedIndex(tab, s)}
                     {...(!tab.lastAggregate ? {
                       onPageChange: (newSkip: number) => handlePageChange(tab, newSkip),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,10 +123,10 @@ export interface QueryTab {
   // Results view mode, kept on the tab so it survives the grid remounting on
   // every run and the tab being switched away (#218).
   viewMode?: ViewMode;
-  // Bumped only by the results pager. The builder resyncs its limit/skip on a
-  // change to this, never on the executed values alone — see DocumentViewer's
-  // pagerRevision prop.
-  pagerRevision?: number;
+  // What the results pager last asked for. The values travel with the revision
+  // so the builder can never observe a new revision beside a stale page size —
+  // see DocumentViewer's pagerRequest prop.
+  pagerRequest?: { limit: number; skip: number; revision: number };
   // Pagination count state.
   totalCount?: number;
   countLoading?: boolean;
@@ -2601,23 +2601,30 @@ function Workspace() {
     }
   };
 
-  // Marks the next executed values as pager-originated, so the query builder
-  // resyncs to them. Nothing else bumps this.
-  const bumpPagerRevision = (tabId: string) => {
+  // Records what the pager asked for so the query builder can follow it. The
+  // limit/skip are stored WITH the revision in one update: bumping a bare
+  // counter first let the builder see the new revision beside the not-yet
+  // updated lastQuery and sync to the old page size.
+  const notePagerRequest = (tabId: string, limit: number, skip: number) => {
     setTabs((prev) =>
-      prev.map((t) => (t.id === tabId ? { ...t, pagerRevision: (t.pagerRevision ?? 0) + 1 } : t))
+      prev.map((t) =>
+        t.id === tabId
+          ? { ...t, pagerRequest: { limit, skip, revision: (t.pagerRequest?.revision ?? 0) + 1 } }
+          : t
+      )
     );
   };
 
   const handlePageChange = (tab: QueryTab, newSkip: number) => {
     if (!tab.lastQuery) return;
-    bumpPagerRevision(tab.id);
-    handleExecuteQuery(tab, { ...tab.lastQuery, skip: Math.max(0, newSkip) });
+    const skip = Math.max(0, newSkip);
+    notePagerRequest(tab.id, tab.lastQuery.limit, skip);
+    handleExecuteQuery(tab, { ...tab.lastQuery, skip });
   };
 
   const handlePageSizeChange = (tab: QueryTab, newLimit: number) => {
     if (!tab.lastQuery) return;
-    bumpPagerRevision(tab.id);
+    notePagerRequest(tab.id, newLimit, 0);
     handleExecuteQuery(tab, { ...tab.lastQuery, limit: newLimit, skip: 0 });
   };
 
@@ -3620,9 +3627,7 @@ function Workspace() {
                 ?? builderStateFromQueryTab(tab.lastQuery, tab.lastAggregate)
               }
               onBuilderStateChange={(state) => handleBuilderStateChange(tab.id, state)}
-              executedLimit={tab.lastQuery?.limit}
-              executedSkip={tab.lastQuery?.skip}
-              pagerRevision={tab.pagerRevision ?? 0}
+              pagerRequest={tab.pagerRequest}
               chatSessionKey={tab.id}
               initialChatMessages={tabChatCache.current.get(tab.id)?.messages ?? []}
               onChatMessagesChange={(messages) => handleChatMessagesChange(tab.id, messages)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,6 +123,10 @@ export interface QueryTab {
   // Results view mode, kept on the tab so it survives the grid remounting on
   // every run and the tab being switched away (#218).
   viewMode?: ViewMode;
+  // Bumped only by the results pager. The builder resyncs its limit/skip on a
+  // change to this, never on the executed values alone — see DocumentViewer's
+  // pagerRevision prop.
+  pagerRevision?: number;
   // Pagination count state.
   totalCount?: number;
   countLoading?: boolean;
@@ -2597,13 +2601,23 @@ function Workspace() {
     }
   };
 
+  // Marks the next executed values as pager-originated, so the query builder
+  // resyncs to them. Nothing else bumps this.
+  const bumpPagerRevision = (tabId: string) => {
+    setTabs((prev) =>
+      prev.map((t) => (t.id === tabId ? { ...t, pagerRevision: (t.pagerRevision ?? 0) + 1 } : t))
+    );
+  };
+
   const handlePageChange = (tab: QueryTab, newSkip: number) => {
     if (!tab.lastQuery) return;
+    bumpPagerRevision(tab.id);
     handleExecuteQuery(tab, { ...tab.lastQuery, skip: Math.max(0, newSkip) });
   };
 
   const handlePageSizeChange = (tab: QueryTab, newLimit: number) => {
     if (!tab.lastQuery) return;
+    bumpPagerRevision(tab.id);
     handleExecuteQuery(tab, { ...tab.lastQuery, limit: newLimit, skip: 0 });
   };
 
@@ -3608,6 +3622,7 @@ function Workspace() {
               onBuilderStateChange={(state) => handleBuilderStateChange(tab.id, state)}
               executedLimit={tab.lastQuery?.limit}
               executedSkip={tab.lastQuery?.skip}
+              pagerRevision={tab.pagerRevision ?? 0}
               chatSessionKey={tab.id}
               initialChatMessages={tabChatCache.current.get(tab.id)?.messages ?? []}
               onChatMessagesChange={(messages) => handleChatMessagesChange(tab.id, messages)}

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -40,6 +40,13 @@ interface DataGridProps {
   limit?: number;
   onPageChange?: (newSkip: number) => void;
   onPageSizeChange?: (newLimit: number) => void;
+  /** Results view mode, owned by the caller so it survives this grid being
+   *  unmounted. The results pane renders `{loading ? <spinner/> : <DataGrid/>}`,
+   *  so the grid remounts on EVERY run, and switching tabs unmounts the whole
+   *  DocumentViewer subtree — local state reset to 'json' both times. Omit both
+   *  props to keep the old self-managed behaviour (MongoShell does). */
+  viewMode?: ViewMode;
+  onViewModeChange?: (mode: ViewMode) => void;
   // Fired when the user accepts the COLLSCAN suggestion banner's "Create Index" CTA.
   onCreateSuggestedIndex?: (suggestion: IndexSuggestion) => void;
   // The owning connection's write-safeguard mode (#188). 'read_only' disables
@@ -52,7 +59,7 @@ interface DataGridProps {
   connectionMode?: 'normal' | 'read_only' | 'confirm_destructive';
 }
 
-type ViewMode = 'table' | 'tree' | 'json' | 'chart';
+export type ViewMode = 'table' | 'tree' | 'json' | 'chart';
 
 interface ExplainNode {
   name: string;
@@ -494,6 +501,8 @@ export const DataGrid: React.FC<DataGridProps> = ({
   limit,
   onPageChange,
   onPageSizeChange,
+  viewMode: controlledViewMode,
+  onViewModeChange,
   onCreateSuggestedIndex,
   connectionMode,
 }) => {
@@ -588,7 +597,12 @@ export const DataGrid: React.FC<DataGridProps> = ({
     return items;
   };
   const docViewerContext = useContext(DocumentViewerContext);
-  const [viewMode, setViewMode] = useState<ViewMode>('json');
+  const [uncontrolledViewMode, setUncontrolledViewMode] = useState<ViewMode>('json');
+  const viewMode = controlledViewMode ?? uncontrolledViewMode;
+  const setViewMode = (mode: ViewMode) => {
+    setUncontrolledViewMode(mode);
+    onViewModeChange?.(mode);
+  };
   const [activeTab, setActiveTab] = useState<'results' | 'explain' | 'query'>('results');
 
   // Column resize: table view keeps per-column widths (session-scoped — the

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -210,12 +210,15 @@ interface DocumentViewerProps {
   /** Restored when remounting this tab's viewer (see App tab cache). */
   initialBuilderState?: BuilderState;
   onBuilderStateChange?: (state: BuilderState) => void;
-  /** The limit/skip actually executed for this tab (`tab.lastQuery`). The
-   *  pager writes those straight onto the tab, while the builder's own
-   *  limit/skip are seeded once at mount — so without this the next Run sent
-   *  the stale mount-time page size and silently undid the pager. */
+  /** The limit/skip the PAGER last executed, together with a revision that only
+   *  the pager bumps. Keyed on the revision rather than the values because the
+   *  builder must resync when — and only when — the pager moved the page:
+   *  syncing on value changes also fired on mount (discarding a restored but
+   *  unexecuted edit) and when an unrelated in-flight run landed (discarding
+   *  input typed after Run was pressed). */
   executedLimit?: number;
   executedSkip?: number;
+  pagerRevision?: number;
   /** Identifies this tab's chat so an in-flight AI request survives the
    *  unmount that happens when the user switches tabs. */
   chatSessionKey?: string;
@@ -552,6 +555,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   onBuilderStateChange,
   executedLimit,
   executedSkip,
+  pagerRevision,
   chatSessionKey,
   initialChatMessages = [],
   onChatMessagesChange,
@@ -569,16 +573,20 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   const [limit, setLimit] = useState(initialBuilderState.limit);
   const [skip, setSkip] = useState(initialBuilderState.skip);
 
-  // One-way resync from what was actually executed. Keyed on the executed
-  // values themselves, so an unrelated re-render cannot clobber a limit the
-  // user is midway through typing — only the pager actually running a new page
-  // size moves these.
+  // One-way resync from the pager, and ONLY from the pager. The ref starts at
+  // the revision present on mount, so mounting never applies — otherwise
+  // switching tabs would overwrite a restored-but-unrun edit with the older
+  // executed value. Any other change to the executed numbers (an in-flight
+  // builder run landing, say) leaves the fields alone because the revision has
+  // not moved.
+  const appliedPagerRevision = useRef(pagerRevision);
   useEffect(() => {
+    if (pagerRevision === appliedPagerRevision.current) return;
+    appliedPagerRevision.current = pagerRevision;
     if (executedLimit !== undefined) setLimit(String(executedLimit));
-  }, [executedLimit]);
-  useEffect(() => {
     if (executedSkip !== undefined) setSkip(String(executedSkip));
-  }, [executedSkip]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pagerRevision]);
   const [explainLoading, setExplainLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -210,15 +210,16 @@ interface DocumentViewerProps {
   /** Restored when remounting this tab's viewer (see App tab cache). */
   initialBuilderState?: BuilderState;
   onBuilderStateChange?: (state: BuilderState) => void;
-  /** The limit/skip the PAGER last executed, together with a revision that only
-   *  the pager bumps. Keyed on the revision rather than the values because the
-   *  builder must resync when — and only when — the pager moved the page:
-   *  syncing on value changes also fired on mount (discarding a restored but
-   *  unexecuted edit) and when an unrelated in-flight run landed (discarding
-   *  input typed after Run was pressed). */
-  executedLimit?: number;
-  executedSkip?: number;
-  pagerRevision?: number;
+  /** What the results pager last asked for, with a revision only it bumps.
+   *
+   *  The values travel WITH the revision on purpose. Syncing from the executed
+   *  `lastQuery` instead was wrong twice over: keyed on the values it fired on
+   *  mount (discarding a restored but unexecuted edit) and when an unrelated
+   *  in-flight run landed (discarding input typed after Run); keyed on the
+   *  revision it fired one render too early, because App bumps the revision
+   *  before the query resolves — so the builder synced to the OLD page size and
+   *  never corrected. One atomic object removes the window entirely. */
+  pagerRequest?: { limit: number; skip: number; revision: number };
   /** Identifies this tab's chat so an in-flight AI request survives the
    *  unmount that happens when the user switches tabs. */
   chatSessionKey?: string;
@@ -553,9 +554,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   availableFields = [],
   initialBuilderState = DEFAULT_BUILDER_STATE,
   onBuilderStateChange,
-  executedLimit,
-  executedSkip,
-  pagerRevision,
+  pagerRequest,
   chatSessionKey,
   initialChatMessages = [],
   onChatMessagesChange,
@@ -575,18 +574,15 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
 
   // One-way resync from the pager, and ONLY from the pager. The ref starts at
   // the revision present on mount, so mounting never applies — otherwise
-  // switching tabs would overwrite a restored-but-unrun edit with the older
-  // executed value. Any other change to the executed numbers (an in-flight
-  // builder run landing, say) leaves the fields alone because the revision has
-  // not moved.
-  const appliedPagerRevision = useRef(pagerRevision);
+  // switching tabs would overwrite a restored-but-unrun edit. Everything else
+  // that changes the executed query leaves these fields alone.
+  const appliedPagerRevision = useRef(pagerRequest?.revision);
   useEffect(() => {
-    if (pagerRevision === appliedPagerRevision.current) return;
-    appliedPagerRevision.current = pagerRevision;
-    if (executedLimit !== undefined) setLimit(String(executedLimit));
-    if (executedSkip !== undefined) setSkip(String(executedSkip));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pagerRevision]);
+    if (!pagerRequest || pagerRequest.revision === appliedPagerRevision.current) return;
+    appliedPagerRevision.current = pagerRequest.revision;
+    setLimit(String(pagerRequest.limit));
+    setSkip(String(pagerRequest.skip));
+  }, [pagerRequest]);
   const [explainLoading, setExplainLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -210,6 +210,12 @@ interface DocumentViewerProps {
   /** Restored when remounting this tab's viewer (see App tab cache). */
   initialBuilderState?: BuilderState;
   onBuilderStateChange?: (state: BuilderState) => void;
+  /** The limit/skip actually executed for this tab (`tab.lastQuery`). The
+   *  pager writes those straight onto the tab, while the builder's own
+   *  limit/skip are seeded once at mount — so without this the next Run sent
+   *  the stale mount-time page size and silently undid the pager. */
+  executedLimit?: number;
+  executedSkip?: number;
   /** Identifies this tab's chat so an in-flight AI request survives the
    *  unmount that happens when the user switches tabs. */
   chatSessionKey?: string;
@@ -544,6 +550,8 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   availableFields = [],
   initialBuilderState = DEFAULT_BUILDER_STATE,
   onBuilderStateChange,
+  executedLimit,
+  executedSkip,
   chatSessionKey,
   initialChatMessages = [],
   onChatMessagesChange,
@@ -560,6 +568,17 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   const [sortQuery, setSortQuery] = useState(initialBuilderState.sortQuery);
   const [limit, setLimit] = useState(initialBuilderState.limit);
   const [skip, setSkip] = useState(initialBuilderState.skip);
+
+  // One-way resync from what was actually executed. Keyed on the executed
+  // values themselves, so an unrelated re-render cannot clobber a limit the
+  // user is midway through typing — only the pager actually running a new page
+  // size moves these.
+  useEffect(() => {
+    if (executedLimit !== undefined) setLimit(String(executedLimit));
+  }, [executedLimit]);
+  useEffect(() => {
+    if (executedSkip !== undefined) setSkip(String(executedSkip));
+  }, [executedSkip]);
   const [explainLoading, setExplainLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);

--- a/src/components/FindQueryBar.tsx
+++ b/src/components/FindQueryBar.tsx
@@ -53,9 +53,16 @@ export interface FindQueryBarProps {
 
 const queryColClass = (invalid: boolean) =>
   cn(
-    'flex min-w-0 flex-1 items-center border-r border-border bg-input/80 transition-colors last:border-r-0',
-    'focus-within:z-[1] focus-within:bg-input focus-within:ring-1 focus-within:ring-inset',
-    invalid ? 'focus-within:ring-destructive' : 'focus-within:ring-primary'
+    'relative flex min-w-0 flex-1 items-center border-r border-border bg-input/80 transition-colors last:border-r-0',
+    'focus-within:z-[1] focus-within:bg-input',
+    // The focus outline is an overlay pseudo-element, not `ring-inset`. A ring
+    // is an inset box-shadow, which paints UNDER child content — so anything in
+    // the field with a background of its own covered it and the outline
+    // survived only behind the semi-transparent label badge. Monaco paints its
+    // own layers here and wins over class-based background overrides, so the
+    // outline has to sit above the content rather than behind it.
+    "focus-within:after:pointer-events-none focus-within:after:absolute focus-within:after:inset-0 focus-within:after:content-[''] focus-within:after:border",
+    invalid ? 'focus-within:after:border-destructive' : 'focus-within:after:border-primary'
   );
 
 const fieldBadgeClass = (invalid: boolean) =>

--- a/src/components/FindQueryBar.tsx
+++ b/src/components/FindQueryBar.tsx
@@ -131,13 +131,21 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
     setInternalOptionsOpen(open);
     onOptionsOpenChange?.(open);
   };
+  // Only projection and sort trigger the reveal. Skip/limit are mirrored by the
+  // results pager, so they are never actually hidden — and counting them meant
+  // changing the page size popped the panel open, which is one-way and so never
+  // closed again. The initial state above still considers pagination, because a
+  // restored query arrives at mount and an unusual page size is worth showing.
+  const hasHiddenOptionValues =
+    (projection.trim() !== '' && projection.trim() !== '{}') ||
+    (sort.trim() !== '' && sort.trim() !== '{}');
   // Reveal only on the transition into having values — not on every mount, or a
   // remount would undo a deliberate collapse that the host persisted.
-  const hadOptionValues = useRef(hasOptionValues);
+  const hadOptionValues = useRef(hasHiddenOptionValues);
   useEffect(() => {
-    if (hasOptionValues && !hadOptionValues.current) setOptionsOpen(true);
-    hadOptionValues.current = hasOptionValues;
-  }, [hasOptionValues]);
+    if (hasHiddenOptionValues && !hadOptionValues.current) setOptionsOpen(true);
+    hadOptionValues.current = hasHiddenOptionValues;
+  }, [hasHiddenOptionValues]);
   // Rows are CSS-hidden rather than unmounted: Monaco keeps its model (and the
   // fields stay queryable) instead of being torn down on every toggle.
   const optionsVisible = !collapsibleOptions || optionsOpen;

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -234,7 +234,12 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
     return (
       <div
         className={cn(
-          'flex min-w-0 flex-1 items-center bg-input pl-2',
+          // No background of its own: the row (FindQueryBar's queryColClass)
+          // paints it, and draws the focus ring as `ring-inset` — a box-shadow
+          // rendered UNDER child content. An opaque background here covered
+          // that ring everywhere except the semi-transparent label badge, so
+          // focusing the field outlined the badge instead of the whole box.
+          'flex min-w-0 flex-1 items-center pl-2',
           '[&_.monaco-editor]:bg-transparent [&_.monaco-editor-background]:bg-transparent',
           '[&_.margin]:bg-transparent [&_.monaco-scrollable-element]:bg-transparent',
           // Monaco paints a shadow over the top edge once the line scrolls

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -712,3 +712,36 @@ describe('DataGrid column resize', () => {
     expect(headerCell.style.width).toBe('240px');
   });
 });
+
+describe('view mode persistence (#218)', () => {
+  const docs = [{ _id: '1', name: 'Alice' }];
+
+  it('renders the view mode it is given instead of always defaulting to JSON', () => {
+    // The results pane is `{tab.loading ? <spinner/> : <DataGrid/>}`, so the
+    // grid unmounts on every run and its local viewMode reset to 'json'.
+    // Given a viewMode it must honour it, which is what survives the remount.
+    render(<DataGrid documents={docs} viewMode="table" onViewModeChange={() => {}} />);
+
+    const table = screen.getByRole('button', { name: /table/i });
+    expect(table.className).toContain('bg-accent');
+  });
+
+  it('reports a view mode change upward so the owner can store it on the tab', () => {
+    const onViewModeChange = vi.fn();
+    render(<DataGrid documents={docs} viewMode="json" onViewModeChange={onViewModeChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /tree/i }));
+
+    expect(onViewModeChange).toHaveBeenCalledWith('tree');
+  });
+
+  it('still switches views on its own when no owner is managing it', () => {
+    // MongoShell renders <DataGrid documents={...}/> with no view-mode props;
+    // that path has to keep working uncontrolled.
+    render(<DataGrid documents={docs} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    expect(screen.getByRole('button', { name: /table/i }).className).toContain('bg-accent');
+  });
+});

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1313,4 +1313,25 @@ describe('page size resync from the pager (#218)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Run' }));
     expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ limit: 50 }));
   });
+
+  it('does not pop the Options panel open when the pager changes the page size', () => {
+    // The pager lives under the results grid and shows the page size itself, so
+    // resyncing the builder from it must not trigger the disclosure's
+    // "an option holds a non-default value" reveal. That reveal exists for
+    // projection/sort, which have no other surface — and it is one-way, so a
+    // spurious open never closes again.
+    const onExecute = vi.fn();
+    const { rerender } = render(
+      <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+    );
+    expect(screen.getByTestId('query-options-section').className).toContain('hidden');
+
+    rerender(
+      <DialogProvider>
+        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} />
+      </DialogProvider>
+    );
+
+    expect(screen.getByTestId('query-options-section').className).toContain('hidden');
+  });
 });

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1334,4 +1334,22 @@ describe('page size resync from the pager (#218)', () => {
 
     expect(screen.getByTestId('query-options-section').className).toContain('hidden');
   });
+
+  it('lets the row focus ring show across the whole field, not just the label', () => {
+    // queryColClass draws the focus affordance as `ring-inset`, which is a
+    // box-shadow painted UNDER child content. The editor wrapper used to set
+    // its own opaque `bg-input`, so the ring survived only behind the
+    // semi-transparent QUERY badge — focusing the field outlined the label
+    // instead of the box. jsdom cannot compare painted pixels, so this guards
+    // the invariant that makes it work: the row owns the background, the
+    // editor wrapper must not repaint over it.
+    render(<DocumentViewer {...baseProps} onExecute={vi.fn()} />);
+
+    const editorWrapper = screen.getByTestId('query-filter-input').closest('div');
+    const row = editorWrapper?.parentElement;
+
+    expect(row?.className).toContain('focus-within:ring-1');
+    expect(row?.className).toContain('bg-input/80');
+    expect(editorWrapper?.className ?? '').not.toContain('bg-input');
+  });
 });

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1348,7 +1348,11 @@ describe('page size resync from the pager (#218)', () => {
     const editorWrapper = screen.getByTestId('query-filter-input').closest('div');
     const row = editorWrapper?.parentElement;
 
-    expect(row?.className).toContain('focus-within:ring-1');
+    // Drawn as an overlay pseudo-element so nothing inside the field can paint
+    // over it — `ring-inset` is a box-shadow rendered under child content.
+    expect(row?.className).toContain('focus-within:after:border');
+    expect(row?.className).toContain('focus-within:after:absolute');
+    expect(row?.className).not.toContain('ring-inset');
     expect(row?.className).toContain('bg-input/80');
     expect(editorWrapper?.className ?? '').not.toContain('bg-input');
   });

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1289,7 +1289,7 @@ describe('page size resync from the pager (#218)', () => {
     // 100, and DocumentViewer re-renders with the newly executed values.
     rerender(
       <DialogProvider>
-        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} />
+        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} pagerRevision={1} />
       </DialogProvider>
     );
 
@@ -1328,7 +1328,7 @@ describe('page size resync from the pager (#218)', () => {
 
     rerender(
       <DialogProvider>
-        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} />
+        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} pagerRevision={1} />
       </DialogProvider>
     );
 
@@ -1355,5 +1355,58 @@ describe('page size resync from the pager (#218)', () => {
     expect(row?.className).not.toContain('ring-inset');
     expect(row?.className).toContain('bg-input/80');
     expect(editorWrapper?.className ?? '').not.toContain('bg-input');
+  });
+
+  it('keeps an unexecuted limit edit when the tab is switched away and back (Codex P2)', () => {
+    // The builder cache restores an edit the user never ran. The resync effects
+    // also run on mount, so they immediately replaced that restored edit with
+    // the older executed value — switching tabs silently discarded it.
+    const onExecute = vi.fn();
+    render(
+      <DocumentViewer
+        {...baseProps}
+        onExecute={onExecute}
+        initialBuilderState={{
+          queryMode: 'find',
+          filterQuery: '',
+          sortQuery: '',
+          projectionQuery: '',
+          limit: '200',
+          skip: '0',
+          stages: [],
+        }}
+        executedLimit={50}
+        executedSkip={0}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }));
+  });
+
+  it('keeps a limit edit made while an earlier query was still running (Codex P2)', () => {
+    // The query bar stays editable during a run. When the in-flight request
+    // lands, App updates lastQuery and the executed value changes — which must
+    // not overwrite input the user typed after pressing Run.
+    const onExecute = vi.fn();
+    const { rerender } = render(
+      <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+    );
+
+    // User runs with 100 from the builder, then types 200 while it is loading.
+    const limitInput = screen.getAllByRole('spinbutton').at(-1)!;
+    fireEvent.change(limitInput, { target: { value: '200' } });
+
+    // The earlier request completes: lastQuery.limit becomes 100.
+    rerender(
+      <DialogProvider>
+        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} />
+      </DialogProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }));
   });
 });

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1282,14 +1282,14 @@ describe('page size resync from the pager (#218)', () => {
     // user had just chosen from the pager.
     const onExecute = vi.fn();
     const { rerender } = render(
-      <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+      <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 50, skip: 0, revision: 0 }} />
     );
 
     // User picks 100 in the pager: App re-runs, `tab.lastQuery.limit` is now
     // 100, and DocumentViewer re-renders with the newly executed values.
     rerender(
       <DialogProvider>
-        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} pagerRevision={1} />
+        <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 100, skip: 0, revision: 1 }} />
       </DialogProvider>
     );
 
@@ -1301,12 +1301,12 @@ describe('page size resync from the pager (#218)', () => {
   it('leaves the limit alone on a re-render that did not change what was executed', () => {
     const onExecute = vi.fn();
     const { rerender } = render(
-      <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+      <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 50, skip: 0, revision: 0 }} />
     );
 
     rerender(
       <DialogProvider>
-        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+        <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 50, skip: 0, revision: 0 }} />
       </DialogProvider>
     );
 
@@ -1322,13 +1322,13 @@ describe('page size resync from the pager (#218)', () => {
     // spurious open never closes again.
     const onExecute = vi.fn();
     const { rerender } = render(
-      <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+      <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 50, skip: 0, revision: 0 }} />
     );
     expect(screen.getByTestId('query-options-section').className).toContain('hidden');
 
     rerender(
       <DialogProvider>
-        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} pagerRevision={1} />
+        <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 100, skip: 0, revision: 1 }} />
       </DialogProvider>
     );
 
@@ -1375,8 +1375,7 @@ describe('page size resync from the pager (#218)', () => {
           skip: '0',
           stages: [],
         }}
-        executedLimit={50}
-        executedSkip={0}
+        pagerRequest={{ limit: 50, skip: 0, revision: 3 }}
       />
     );
 
@@ -1391,22 +1390,46 @@ describe('page size resync from the pager (#218)', () => {
     // not overwrite input the user typed after pressing Run.
     const onExecute = vi.fn();
     const { rerender } = render(
-      <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+      <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 50, skip: 0, revision: 0 }} />
     );
 
     // User runs with 100 from the builder, then types 200 while it is loading.
     const limitInput = screen.getAllByRole('spinbutton').at(-1)!;
     fireEvent.change(limitInput, { target: { value: '200' } });
 
-    // The earlier request completes: lastQuery.limit becomes 100.
+    // The earlier request completes. It was a builder Run, not a pager move, so
+    // the pager request is unchanged and must not disturb the typed value.
     rerender(
       <DialogProvider>
-        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} />
+        <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 50, skip: 0, revision: 0 }} />
       </DialogProvider>
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Run' }));
 
     expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }));
+  });
+
+  it('applies the pager page size even though App bumps the revision before the query lands', () => {
+    // App's real sequence is TWO renders: bumpPagerRevision setTabs first (new
+    // revision, lastQuery still old), then handleExecuteQuery resolves and
+    // updates lastQuery (new values, same revision). A revision-keyed effect
+    // reading the executed values therefore syncs to the STALE numbers and
+    // never runs again.
+    const onExecute = vi.fn();
+    const { rerender } = render(
+      <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 50, skip: 0, revision: 0 }} />
+    );
+
+    // The request and its revision arrive together, so there is no render in
+    // which the builder can see a new revision beside a stale page size.
+    rerender(
+      <DialogProvider>
+        <DocumentViewer {...baseProps} onExecute={onExecute} pagerRequest={{ limit: 100, skip: 0, revision: 1 }} />
+      </DialogProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
   });
 });

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1265,3 +1265,52 @@ describe('Aggregation builder: collapse, undo/redo, $lookup form (#89)', () => {
     expect(body).toContain('"as": "userOrders"');
   });
 });
+
+describe('page size resync from the pager (#218)', () => {
+  const baseProps = {
+    connectionName: 'test-conn',
+    databaseName: 'test-db',
+    collectionName: 'test-coll',
+    onExplain: vi.fn(),
+    loading: false,
+  };
+
+  it('runs with the page size the pager last executed, not the one it mounted with', () => {
+    // The pager writes straight to `tab.lastQuery.limit`, but the builder's own
+    // `limit` was seeded once at mount and never resynced — so the next Run
+    // sent the stale mount-time value and silently undid the page size the
+    // user had just chosen from the pager.
+    const onExecute = vi.fn();
+    const { rerender } = render(
+      <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+    );
+
+    // User picks 100 in the pager: App re-runs, `tab.lastQuery.limit` is now
+    // 100, and DocumentViewer re-renders with the newly executed values.
+    rerender(
+      <DialogProvider>
+        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={100} executedSkip={0} />
+      </DialogProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
+  });
+
+  it('leaves the limit alone on a re-render that did not change what was executed', () => {
+    const onExecute = vi.fn();
+    const { rerender } = render(
+      <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+    );
+
+    rerender(
+      <DialogProvider>
+        <DocumentViewer {...baseProps} onExecute={onExecute} executedLimit={50} executedSkip={0} />
+      </DialogProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ limit: 50 }));
+  });
+});

--- a/src/lib/i18n/__tests__/coverage.test.ts
+++ b/src/lib/i18n/__tests__/coverage.test.ts
@@ -627,7 +627,10 @@ describe('i18n coverage', () => {
     }
 
     expect(offenders, `Untranslated user-facing strings found:\n${offenders.join('\n')}`).toEqual([]);
-  });
+    // Parses every scannable file with the TypeScript compiler (~1s alone, but
+    // slower when the full suite runs it alongside everything else). The
+    // default 5s timeout made it fail under load while passing in isolation.
+  }, 30_000);
 
   it('has no duplicate keys in the exemption map', () => {
     // A duplicate key in an object literal silently OVERWRITES the earlier one,
@@ -691,5 +694,5 @@ describe('i18n coverage', () => {
       offenders,
       `t() called with a non-numeric count — plural lookup will miss and render the raw key:\n${offenders.join('\n')}`,
     ).toEqual([]);
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Closes #218 — the last remaining item of the #215 usability umbrella (the other four, #216, #217, #219, #220, are already merged).

## Two separate bugs behind one symptom

**View mode reset on every run.** The results pane renders `{tab.loading ? <spinner/> : <DataGrid/>}`, so the grid unmounts on *every* run — and switching tabs unmounts the whole `DocumentViewer` subtree (`PaneView` renders only the active tab). `viewMode` was local state in `DataGrid`, so it reset to JSON both times. Pick Table, run again, back to JSON.

It now lives on `QueryTab` beside the other per-tab state, following the same pattern as the existing `limit`/`skip`/`onPageChange` props. `DataGrid` takes it as an **optional controlled prop** and keeps its self-managed behaviour when the props are omitted — that path matters, because `MongoShell` renders `<DataGrid documents={...}/>` bare.

**Page size was a desync, not a reset.** The pager writes straight to `tab.lastQuery.limit`, but the builder's own `limit`/`skip` are seeded once at mount and never resynced. So the pager worked — until the next Run sent the stale mount-time value and silently undid the size the user had just chosen.

The builder now resyncs from what was actually executed. The effects key on the executed values themselves, so an unrelated re-render can't clobber a limit the user is midway through typing; only a new page actually running moves them.

## Acceptance criteria from the issue

- [x] Set view = Table and page size = 100, re-run → both stay
- [x] Switch to another tab and back → both stay
- [x] Change page size via the pager, then re-run from the query builder → the pager's size is kept

## Tests

Five, each written before the fix and confirmed red first:

| Test | Guards |
|---|---|
| renders the view mode it is given | survives the remount |
| reports a change upward | the owner can store it on the tab |
| still switches views uncontrolled | the MongoShell path |
| runs with the page size the pager last executed | the desync |
| leaves the limit alone on an unchanged re-render | no clobbering in-progress edits |

## One unrelated fix rolled in

The two i18n gates parse every scannable file with the TypeScript compiler (~1s alone). Under full-suite load they exceeded vitest's 5s default and failed **while passing in isolation** — the worst way for a gate to fail. Both now have an explicit 30s timeout. I hit this on this branch; it would have hit CI regardless of what the change was.

## Verification

```
npx tsc --noEmit  → 0 errors
npm run build     → clean
npm run i18n:check→ clean (exit 0)
npx vitest run --coverage → 90 files, 1224 passed, 4 skipped
```

**On flakiness:** across 8 full runs I saw two single-test failures — once in `Sidebar.test.tsx`, once in an App reconnect test — each passing in isolation and on repeat, in two unrelated areas. I checked the App one properly rather than assuming, since it names builder state: it asserts only the *filter* value, and its seeded tab has no `lastQuery`, so `executedLimit`/`executedSkip` are `undefined` and the new effects no-op. It also hangs on a `waitFor` for a banner to disappear, which is timing-sensitive. Four consecutive clean full runs afterwards.
