### PR TITLE
feat(shell): keep the mongosh session alive across tab switches

### DIFF
--- a/docs/linkedin-post-v0.13.0.md
+++ b/docs/linkedin-post-v0.13.0.md
@@ -1,0 +1,73 @@
+# LinkedIn post — MQLens v0.13.0 (company page)
+
+Released 2026-07-21 (`mqlens-v0.13.0`). Post from the MQLens company page. LinkedIn favors a strong first line (it truncates after ~2 lines before "…see more"), short paragraphs, a few emojis, and 3–5 hashtags at the end. Attach a screenshot/GIF or a short demo video for reach.
+
+---
+
+## Version A — feature announcement (recommended)
+
+🚀 **MQLens v0.13.0 is here.**
+
+The free, open-source MongoDB GUI just got a lot more capable — and it's still native, private, and telemetry-free.
+
+What's new:
+
+🪟 **Multi-window workspace** — split panes and pop tabs into their own windows across monitors. Your layout and connections come back after a restart.
+
+🤖 **MCP server** — point Claude Code, Cursor, or any MCP client at your databases and let an AI agent list, query, aggregate, explain, and analyze schema. Off by default, opt-in per connection, every write gated behind confirmation.
+
+🎲 **Data generation** — seed collections with realistic fake documents. Point it at an existing collection and it infers the template from your schema.
+
+🛡️ **Production safeguards** — mark a connection read-only or confirm-destructive. Enforced at the command layer, for the UI and AI agents alike. Safe to point at prod.
+
+Free · Apache-2.0 · no telemetry · no account · native (Tauri/Rust, not Electron) · macOS / Windows / Linux.
+
+⬇️ Download & repo: https://github.com/mqlens/mqlens-mongodb
+
+We'd love your feedback — especially on the MCP tooling and the prod-safeguard flow.
+
+\#MongoDB #DeveloperTools #OpenSource #Rust #AI #MCP #Database
+
+---
+
+## Version B — the AI-agent angle (punchier, for wider reach)
+
+🤖 **You can now drive MongoDB from your AI coding agent.**
+
+MQLens v0.13.0 ships an **MCP server**: connect Claude Code or Cursor and an agent can list databases, run queries and aggregations, read explain plans, and analyze schema — as first-class tools.
+
+The part we care most about: it's **safe by design.** Off by default. Opt-in per connection. Every write gated behind explicit confirmation. And you can mark any connection read-only or confirm-destructive — enforced at the command layer, so the agent can't touch what you didn't allow.
+
+Also in v0.13.0: a detachable multi-window workspace across monitors, and schema-aware data generation for seeding test data.
+
+Free, open-source (Apache-2.0), native, no telemetry, no account.
+
+⬇️ https://github.com/mqlens/mqlens-mongodb
+
+\#AI #MCP #MongoDB #DeveloperTools #OpenSource #ClaudeCode #Cursor
+
+---
+
+## Version C — short / mission-led
+
+Working with production data shouldn't feel risky.
+
+**MQLens v0.13.0** adds read-only and confirm-destructive connection modes — mark a connection as protected and writes are blocked (or require typing the collection name), enforced at the command layer for both the UI and AI agents.
+
+It also brings a detachable multi-window workspace, an MCP server so AI agents can query your databases safely, and schema-aware data generation.
+
+Free, open-source, private by default. That's the whole point.
+
+⬇️ https://github.com/mqlens/mqlens-mongodb
+
+\#MongoDB #OpenSource #DeveloperTools #DataSafety
+
+---
+
+## Notes
+
+- **First line matters most** — LinkedIn truncates the preview; Version A/B lead with a hook that stands on its own.
+- **Visual**: attach a screenshot, GIF, or a 20–40s demo video (native video gets more reach than an image, and far more than a bare link). Best demos: tab dragged to a second monitor, the read-only banner blocking a write, or an agent running a query via MCP. See `docs/promotion-screenshot-plan.md`.
+- **Hashtags**: 3–5 is the sweet spot; more looks spammy. Keep #MongoDB + #OpenSource, swap the rest to match the version's angle.
+- **Timing**: Tue–Thu mornings (audience timezone) tend to perform best for B2B/dev content.
+- Reply to early comments — LinkedIn's algorithm rewards first-hour engagement.

--- a/docs/promotion-screenshot-plan.md
+++ b/docs/promotion-screenshot-plan.md
@@ -1,0 +1,40 @@
+# Promotion Screenshot Plan
+
+## Goal
+
+Create real MQLens product screenshots against a seeded local MongoDB database and use them on the website and docs.
+
+## Demo Data
+
+- Database: `mqlens_demo`
+- Collections:
+  - `orders`: order documents with status, customer, region, totals, items, payment, shipping, and timestamps.
+  - `customers`: customer profiles with plan, region, spend, and support metadata.
+  - `products`: product catalog rows for lookup and browsing examples.
+  - `events`: application event documents for query/filter examples.
+- Indexes:
+  - `orders.status + orders.createdAt`
+  - `orders.region + orders.total`
+  - `customers.email`
+  - `events.type + events.createdAt`
+
+## Screenshot Set
+
+1. Quick Start: clean first-run workspace.
+2. Connection setup: URI/profile flow for local MongoDB.
+3. Documents browser: connected database tree plus real customer documents.
+4. Visual query builder and AI assistant panels.
+5. Index detail and GridFS file browsing screens.
+
+## Website Updates
+
+- Add a real screenshot strip/gallery to the homepage near the hero/features.
+- Add screenshots to docs under the first-connection workflow.
+- Add a collection-workspace screenshot to the aggregation guide to show where the Aggregation tab lives.
+
+## Verification
+
+- Seed script runs idempotently against local MongoDB.
+- MQLens launches against the seeded database.
+- Real app screenshots are committed under `website/public/screenshots/`.
+- `npm run build` in `website/` completes.

--- a/docs/reddit-post-v0.13.0.md
+++ b/docs/reddit-post-v0.13.0.md
@@ -1,0 +1,108 @@
+# Reddit post — MQLens v0.13.0
+
+Released 2026-07-21 (`mqlens-v0.13.0`). Post as a **text/self post** (not a bare link — self-promo filters), add a screenshot or GIF, and check each sub's self-promotion rules first.
+
+---
+
+## Primary — r/mongodb (also fits r/database)
+
+**Title**
+
+```
+MQLens v0.13.0 — a free, native MongoDB GUI: multi-window workspace, an MCP server for AI agents, data generation, and read-only "prod safeguard" connections
+```
+
+**Body**
+
+Hey r/mongodb — I've been building **MQLens**, a free and open-source (Apache-2.0) MongoDB desktop app, and just shipped v0.13.0. It's native (Tauri/Rust, not Electron), no telemetry, no account, and your connection credentials are encrypted locally. Here's what's new in this release:
+
+**🪟 Detachable multi-window workspace** — split the workspace into panes and pop tabs out into their own OS windows, so you can spread a shell, a query, and cluster health across monitors. Your layout, tabs, and open connections come back after a restart (one click to reconnect).
+
+**🤖 MCP server** — expose your connections to Claude Code, Cursor, or any MCP client as tools, so an AI agent can list databases, run finds/aggregations, explain plans, and analyze schema. It's **off by default**, opt-in per connection, and every write is gated behind explicit confirmation — the agent can't touch a connection you didn't tick.
+
+**🎲 Data generation** — seed a collection with realistic fake documents from a template (names, emails, dates, nested objects, arrays, enums). "Generate more like this" infers the template from an existing collection's schema. Preview before you insert; large counts run as a background task.
+
+**🛡️ Production safeguards** — mark a connection **read-only** or **confirm-destructive**. Enforced at the command layer (not just hidden buttons), for the UI *and* AI agents alike — read-only blocks every write; confirm-destructive makes you type the collection name before a drop/delete-many. "Safe to point at prod."
+
+Also in there from recent releases: cluster health monitor, index usage stats + ESR suggestions, validation-rules editor, side-by-side document diff, import/export, GridFS, embedded mongosh.
+
+Free, cross-platform (macOS/Windows/Linux), signed + notarized builds. Would genuinely love feedback — especially on the MCP tooling and the prod-safeguard flow, both new this release.
+
+Repo + downloads: https://github.com/mqlens/mqlens-mongodb
+
+---
+
+## r/rust
+
+**Title**
+
+```
+MQLens v0.13.0 — a MongoDB GUI built in Rust + Tauri (not Electron): multi-window, an MCP server, and command-layer write safeguards
+```
+
+**Body**
+
+Shipped v0.13.0 of **MQLens**, a free/open-source (Apache-2.0) MongoDB desktop app built on **Tauri v2 + Rust** (React 19 frontend). It stays native and light — no Electron, no telemetry, no account, credentials encrypted locally with AES-256-GCM + Argon2id.
+
+New this release:
+
+- **Detachable multi-window workspace** — split panes + tabs you can pop into their own OS windows across monitors, with full session restore. The layout model is a pure Rust-mirrored reducer, kept in sync across windows via a backend event broadcast.
+- **Embedded MCP server** (`rmcp` over loopback HTTP) — exposes your connections to Claude Code / Cursor as MCP tools; opt-in per connection, off by default, bearer-token auth, every write gated behind explicit confirmation.
+- **Production-safeguard connection modes** — read-only / confirm-destructive, enforced by a single `guard_writable` choke point that every mutating command routes through (with a test that parses the real command list and asserts all ~110 are classified — so a new unguarded write fails CI). The AI agents inherit the same gate.
+- **Data generation** — deterministic seeded fake-document generator (using `fake`) with schema inference.
+
+Cross-platform, signed + notarized builds. Happy to talk about the Tauri architecture, the multi-window sync, or the command-guard design.
+
+Repo: https://github.com/mqlens/mqlens-mongodb
+
+---
+
+## r/opensource / r/selfhosted
+
+**Title**
+
+```
+MQLens v0.13.0 — free, Apache-2.0 MongoDB GUI, no telemetry, no account, local encrypted vault (now with multi-window, AI-agent tools, and read-only prod safeguards)
+```
+
+**Body**
+
+**MQLens** is a free and open-source (Apache-2.0) MongoDB desktop client focused on owning your own tooling: **no telemetry, no account, nothing phoned home**, credentials encrypted locally, signed + notarized builds. Native Tauri/Rust app, not Electron.
+
+Just shipped v0.13.0:
+
+- **Multi-window workspace** — split panes and detachable windows across monitors, with session restore.
+- **MCP server** — let Claude Code / Cursor / any MCP client drive your databases as tools; off by default, opt-in per connection, writes gated.
+- **Data generation** — seed collections with realistic fake data, schema-aware.
+- **Read-only / confirm-destructive connection modes** — command-layer enforced, so "safe to point at prod" actually means it.
+
+Plus cluster health, index stats, validation rules, document diff, import/export, GridFS, embedded mongosh.
+
+macOS / Windows / Linux. Feedback welcome.
+
+Repo + downloads: https://github.com/mqlens/mqlens-mongodb
+
+---
+
+## r/programming / r/webdev (short)
+
+**Title**
+
+```
+I built a free MongoDB GUI you can drive from Claude Code / Cursor — MQLens v0.13.0 ships an MCP server (plus multi-window + prod safeguards)
+```
+
+**Body**
+
+v0.13.0 of **MQLens** (free, Apache-2.0, native Tauri app) adds an **MCP server**: point Claude Code or Cursor at it and an agent can list databases, run queries/aggregations, explain plans, and analyze schema — off by default, opt-in per connection, every write gated behind confirmation. Also new: detachable multi-window workspace across monitors, schema-aware data generation, and read-only / confirm-destructive connection modes enforced at the command layer (for the UI and the AI agent alike). No telemetry, no account, local encrypted vault.
+
+https://github.com/mqlens/mqlens-mongodb
+
+---
+
+## Pre-post checklist
+
+- [ ] Add a screenshot or short GIF (best demos: dragging a tab to a second monitor, the data-generation preview, or the read-only banner blocking a write). See `docs/promotion-screenshot-plan.md`.
+- [ ] Post as a self/text post, repo link in the body — not a bare link post.
+- [ ] Re-read each subreddit's self-promotion / "Show-off" rules; some require a flair or a dedicated thread.
+- [ ] Reply to early comments quickly — engagement in the first hour drives reach.

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -82,7 +82,6 @@ const LOCAL_COMMANDS: &[&str] = &[
     "set_shell_tab_state",
     "clear_shell_tab_state",
     "rename_shell_tab_state",
-    "clear_all_shell_tab_state",
     "disconnect_db",
     "set_connection_meta", // renderer-callable with an arbitrary mode — see its own doc comment
     "connection_list",

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -76,6 +76,13 @@ const LOCAL_COMMANDS: &[&str] = &[
     "generate_mql_query",
     "detect_local_agents",
     "stop_mongosh_session", // kills the local child process, no DB write
+    // Per-tab shell state (session id, scrollback). In-process only — no DB
+    // access, and clearing a tab's entry deliberately does not stop its child.
+    "get_shell_tab_state",
+    "set_shell_tab_state",
+    "clear_shell_tab_state",
+    "rename_shell_tab_state",
+    "clear_all_shell_tab_state",
     "disconnect_db",
     "set_connection_meta", // renderer-callable with an arbitrary mode — see its own doc comment
     "connection_list",

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -81,6 +81,9 @@ const LOCAL_COMMANDS: &[&str] = &[
     "get_shell_tab_state",
     "set_shell_tab_state",
     "clear_shell_tab_state",
+    // Takes a tab's entry and stops the child it named, atomically — same
+    // local-only footprint as the two above plus `stop_mongosh_session`.
+    "close_shell_tab_session",
     "rename_shell_tab_state",
     "disconnect_db",
     "set_connection_meta", // renderer-callable with an arbitrary mode — see its own doc comment

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -612,6 +612,9 @@ pub async fn start_mongosh_session_impl(
     uri: &str,
     database: &str,
     mongosh_path: &str,
+    // The window asking for the session, so a start still in flight when that
+    // window closes can stop the child it spawned. Empty opts out.
+    window_id: &str,
 ) -> Result<MongoshSessionInfo, String> {
     if write_guard::connection_mode(state, connection_id)? == connections::ConnectionMode::ReadOnly
     {
@@ -673,6 +676,15 @@ pub async fn start_mongosh_session_impl(
     {
         let mut sessions = state.mongosh_sessions.lock_safe()?;
         sessions.insert(session_id.clone(), session.clone());
+    }
+
+    // The window that asked for this may have closed while mongosh was
+    // starting. Its renderer is gone, so nothing is left to cancel the start or
+    // to record the id, and the tab-state cleanup that ran on close had no id
+    // to stop — this child would simply survive until the app exits.
+    if window_is_closed(state, window_id)? {
+        let _ = stop_mongosh_session_impl(state, &session_id).await;
+        return Err(format!("window {window_id} closed while mongosh was starting"));
     }
 
     let startup = drain_mongosh_output(&session).await;
@@ -742,6 +754,20 @@ pub fn rename_shell_tab_state_impl(
         map.insert(new_id.to_string(), value);
     }
     Ok(())
+}
+
+/// Whether `window_id` has been closed, so work still in flight for it should
+/// be abandoned rather than completed. An empty id means "no owning window
+/// recorded" and is never treated as closed.
+///
+/// Split out from `start_mongosh_session_impl` so the decision is testable on
+/// its own: the surrounding path spawns a real mongosh binary, which the mock
+/// connections the suite uses cannot reach.
+pub fn window_is_closed(state: &AppState, window_id: &str) -> Result<bool, String> {
+    if window_id.is_empty() {
+        return Ok(false);
+    }
+    Ok(state.closed_windows.lock_safe()?.contains(window_id))
 }
 
 /// The tab ids whose stored shell state was written by `window_id`.
@@ -1018,11 +1044,20 @@ async fn start_mongosh_session(
     uri: String,
     database: String,
     mongosh_path: String,
+    window_id: Option<String>,
 ) -> Result<MongoshSessionInfo, String> {
     use tauri::Manager;
     let app_data_dir = app_handle.path().app_data_dir().ok();
     let resolved_path = toolsetup::resolve_mongosh_executable(&mongosh_path, app_data_dir.as_deref());
-    start_mongosh_session_impl(&state, &connection_id, &uri, &database, &resolved_path).await
+    start_mongosh_session_impl(
+        &state,
+        &connection_id,
+        &uri,
+        &database,
+        &resolved_path,
+        window_id.as_deref().unwrap_or_default(),
+    )
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -696,6 +696,59 @@ pub async fn run_mongosh_command_impl(
     run_mongosh_command_on_session(&session, command).await
 }
 
+/// Per-tab shell state, held backend-side so a frontend hot reload or window
+/// refresh cannot lose the mapping from a tab to its running mongosh process.
+///
+/// Module state in the renderer did not survive either: the map came back
+/// empty, the tab concluded it had no session and started a second one, and the
+/// original mongosh child was orphaned with no id left to stop it. The backend
+/// already owns those children, so it is the honest owner of the mapping too.
+/// The payload stays opaque JSON — its shape is a frontend concern.
+pub fn get_shell_tab_state_impl(
+    state: &AppState,
+    tab_id: &str,
+) -> Result<Option<serde_json::Value>, String> {
+    Ok(state.shell_tab_state.lock_safe()?.get(tab_id).cloned())
+}
+
+pub fn set_shell_tab_state_impl(
+    state: &AppState,
+    tab_id: &str,
+    value: serde_json::Value,
+) -> Result<(), String> {
+    state
+        .shell_tab_state
+        .lock_safe()?
+        .insert(tab_id.to_string(), value);
+    Ok(())
+}
+
+/// Forget a tab's state. Deliberately does NOT stop its mongosh session: the
+/// frontend stops that explicitly, which keeps "this tab closed" and "restart
+/// this session" distinguishable.
+pub fn clear_shell_tab_state_impl(state: &AppState, tab_id: &str) -> Result<(), String> {
+    state.shell_tab_state.lock_safe()?.remove(tab_id);
+    Ok(())
+}
+
+/// Move a tab's state to a new id, for the rebind that renames a restored tab.
+pub fn rename_shell_tab_state_impl(
+    state: &AppState,
+    old_id: &str,
+    new_id: &str,
+) -> Result<(), String> {
+    let mut map = state.shell_tab_state.lock_safe()?;
+    if let Some(value) = map.remove(old_id) {
+        map.insert(new_id.to_string(), value);
+    }
+    Ok(())
+}
+
+pub fn clear_all_shell_tab_state_impl(state: &AppState) -> Result<(), String> {
+    state.shell_tab_state.lock_safe()?.clear();
+    Ok(())
+}
+
 pub async fn stop_mongosh_session_impl(state: &AppState, session_id: &str) -> Result<(), String> {
     let session = {
         let mut sessions = state.mongosh_sessions.lock_safe()?;
@@ -968,6 +1021,42 @@ async fn run_mongosh_command(
     command: String,
 ) -> Result<MongoshCommandOutput, String> {
     run_mongosh_command_impl(&state, &session_id, &command).await
+}
+
+#[tauri::command]
+fn get_shell_tab_state(
+    state: tauri::State<'_, AppState>,
+    tab_id: String,
+) -> Result<Option<serde_json::Value>, String> {
+    get_shell_tab_state_impl(&state, &tab_id)
+}
+
+#[tauri::command]
+fn set_shell_tab_state(
+    state: tauri::State<'_, AppState>,
+    tab_id: String,
+    value: serde_json::Value,
+) -> Result<(), String> {
+    set_shell_tab_state_impl(&state, &tab_id, value)
+}
+
+#[tauri::command]
+fn clear_shell_tab_state(state: tauri::State<'_, AppState>, tab_id: String) -> Result<(), String> {
+    clear_shell_tab_state_impl(&state, &tab_id)
+}
+
+#[tauri::command]
+fn rename_shell_tab_state(
+    state: tauri::State<'_, AppState>,
+    old_id: String,
+    new_id: String,
+) -> Result<(), String> {
+    rename_shell_tab_state_impl(&state, &old_id, &new_id)
+}
+
+#[tauri::command]
+fn clear_all_shell_tab_state(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    clear_all_shell_tab_state_impl(&state)
 }
 
 #[tauri::command]
@@ -2111,6 +2200,11 @@ pub fn run() {
             start_mongosh_session,
             run_mongosh_command,
             stop_mongosh_session,
+            get_shell_tab_state,
+            set_shell_tab_state,
+            clear_shell_tab_state,
+            rename_shell_tab_state,
+            clear_all_shell_tab_state,
             disconnect_db,
             set_connection_meta,
             connection_list,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -744,6 +744,22 @@ pub fn rename_shell_tab_state_impl(
     Ok(())
 }
 
+/// The tab ids whose stored shell state was written by `window_id`.
+///
+/// Ownership is read from the state the renderer stamped, not from the
+/// workspace's tab list: the workspace stores PROFILE-space ids while these
+/// keys are LIVE-space, so a shell tab that has been rebound to a connection is
+/// filed under an id the workspace never mentions.
+pub fn shell_tab_ids_for_window(state: &AppState, window_id: &str) -> Result<Vec<String>, String> {
+    Ok(state
+        .shell_tab_state
+        .lock_safe()?
+        .iter()
+        .filter(|(_, value)| value.get("windowId").and_then(|w| w.as_str()) == Some(window_id))
+        .map(|(tab_id, _)| tab_id.clone())
+        .collect())
+}
+
 pub async fn stop_mongosh_session_impl(state: &AppState, session_id: &str) -> Result<(), String> {
     let session = {
         let mut sessions = state.mongosh_sessions.lock_safe()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -692,6 +692,15 @@ pub async fn start_mongosh_session_impl(
         let _ = run_mongosh_command_on_session(&session, &format!("use {}", database.trim())).await;
     }
 
+    // Rechecked, because the two awaits above can take seconds (the `use` alone
+    // has a 20s ceiling) and the window can close during them. Until this
+    // function returns, the id exists nowhere the close sweep can see it, and
+    // the renderer that would have handled the result is gone.
+    if window_is_closed(state, window_id)? {
+        let _ = stop_mongosh_session_impl(state, &session_id).await;
+        return Err(format!("window {window_id} closed while mongosh was starting"));
+    }
+
     Ok(MongoshSessionInfo {
         session_id,
         stdout: startup.stdout,
@@ -741,6 +750,19 @@ pub fn set_shell_tab_state_impl(
 pub fn clear_shell_tab_state_impl(state: &AppState, tab_id: &str) -> Result<(), String> {
     state.shell_tab_state.lock_safe()?.remove(tab_id);
     Ok(())
+}
+
+/// Remove a tab's state and return whatever it held, under one lock.
+///
+/// Closing a tab has to read the session id and forget the state, and doing
+/// that as two commands is a race the frontend cannot win: an inactive tab's id
+/// exists only here, so a clear that overtakes the read leaves the mongosh
+/// child running with nothing left pointing at it.
+pub fn take_shell_tab_state_impl(
+    state: &AppState,
+    tab_id: &str,
+) -> Result<Option<serde_json::Value>, String> {
+    Ok(state.shell_tab_state.lock_safe()?.remove(tab_id))
 }
 
 /// Move a tab's state to a new id, for the rebind that renames a restored tab.
@@ -1089,6 +1111,24 @@ fn set_shell_tab_state(
 #[tauri::command]
 fn clear_shell_tab_state(state: tauri::State<'_, AppState>, tab_id: String) -> Result<(), String> {
     clear_shell_tab_state_impl(&state, &tab_id)
+}
+
+/// Close a tab's shell for good: take its state and stop the child it named,
+/// so the read and the removal cannot be reordered against each other.
+#[tauri::command]
+async fn close_shell_tab_session(
+    state: tauri::State<'_, AppState>,
+    tab_id: String,
+) -> Result<(), String> {
+    let session_id = take_shell_tab_state_impl(&state, &tab_id)?.and_then(|v| {
+        v.get("sessionId")
+            .and_then(|s| s.as_str())
+            .map(|s| s.to_string())
+    });
+    if let Some(session_id) = session_id {
+        let _ = stop_mongosh_session_impl(&state, &session_id).await;
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -2244,6 +2284,7 @@ pub fn run() {
             get_shell_tab_state,
             set_shell_tab_state,
             clear_shell_tab_state,
+            close_shell_tab_session,
             rename_shell_tab_state,
             disconnect_db,
             set_connection_meta,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -744,11 +744,6 @@ pub fn rename_shell_tab_state_impl(
     Ok(())
 }
 
-pub fn clear_all_shell_tab_state_impl(state: &AppState) -> Result<(), String> {
-    state.shell_tab_state.lock_safe()?.clear();
-    Ok(())
-}
-
 pub async fn stop_mongosh_session_impl(state: &AppState, session_id: &str) -> Result<(), String> {
     let session = {
         let mut sessions = state.mongosh_sessions.lock_safe()?;
@@ -1052,11 +1047,6 @@ fn rename_shell_tab_state(
     new_id: String,
 ) -> Result<(), String> {
     rename_shell_tab_state_impl(&state, &old_id, &new_id)
-}
-
-#[tauri::command]
-fn clear_all_shell_tab_state(state: tauri::State<'_, AppState>) -> Result<(), String> {
-    clear_all_shell_tab_state_impl(&state)
 }
 
 #[tauri::command]
@@ -2204,7 +2194,6 @@ pub fn run() {
             set_shell_tab_state,
             clear_shell_tab_state,
             rename_shell_tab_state,
-            clear_all_shell_tab_state,
             disconnect_db,
             set_connection_meta,
             connection_list,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3,7 +3,7 @@
 use crate::{mcp, ssh_tunnel, workspace, IndexInfo, MongoshSession, TaskInfo};
 use mongodb::Client;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -91,6 +91,15 @@ pub struct AppState {
     /// The backend already owns those processes, so it is the honest owner of
     /// the mapping to them too. Opaque JSON keeps the shape a frontend concern.
     pub shell_tab_state: Mutex<HashMap<String, serde_json::Value>>,
+    /// Windows that have been closed, so a mongosh start still in flight for
+    /// one of them can stop the child it just spawned.
+    ///
+    /// Closing a window destroys its renderer, which is what would otherwise
+    /// have cancelled the start; and the child has no session id to record
+    /// until it exists, so the tab-state cleanup that runs on close finds
+    /// nothing to stop. Without this the process survives until app exit.
+    /// Cleared when a window with the same label is spawned again.
+    pub closed_windows: Mutex<HashSet<String>>,
     pub tasks: Arc<Mutex<HashMap<String, TaskInfo>>>,
     /// Per-task cancel flags for cancellable copy tasks (copy-only).
     pub cancels: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
@@ -146,6 +155,7 @@ impl AppState {
             mock_indexes: Mutex::new(HashMap::new()),
             mongosh_sessions: Mutex::new(HashMap::new()),
             shell_tab_state: Mutex::new(HashMap::new()),
+            closed_windows: Mutex::new(HashSet::new()),
             tasks: Arc::new(Mutex::new(HashMap::new())),
             cancels: Arc::new(Mutex::new(HashMap::new())),
             ssh_tunnels: Mutex::new(HashMap::new()),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -81,6 +81,16 @@ pub struct AppState {
     pub mocks: Mutex<HashMap<String, bool>>,
     pub mock_indexes: Mutex<HashMap<String, Vec<IndexInfo>>>,
     pub mongosh_sessions: Mutex<HashMap<String, Arc<MongoshSession>>>,
+    /// Per-tab shell state (session id, scrollback, AI transcript), keyed by
+    /// frontend tab id and stored as an opaque JSON blob.
+    ///
+    /// It lives here rather than in a frontend module because module state does
+    /// not survive a Vite hot reload or a window refresh: the map came back
+    /// empty, the tab concluded it had no session and started a second one, and
+    /// the original mongosh process was orphaned with no id left to stop it.
+    /// The backend already owns those processes, so it is the honest owner of
+    /// the mapping to them too. Opaque JSON keeps the shape a frontend concern.
+    pub shell_tab_state: Mutex<HashMap<String, serde_json::Value>>,
     pub tasks: Arc<Mutex<HashMap<String, TaskInfo>>>,
     /// Per-task cancel flags for cancellable copy tasks (copy-only).
     pub cancels: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
@@ -135,6 +145,7 @@ impl AppState {
             mocks: Mutex::new(HashMap::new()),
             mock_indexes: Mutex::new(HashMap::new()),
             mongosh_sessions: Mutex::new(HashMap::new()),
+            shell_tab_state: Mutex::new(HashMap::new()),
             tasks: Arc::new(Mutex::new(HashMap::new())),
             cancels: Arc::new(Mutex::new(HashMap::new())),
             ssh_tunnels: Mutex::new(HashMap::new()),

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4187,3 +4187,73 @@ mod tests {
             .expect("disconnect must succeed even with no registered meta");
     }
 }
+
+#[cfg(test)]
+mod shell_tab_state_tests {
+    use crate::state::AppState;
+    use crate::{
+        clear_all_shell_tab_state_impl, clear_shell_tab_state_impl, get_shell_tab_state_impl,
+        rename_shell_tab_state_impl, set_shell_tab_state_impl,
+    };
+
+    fn state() -> AppState {
+        AppState::new()
+    }
+
+    #[test]
+    fn stores_and_returns_a_tabs_state() {
+        let st = state();
+        let value = serde_json::json!({ "sessionId": "sess-1", "entries": [] });
+        set_shell_tab_state_impl(&st, "tab-1", value.clone()).unwrap();
+
+        assert_eq!(get_shell_tab_state_impl(&st, "tab-1").unwrap(), Some(value));
+    }
+
+    #[test]
+    fn an_unknown_tab_has_no_state() {
+        assert_eq!(get_shell_tab_state_impl(&state(), "nope").unwrap(), None);
+    }
+
+    #[test]
+    fn clearing_one_tab_leaves_the_others() {
+        let st = state();
+        set_shell_tab_state_impl(&st, "tab-1", serde_json::json!({ "sessionId": "a" })).unwrap();
+        set_shell_tab_state_impl(&st, "tab-2", serde_json::json!({ "sessionId": "b" })).unwrap();
+
+        clear_shell_tab_state_impl(&st, "tab-1").unwrap();
+
+        assert_eq!(get_shell_tab_state_impl(&st, "tab-1").unwrap(), None);
+        assert!(get_shell_tab_state_impl(&st, "tab-2").unwrap().is_some());
+    }
+
+    #[test]
+    fn rename_moves_the_state_to_the_new_tab_id() {
+        let st = state();
+        let value = serde_json::json!({ "sessionId": "sess-1" });
+        set_shell_tab_state_impl(&st, "old", value.clone()).unwrap();
+
+        rename_shell_tab_state_impl(&st, "old", "new").unwrap();
+
+        assert_eq!(get_shell_tab_state_impl(&st, "old").unwrap(), None);
+        assert_eq!(get_shell_tab_state_impl(&st, "new").unwrap(), Some(value));
+    }
+
+    #[test]
+    fn renaming_an_unknown_tab_is_a_no_op() {
+        let st = state();
+        rename_shell_tab_state_impl(&st, "missing", "new").unwrap();
+        assert_eq!(get_shell_tab_state_impl(&st, "new").unwrap(), None);
+    }
+
+    #[test]
+    fn clear_all_empties_every_tab() {
+        let st = state();
+        set_shell_tab_state_impl(&st, "tab-1", serde_json::json!({})).unwrap();
+        set_shell_tab_state_impl(&st, "tab-2", serde_json::json!({})).unwrap();
+
+        clear_all_shell_tab_state_impl(&st).unwrap();
+
+        assert_eq!(get_shell_tab_state_impl(&st, "tab-1").unwrap(), None);
+        assert_eq!(get_shell_tab_state_impl(&st, "tab-2").unwrap(), None);
+    }
+}

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4193,11 +4193,39 @@ mod shell_tab_state_tests {
     use crate::state::AppState;
     use crate::{
         clear_shell_tab_state_impl, get_shell_tab_state_impl, rename_shell_tab_state_impl,
-        set_shell_tab_state_impl,
+        set_shell_tab_state_impl, shell_tab_ids_for_window,
     };
 
     fn state() -> AppState {
         AppState::new()
+    }
+
+    #[test]
+    fn lists_only_the_tabs_a_given_window_owns() {
+        // Closing a secondary window with the OS X button runs no frontend
+        // code, so the backend stops that window's shells itself. It has to
+        // find them by the recorded owner: the workspace's tab ids are
+        // profile-space while these keys are live-space, so a shell rebound to
+        // a connection — the only kind with a child worth stopping — is filed
+        // under an id the workspace never mentions.
+        let st = state();
+        let owned = serde_json::json!({ "sessionId": "a", "windowId": "window-2" });
+        set_shell_tab_state_impl(&st, "live.tab-1", owned).unwrap();
+        set_shell_tab_state_impl(
+            &st,
+            "main.tab",
+            serde_json::json!({ "sessionId": "b", "windowId": "main" }),
+        )
+        .unwrap();
+        // Predates the stamp, or was written by an older build.
+        set_shell_tab_state_impl(&st, "unstamped", serde_json::json!({ "sessionId": "c" }))
+            .unwrap();
+
+        assert_eq!(
+            shell_tab_ids_for_window(&st, "window-2").unwrap(),
+            vec!["live.tab-1".to_string()]
+        );
+        assert!(shell_tab_ids_for_window(&st, "window-9").unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4192,8 +4192,8 @@ mod tests {
 mod shell_tab_state_tests {
     use crate::state::AppState;
     use crate::{
-        clear_all_shell_tab_state_impl, clear_shell_tab_state_impl, get_shell_tab_state_impl,
-        rename_shell_tab_state_impl, set_shell_tab_state_impl,
+        clear_shell_tab_state_impl, get_shell_tab_state_impl, rename_shell_tab_state_impl,
+        set_shell_tab_state_impl,
     };
 
     fn state() -> AppState {
@@ -4245,15 +4245,4 @@ mod shell_tab_state_tests {
         assert_eq!(get_shell_tab_state_impl(&st, "new").unwrap(), None);
     }
 
-    #[test]
-    fn clear_all_empties_every_tab() {
-        let st = state();
-        set_shell_tab_state_impl(&st, "tab-1", serde_json::json!({})).unwrap();
-        set_shell_tab_state_impl(&st, "tab-2", serde_json::json!({})).unwrap();
-
-        clear_all_shell_tab_state_impl(&st).unwrap();
-
-        assert_eq!(get_shell_tab_state_impl(&st, "tab-1").unwrap(), None);
-        assert_eq!(get_shell_tab_state_impl(&st, "tab-2").unwrap(), None);
-    }
 }

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1791,7 +1791,7 @@ mod tests {
         )
         .unwrap();
 
-        let err = start_mongosh_session_impl(&state, &conn_id, "mongodb://mock", "db", "")
+        let err = start_mongosh_session_impl(&state, &conn_id, "mongodb://mock", "db", "", "")
             .await
             .err()
             .expect("read-only connection must refuse a mongosh session");
@@ -1816,7 +1816,7 @@ mod tests {
             crate::connections::ConnectionMode::ConfirmDestructive,
         )
         .unwrap();
-        let err = start_mongosh_session_impl(&cd_state, &cd_id, "mongodb://mock", "db", "")
+        let err = start_mongosh_session_impl(&cd_state, &cd_id, "mongodb://mock", "db", "", "")
             .await
             .err()
             .expect("mock connections still can't run an external mongosh");
@@ -1832,7 +1832,7 @@ mod tests {
         let normal_id = connect_db_impl(&normal_state, "mongodb://mock", None)
             .await
             .expect("connect mock");
-        let err = start_mongosh_session_impl(&normal_state, &normal_id, "mongodb://mock", "db", "")
+        let err = start_mongosh_session_impl(&normal_state, &normal_id, "mongodb://mock", "db", "", "")
             .await
             .err()
             .expect("mock connections still can't run an external mongosh");
@@ -4198,6 +4198,33 @@ mod shell_tab_state_tests {
 
     fn state() -> AppState {
         AppState::new()
+    }
+
+    #[test]
+    fn a_closed_window_is_remembered_so_a_pending_start_can_abandon_itself() {
+        // Closing a window destroys the renderer that would have cancelled a
+        // `start_mongosh_session` still in flight, and that child has no
+        // session id to record until it exists — so the close sweep finds
+        // nothing to stop and the process survives until the app exits. The
+        // start consults this and stops the child it just spawned.
+        use crate::state::LockExt;
+        use crate::window_is_closed;
+        let st = state();
+
+        assert!(!window_is_closed(&st, "win-1").unwrap());
+        // No owning window recorded (an older frontend, or the main window
+        // before it has a label) must never look closed.
+        assert!(!window_is_closed(&st, "").unwrap());
+
+        st.closed_windows.lock_safe().unwrap().insert("win-1".into());
+
+        assert!(window_is_closed(&st, "win-1").unwrap());
+        assert!(!window_is_closed(&st, "win-2").unwrap());
+
+        // Labels are reused within a session, so respawning one must clear it —
+        // otherwise every start in the new window would kill its own child.
+        st.closed_windows.lock_safe().unwrap().remove("win-1");
+        assert!(!window_is_closed(&st, "win-1").unwrap());
     }
 
     #[test]

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -152,16 +152,13 @@ fn apply_window_closed_and_broadcast(app: &AppHandle, label: &str, origin: Strin
     // with the OS X button runs no frontend code at all, so without this the
     // sessions it owned stay alive — with their child processes and database
     // connections — until the whole app exits.
-    let doomed_tabs: Vec<String> = state
-        .workspace
-        .lock()
-        .ok()
-        .and_then(|guard| {
-            guard
-                .as_ref()
-                .map(|ws| workspace::window_tab_ids(ws, label))
-        })
-        .unwrap_or_default();
+    //
+    // Ownership comes from the shell state itself rather than from the
+    // workspace's tab list: the workspace holds profile-space tab ids, while
+    // shell state is keyed by the live-space id a rebound tab is re-keyed to,
+    // so enumerating the workspace would miss exactly the connected shells that
+    // have a child to stop.
+    let doomed_tabs = crate::shell_tab_ids_for_window(&state, label).unwrap_or_default();
     for tab_id in doomed_tabs {
         stop_shell_session_for_tab(app, &tab_id);
     }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -78,6 +78,7 @@
 //!   no-ops — but wasteful and not the simplest correct wiring).
 
 use crate::workspace::{self, Workspace, WorkspaceOp};
+use crate::state::LockExt;
 use crate::AppState;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent};
 
@@ -158,6 +159,14 @@ fn apply_window_closed_and_broadcast(app: &AppHandle, label: &str, origin: Strin
     // shell state is keyed by the live-space id a rebound tab is re-keyed to,
     // so enumerating the workspace would miss exactly the connected shells that
     // have a child to stop.
+    //
+    // Recorded BEFORE the sweep: a `start_mongosh_session` still in flight for
+    // this window has no session id yet, so the sweep below cannot see it and
+    // the renderer that would have cancelled it is about to be destroyed. The
+    // start itself checks this set and stops the child it spawned.
+    if let Ok(mut closed) = state.closed_windows.lock_safe() {
+        closed.insert(label.to_string());
+    }
     let doomed_tabs = crate::shell_tab_ids_for_window(&state, label).unwrap_or_default();
     for tab_id in doomed_tabs {
         stop_shell_session_for_tab(app, &tab_id);
@@ -224,6 +233,14 @@ pub fn wire_main_window_exit(app: &AppHandle) {
 pub fn spawn_workspace_window(app: &AppHandle, label: &str) -> Result<(), String> {
     if let Some(existing) = app.get_webview_window(label) {
         return existing.set_focus().map_err(|e| e.to_string());
+    }
+
+    // This label is live again, so a previous close must not keep poisoning it
+    // — window ids are reused across a session (`win-1` reappears after the
+    // first one closes), and a stale entry would make every start in the new
+    // window kill its own child.
+    if let Ok(mut closed) = app.state::<AppState>().closed_windows.lock_safe() {
+        closed.remove(label);
     }
 
     let window = WebviewWindowBuilder::new(app, label, WebviewUrl::App("index.html".into()))

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -81,6 +81,28 @@ use crate::workspace::{self, Workspace, WorkspaceOp};
 use crate::AppState;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent};
 
+/// Stop the mongosh child a tab owns, if any, and forget its stored state.
+/// Best-effort: a window closing must never be blocked by shell teardown.
+fn stop_shell_session_for_tab(app: &AppHandle, tab_id: &str) {
+    let state = app.state::<AppState>();
+    let session_id = crate::get_shell_tab_state_impl(&state, tab_id)
+        .ok()
+        .flatten()
+        .and_then(|v| {
+            v.get("sessionId")
+                .and_then(|s| s.as_str())
+                .map(|s| s.to_string())
+        });
+    let _ = crate::clear_shell_tab_state_impl(&state, tab_id);
+    if let Some(session_id) = session_id {
+        let app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            let state = app.state::<AppState>();
+            let _ = crate::stop_mongosh_session_impl(&state, &session_id).await;
+        });
+    }
+}
+
 const WINDOW_TITLE: &str = "MQLens";
 const DEFAULT_WIDTH: f64 = 1000.0;
 const DEFAULT_HEIGHT: f64 = 700.0;
@@ -125,6 +147,24 @@ pub(crate) fn window_is_known(ws: &Workspace, label: &str) -> bool {
 fn apply_window_closed_and_broadcast(app: &AppHandle, label: &str, origin: String) {
     let state = app.state::<AppState>();
     let path = workspace::workspace_path(app);
+    // End this window's mongosh children BEFORE the op removes it from the
+    // store, while its tabs can still be enumerated. Closing a secondary window
+    // with the OS X button runs no frontend code at all, so without this the
+    // sessions it owned stay alive — with their child processes and database
+    // connections — until the whole app exits.
+    let doomed_tabs: Vec<String> = state
+        .workspace
+        .lock()
+        .ok()
+        .and_then(|guard| {
+            guard
+                .as_ref()
+                .map(|ws| workspace::window_tab_ids(ws, label))
+        })
+        .unwrap_or_default();
+    for tab_id in doomed_tabs {
+        stop_shell_session_for_tab(app, &tab_id);
+    }
     match workspace::apply_impl(&state, &path, WorkspaceOp::WindowClosed { window_id: label.to_string() }, origin) {
         Ok(Some(payload)) => {
             let _ = app.emit("workspace-changed", payload);

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1046,6 +1046,17 @@ pub(crate) fn window_containing_tab<'a>(ws: &'a Workspace, tab_id: &str) -> Opti
         .map(|w| w.id.as_str())
 }
 
+/// Tab ids laid out in one window. Used when that window closes, to end the
+/// mongosh sessions its tabs owned: the OS X button runs no frontend code, so
+/// nothing else would ever stop those child processes before app exit.
+pub fn window_tab_ids(ws: &Workspace, window_id: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(win) = ws.windows.iter().find(|w| w.id == window_id) {
+        collect_tab_ids(&win.split_tree, &mut out);
+    }
+    out
+}
+
 /// Port of TS's tab-id collection helpers (`allTabIds`), used only by
 /// `validate` below — flattens every `tabIds` entry across an entire
 /// `LayoutNode` tree, panes and splits alike.

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1046,17 +1046,6 @@ pub(crate) fn window_containing_tab<'a>(ws: &'a Workspace, tab_id: &str) -> Opti
         .map(|w| w.id.as_str())
 }
 
-/// Tab ids laid out in one window. Used when that window closes, to end the
-/// mongosh sessions its tabs owned: the OS X button runs no frontend code, so
-/// nothing else would ever stop those child processes before app exit.
-pub fn window_tab_ids(ws: &Workspace, window_id: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    if let Some(win) = ws.windows.iter().find(|w| w.id == window_id) {
-        collect_tab_ids(&win.split_tree, &mut out);
-    }
-    out
-}
-
 /// Port of TS's tab-id collection helpers (`allTabIds`), used only by
 /// `validate` below — flattens every `tabIds` entry across an entire
 /// `LayoutNode` tree, panes and splits alike.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2020,9 +2020,12 @@ function Workspace() {
         // the retained mongosh child is still `use`-d into the old name, and
         // Sidebar renames with `dropSource: true`, so a write from this
         // apparently-renamed tab would recreate the database the rename just
-        // dropped. Awaited, because the retarget reads the state back under the
-        // new key — which only exists once the rename above has landed.
-        void moved.then(() => retargetShellSessionDatabase(newId, newName));
+        // dropped. Called synchronously, not off `moved`: the `setTabs` above
+        // re-keys this tab, so React remounts the shell before any awaited
+        // continuation would run and the new instance would seed itself from a
+        // registry entry still naming the old database. The retarget only falls
+        // back to awaiting the rename when nothing is cached to remount from.
+        void retargetShellSessionDatabase(newId, newName, moved);
       }
       dispatchWorkspace({ type: 'rename_tab', oldId, newId });
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,7 @@ import {
   disposeShellSession,
   disposeShellSessionsForTabs,
   renameShellSession,
-  stopShellSessionProcess,
-  writeShellSession,
+  retargetShellSessionDatabase,
 } from './lib/mongoshSession';
 import { DataGrid, type ViewMode } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
@@ -2015,16 +2014,15 @@ function Workspace() {
       // A rename mints a new tab id, so the shell session has to follow it —
       // otherwise the live mongosh child is stranded under the dead id and the
       // renamed tab starts a second one.
-      renameShellSession(oldId, newId);
+      const moved = renameShellSession(oldId, newId);
       if (isShell) {
         // Moving the session is not enough when the DATABASE is what changed:
         // the retained mongosh child is still `use`-d into the old name, and
         // Sidebar renames with `dropSource: true`, so a write from this
         // apparently-renamed tab would recreate the database the rename just
-        // dropped. Retarget the stored context and end the process — the
-        // remount opens a fresh session against `newName`, scrollback intact.
-        writeShellSession(newId, { currentDb: newName });
-        void stopShellSessionProcess(newId);
+        // dropped. Awaited, because the retarget reads the state back under the
+        // new key — which only exists once the rename above has landed.
+        void moved.then(() => retargetShellSessionDatabase(newId, newName));
       }
       dispatchWorkspace({ type: 'rename_tab', oldId, newId });
     });
@@ -2913,8 +2911,14 @@ function Workspace() {
           // the destination with a dead session id or lose the REPL state it is
           // supposed to carry across. Only dispose tabs that left the workspace
           // entirely.
+          // Translated to live space, exactly like `foreignLiveIds` above: the
+          // workspace stores profile-space ids, `leavingIds` holds live ones, so
+          // an untranslated comparison would report every rebound tab as gone
+          // from the document and kill the session the move was meant to carry.
           const stillInWorkspace = new Set(
-            payload.workspace.windows.flatMap((w) => allPanes(w.splitTree).flatMap((p) => p.tabIds))
+            payload.workspace.windows
+              .flatMap((w) => allPanes(w.splitTree).flatMap((p) => p.tabIds))
+              .map((id) => toLiveSpaceId(id, connections))
           );
           leavingIds.forEach((id) => {
             tabBuilderStateCache.current.delete(id);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,12 @@ import { CommandPalette, type PaletteAction } from './components/CommandPalette'
 import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import type { ChatMessage } from './components/AIChatPanel';
 import { clearChatRequest, renameChatRequest, resetChatRequests } from './lib/aiChatRequest';
-import { disposeAllShellSessions, disposeShellSession, renameShellSession } from './lib/mongoshSession';
+import {
+  disposeAllShellSessions,
+  disposeAllShellTabState,
+  disposeShellSession,
+  renameShellSession,
+} from './lib/mongoshSession';
 import { DataGrid, type ViewMode } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
 import { SettingsView, type SettingsTabId, MONGO_TOOLS_DIR_KEY } from './components/SettingsModal';
@@ -801,7 +806,7 @@ function Workspace() {
             // stale transcript after hydrate reuses ids.
             tabChatCache.current.clear();
             resetChatRequests();
-            void disposeAllShellSessions();
+            void disposeAllShellSessions().then(disposeAllShellTabState);
             const windowTabIds = new Set(snapshot.tabs.map((t) => t.id));
             const profileNames = new Map<string, string>();
             for (const t of ws.tabs) {
@@ -2813,7 +2818,7 @@ function Workspace() {
           tabBuilderStateCache.current.clear();
           tabChatCache.current.clear();
           resetChatRequests();
-          void disposeAllShellSessions();
+          void disposeAllShellSessions().then(disposeAllShellTabState);
           dispatchLayout({ type: 'hydrate', layout: createInitialLayout([], null) });
           return;
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import {
   disposeShellSession,
   disposeShellSessionsForTabs,
   renameShellSession,
+  stopShellSessionProcess,
+  writeShellSession,
 } from './lib/mongoshSession';
 import { DataGrid, type ViewMode } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
@@ -2006,14 +2008,24 @@ function Workspace() {
     };
 
     const renamedPairs = tabs
-      .map(t => ({ oldId: t.id, newId: renameTab(t).id }))
+      .map(t => ({ oldId: t.id, newId: renameTab(t).id, isShell: t.type === 'shell' }))
       .filter(p => p.oldId !== p.newId);
     setTabs(prev => prev.map(renameTab));
-    renamedPairs.forEach(({ oldId, newId }) => {
+    renamedPairs.forEach(({ oldId, newId, isShell }) => {
       // A rename mints a new tab id, so the shell session has to follow it —
       // otherwise the live mongosh child is stranded under the dead id and the
       // renamed tab starts a second one.
       renameShellSession(oldId, newId);
+      if (isShell) {
+        // Moving the session is not enough when the DATABASE is what changed:
+        // the retained mongosh child is still `use`-d into the old name, and
+        // Sidebar renames with `dropSource: true`, so a write from this
+        // apparently-renamed tab would recreate the database the rename just
+        // dropped. Retarget the stored context and end the process — the
+        // remount opens a fresh session against `newName`, scrollback intact.
+        writeShellSession(newId, { currentDb: newName });
+        void stopShellSessionProcess(newId);
+      }
       dispatchWorkspace({ type: 'rename_tab', oldId, newId });
     });
     invalidatePaletteNamespaceIndex(connectionId);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,9 +11,8 @@ import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './c
 import type { ChatMessage } from './components/AIChatPanel';
 import { clearChatRequest, renameChatRequest, resetChatRequests } from './lib/aiChatRequest';
 import {
-  disposeAllShellSessions,
-  disposeAllShellTabState,
   disposeShellSession,
+  disposeShellSessionsForTabs,
   renameShellSession,
 } from './lib/mongoshSession';
 import { DataGrid, type ViewMode } from './components/DataGrid';
@@ -806,7 +805,9 @@ function Workspace() {
             // stale transcript after hydrate reuses ids.
             tabChatCache.current.clear();
             resetChatRequests();
-            void disposeAllShellSessions().then(disposeAllShellTabState);
+            // Scoped to the ids this window is about to hydrate: a global clear
+            // would strip other windows' live shells of their recovery mapping.
+            void disposeShellSessionsForTabs(snapshot.tabs.map((t) => t.id));
             const windowTabIds = new Set(snapshot.tabs.map((t) => t.id));
             const profileNames = new Map<string, string>();
             for (const t of ws.tabs) {
@@ -2830,7 +2831,7 @@ function Workspace() {
           tabBuilderStateCache.current.clear();
           tabChatCache.current.clear();
           resetChatRequests();
-          void disposeAllShellSessions().then(disposeAllShellTabState);
+          void disposeShellSessionsForTabs(tabsRef.current.map((t) => t.id));
           dispatchLayout({ type: 'hydrate', layout: createInitialLayout([], null) });
           return;
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { clearChatRequest, renameChatRequest, resetChatRequests } from './lib/ai
 import {
   disposeShellSession,
   disposeShellSessionsForTabs,
+  forgetShellSession,
   renameShellSession,
   retargetShellSessionDatabase,
 } from './lib/mongoshSession';
@@ -2927,7 +2928,14 @@ function Workspace() {
             tabBuilderStateCache.current.delete(id);
             tabChatCache.current.delete(id);
             clearChatRequest(id);
-            if (!stillInWorkspace.has(id)) void disposeShellSession(id);
+            // Gone from the document: end the session. Merely moved to another
+            // window: that window owns the child now, so it must keep running —
+            // but this renderer's cached copy has to go, or moving the tab back
+            // would seed it from a snapshot predating everything the other
+            // window did, and a command still in flight here would mirror its
+            // stale transcript over the newer one.
+            if (stillInWorkspace.has(id)) forgetShellSession(id);
+            else void disposeShellSession(id);
             unmirroredTabIdsRef.current.delete(id);
           });
           setTabs((prev) => prev.filter((t) => !leavingIds.has(t.id)));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { CommandPalette, type PaletteAction } from './components/CommandPalette'
 import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import type { ChatMessage } from './components/AIChatPanel';
 import { clearChatRequest, renameChatRequest, resetChatRequests } from './lib/aiChatRequest';
+import { disposeAllShellSessions, disposeShellSession } from './lib/mongoshSession';
 import { DataGrid, type ViewMode } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
 import { SettingsView, type SettingsTabId, MONGO_TOOLS_DIR_KEY } from './components/SettingsModal';
@@ -797,6 +798,7 @@ function Workspace() {
             // stale transcript after hydrate reuses ids.
             tabChatCache.current.clear();
             resetChatRequests();
+            void disposeAllShellSessions();
             const windowTabIds = new Set(snapshot.tabs.map((t) => t.id));
             const profileNames = new Map<string, string>();
             for (const t of ws.tabs) {
@@ -2183,6 +2185,7 @@ function Workspace() {
       tabBuilderStateCache.current.delete(action.tabId);
       tabChatCache.current.delete(action.tabId);
       clearChatRequest(action.tabId);
+      void disposeShellSession(action.tabId);
       // #91: forget this tab's generate-task tracking on close (running or
       // finished) — otherwise reopening "Generate Data…" on the same
       // namespace reuses the same deterministic tab id and the fresh view
@@ -2209,6 +2212,7 @@ function Workspace() {
         generateTaskIdsRef.current.delete(id);
         tabChatCache.current.delete(id);
         clearChatRequest(id);
+        void disposeShellSession(id);
       });
     }
     dispatchLayout(action);
@@ -2806,6 +2810,7 @@ function Workspace() {
           tabBuilderStateCache.current.clear();
           tabChatCache.current.clear();
           resetChatRequests();
+          void disposeAllShellSessions();
           dispatchLayout({ type: 'hydrate', layout: createInitialLayout([], null) });
           return;
         }
@@ -2873,6 +2878,7 @@ function Workspace() {
             tabBuilderStateCache.current.delete(id);
             tabChatCache.current.delete(id);
             clearChatRequest(id);
+            void disposeShellSession(id);
             unmirroredTabIdsRef.current.delete(id);
           });
           setTabs((prev) => prev.filter((t) => !leavingIds.has(t.id)));
@@ -3015,6 +3021,7 @@ function Workspace() {
             tabBuilderStateCache.current.delete(id);
             tabChatCache.current.delete(id);
             clearChatRequest(id);
+            void disposeShellSession(id);
             unmirroredTabIdsRef.current.delete(id);
           });
           setTabs((prev) => prev.filter((t) => !removedIds.has(t.id)));
@@ -3934,6 +3941,7 @@ function Workspace() {
               onOpenSettings={handleOpenToolsSettings}
               onInstallTools={handleOpenToolSetup}
               reconnectSignal={shellReconnectNonce}
+              sessionKey={tab.id}
             />
           );
         })()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1952,7 +1952,13 @@ function Workspace() {
       .map(t => ({ oldId: t.id, newId: renameTab(t).id }))
       .filter(p => p.oldId !== p.newId);
     setTabs(prev => prev.map(renameTab));
-    renamedPairs.forEach(({ oldId, newId }) => dispatchWorkspace({ type: 'rename_tab', oldId, newId }));
+    renamedPairs.forEach(({ oldId, newId }) => {
+      // A rename mints a new tab id, so the shell session has to follow it —
+      // otherwise the live mongosh child is stranded under the dead id and the
+      // renamed tab starts a second one.
+      renameShellSession(oldId, newId);
+      dispatchWorkspace({ type: 'rename_tab', oldId, newId });
+    });
     invalidatePaletteNamespaceIndex(connectionId);
   };
 
@@ -2002,7 +2008,13 @@ function Workspace() {
       .map(t => ({ oldId: t.id, newId: renameTab(t).id }))
       .filter(p => p.oldId !== p.newId);
     setTabs(prev => prev.map(renameTab));
-    renamedPairs.forEach(({ oldId, newId }) => dispatchWorkspace({ type: 'rename_tab', oldId, newId }));
+    renamedPairs.forEach(({ oldId, newId }) => {
+      // A rename mints a new tab id, so the shell session has to follow it —
+      // otherwise the live mongosh child is stranded under the dead id and the
+      // renamed tab starts a second one.
+      renameShellSession(oldId, newId);
+      dispatchWorkspace({ type: 'rename_tab', oldId, newId });
+    });
     invalidatePaletteNamespaceIndex(connectionId);
   };
 
@@ -2882,11 +2894,20 @@ function Workspace() {
         );
         if (leaving.length > 0) {
           const leavingIds = new Set(leaving.map((t) => t.id));
+          // "Leaving" means gone from THIS window's tree — which includes a tab
+          // that was merely moved or detached to another window. Those are still
+          // in the document, and killing their mongosh child would either strand
+          // the destination with a dead session id or lose the REPL state it is
+          // supposed to carry across. Only dispose tabs that left the workspace
+          // entirely.
+          const stillInWorkspace = new Set(
+            payload.workspace.windows.flatMap((w) => allPanes(w.splitTree).flatMap((p) => p.tabIds))
+          );
           leavingIds.forEach((id) => {
             tabBuilderStateCache.current.delete(id);
             tabChatCache.current.delete(id);
             clearChatRequest(id);
-            void disposeShellSession(id);
+            if (!stillInWorkspace.has(id)) void disposeShellSession(id);
             unmirroredTabIdsRef.current.delete(id);
           });
           setTabs((prev) => prev.filter((t) => !leavingIds.has(t.id)));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { CommandPalette, type PaletteAction } from './components/CommandPalette'
 import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import type { ChatMessage } from './components/AIChatPanel';
 import { clearChatRequest, renameChatRequest, resetChatRequests } from './lib/aiChatRequest';
-import { disposeAllShellSessions, disposeShellSession } from './lib/mongoshSession';
+import { disposeAllShellSessions, disposeShellSession, renameShellSession } from './lib/mongoshSession';
 import { DataGrid, type ViewMode } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
 import { SettingsView, type SettingsTabId, MONGO_TOOLS_DIR_KEY } from './components/SettingsModal';
@@ -654,6 +654,9 @@ function Workspace() {
       // The in-flight request follows the tab; dropping it here would lose a
       // reply that is already on its way.
       renameChatRequest(oldId, newId);
+      // So does the shell session — it is a live process, and leaving it under
+      // the dead id would strand it while the rebound tab spawned another.
+      renameShellSession(oldId, newId);
     }
 
     // Dispatched straight to the layout reducer via `dispatchLayout`,

--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -94,7 +94,17 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
   // started a request still resumes after the tab is switched away. It must not
   // consume the settled reply in that case — the next mount needs to find it.
   const mountedRef = React.useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  // Must SET the flag, not only clear it on cleanup. StrictMode double-invokes
+  // effects in development — run, clean up, run again — so a cleanup-only
+  // version latched the flag to false on mount and every reply was then
+  // discarded by the guard below: no answer, and no spinner either, because
+  // the `finally` still cleared the loading state.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
   const nextChatId = () => `m${chatIdRef.current++}`;
 
   useEffect(() => {

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -441,10 +441,25 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   }, []);
   const appendEntries = (added: ShellEntry[]) => {
     if (added.length === 0) return;
-    const next = [...entriesRef.current, ...added];
+    if (mountedRef.current) {
+      setEntries((prev) => {
+        const next = [...prev, ...added];
+        entriesRef.current = next;
+        return next;
+      });
+      return;
+    }
+    if (!sessionKey) return;
+    // Off-screen, append against the REGISTRY rather than this instance's
+    // snapshot. A slow command can still be running when the tab is switched
+    // away and back, which leaves two MongoShell instances alive with two
+    // independent `entriesRef`s; each would write a full replacement array
+    // built from its own stale view, and the later completion would silently
+    // drop whatever the other one had appended.
+    const base = readShellSession(sessionKey)?.entries ?? entriesRef.current;
+    const next = [...base, ...added];
     entriesRef.current = next;
-    if (mountedRef.current) setEntries(next);
-    else if (sessionKey) writeShellSession(sessionKey, { entries: next });
+    writeShellSession(sessionKey, { entries: next });
   };
 
   const appendCommandOutput = (output: MongoshCommandOutput) => {
@@ -745,6 +760,13 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       const useMatch = raw.match(/^use\s+([A-Za-z0-9_.-]+)$/);
       if (useMatch) {
         setCurrentDb(useMatch[1]);
+        // Persist directly, not just via the mirroring effect: the switch is
+        // awaited above, so the tab may already have been switched away and
+        // this instance unmounted. `setCurrentDb` would then be a no-op and the
+        // mongosh child would sit on the new database while the remounted UI
+        // restored the old one — with the prompt and the driver-backed
+        // commands aimed somewhere the raw shell commands are not.
+        if (sessionKey) writeShellSession(sessionKey, { currentDb: useMatch[1] });
         if (!ranExternally) {
           setEntries((prev) => [
             ...prev,

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -26,6 +26,7 @@ import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 type ShellTab = 'console' | 'viewer';
 
 import {
+  loadShellSession,
   readShellSession,
   stopShellSessionProcess,
   writeShellSession,
@@ -276,6 +277,35 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   // Which retry generation we are already attached for. Seeded to 0 when a
   // session was restored, so the start effect reattaches instead of respawning.
   const attachedNonce = useRef<number | null>(storedSession?.sessionId ? 0 : null);
+
+  // After a hot reload or a window refresh the in-memory cache is empty, but the
+  // backend still holds this tab's state and its mongosh child is still running.
+  // Pull it back before the start effect can decide there is nothing to attach
+  // to and spawn a duplicate.
+  const [hydrated, setHydrated] = useState(Boolean(storedSession) || !sessionKey);
+  useEffect(() => {
+    if (hydrated || !sessionKey) return;
+    let alive = true;
+    void loadShellSession(sessionKey).then((restored) => {
+      if (!alive) return;
+      if (restored) {
+        if (restored.entries.length) setEntries(restored.entries);
+        if (restored.currentDb) setCurrentDb(restored.currentDb);
+        setAiMessages(restored.aiMessages);
+        setIsAIOpenState(restored.aiOpen);
+        autoRunRef.current = restored.autoRanCommand;
+        if (restored.sessionId) {
+          setSessionId(restored.sessionId);
+          setSessionAttempted(true);
+          attachedNonce.current = 0;
+        }
+      }
+      setHydrated(true);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [hydrated, sessionKey]);
   const [retryNonce, setRetryNonce] = useState(0);
 
   // Restart the session without losing the scrollback: stop the process, note
@@ -402,6 +432,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   };
 
   useEffect(() => {
+    // Waiting on the backend lookup above: starting before it lands would spawn
+    // a second child for a tab that already has one.
+    if (!hydrated) return;
     if (mongoshPath === null) return;
     if (!connectionUri) {
       setSessionAttempted(true);
@@ -479,7 +512,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     };
     // The session is started once per shell tab. currentDb is intentionally used only as startup database.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectionId, connectionUri, mongoshPath, retryNonce, sessionKey]);
+  }, [connectionId, connectionUri, mongoshPath, retryNonce, sessionKey, hydrated]);
 
   useEffect(() => {
     const el = scrollRef.current;

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -27,9 +27,12 @@ import { windowLabel } from '../workspace/workspaceStore';
 type ShellTab = 'console' | 'viewer';
 
 import {
+  dropPendingShellStart,
   loadShellSession,
   readShellSession,
+  shareShellStart,
   shellSessionEpoch,
+  watchShellSession,
   stopShellSessionProcess,
   writeShellSession,
   type ShellEntry,
@@ -353,6 +356,21 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     if (!sessionKey) return;
     persistSession({ entries, currentDb });
   }, [sessionKey, entries, currentDb]);
+
+  // ...and the other direction: pick up writes made by SOMEONE ELSE. A command
+  // that was still running when the user switched away completes against the
+  // registry, and that instance has no way to reach this one — so without this
+  // its output sat in storage, invisible until the next local append or tab
+  // switch. Assigning the same array back is a no-op for React, which is what
+  // keeps this from looping against the mirror effect above.
+  useEffect(() => {
+    if (!sessionKey) return;
+    return watchShellSession(sessionKey, (session) => {
+      setEntries((prev) => (session.entries === prev ? prev : session.entries));
+      entriesRef.current = session.entries;
+      if (session.currentDb) setCurrentDb(session.currentDb);
+    });
+  }, [sessionKey]);
   // Guided setup on session failure: a working mongosh found outside the
   // configured path (offered as one click), or null when nothing was found.
   const [detectedMongosh, setDetectedMongosh] = useState<
@@ -501,11 +519,26 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     }
     // A session already attached to this tab is still running — the process
     // outlives the unmount now, so reattach instead of spawning a second one.
-    // `retryNonce` is the deliberate exception: Retry means start fresh.
-    if (sessionKey && readShellSession(sessionKey)?.sessionId && retryNonce === attachedNonce.current) {
+    // `retryNonce` is the deliberate exception: Retry means start fresh (it
+    // clears the stored id first, so `attachedSessionId` is null by then).
+    //
+    // Read live rather than from the mount-time snapshot: an instance that
+    // mounted DURING a start has `attachedNonce.current === null`, and against
+    // a snapshot the check could never match afterwards — so it started a
+    // second child even once the first had recorded its id.
+    const attachedSessionId = sessionKey ? readShellSession(sessionKey)?.sessionId : null;
+    if (attachedSessionId && (attachedNonce.current === null || retryNonce === attachedNonce.current)) {
+      attachedNonce.current = retryNonce;
+      // Adopt it: this instance may have mounted before the id existed, and
+      // would otherwise sit behind the starting gate forever.
+      setSessionId(attachedSessionId);
+      setSessionAttempted(true);
       return;
     }
     attachedNonce.current = retryNonce;
+    // Retry/reconnect means start fresh: drop any in-flight start so the next
+    // call issues its own rather than joining the attempt being replaced.
+    if (sessionKey && retryNonce > 0) dropPendingShellStart(sessionKey);
 
     // Which start attempt this is. A dependency change (a Retry, or
     // `reconnectSignal` firing when a tool install finishes) tears this effect
@@ -523,17 +556,24 @@ export const MongoShell: React.FC<MongoShellProps> = ({
 
     const startSession = async () => {
       try {
-        const session = await invoke<MongoshSessionInfo>('start_mongosh_session', {
-          connectionId,
-          uri: connectionUri,
-          database: currentDb,
-          mongoshPath,
-          // So the backend can stop this child itself if the window closes
-          // before the start returns — at that point this renderer is gone and
-          // cannot cancel anything, and the id it would have recorded never
-          // reaches the tab state the close sweep reads.
-          windowId: windowLabel(),
-        });
+        const runStart = () =>
+          invoke<MongoshSessionInfo>('start_mongosh_session', {
+            connectionId,
+            uri: connectionUri,
+            database: currentDb,
+            mongoshPath,
+            // So the backend can stop this child itself if the window closes
+            // before the start returns — at that point this renderer is gone and
+            // cannot cancel anything, and the id it would have recorded never
+            // reaches the tab state the close sweep reads.
+            windowId: windowLabel(),
+          });
+        // Joins the start already running for this tab, if there is one. A
+        // start is slow and records nothing until it returns, so a remount
+        // partway through used to see an unattached tab and spawn a rival
+        // child — after which the two ids overwrote each other and one process
+        // was left with nothing pointing at it.
+        const session = sessionKey ? await shareShellStart(sessionKey, runStart) : await runStart();
         // Record it before the cancellation check: the tab owns the session, so
         // it must be findable by `disposeShellSession` even if this mount is
         // already gone.

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -25,12 +25,11 @@ import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 
 type ShellTab = 'console' | 'viewer';
 
-type ShellEntry =
-  | { kind: 'input'; db: string; text: string }
-  | { kind: 'text'; lines: string[] }
-  | { kind: 'value'; value: unknown }
-  | { kind: 'note'; text: string }
-  | { kind: 'error'; message: string };
+import {
+  readShellSession,
+  writeShellSession,
+  type ShellEntry,
+} from '../lib/mongoshSession';
 
 interface AppSettings {
   mongosh_path?: string;
@@ -59,6 +58,10 @@ interface MongoShellProps {
   onInstallTools?: () => void;
   /** Bump this (e.g. after a tool install completes) to re-attempt the mongosh session. */
   reconnectSignal?: number;
+  /** Identifies this shell across unmounts so its mongosh process and
+   *  scrollback survive a tab switch (#240). Without it the shell falls back
+   *  to the old behaviour: a session per mount. */
+  sessionKey?: string;
 }
 
 interface ParsedCall {
@@ -226,9 +229,12 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   onOpenSettings,
   onInstallTools,
   reconnectSignal,
+  sessionKey,
 }) => {
   const { t } = useTranslation('shell');
-  const [currentDb, setCurrentDb] = useState(databaseName);
+  // Restored transcript/session for this tab, if it survived an unmount (#240).
+  const storedSession = sessionKey ? readShellSession(sessionKey) : undefined;
+  const [currentDb, setCurrentDb] = useState(storedSession?.currentDb || databaseName);
   const startupLogId = useMemo(createLogId, []);
   // Display the connection name in the startup banner, never the URI — the URI
   // can contain credentials (e.g. user:password@host) that must not be logged.
@@ -243,17 +249,30 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const [isAIOpen, setIsAIOpen] = useState(false);
   const [pendingDestructive, setPendingDestructive] =
     useState<{ command: string; operation: string } | null>(null);
-  const [entries, setEntries] = useState<ShellEntry[]>([
-    { kind: 'text', lines: buildStartupLines(startupLogId, connectionTarget) },
-  ]);
+  // Restored transcript wins over a fresh banner: returning to this tab should
+  // look like the session was never interrupted.
+  const [entries, setEntries] = useState<ShellEntry[]>(
+    storedSession?.entries.length
+      ? storedSession.entries
+      : [{ kind: 'text', lines: buildStartupLines(startupLogId, connectionTarget) }]
+  );
   const [viewer, setViewer] = useState<{ docs: Record<string, any>[]; label: string; ms: number } | null>(null);
   const [tab, setTab] = useState<ShellTab>('console');
   const [running, setRunning] = useState(false);
   const [topHeight, setTopHeight] = useState<number | null>(null);
   const [mongoshPath, setMongoshPath] = useState<string | null>(null);
-  const [sessionId, setSessionId] = useState<string | null>(null);
-  const [sessionAttempted, setSessionAttempted] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(storedSession?.sessionId ?? null);
+  const [sessionAttempted, setSessionAttempted] = useState(Boolean(storedSession?.sessionId));
+  // Which retry generation we are already attached for. Seeded to 0 when a
+  // session was restored, so the start effect reattaches instead of respawning.
+  const attachedNonce = useRef<number | null>(storedSession?.sessionId ? 0 : null);
   const [retryNonce, setRetryNonce] = useState(0);
+
+  // Mirror the pieces that must outlive an unmount into the session registry.
+  useEffect(() => {
+    if (!sessionKey) return;
+    writeShellSession(sessionKey, { entries, currentDb, sessionId });
+  }, [sessionKey, entries, currentDb, sessionId]);
   // Guided setup on session failure: a working mongosh found outside the
   // configured path (offered as one click), or null when nothing was found.
   const [detectedMongosh, setDetectedMongosh] = useState<
@@ -355,6 +374,14 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       setSessionAttempted(true);
       return;
     }
+    // A session already attached to this tab is still running — the process
+    // outlives the unmount now, so reattach instead of spawning a second one.
+    // `retryNonce` is the deliberate exception: Retry means start fresh.
+    if (sessionKey && readShellSession(sessionKey)?.sessionId && retryNonce === attachedNonce.current) {
+      return;
+    }
+    attachedNonce.current = retryNonce;
+
     let cancelled = false;
     let openedSessionId: string | null = null;
     setSessionId(null);
@@ -398,13 +425,18 @@ export const MongoShell: React.FC<MongoShellProps> = ({
 
     return () => {
       cancelled = true;
-      if (openedSessionId) {
+      // Deliberately does NOT stop the session. Unmounting means the user
+      // switched tabs, not that they are done with the shell; the process is
+      // now owned by the tab and torn down by `disposeShellSession` when the
+      // tab closes (#240). Without a `sessionKey` there is nothing to reattach
+      // to later, so keep the old behaviour and clean up.
+      if (!sessionKey && openedSessionId) {
         invoke('stop_mongosh_session', { sessionId: openedSessionId }).catch(() => undefined);
       }
     };
     // The session is started once per shell tab. currentDb is intentionally used only as startup database.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectionId, connectionUri, mongoshPath, retryNonce]);
+  }, [connectionId, connectionUri, mongoshPath, retryNonce, sessionKey]);
 
   useEffect(() => {
     const el = scrollRef.current;

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -31,7 +31,6 @@ import {
   readShellSession,
   shellSessionEpoch,
   stopShellSessionProcess,
-  wasDisposedSince,
   writeShellSession,
   type ShellEntry,
   type ShellSession,
@@ -549,13 +548,15 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           return;
         }
         if (sessionKey) {
-          if (wasDisposedSince(sessionKey, epochRef.current)) {
-            // The tab was CLOSED while mongosh was starting, so its disposal
-            // ran before there was a session id to stop. Nothing will ever read
-            // this state or reach this child again — record it and it leaks, so
-            // stop it here instead. Deliberately narrower than "the epoch
-            // moved": a tab that was MOVED still needs the id recorded below,
-            // because the destination window reattaches to this very process.
+          if (shellSessionEpoch(sessionKey) !== epochRef.current) {
+            // This tab stopped belonging to this renderer while mongosh was
+            // starting — closed, or moved to another window. Either way nobody
+            // is coming back for this particular child: a closed tab has
+            // nothing left to read its id, and a moved tab is served by the
+            // destination window's own session. Recording it would be worse
+            // than useless, since the write re-stamps this window as the owner
+            // and can overwrite the mapping the destination is using — so
+            // closing this window would then kill the process it is showing.
             await invoke('stop_mongosh_session', { sessionId: session.session_id }).catch(
               () => undefined
             );
@@ -569,17 +570,16 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           if (session.stderr.length > 0)
             startupEntries.push({ kind: 'error', message: session.stderr.join('\n') });
           startupEntries.push({ kind: 'note', text: t('mongoShell.notes.sessionAttached') });
-          // The id itself is written unconditionally — a moved tab's new window
-          // must be able to find this process. The transcript is not: it would
-          // overwrite whatever that window has since appended.
-          const stillOurs = shellSessionEpoch(sessionKey) === epochRef.current;
+          // Past the epoch check above, so this tab is still ours; the write
+          // carries the epoch anyway, since nothing guarantees it stays ours
+          // between here and the next line.
           writeShellSession(sessionKey, {
             sessionId: session.session_id,
             // Against the registry, like every other append: by the time a
             // slow start returns, the tab may have been remounted and another
             // completion may already have landed. Building this from
             // `entriesRef` would erase it.
-            ...(cancelled && stillOurs
+            ...(cancelled
               ? {
                   entries: [
                     ...(readShellSession(sessionKey)?.entries ?? entriesRef.current),
@@ -587,7 +587,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
                   ],
                 }
               : {}),
-          });
+          }, epochRef.current);
         }
         if (cancelled) {
           // Unmounting means the user switched tabs mid-startup. With a tab

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -263,10 +263,15 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   // Restored transcript wins over a fresh banner: returning to this tab should
   // look like the session was never interrupted.
   const [entries, setEntries] = useState<ShellEntry[]>(
-    storedSession?.entries.length
+    // Presence of a stored session, NOT the length of its transcript: `clear`
+    // legitimately leaves it empty, and treating that as "nothing stored"
+    // resurrected the startup banner on the next tab switch.
+    storedSession
       ? storedSession.entries
       : [{ kind: 'text', lines: buildStartupLines(startupLogId, connectionTarget) }]
   );
+  const entriesRef = useRef(entries);
+  entriesRef.current = entries;
   const [viewer, setViewer] = useState<{ docs: Record<string, any>[]; label: string; ms: number } | null>(null);
   const [tab, setTab] = useState<ShellTab>('console');
   const [running, setRunning] = useState(false);
@@ -289,7 +294,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     void loadShellSession(sessionKey).then((restored) => {
       if (!alive) return;
       if (restored) {
-        if (restored.entries.length) setEntries(restored.entries);
+        setEntries(restored.entries);
         if (restored.currentDb) setCurrentDb(restored.currentDb);
         setAiMessages(restored.aiMessages);
         setIsAIOpenState(restored.aiOpen);
@@ -422,13 +427,31 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     };
   }, [connectionId, connectionTarget, startupLogId, retryNonce]);
 
+  // Appends that must land even if the tab was switched away mid-command.
+  // While mounted, setEntries drives the mirror effect as usual; once unmounted
+  // that effect is gone, so the transcript is written straight to the tab's
+  // session — otherwise the command runs, the backend answers, and the output
+  // is discarded because there is no component left to hold it.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+  const appendEntries = (added: ShellEntry[]) => {
+    if (added.length === 0) return;
+    const next = [...entriesRef.current, ...added];
+    entriesRef.current = next;
+    if (mountedRef.current) setEntries(next);
+    else if (sessionKey) writeShellSession(sessionKey, { entries: next });
+  };
+
   const appendCommandOutput = (output: MongoshCommandOutput) => {
     const nextEntries: ShellEntry[] = [];
     if (output.stdout.length > 0) nextEntries.push({ kind: 'text', lines: output.stdout });
     if (output.stderr.length > 0) nextEntries.push({ kind: 'error', message: output.stderr.join('\n') });
-    if (nextEntries.length > 0) {
-      setEntries((prev) => [...prev, ...nextEntries]);
-    }
+    appendEntries(nextEntries);
   };
 
   useEffect(() => {
@@ -464,7 +487,20 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         // Record it before the cancellation check: the tab owns the session, so
         // it must be findable by `disposeShellSession` even if this mount is
         // already gone.
-        if (sessionKey) writeShellSession(sessionKey, { sessionId: session.session_id });
+        if (sessionKey) {
+          // The backend has already drained the startup output; if this mount is
+          // gone, appending it to state would vanish, so fold it into the stored
+          // transcript instead of losing warnings and errors.
+          const startupEntries: ShellEntry[] = [];
+          if (session.stdout.length > 0) startupEntries.push({ kind: 'text', lines: session.stdout });
+          if (session.stderr.length > 0)
+            startupEntries.push({ kind: 'error', message: session.stderr.join('\n') });
+          startupEntries.push({ kind: 'note', text: t('mongoShell.notes.sessionAttached') });
+          writeShellSession(sessionKey, {
+            sessionId: session.session_id,
+            ...(cancelled ? { entries: [...entriesRef.current, ...startupEntries] } : {}),
+          });
+        }
         if (cancelled) {
           // Unmounting means the user switched tabs mid-startup. With a tab
           // identity the session survives that; without one there is nothing to
@@ -779,7 +815,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       if (ranExternally) return;
       throw new Error(t('mongoShell.errors.sessionRequiredForScripts'));
     } catch (err: any) {
-      setEntries((prev) => [...prev, { kind: 'error', message: err.message || String(err) }]);
+      appendEntries([{ kind: 'error', message: err.message || String(err) }]);
       setTab('console');
     } finally {
       setRunning(false);

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -268,11 +268,14 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const attachedNonce = useRef<number | null>(storedSession?.sessionId ? 0 : null);
   const [retryNonce, setRetryNonce] = useState(0);
 
-  // Mirror the pieces that must outlive an unmount into the session registry.
+  // Mirror the transcript and current database into the session registry.
+  // `sessionId` is deliberately NOT mirrored here: the start path sets it to
+  // null before spawning, and persisting that transient null would make a
+  // remount think there is nothing to reattach to.
   useEffect(() => {
     if (!sessionKey) return;
-    writeShellSession(sessionKey, { entries, currentDb, sessionId });
-  }, [sessionKey, entries, currentDb, sessionId]);
+    writeShellSession(sessionKey, { entries, currentDb });
+  }, [sessionKey, entries, currentDb]);
   // Guided setup on session failure: a working mongosh found outside the
   // configured path (offered as one click), or null when nothing was found.
   const [detectedMongosh, setDetectedMongosh] = useState<
@@ -397,8 +400,17 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           database: currentDb,
           mongoshPath,
         });
+        // Record it before the cancellation check: the tab owns the session, so
+        // it must be findable by `disposeShellSession` even if this mount is
+        // already gone.
+        if (sessionKey) writeShellSession(sessionKey, { sessionId: session.session_id });
         if (cancelled) {
-          await invoke('stop_mongosh_session', { sessionId: session.session_id }).catch(() => undefined);
+          // Unmounting means the user switched tabs mid-startup. With a tab
+          // identity the session survives that; without one there is nothing to
+          // reattach to later, so it has to be stopped.
+          if (!sessionKey) {
+            await invoke('stop_mongosh_session', { sessionId: session.session_id }).catch(() => undefined);
+          }
           return;
         }
         openedSessionId = session.session_id;
@@ -408,6 +420,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         }
         setEntries((prev) => [...prev, { kind: 'note', text: t('mongoShell.notes.sessionAttached') }]);
       } catch (err: any) {
+        if (sessionKey) writeShellSession(sessionKey, { sessionId: null });
         if (!cancelled) {
           setSessionId(null);
           setEntries((prev) => [

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -22,6 +22,7 @@ import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '.
 import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
 import { registerMqlensMonacoThemes } from '../lib/monacoAppTheme';
 import { formatShortcut, shortcutById } from '@/lib/shortcuts';
+import { windowLabel } from '../workspace/workspaceStore';
 
 type ShellTab = 'console' | 'viewer';
 
@@ -293,6 +294,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   // Which retry generation we are already attached for. Seeded to 0 when a
   // session was restored, so the start effect reattaches instead of respawning.
   const attachedNonce = useRef<number | null>(storedSession?.sessionId ? 0 : null);
+  /** Counts start attempts, so a completion can tell whether a newer attempt
+   *  has already replaced it. See the start effect. */
+  const startRunRef = useRef(0);
 
   // After a hot reload or a window refresh the in-memory cache is empty, but the
   // backend still holds this tab's state and its mongosh child is still running.
@@ -335,7 +339,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       else if (sessionId) await invoke('stop_mongosh_session', { sessionId }).catch(() => undefined);
       setSessionId(null);
       setSessionAttempted(false);
-      setEntries((prev) => [...prev, { kind: 'note', text: t('mongoShell.notes.sessionRestarting') }]);
+      appendEntries([{ kind: 'note', text: t('mongoShell.notes.sessionRestarting') }]);
       setRetryNonce((n) => n + 1);
     } finally {
       setRestarting(false);
@@ -452,24 +456,31 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   }, []);
   const appendEntries = (added: ShellEntry[]) => {
     if (added.length === 0) return;
-    if (mountedRef.current) {
-      setEntries((prev) => {
-        const next = [...prev, ...added];
-        entriesRef.current = next;
-        return next;
-      });
+    if (!sessionKey) {
+      // No tab identity: this instance's state is the only transcript there is.
+      if (mountedRef.current) {
+        setEntries((prev) => {
+          const next = [...prev, ...added];
+          entriesRef.current = next;
+          return next;
+        });
+      }
       return;
     }
-    if (!sessionKey) return;
-    // Off-screen, append against the REGISTRY rather than this instance's
-    // snapshot. A slow command can still be running when the tab is switched
-    // away and back, which leaves two MongoShell instances alive with two
-    // independent `entriesRef`s; each would write a full replacement array
-    // built from its own stale view, and the later completion would silently
-    // drop whatever the other one had appended.
+    // Append against the REGISTRY, mounted or not. A slow command can still be
+    // running when the tab is switched away and back, leaving two MongoShell
+    // instances alive with two independent `entriesRef`s. Basing either one on
+    // its own snapshot means the later completion silently drops whatever the
+    // other appended — and doing it only off-screen is not enough: when the old
+    // command finishes after the remount, the mounted instance's next append
+    // (and the mirror effect behind it) would overwrite the registry with a
+    // `prev` that never saw that output.
     const base = readShellSession(sessionKey)?.entries ?? entriesRef.current;
     const next = [...base, ...added];
     entriesRef.current = next;
+    // Also show it here, so the visible console reflects everything the tab has
+    // accumulated rather than only what this instance witnessed.
+    if (mountedRef.current) setEntries(next);
     persistSession({ entries: next });
   };
 
@@ -497,6 +508,15 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     }
     attachedNonce.current = retryNonce;
 
+    // Which start attempt this is. A dependency change (a Retry, or
+    // `reconnectSignal` firing when a tool install finishes) tears this effect
+    // down and immediately starts another, so "cancelled" alone cannot tell a
+    // real unmount from a supersession — and treating a superseded attempt as
+    // an unmount retains its child, whose id the replacement then overwrites,
+    // leaving the first mongosh process untracked.
+    const thisRun = ++startRunRef.current;
+    const superseded = () => startRunRef.current !== thisRun;
+
     let cancelled = false;
     let openedSessionId: string | null = null;
     setSessionId(null);
@@ -509,10 +529,25 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           uri: connectionUri,
           database: currentDb,
           mongoshPath,
+          // So the backend can stop this child itself if the window closes
+          // before the start returns — at that point this renderer is gone and
+          // cannot cancel anything, and the id it would have recorded never
+          // reaches the tab state the close sweep reads.
+          windowId: windowLabel(),
         });
         // Record it before the cancellation check: the tab owns the session, so
         // it must be findable by `disposeShellSession` even if this mount is
         // already gone.
+        if (superseded()) {
+          // A newer attempt is already running for this same tab. Recording
+          // this id would only get overwritten by that attempt, so stop the
+          // child here — this is the one case where a keyed session must NOT
+          // outlive its start.
+          await invoke('stop_mongosh_session', { sessionId: session.session_id }).catch(
+            () => undefined
+          );
+          return;
+        }
         if (sessionKey) {
           if (wasDisposedSince(sessionKey, epochRef.current)) {
             // The tab was CLOSED while mongosh was starting, so its disposal
@@ -540,7 +575,18 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           const stillOurs = shellSessionEpoch(sessionKey) === epochRef.current;
           writeShellSession(sessionKey, {
             sessionId: session.session_id,
-            ...(cancelled && stillOurs ? { entries: [...entriesRef.current, ...startupEntries] } : {}),
+            // Against the registry, like every other append: by the time a
+            // slow start returns, the tab may have been remounted and another
+            // completion may already have landed. Building this from
+            // `entriesRef` would erase it.
+            ...(cancelled && stillOurs
+              ? {
+                  entries: [
+                    ...(readShellSession(sessionKey)?.entries ?? entriesRef.current),
+                    ...startupEntries,
+                  ],
+                }
+              : {}),
           });
         }
         if (cancelled) {
@@ -557,13 +603,12 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         if (session.stdout.length > 0 || session.stderr.length > 0) {
           appendCommandOutput({ stdout: session.stdout, stderr: session.stderr });
         }
-        setEntries((prev) => [...prev, { kind: 'note', text: t('mongoShell.notes.sessionAttached') }]);
+        appendEntries([{ kind: 'note', text: t('mongoShell.notes.sessionAttached') }]);
       } catch (err: any) {
         persistSession({ sessionId: null });
         if (!cancelled) {
           setSessionId(null);
-          setEntries((prev) => [
-            ...prev,
+          appendEntries([
             {
               kind: 'error',
               message: t('mongoShell.notes.sessionUnavailable', { detail: err.message || String(err) }),
@@ -682,8 +727,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     const docs = result.map((doc) => JSON.parse(doc));
     setViewer({ docs, label, ms: Math.round((performance.now() - started) * 10) / 10 });
     setTab('viewer');
-    setEntries((prev) => [
-      ...prev,
+    appendEntries([
       {
         kind: 'note',
         text: t('mongoShell.notes.resultToDataViewer', { count: docs.length }),
@@ -706,8 +750,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     const docs = result.map((doc) => JSON.parse(doc));
     setViewer({ docs, label: `db.${collName}.aggregate()`, ms: Math.round((performance.now() - started) * 10) / 10 });
     setTab('viewer');
-    setEntries((prev) => [
-      ...prev,
+    appendEntries([
       {
         kind: 'note',
         text: t('mongoShell.notes.resultToDataViewer', { count: docs.length }),
@@ -756,13 +799,13 @@ export const MongoShell: React.FC<MongoShellProps> = ({
 
   const cancelDestructive = () => {
     setPendingDestructive(null);
-    setEntries((prev) => [...prev, { kind: 'note', text: t('mongoShell.notes.destructiveCancelled') }]);
+    appendEntries([{ kind: 'note', text: t('mongoShell.notes.destructiveCancelled') }]);
   };
 
   const runCommand = async (commandOverride?: string) => {
     const raw = (commandOverride ?? command).trim().replace(/;$/, '');
     if (!raw || running) return;
-    setEntries((prev) => [...prev, { kind: 'input', db: currentDb, text: raw }]);
+    appendEntries([{ kind: 'input', db: currentDb, text: raw }]);
     setRunning(true);
     try {
       if (/^(cls|clear)$/i.test(raw)) {
@@ -772,7 +815,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       }
       if (/^help$/i.test(raw)) {
         const helpLines = HELP_LINE_KEYS.map((key) => (key ? t(`mongoShell.${key}`) : ''));
-        setEntries((prev) => [...prev, { kind: 'text', lines: helpLines }]);
+        appendEntries([{ kind: 'text', lines: helpLines }]);
         setTab('console');
         return;
       }
@@ -780,7 +823,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
 
       if (raw === 'db') {
         if (ranExternally) return;
-        setEntries((prev) => [...prev, { kind: 'text', lines: [currentDb] }]);
+        appendEntries([{ kind: 'text', lines: [currentDb] }]);
         setTab('console');
         return;
       }
@@ -795,8 +838,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         // commands aimed somewhere the raw shell commands are not.
         persistSession({ currentDb: useMatch[1] });
         if (!ranExternally) {
-          setEntries((prev) => [
-            ...prev,
+          appendEntries([
             { kind: 'note', text: t('mongoShell.notes.switchedToDb', { db: useMatch[1] }) },
           ]);
         }
@@ -806,14 +848,14 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       if (/^show\s+(dbs|databases)$/i.test(raw)) {
         if (ranExternally) return;
         const dbs = await invoke<string[]>('list_databases', { id: connectionId });
-        setEntries((prev) => [...prev, { kind: 'text', lines: dbs }]);
+        appendEntries([{ kind: 'text', lines: dbs }]);
         setTab('console');
         return;
       }
       if (/^show\s+(collections|tables)$/i.test(raw)) {
         if (ranExternally) return;
         const collections = await invoke<{ name: string }[]>('list_collections', { id: connectionId, db: currentDb });
-        setEntries((prev) => [...prev, { kind: 'text', lines: collections.map((c) => c.name) }]);
+        appendEntries([{ kind: 'text', lines: collections.map((c) => c.name) }]);
         setTab('console');
         return;
       }
@@ -847,11 +889,11 @@ export const MongoShell: React.FC<MongoShellProps> = ({
             collection: collName,
             filter: JSON.stringify(parseLoose(firstArg(calls[0].argText), {}, t)),
           });
-          setEntries((prev) => [...prev, { kind: 'value', value: count }, { kind: 'note', text: `${Math.round((performance.now() - started) * 10) / 10} ms` }]);
+          appendEntries([{ kind: 'value', value: count }, { kind: 'note', text: `${Math.round((performance.now() - started) * 10) / 10} ms` }]);
           setTab('console');
         } else if (op === 'getIndexes') {
           const indexes = await invoke<string[]>('list_indexes', { id: connectionId, db: currentDb, collection: collName });
-          setEntries((prev) => [...prev, { kind: 'value', value: indexes.map((name) => ({ name })) }]);
+          appendEntries([{ kind: 'value', value: indexes.map((name) => ({ name })) }]);
           setTab('console');
         }
         return;

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -4,7 +4,7 @@ import Editor from '@monaco-editor/react';
 import { invoke } from '@tauri-apps/api/core';
 import { open as openFileDialog } from '@tauri-apps/plugin-dialog';
 import { openUrl } from '@tauri-apps/plugin-opener';
-import { AlertCircle, Braces, CornerDownLeft, Eraser, Play, Sparkles, Terminal } from 'lucide-react';
+import { AlertCircle, Braces, CornerDownLeft, Eraser, Play, RotateCcw, Sparkles, Terminal } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -15,7 +15,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { AIChatPanel } from './AIChatPanel';
+import { AIChatPanel, type ChatMessage } from './AIChatPanel';
 import { buildRunnableCommand, guardScriptRun, type GeneratedQuery } from '../lib/mongoCommand';
 import { DataGrid } from './DataGrid';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
@@ -27,6 +27,7 @@ type ShellTab = 'console' | 'viewer';
 
 import {
   readShellSession,
+  stopShellSessionProcess,
   writeShellSession,
   type ShellEntry,
 } from '../lib/mongoshSession';
@@ -246,7 +247,16 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const [command, setCommand] = useState(defaultCommand);
   const monacoTheme = useMonacoTheme();
   const monacoFontSize = useMonacoFontSize(13);
-  const [isAIOpen, setIsAIOpen] = useState(false);
+  const [isAIOpen, setIsAIOpenState] = useState(storedSession?.aiOpen ?? false);
+  const [aiMessages, setAiMessages] = useState<ChatMessage[]>(storedSession?.aiMessages ?? []);
+  const setIsAIOpen = (open: boolean) => {
+    setIsAIOpenState(open);
+    if (sessionKey) writeShellSession(sessionKey, { aiOpen: open });
+  };
+  const handleAiMessagesChange = (messages: ChatMessage[]) => {
+    setAiMessages(messages);
+    if (sessionKey) writeShellSession(sessionKey, { aiMessages: messages });
+  };
   const [pendingDestructive, setPendingDestructive] =
     useState<{ command: string; operation: string } | null>(null);
   // Restored transcript wins over a fresh banner: returning to this tab should
@@ -267,6 +277,24 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   // session was restored, so the start effect reattaches instead of respawning.
   const attachedNonce = useRef<number | null>(storedSession?.sessionId ? 0 : null);
   const [retryNonce, setRetryNonce] = useState(0);
+
+  // Restart the session without losing the scrollback: stop the process, note
+  // it in the transcript, then let the start effect attach a fresh one. Bumping
+  // `retryNonce` is what makes that effect skip its reattach shortcut.
+  const [restarting, setRestarting] = useState(false);
+  const restartSession = async () => {
+    setRestarting(true);
+    try {
+      if (sessionKey) await stopShellSessionProcess(sessionKey);
+      else if (sessionId) await invoke('stop_mongosh_session', { sessionId }).catch(() => undefined);
+      setSessionId(null);
+      setSessionAttempted(false);
+      setEntries((prev) => [...prev, { kind: 'note', text: t('mongoShell.notes.sessionRestarting') }]);
+      setRetryNonce((n) => n + 1);
+    } finally {
+      setRestarting(false);
+    }
+  };
 
   // Mirror the transcript and current database into the session registry.
   // `sessionId` is deliberately NOT mirrored here: the start path sets it to
@@ -861,7 +889,18 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => setIsAIOpen((v) => !v)}
+            onClick={() => void restartSession()}
+            disabled={restarting || running}
+            data-testid="shell-restart-session"
+            title={t('mongoShell.toolbar.restartSessionTitle')}
+          >
+            <RotateCcw size={11} />
+            {t('mongoShell.toolbar.restartSession')}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIsAIOpen(!isAIOpen)}
             data-testid="shell-ai-toggle"
             title={t('mongoShell.toolbar.aiToggleTitle')}
           >
@@ -1049,6 +1088,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       onClose={() => setIsAIOpen(false)}
       onInsertQuery={handleAIInsert}
       onInsertAndRunQuery={handleAIInsertAndRun}
+      sessionKey={sessionKey}
+      initialMessages={aiMessages}
+      onMessagesChange={handleAiMessagesChange}
     />
     {pendingDestructive && (
       <Dialog open onOpenChange={() => {}}>

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -296,7 +296,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const scrollRef = useRef<HTMLDivElement>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
   const runRef = useRef<() => void>(() => {});
-  const autoRunRef = useRef(false);
+  // Seeded from the tab's session: the opening command must run once per TAB,
+  // not once per mount, or switching tabs re-executes it (#240).
+  const autoRunRef = useRef(storedSession?.autoRanCommand ?? false);
   // Tracks the latest result docs so the Monaco completion provider (registered
   // once in onMount) can derive field names from the current results.
   const viewerRef = useRef<{ docs: Record<string, any>[] } | null>(null);
@@ -716,10 +718,11 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   useEffect(() => {
     if (!initialCommand || autoRunRef.current || !sessionAttempted || !sessionId) return;
     autoRunRef.current = true;
+    if (sessionKey) writeShellSession(sessionKey, { autoRanCommand: true });
     runCommand(initialCommand);
     // Run exactly once for the command that opened this shell tab.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialCommand, sessionAttempted, sessionId]);
+  }, [initialCommand, sessionAttempted, sessionId, sessionKey]);
 
   const dragging = useRef(false);
   useEffect(() => {

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -28,9 +28,12 @@ type ShellTab = 'console' | 'viewer';
 import {
   loadShellSession,
   readShellSession,
+  shellSessionEpoch,
   stopShellSessionProcess,
+  wasDisposedSince,
   writeShellSession,
   type ShellEntry,
+  type ShellSession,
 } from '../lib/mongoshSession';
 
 interface AppSettings {
@@ -236,6 +239,14 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const { t } = useTranslation('shell');
   // Restored transcript/session for this tab, if it survived an unmount (#240).
   const storedSession = sessionKey ? readShellSession(sessionKey) : undefined;
+  // Captured once, at mount. Every write below carries it, so if this tab is
+  // closed or moved to another window while a command is still running, the
+  // completion that lands afterwards is dropped instead of resurrecting a
+  // discarded session or overwriting the destination window's newer state.
+  const epochRef = useRef(sessionKey ? shellSessionEpoch(sessionKey) : 0);
+  const persistSession = (patch: Partial<ShellSession>) => {
+    if (sessionKey) writeShellSession(sessionKey, patch, epochRef.current);
+  };
   const [currentDb, setCurrentDb] = useState(storedSession?.currentDb || databaseName);
   const startupLogId = useMemo(createLogId, []);
   // Display the connection name in the startup banner, never the URI — the URI
@@ -252,11 +263,11 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const [aiMessages, setAiMessages] = useState<ChatMessage[]>(storedSession?.aiMessages ?? []);
   const setIsAIOpen = (open: boolean) => {
     setIsAIOpenState(open);
-    if (sessionKey) writeShellSession(sessionKey, { aiOpen: open });
+    persistSession({ aiOpen: open });
   };
   const handleAiMessagesChange = (messages: ChatMessage[]) => {
     setAiMessages(messages);
-    if (sessionKey) writeShellSession(sessionKey, { aiMessages: messages });
+    persistSession({ aiMessages: messages });
   };
   const [pendingDestructive, setPendingDestructive] =
     useState<{ command: string; operation: string } | null>(null);
@@ -337,7 +348,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   // remount think there is nothing to reattach to.
   useEffect(() => {
     if (!sessionKey) return;
-    writeShellSession(sessionKey, { entries, currentDb });
+    persistSession({ entries, currentDb });
   }, [sessionKey, entries, currentDb]);
   // Guided setup on session failure: a working mongosh found outside the
   // configured path (offered as one click), or null when nothing was found.
@@ -459,7 +470,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     const base = readShellSession(sessionKey)?.entries ?? entriesRef.current;
     const next = [...base, ...added];
     entriesRef.current = next;
-    writeShellSession(sessionKey, { entries: next });
+    persistSession({ entries: next });
   };
 
   const appendCommandOutput = (output: MongoshCommandOutput) => {
@@ -503,6 +514,18 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         // it must be findable by `disposeShellSession` even if this mount is
         // already gone.
         if (sessionKey) {
+          if (wasDisposedSince(sessionKey, epochRef.current)) {
+            // The tab was CLOSED while mongosh was starting, so its disposal
+            // ran before there was a session id to stop. Nothing will ever read
+            // this state or reach this child again — record it and it leaks, so
+            // stop it here instead. Deliberately narrower than "the epoch
+            // moved": a tab that was MOVED still needs the id recorded below,
+            // because the destination window reattaches to this very process.
+            await invoke('stop_mongosh_session', { sessionId: session.session_id }).catch(
+              () => undefined
+            );
+            return;
+          }
           // The backend has already drained the startup output; if this mount is
           // gone, appending it to state would vanish, so fold it into the stored
           // transcript instead of losing warnings and errors.
@@ -511,9 +534,13 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           if (session.stderr.length > 0)
             startupEntries.push({ kind: 'error', message: session.stderr.join('\n') });
           startupEntries.push({ kind: 'note', text: t('mongoShell.notes.sessionAttached') });
+          // The id itself is written unconditionally — a moved tab's new window
+          // must be able to find this process. The transcript is not: it would
+          // overwrite whatever that window has since appended.
+          const stillOurs = shellSessionEpoch(sessionKey) === epochRef.current;
           writeShellSession(sessionKey, {
             sessionId: session.session_id,
-            ...(cancelled ? { entries: [...entriesRef.current, ...startupEntries] } : {}),
+            ...(cancelled && stillOurs ? { entries: [...entriesRef.current, ...startupEntries] } : {}),
           });
         }
         if (cancelled) {
@@ -532,7 +559,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         }
         setEntries((prev) => [...prev, { kind: 'note', text: t('mongoShell.notes.sessionAttached') }]);
       } catch (err: any) {
-        if (sessionKey) writeShellSession(sessionKey, { sessionId: null });
+        persistSession({ sessionId: null });
         if (!cancelled) {
           setSessionId(null);
           setEntries((prev) => [
@@ -766,7 +793,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         // mongosh child would sit on the new database while the remounted UI
         // restored the old one — with the prompt and the driver-backed
         // commands aimed somewhere the raw shell commands are not.
-        if (sessionKey) writeShellSession(sessionKey, { currentDb: useMatch[1] });
+        persistSession({ currentDb: useMatch[1] });
         if (!ranExternally) {
           setEntries((prev) => [
             ...prev,
@@ -850,7 +877,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   useEffect(() => {
     if (!initialCommand || autoRunRef.current || !sessionAttempted || !sessionId) return;
     autoRunRef.current = true;
-    if (sessionKey) writeShellSession(sessionKey, { autoRanCommand: true });
+    persistSession({ autoRanCommand: true });
     runCommand(initialCommand);
     // Run exactly once for the command that opened this shell tab.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/__tests__/AIChatPanel.test.tsx
+++ b/src/components/__tests__/AIChatPanel.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AIChatPanel } from '../AIChatPanel';
@@ -271,5 +272,29 @@ describe('AIChatPanel', () => {
     localStorage.setItem('mqlens-ai-helper-width', '420');
     renderPanel('editor');
     expect(screen.getByTestId('ai-helper-panel')).toHaveStyle({ width: '420px' });
+  });
+
+  it('delivers the reply under StrictMode, which double-invokes effects', async () => {
+    // The mounted guard was cleanup-only, so StrictMode's mount/cleanup/mount
+    // left it false and every reply was dropped — messages sent, nothing back,
+    // not even a spinner.
+    invokeMock.mockResolvedValue(
+      JSON.stringify({ explanation: 'Here are the results.', queryType: 'find', filter: {} })
+    );
+
+    render(
+      <React.StrictMode>
+        <AIChatPanel
+          connectionId="c1" databaseName="test-db" collectionName="users" fields={[]}
+          variant="editor" isOpen sessionKey="strict-tab"
+          onClose={onClose} onInsertQuery={onInsertQuery} onInsertAndRunQuery={onInsertAndRunQuery}
+        />
+      </React.StrictMode>
+    );
+
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'show me users' } });
+    fireEvent.click(screen.getByTestId('chat-send-btn'));
+
+    expect(await screen.findByText('Here are the results.')).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -2726,6 +2726,13 @@ describe('App Component', () => {
         expect(screen.queryAllByTestId('reconnect-banner')).toHaveLength(0);
       });
 
+      // A live session for the tab that is about to move.
+      const { writeShellSession, readShellSession } = await import('../../lib/mongoshSession');
+      writeShellSession('new-conn-1.sales_db.customers', {
+        sessionId: 'sess-live',
+        currentDb: 'sales_db',
+      });
+
       calls.length = 0;
 
       // `customers` has moved to win-1; main keeps only `orders`.
@@ -2769,6 +2776,12 @@ describe('App Component', () => {
         (c) => c.cmd === 'clear_shell_tab_state' && c.args?.tabId === 'new-conn-1.sales_db.customers'
       );
       expect(cleared).toEqual([]);
+      expect(calls.filter((c) => c.cmd === 'stop_mongosh_session')).toEqual([]);
+
+      // The backend session lives on for the destination window, but THIS
+      // renderer forgets its copy: moving the tab back must re-read the state
+      // the other window has been updating, not this stale snapshot.
+      expect(readShellSession('new-conn-1.sales_db.customers')).toBeUndefined();
     });
   });
 

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -2698,6 +2698,78 @@ describe('App Component', () => {
       const filterInput = await screen.findByTestId('query-filter-input');
       expect((filterInput as HTMLInputElement).value).toBe('{"seeded":true}');
     });
+
+    it('a rebound tab MOVED to another window keeps its session — the survival check translates profile-space ids', async () => {
+      // Reconnecting re-keys the tab to `new-conn-1.…` while the workspace goes
+      // on storing `profile:p1.…`. A tab that merely moved to another window is
+      // gone from THIS window's tree but still in the document; comparing the
+      // two id spaces directly made it look deleted, and the dispose that
+      // followed killed the mongosh child the move was meant to carry across.
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'workspace_get') return Promise.resolve(workspaceSnapshot);
+        if (cmd === 'load_connection_profiles') {
+          return Promise.resolve([{ id: 'p1', name: 'Prod Cluster', uri: 'mongodb://prod', ssh: null }]);
+        }
+        if (cmd === 'connect_db') return Promise.resolve('new-conn-1');
+        if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
+        return Promise.resolve([]);
+      });
+
+      const { fireEvent, waitFor, act } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+
+      const [firstBtn] = await screen.findAllByRole('button', { name: /Reconnect Prod Cluster/ });
+      fireEvent.click(firstBtn);
+      await waitFor(() => {
+        expect(screen.queryAllByTestId('reconnect-banner')).toHaveLength(0);
+      });
+
+      calls.length = 0;
+
+      // `customers` has moved to win-1; main keeps only `orders`.
+      await act(async () => {
+        fireMockEvent('workspace-changed', {
+          revision: 2,
+          origin: 'win-1',
+          crossWindow: true,
+          workspace: {
+            revision: 2,
+            windows: [
+              {
+                id: 'main',
+                focusedPaneId: 'pane-2',
+                splitTree: {
+                  kind: 'pane',
+                  id: 'pane-2',
+                  tabIds: ['profile:p1.sales_db.orders'],
+                  activeTabId: 'profile:p1.sales_db.orders',
+                },
+              },
+              {
+                id: 'win-1',
+                focusedPaneId: 'pane-9',
+                splitTree: {
+                  kind: 'pane',
+                  id: 'pane-9',
+                  tabIds: ['profile:p1.sales_db.customers'],
+                  activeTabId: 'profile:p1.sales_db.customers',
+                },
+              },
+            ],
+            tabs: workspaceSnapshot.tabs,
+          },
+        });
+      });
+
+      // `disposeShellSession` always clears the backend entry, so that call is
+      // the tell that the tab was treated as deleted rather than moved.
+      const cleared = calls.filter(
+        (c) => c.cmd === 'clear_shell_tab_state' && c.args?.tabId === 'new-conn-1.sales_db.customers'
+      );
+      expect(cleared).toEqual([]);
+    });
   });
 
   describe('dispatchWorkspace no-op mirror gate (#97 phase 2 final review Fix 3)', () => {

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MongoShell } from '../MongoShell';
-import { readShellSession, resetShellSessions } from '../../lib/mongoshSession';
+import { readShellSession, resetShellSessions, writeShellSession } from '../../lib/mongoshSession';
 
 const mockInvoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({
@@ -793,6 +793,75 @@ describe('MongoShell Component', () => {
       await waitFor(() => expect(stopCalls()).toBe(1));
       await waitFor(() => expect(startCalls()).toBe(2));
       expect(screen.getByText(/Current Mongosh Log ID/)).toBeInTheDocument();
+    });
+
+    it('does not clobber output another instance appended off-screen', async () => {
+      // Two instances exist whenever a command is still running as the user
+      // switches away and back. The mounted one used to append against its own
+      // React `prev`, so its next write — and the mirror effect behind it —
+      // erased whatever the other instance had finished off-screen. Driven
+      // through the registry rather than a second mount, because the registry
+      // IS the shared transcript the two instances race over.
+      render(<MongoShell {...shellProps} sessionKey="tab-shell-merge" />);
+      await screen.findByText(/mongosh session attached/);
+
+      // What the other instance's completion does.
+      const stored = readShellSession('tab-shell-merge');
+      writeShellSession('tab-shell-merge', {
+        entries: [...(stored?.entries ?? []), { kind: 'text', lines: ['off-screen result'] }],
+      });
+
+      // Now this instance appends.
+      fireEvent.change(screen.getByLabelText('mongosh editor'), {
+        target: { value: 'db.events.countDocuments({})' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+
+      await waitFor(() => {
+        const entries = readShellSession('tab-shell-merge')?.entries ?? [];
+        // The other instance's output is still there...
+        expect(
+          entries.some((e) => e.kind === 'text' && e.lines.includes('off-screen result'))
+        ).toBe(true);
+        // ...and this instance's own input landed after it.
+        expect(entries.some((e) => e.kind === 'input')).toBe(true);
+      });
+    });
+
+    it('stops a start that a retry has already superseded', async () => {
+      // Retry tears the effect down and starts another attempt immediately.
+      // Treating that like an unmount retained the first child, whose id the
+      // second attempt then overwrote — leaving one mongosh process untracked.
+      const starts: ((v: unknown) => void)[] = [];
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '/usr/local/bin/mongosh' });
+        if (cmd === 'test_mongosh_path') return Promise.resolve('2.1.1');
+        if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+        if (cmd === 'start_mongosh_session') return new Promise((res) => { starts.push(res); });
+        return Promise.resolve([]);
+      });
+
+      const { rerender } = render(
+        <MongoShell {...shellProps} sessionKey="tab-shell-retry" reconnectSignal={0} />
+      );
+      await waitFor(() => expect(starts).toHaveLength(1));
+
+      // What a finished tool install does: bump the signal while the first
+      // start is still pending.
+      rerender(<MongoShell {...shellProps} sessionKey="tab-shell-retry" reconnectSignal={1} />);
+      await waitFor(() => expect(starts).toHaveLength(2));
+
+      // The first attempt only now returns — it has been replaced.
+      starts[0]({ session_id: 'superseded', stdout: [], stderr: [] });
+      await waitFor(() =>
+        expect(
+          mockInvoke.mock.calls.some(
+            (c) => c[0] === 'stop_mongosh_session' && c[1]?.sessionId === 'superseded'
+          )
+        ).toBe(true)
+      );
+      // ...and it must not be the id the tab remembers.
+      expect(readShellSession('tab-shell-retry')?.sessionId).not.toBe('superseded');
     });
 
     it('still tears the session down on unmount when it has no tab identity', async () => {

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -828,6 +828,57 @@ describe('MongoShell Component', () => {
       });
     });
 
+    it('shows output that another instance finished off-screen, without waiting for a local append', async () => {
+      // The old instance's completion writes to the registry and has no way to
+      // reach this one. Before the subscription the output simply sat there,
+      // invisible until this instance appended something of its own.
+      render(<MongoShell {...shellProps} sessionKey="tab-shell-live" />);
+      await screen.findByText(/mongosh session attached/);
+
+      const stored = readShellSession('tab-shell-live');
+      writeShellSession('tab-shell-live', {
+        entries: [...(stored?.entries ?? []), { kind: 'text', lines: ['late arrival'] }],
+      });
+
+      expect(await screen.findByText('late arrival')).toBeInTheDocument();
+    });
+
+    it('a remount around a pending start ends up attached to exactly one child', async () => {
+      // A start records nothing until it returns, so a remount partway through
+      // saw an unattached tab and issued its own; the two ids then overwrote
+      // each other and one child was left with nothing pointing at it.
+      //
+      // Which of the two guards this exercises depends on where the remount
+      // lands relative to the start settling — before it, the shared pending
+      // start dedupes; after it, the reattach check has to read the registry
+      // live rather than the mount-time snapshot. The dedupe itself is pinned
+      // deterministically in the registry suite; this covers the invariant the
+      // user actually sees.
+      let resolveStart: (v: unknown) => void = () => {};
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '/usr/local/bin/mongosh' });
+        if (cmd === 'test_mongosh_path') return Promise.resolve('2.1.1');
+        if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+        if (cmd === 'start_mongosh_session') return new Promise((res) => { resolveStart = res; });
+        if (cmd === 'get_shell_tab_state') return Promise.resolve(null);
+        return Promise.resolve([]);
+      });
+
+      const first = render(<MongoShell {...shellProps} sessionKey="tab-shell-join" />);
+      await waitFor(() => expect(startCalls()).toBe(1));
+      first.unmount();                                    // switched away
+      render(<MongoShell {...shellProps} sessionKey="tab-shell-join" />); // and back
+
+      // Still one start, and both instances are served by it.
+      await waitFor(() => expect(startCalls()).toBe(1));
+      resolveStart({ session_id: 'the-only-child', stdout: [], stderr: [] });
+
+      await waitFor(() =>
+        expect(readShellSession('tab-shell-join')?.sessionId).toBe('the-only-child')
+      );
+      expect(startCalls()).toBe(1);
+    });
+
     it('stops a start that a retry has already superseded', async () => {
       // Retry tears the effect down and starts another attempt immediately.
       // Treating that like an unmount retained the first child, whose id the

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -50,6 +50,13 @@ describe('MongoShell Component', () => {
       if (cmd === 'stop_mongosh_session') {
         return Promise.resolve();
       }
+      // The backend returns Option<Value>; unknown tabs are null, not [].
+      if (cmd === 'get_shell_tab_state') {
+        return Promise.resolve(null);
+      }
+      if (cmd === 'set_shell_tab_state' || cmd === 'clear_shell_tab_state') {
+        return Promise.resolve();
+      }
       if (cmd === 'execute_mql_query') {
         return Promise.resolve([
           JSON.stringify({ _id: '1', name: 'Alice Smith', event_type: 'page_view' }),

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -764,6 +764,30 @@ describe('MongoShell Component', () => {
       expect(readShellSession('tab-shell-3')?.sessionId).toBe('late-session');
     });
 
+    it('keeps the AI helper open with its transcript across a tab switch', async () => {
+      const first = render(<MongoShell {...shellProps} sessionKey="tab-shell-ai" />);
+      await waitFor(() => expect(startCalls()).toBe(1));
+      fireEvent.click(screen.getByTestId('shell-ai-toggle'));
+      await screen.findByTestId('ai-helper-panel');
+      first.unmount();
+
+      render(<MongoShell {...shellProps} sessionKey="tab-shell-ai" />); // switched back
+
+      expect(await screen.findByTestId('ai-helper-panel')).toBeInTheDocument();
+    });
+
+    it('restarts the session on demand without losing the scrollback', async () => {
+      render(<MongoShell {...shellProps} sessionKey="tab-shell-restart" />);
+      await waitFor(() => expect(startCalls()).toBe(1));
+
+      fireEvent.click(screen.getByTestId('shell-restart-session'));
+
+      // Old process stopped, a new session started, banner still on screen.
+      await waitFor(() => expect(stopCalls()).toBe(1));
+      await waitFor(() => expect(startCalls()).toBe(2));
+      expect(screen.getByText(/Current Mongosh Log ID/)).toBeInTheDocument();
+    });
+
     it('still tears the session down on unmount when it has no tab identity', async () => {
       // Callers that pass no sessionKey keep the old per-mount lifetime, so a
       // shell rendered outside the tab system cannot leak a process.

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MongoShell } from '../MongoShell';
-import { resetShellSessions } from '../../lib/mongoshSession';
+import { readShellSession, resetShellSessions } from '../../lib/mongoshSession';
 
 const mockInvoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({
@@ -739,6 +739,29 @@ describe('MongoShell Component', () => {
       await waitFor(() => expect(startCalls()).toBe(1));
 
       expect(runs()).toBe(1);
+    });
+
+    it('keeps a session that finished starting after the tab was switched away', async () => {
+      // Switching tabs mid-startup used to stop the session the moment it
+      // arrived, because the cancellation branch could not tell "the user left
+      // this tab" from "there is nobody to own this process".
+      let resolveStart: (v: unknown) => void = () => {};
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '/usr/local/bin/mongosh' });
+        if (cmd === 'test_mongosh_path') return Promise.resolve('2.1.1');
+        if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+        if (cmd === 'start_mongosh_session') return new Promise((res) => { resolveStart = res; });
+        return Promise.resolve([]);
+      });
+
+      const { unmount } = render(<MongoShell {...shellProps} sessionKey="tab-shell-3" />);
+      await waitFor(() => expect(startCalls()).toBe(1));
+      unmount();
+      resolveStart({ session_id: 'late-session', stdout: [], stderr: [] });
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(stopCalls()).toBe(0);
+      expect(readShellSession('tab-shell-3')?.sessionId).toBe('late-session');
     });
 
     it('still tears the session down on unmount when it has no tab identity', async () => {

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MongoShell } from '../MongoShell';
+import { resetShellSessions } from '../../lib/mongoshSession';
 
 const mockInvoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({
@@ -28,6 +29,7 @@ vi.mock('@monaco-editor/react', () => ({
 
 describe('MongoShell Component', () => {
   beforeEach(() => {
+    resetShellSessions();
     vi.clearAllMocks();
     mockInvoke.mockImplementation((cmd) => {
       if (cmd === 'get_mongodb_version') {
@@ -683,6 +685,50 @@ describe('MongoShell Component', () => {
           expect.stringContaining('mongodb.com/docs/mongodb-shell')
         );
       });
+    });
+  });
+
+  describe('session survives a tab switch (#240)', () => {
+    const shellProps = {
+      connectionId: 'conn-1',
+      connectionName: 'mock',
+      connectionUri: 'mongodb://prod-replica-set',
+      databaseName: 'user_analytics',
+    };
+    const startCalls = () =>
+      mockInvoke.mock.calls.filter((c) => c[0] === 'start_mongosh_session').length;
+    const stopCalls = () =>
+      mockInvoke.mock.calls.filter((c) => c[0] === 'stop_mongosh_session').length;
+
+    it('does not kill the mongosh process when the tab is switched away', async () => {
+      const { unmount } = render(<MongoShell {...shellProps} sessionKey="tab-shell-1" />);
+      await waitFor(() => expect(startCalls()).toBe(1));
+
+      unmount(); // user switches to another tab
+
+      expect(stopCalls()).toBe(0);
+    });
+
+    it('reattaches to the running session instead of spawning a second one', async () => {
+      const first = render(<MongoShell {...shellProps} sessionKey="tab-shell-1" />);
+      await waitFor(() => expect(startCalls()).toBe(1));
+      first.unmount();
+
+      render(<MongoShell {...shellProps} sessionKey="tab-shell-1" />); // switched back
+
+      await waitFor(() => expect(startCalls()).toBe(1));
+      expect(stopCalls()).toBe(0);
+    });
+
+    it('still tears the session down on unmount when it has no tab identity', async () => {
+      // Callers that pass no sessionKey keep the old per-mount lifetime, so a
+      // shell rendered outside the tab system cannot leak a process.
+      const { unmount } = render(<MongoShell {...shellProps} />);
+      await waitFor(() => expect(startCalls()).toBe(1));
+
+      unmount();
+
+      await waitFor(() => expect(stopCalls()).toBe(1));
     });
   });
 });

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -720,6 +720,27 @@ describe('MongoShell Component', () => {
       expect(stopCalls()).toBe(0);
     });
 
+    it('does not re-run the opening command on every tab switch', async () => {
+      // The auto-run guard was a component ref, so it reset on each mount.
+      // Invisible while the transcript was wiped on every switch — once the
+      // transcript survived, the same command re-executed and piled up.
+      const runs = () =>
+        mockInvoke.mock.calls.filter((c) => c[0] === 'run_mongosh_command').length;
+
+      const first = render(
+        <MongoShell {...shellProps} sessionKey="tab-shell-2" initialCommand="show collections" />
+      );
+      await waitFor(() => expect(runs()).toBe(1));
+      first.unmount();
+
+      render(
+        <MongoShell {...shellProps} sessionKey="tab-shell-2" initialCommand="show collections" />
+      );
+      await waitFor(() => expect(startCalls()).toBe(1));
+
+      expect(runs()).toBe(1);
+    });
+
     it('still tears the session down on unmount when it has no tab identity', async () => {
       // Callers that pass no sessionKey keep the old per-mount lifetime, so a
       // shell rendered outside the tab system cannot leak a process.

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   disposeAllShellSessions,
+  renameShellSession,
   disposeShellSession,
   readShellSession,
   resetShellSessions,
@@ -77,6 +78,20 @@ describe('mongosh session registry (#240)', () => {
     writeShellSession('tab-1', { entries: [{ kind: 'note', text: 'output' }] });
 
     expect(readShellSession('tab-1')?.autoRanCommand).toBe(true);
+  });
+
+  it('follows a tab that is rebound to a new id', () => {
+    writeShellSession('old-id', { sessionId: 'sess-1', entries: [{ kind: 'note', text: 'x' }] });
+
+    renameShellSession('old-id', 'new-id');
+
+    expect(readShellSession('old-id')).toBeUndefined();
+    expect(readShellSession('new-id')?.sessionId).toBe('sess-1');
+  });
+
+  it('renaming a tab with no session is a no-op', () => {
+    renameShellSession('nothing-here', 'new-id');
+    expect(readShellSession('new-id')).toBeUndefined();
   });
 
   it('disposes every session when the workspace is torn down', async () => {

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -29,6 +29,7 @@ describe('mongosh session registry (#240)', () => {
       sessionId: 'sess-1',
       entries: [{ kind: 'note', text: 'attached' }],
       currentDb: 'sales',
+      autoRanCommand: false,
     });
     expect(invokeMock).not.toHaveBeenCalled();
   });
@@ -41,6 +42,7 @@ describe('mongosh session registry (#240)', () => {
       sessionId: 'sess-1',
       entries: [{ kind: 'note', text: 'later' }],
       currentDb: 'sales',
+      autoRanCommand: false,
     });
   });
 
@@ -68,6 +70,13 @@ describe('mongosh session registry (#240)', () => {
 
     await expect(disposeShellSession('tab-1')).resolves.toBeUndefined();
     expect(readShellSession('tab-1')).toBeUndefined();
+  });
+
+  it('remembers that the opening command already ran, so a remount does not repeat it', () => {
+    writeShellSession('tab-1', { sessionId: 'sess-1', autoRanCommand: true });
+    writeShellSession('tab-1', { entries: [{ kind: 'note', text: 'output' }] });
+
+    expect(readShellSession('tab-1')?.autoRanCommand).toBe(true);
   });
 
   it('disposes every session when the workspace is torn down', async () => {

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -137,6 +137,30 @@ describe('mongosh session registry (#240)', () => {
     expect(invokeMock).toHaveBeenCalledWith('stop_mongosh_session', { sessionId: 'sess-orphan' });
   });
 
+  it('retargets a CACHED session synchronously, before a remount can seed the old database', async () => {
+    // The rename re-keys the tab in the same discrete event, so React remounts
+    // MongoShell before any microtask here runs, and the component reads the
+    // registry once at mount. Anything deferred is therefore invisible to the
+    // instance that matters: it would keep the dropped database and a session
+    // id about to be killed, and restarting it would recreate that database.
+    writeShellSession('tab-1', {
+      sessionId: 'sess-old',
+      currentDb: 'before',
+      entries: [{ kind: 'note', text: 'kept' }],
+    });
+
+    const done = retargetShellSessionDatabase('tab-1', 'after', Promise.resolve());
+
+    // Read with no await at all — this is exactly what the remount sees.
+    const atMount = readShellSession('tab-1');
+    expect(atMount?.currentDb).toBe('after');
+    expect(atMount?.sessionId).toBeNull();
+    expect(atMount?.entries).toEqual([{ kind: 'note', text: 'kept' }]);
+
+    await done;
+    expect(invokeMock).toHaveBeenCalledWith('stop_mongosh_session', { sessionId: 'sess-old' });
+  });
+
   it('retargets a renamed database and stops the child that is still on the old one', async () => {
     // Straight from the backend again: writing `currentDb` without hydrating
     // would create a cache entry with a null session id, and the stop would
@@ -148,7 +172,7 @@ describe('mongosh session registry (#240)', () => {
         : Promise.resolve(undefined),
     );
 
-    await retargetShellSessionDatabase('tab-1', 'after');
+    await retargetShellSessionDatabase('tab-1', 'after', Promise.resolve());
 
     expect(invokeMock).toHaveBeenCalledWith('stop_mongosh_session', { sessionId: 'sess-old' });
     const after = readShellSession('tab-1');

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -6,7 +6,6 @@ import {
   shellSessionEpoch,
   retargetShellSessionDatabase,
   stopShellSessionProcess,
-  wasDisposedSince,
   disposeShellSession,
   forgetShellSession,
   readShellSession,
@@ -257,35 +256,31 @@ describe('mongosh session registry (#240)', () => {
       expect(invokeMock).not.toHaveBeenCalledWith('clear_shell_tab_state', expect.anything());
     });
 
-    it('tells a closed tab apart from a moved one', async () => {
-      writeShellSession('closed', { sessionId: 'a' });
-      writeShellSession('moved', { sessionId: 'b' });
-      const closedEpoch = shellSessionEpoch('closed');
-      const movedEpoch = shellSessionEpoch('moved');
+    it('ends the epoch synchronously, before any backend lookup', async () => {
+      // The state of an inactive tab lives only in the backend, so disposal has
+      // to read it — but tab ids are deterministic, so the same key can be
+      // reopened while that read is in flight. Doing the bookkeeping after the
+      // await would end the REOPENED tab's epoch and delete its cache entry.
+      let releaseLookup: (v: unknown) => void = () => {};
+      invokeMock.mockImplementation((cmd: string) =>
+        cmd === 'get_shell_tab_state'
+          ? new Promise((res) => { releaseLookup = res; })
+          : Promise.resolve(undefined),
+      );
 
-      await disposeShellSession('closed');
-      forgetShellSession('moved');
+      const disposal = disposeShellSession('tab-1');
+      await Promise.resolve();
 
-      // The async start path uses this to decide whether the child it just
-      // spawned should be stopped (closed) or recorded (moved, so the
-      // destination window can reattach to it).
-      expect(wasDisposedSince('closed', closedEpoch)).toBe(true);
-      expect(wasDisposedSince('moved', movedEpoch)).toBe(false);
-    });
+      // A fresh mount takes the key over while the lookup is still pending.
+      const reopenedEpoch = shellSessionEpoch('tab-1');
+      writeShellSession('tab-1', { sessionId: 'sess-new' }, reopenedEpoch);
 
-    it('drops a completion that lands after its tab was renamed', () => {
-      // A rename remounts the shell under the new key, so the old instance is
-      // finishing work for a key nothing will read again. Persisting to it
-      // would recreate the obsolete entry — a session mapping the renamed
-      // tab's close never clears — and lose the output from the visible tab.
-      writeShellSession('old-id', { sessionId: 'sess-1' });
-      const epoch = shellSessionEpoch('old-id');
+      releaseLookup({ sessionId: 'sess-old' });
+      await disposal;
 
-      renameShellSession('old-id', 'new-id');
-      writeShellSession('old-id', { entries: [{ kind: 'note', text: 'late' }] }, epoch);
-
-      expect(readShellSession('old-id')).toBeUndefined();
-      expect(readShellSession('new-id')?.sessionId).toBe('sess-1');
+      // The old child is stopped, the reopened tab is untouched.
+      expect(invokeMock).toHaveBeenCalledWith('stop_mongosh_session', { sessionId: 'sess-old' });
+      expect(readShellSession('tab-1')?.sessionId).toBe('sess-new');
     });
 
     it('a reopened tab is not silenced by the previous tab\'s disposal', async () => {
@@ -297,7 +292,9 @@ describe('mongosh session registry (#240)', () => {
       writeShellSession('tab-1', { sessionId: 'sess-2' }, epoch);
 
       expect(readShellSession('tab-1')?.sessionId).toBe('sess-2');
-      expect(wasDisposedSince('tab-1', epoch)).toBe(false);
+      // ...and the previous tab's writes, holding the older epoch, still are.
+      writeShellSession('tab-1', { sessionId: 'ghost' }, epoch - 1);
+      expect(readShellSession('tab-1')?.sessionId).toBe('sess-2');
     });
   });
 

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
-  disposeAllShellSessions,
+  disposeShellSessionsForTabs,
   loadShellSession,
   renameShellSession,
   stopShellSessionProcess,
@@ -127,17 +127,22 @@ describe('mongosh session registry (#240)', () => {
     expect(after?.currentDb).toBe('sales');
   });
 
-  it('disposes every session when the workspace is torn down', async () => {
-    writeShellSession('tab-1', { sessionId: 'sess-1', entries: [], currentDb: 'a' });
-    writeShellSession('tab-2', { sessionId: 'sess-2', entries: [], currentDb: 'b' });
+  it('disposes only the tabs it is given, leaving other windows alone', async () => {
+    // A global clear here would strip a live shell owned by ANOTHER window of
+    // its recovery mapping without stopping the child — unreattachable and
+    // unkillable.
+    writeShellSession('mine-1', { sessionId: 'sess-1' });
+    writeShellSession('mine-2', { sessionId: 'sess-2' });
+    writeShellSession('other-window', { sessionId: 'sess-other' });
 
-    await disposeAllShellSessions();
+    await disposeShellSessionsForTabs(['mine-1', 'mine-2']);
 
-    expect(invokeMock.mock.calls.map((c) => c[1])).toEqual(
-      expect.arrayContaining([{ sessionId: 'sess-1' }, { sessionId: 'sess-2' }]),
-    );
-    expect(readShellSession('tab-1')).toBeUndefined();
-    expect(readShellSession('tab-2')).toBeUndefined();
+    const stopped = invokeMock.mock.calls
+      .filter((c) => c[0] === 'stop_mongosh_session')
+      .map((c) => (c[1] as { sessionId: string }).sessionId);
+    expect(stopped).toEqual(expect.arrayContaining(['sess-1', 'sess-2']));
+    expect(stopped).not.toContain('sess-other');
+    expect(readShellSession('other-window')?.sessionId).toBe('sess-other');
   });
 
   it('keeps its sessions in a store that survives hot module replacement', async () => {

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -3,9 +3,12 @@ import {
   disposeShellSessionsForTabs,
   loadShellSession,
   renameShellSession,
+  shellSessionEpoch,
   retargetShellSessionDatabase,
   stopShellSessionProcess,
+  wasDisposedSince,
   disposeShellSession,
+  forgetShellSession,
   readShellSession,
   resetShellSessions,
   writeShellSession,
@@ -212,6 +215,75 @@ describe('mongosh session registry (#240)', () => {
     expect(stopped).toEqual(expect.arrayContaining(['sess-1', 'sess-2']));
     expect(stopped).not.toContain('sess-other');
     expect(readShellSession('other-window')?.sessionId).toBe('sess-other');
+  });
+
+  describe('writes that outlive ownership', () => {
+    it('drops a completion that lands after its tab was closed', async () => {
+      // Tab ids are deterministic, so reopening the same shell lands on the
+      // same key: a late write would hand the new tab the old transcript and a
+      // set `autoRanCommand`, which also suppresses its opening command.
+      writeShellSession('tab-1', { sessionId: 'sess-1', autoRanCommand: true });
+      const epoch = shellSessionEpoch('tab-1');
+
+      await disposeShellSession('tab-1');
+      writeShellSession('tab-1', { entries: [{ kind: 'note', text: 'late output' }] }, epoch);
+
+      expect(readShellSession('tab-1')).toBeUndefined();
+    });
+
+    it('drops a completion that lands after its tab moved to another window', () => {
+      // The destination owns the state now. A stale mirror from here would
+      // overwrite what that window has since appended — and because every write
+      // stamps the owning window, it would also steal ownership back, so
+      // closing THIS window would kill a process the other one is showing.
+      writeShellSession('tab-1', { sessionId: 'sess-1', entries: [] });
+      const epoch = shellSessionEpoch('tab-1');
+
+      forgetShellSession('tab-1');
+      invokeMock.mockClear();
+      writeShellSession('tab-1', { entries: [{ kind: 'note', text: 'stale' }] }, epoch);
+
+      expect(readShellSession('tab-1')).toBeUndefined();
+      expect(invokeMock).not.toHaveBeenCalledWith('set_shell_tab_state', expect.anything());
+    });
+
+    it('forgetting keeps the backend session alive — only disposing ends it', async () => {
+      writeShellSession('tab-1', { sessionId: 'sess-1' });
+      invokeMock.mockClear();
+
+      forgetShellSession('tab-1');
+
+      expect(invokeMock).not.toHaveBeenCalledWith('stop_mongosh_session', expect.anything());
+      expect(invokeMock).not.toHaveBeenCalledWith('clear_shell_tab_state', expect.anything());
+    });
+
+    it('tells a closed tab apart from a moved one', async () => {
+      writeShellSession('closed', { sessionId: 'a' });
+      writeShellSession('moved', { sessionId: 'b' });
+      const closedEpoch = shellSessionEpoch('closed');
+      const movedEpoch = shellSessionEpoch('moved');
+
+      await disposeShellSession('closed');
+      forgetShellSession('moved');
+
+      // The async start path uses this to decide whether the child it just
+      // spawned should be stopped (closed) or recorded (moved, so the
+      // destination window can reattach to it).
+      expect(wasDisposedSince('closed', closedEpoch)).toBe(true);
+      expect(wasDisposedSince('moved', movedEpoch)).toBe(false);
+    });
+
+    it('a reopened tab is not silenced by the previous tab\'s disposal', async () => {
+      writeShellSession('tab-1', { sessionId: 'sess-1' });
+      await disposeShellSession('tab-1');
+
+      // What a fresh mount under the same deterministic id captures.
+      const epoch = shellSessionEpoch('tab-1');
+      writeShellSession('tab-1', { sessionId: 'sess-2' }, epoch);
+
+      expect(readShellSession('tab-1')?.sessionId).toBe('sess-2');
+      expect(wasDisposedSince('tab-1', epoch)).toBe(false);
+    });
   });
 
   it('keeps its sessions in a store that survives hot module replacement', async () => {

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   disposeAllShellSessions,
   renameShellSession,
+  stopShellSessionProcess,
   disposeShellSession,
   readShellSession,
   resetShellSessions,
@@ -31,6 +32,8 @@ describe('mongosh session registry (#240)', () => {
       entries: [{ kind: 'note', text: 'attached' }],
       currentDb: 'sales',
       autoRanCommand: false,
+      aiOpen: false,
+      aiMessages: [],
     });
     expect(invokeMock).not.toHaveBeenCalled();
   });
@@ -44,6 +47,8 @@ describe('mongosh session registry (#240)', () => {
       entries: [{ kind: 'note', text: 'later' }],
       currentDb: 'sales',
       autoRanCommand: false,
+      aiOpen: false,
+      aiMessages: [],
     });
   });
 
@@ -92,6 +97,22 @@ describe('mongosh session registry (#240)', () => {
   it('renaming a tab with no session is a no-op', () => {
     renameShellSession('nothing-here', 'new-id');
     expect(readShellSession('new-id')).toBeUndefined();
+  });
+
+  it('stops the process for a restart but keeps the transcript', async () => {
+    writeShellSession('tab-1', {
+      sessionId: 'sess-1',
+      entries: [{ kind: 'note', text: 'earlier output' }],
+      currentDb: 'sales',
+    });
+
+    await stopShellSessionProcess('tab-1');
+
+    expect(invokeMock).toHaveBeenCalledWith('stop_mongosh_session', { sessionId: 'sess-1' });
+    const after = readShellSession('tab-1');
+    expect(after?.sessionId).toBeNull();
+    expect(after?.entries).toEqual([{ kind: 'note', text: 'earlier output' }]);
+    expect(after?.currentDb).toBe('sales');
   });
 
   it('disposes every session when the workspace is torn down', async () => {

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -3,6 +3,7 @@ import {
   disposeShellSessionsForTabs,
   loadShellSession,
   renameShellSession,
+  retargetShellSessionDatabase,
   stopShellSessionProcess,
   disposeShellSession,
   readShellSession,
@@ -120,6 +121,39 @@ describe('mongosh session registry (#240)', () => {
   it('renaming a tab with no session is a no-op', () => {
     renameShellSession('nothing-here', 'new-id');
     expect(readShellSession('new-id')).toBeUndefined();
+  });
+
+  it('stops a process it only learns about from the backend', async () => {
+    // The tab has not mounted since a refresh, so nothing has hydrated the
+    // cache — but the child is running and must still be stoppable.
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === 'get_shell_tab_state'
+        ? Promise.resolve({ sessionId: 'sess-orphan' })
+        : Promise.resolve(undefined),
+    );
+
+    await stopShellSessionProcess('tab-1');
+
+    expect(invokeMock).toHaveBeenCalledWith('stop_mongosh_session', { sessionId: 'sess-orphan' });
+  });
+
+  it('retargets a renamed database and stops the child that is still on the old one', async () => {
+    // Straight from the backend again: writing `currentDb` without hydrating
+    // would create a cache entry with a null session id, and the stop would
+    // then find nothing — leaving mongosh attached to a database the rename
+    // has already dropped.
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === 'get_shell_tab_state'
+        ? Promise.resolve({ sessionId: 'sess-old', currentDb: 'before', entries: [] })
+        : Promise.resolve(undefined),
+    );
+
+    await retargetShellSessionDatabase('tab-1', 'after');
+
+    expect(invokeMock).toHaveBeenCalledWith('stop_mongosh_session', { sessionId: 'sess-old' });
+    const after = readShellSession('tab-1');
+    expect(after?.currentDb).toBe('after');
+    expect(after?.sessionId).toBeNull();
   });
 
   it('stops the process for a restart but keeps the transcript', async () => {

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -273,6 +273,21 @@ describe('mongosh session registry (#240)', () => {
       expect(wasDisposedSince('moved', movedEpoch)).toBe(false);
     });
 
+    it('drops a completion that lands after its tab was renamed', () => {
+      // A rename remounts the shell under the new key, so the old instance is
+      // finishing work for a key nothing will read again. Persisting to it
+      // would recreate the obsolete entry — a session mapping the renamed
+      // tab's close never clears — and lose the output from the visible tab.
+      writeShellSession('old-id', { sessionId: 'sess-1' });
+      const epoch = shellSessionEpoch('old-id');
+
+      renameShellSession('old-id', 'new-id');
+      writeShellSession('old-id', { entries: [{ kind: 'note', text: 'late' }] }, epoch);
+
+      expect(readShellSession('old-id')).toBeUndefined();
+      expect(readShellSession('new-id')?.sessionId).toBe('sess-1');
+    });
+
     it('a reopened tab is not silenced by the previous tab\'s disposal', async () => {
       writeShellSession('tab-1', { sessionId: 'sess-1' });
       await disposeShellSession('tab-1');

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   disposeAllShellSessions,
+  loadShellSession,
   renameShellSession,
   stopShellSessionProcess,
   disposeShellSession,
@@ -150,5 +151,34 @@ describe('mongosh session registry (#240)', () => {
 
     expect(source).toContain('import.meta.hot?.data?.shellSessions');
     expect(source).toContain('import.meta.hot?.data) import.meta.hot.data.shellSessions = sessions');
+  });
+
+  it('rebuilds a session from the backend when the cache is empty', async () => {
+    // What a hot reload or a window refresh produces: no cache, but the child
+    // is still running and the backend still knows about it.
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === 'get_shell_tab_state'
+        ? Promise.resolve({ sessionId: 'sess-live', entries: [{ kind: 'note', text: 'kept' }] })
+        : Promise.resolve(undefined),
+    );
+
+    const restored = await loadShellSession('tab-1');
+
+    expect(restored?.sessionId).toBe('sess-live');
+    expect(restored?.entries).toEqual([{ kind: 'note', text: 'kept' }]);
+    // Defaults fill in for fields the stored blob predates.
+    expect(restored?.autoRanCommand).toBe(false);
+    expect(readShellSession('tab-1')?.sessionId).toBe('sess-live');
+  });
+
+  it('ignores a backend value that is not a session object', async () => {
+    // The payload crosses IPC as opaque JSON; anything merely truthy (an array,
+    // say) must not be cached and then read for fields it does not have.
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === 'get_shell_tab_state' ? Promise.resolve([]) : Promise.resolve(undefined),
+    );
+
+    expect(await loadShellSession('tab-1')).toBeUndefined();
+    expect(readShellSession('tab-1')).toBeUndefined();
   });
 });

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   disposeShellSessionsForTabs,
+  dropPendingShellStart,
+  shareShellStart,
+  watchShellSession,
   loadShellSession,
   renameShellSession,
   shellSessionEpoch,
@@ -256,31 +259,46 @@ describe('mongosh session registry (#240)', () => {
       expect(invokeMock).not.toHaveBeenCalledWith('clear_shell_tab_state', expect.anything());
     });
 
-    it('ends the epoch synchronously, before any backend lookup', async () => {
-      // The state of an inactive tab lives only in the backend, so disposal has
-      // to read it — but tab ids are deterministic, so the same key can be
-      // reopened while that read is in flight. Doing the bookkeeping after the
-      // await would end the REOPENED tab's epoch and delete its cache entry.
-      let releaseLookup: (v: unknown) => void = () => {};
+    it('ends the epoch synchronously, before the close round trip', async () => {
+      // The state of an inactive tab lives only in the backend, so closing it
+      // has to go there — but tab ids are deterministic, so the same key can be
+      // reopened while that call is in flight. Doing the bookkeeping afterwards
+      // would end the REOPENED tab's epoch and delete its cache entry.
+      let releaseClose: (v: unknown) => void = () => {};
       invokeMock.mockImplementation((cmd: string) =>
-        cmd === 'get_shell_tab_state'
-          ? new Promise((res) => { releaseLookup = res; })
+        cmd === 'close_shell_tab_session'
+          ? new Promise((res) => { releaseClose = res; })
           : Promise.resolve(undefined),
       );
 
       const disposal = disposeShellSession('tab-1');
       await Promise.resolve();
 
-      // A fresh mount takes the key over while the lookup is still pending.
+      // A fresh mount takes the key over while the close is still pending.
       const reopenedEpoch = shellSessionEpoch('tab-1');
       writeShellSession('tab-1', { sessionId: 'sess-new' }, reopenedEpoch);
 
-      releaseLookup({ sessionId: 'sess-old' });
+      releaseClose(undefined);
       await disposal;
 
-      // The old child is stopped, the reopened tab is untouched.
-      expect(invokeMock).toHaveBeenCalledWith('stop_mongosh_session', { sessionId: 'sess-old' });
+      expect(invokeMock).toHaveBeenCalledWith('close_shell_tab_session', { tabId: 'tab-1' });
       expect(readShellSession('tab-1')?.sessionId).toBe('sess-new');
+    });
+
+    it('takes the backend entry and stops its child in ONE call', async () => {
+      // Reading the id and clearing the entry as two commands is a race the
+      // frontend cannot win: an inactive tab's id exists only in the backend,
+      // so a clear that overtook the read would strand the mongosh child with
+      // nothing left pointing at it.
+      await disposeShellSession('tab-only-in-backend');
+
+      expect(invokeMock).toHaveBeenCalledWith('close_shell_tab_session', {
+        tabId: 'tab-only-in-backend',
+      });
+      expect(invokeMock).not.toHaveBeenCalledWith(
+        'clear_shell_tab_state',
+        expect.anything(),
+      );
     });
 
     it('a reopened tab is not silenced by the previous tab\'s disposal', async () => {
@@ -295,6 +313,94 @@ describe('mongosh session registry (#240)', () => {
       // ...and the previous tab's writes, holding the older epoch, still are.
       writeShellSession('tab-1', { sessionId: 'ghost' }, epoch - 1);
       expect(readShellSession('tab-1')?.sessionId).toBe('sess-2');
+    });
+  });
+
+  describe('a start that outlives one mount', () => {
+    it('joins the start already running instead of spawning a rival', async () => {
+      // A start records nothing until it returns, so a remount partway through
+      // saw an unattached tab and issued a second one; the two ids then
+      // overwrote each other and one child was left untracked.
+      let calls = 0;
+      const task = () => {
+        calls += 1;
+        return new Promise<{ session_id: string }>((res) => setTimeout(() => res({ session_id: 'sess-1' }), 5));
+      };
+
+      const first = shareShellStart('tab-1', task);
+      const second = shareShellStart('tab-1', task); // the remount
+
+      expect(calls).toBe(1);
+      expect((await first).session_id).toBe('sess-1');
+      expect((await second).session_id).toBe('sess-1');
+    });
+
+    it('starts fresh once the previous attempt has settled', async () => {
+      let calls = 0;
+      const task = () => {
+        calls += 1;
+        return Promise.resolve({ session_id: 'sess' });
+      };
+
+      await shareShellStart('tab-1', task);
+      await shareShellStart('tab-1', task);
+
+      expect(calls).toBe(2);
+    });
+
+    it('lets Retry replace an attempt rather than join it', async () => {
+      let calls = 0;
+      const task = () => {
+        calls += 1;
+        return new Promise<{ session_id: string }>(() => {}); // never settles
+      };
+
+      shareShellStart('tab-1', task);
+      dropPendingShellStart('tab-1');
+      shareShellStart('tab-1', task);
+
+      expect(calls).toBe(2);
+    });
+
+    it('a failed start does not wedge the tab', async () => {
+      const boom = () => Promise.reject(new Error('no mongosh'));
+      await expect(shareShellStart('tab-1', boom)).rejects.toThrow('no mongosh');
+
+      // The entry is gone, so the next attempt is a real one.
+      let called = false;
+      await shareShellStart('tab-1', () => {
+        called = true;
+        return Promise.resolve({ session_id: 'sess' });
+      });
+      expect(called).toBe(true);
+    });
+  });
+
+  describe('watchers', () => {
+    it('tells the mounted instance about a write made by another one', () => {
+      // The off-screen completion writes to the registry; without this the
+      // visible instance would not know until its own next append.
+      const seen: string[] = [];
+      const stop = watchShellSession('tab-1', (s) => seen.push(s.currentDb));
+
+      writeShellSession('tab-1', { currentDb: 'from-elsewhere' });
+
+      expect(seen).toEqual(['from-elsewhere']);
+      stop();
+      writeShellSession('tab-1', { currentDb: 'after-unsubscribe' });
+      expect(seen).toEqual(['from-elsewhere']);
+    });
+
+    it('does not notify for a write that was dropped as stale', () => {
+      writeShellSession('tab-1', { sessionId: 'sess-1' });
+      const epoch = shellSessionEpoch('tab-1');
+      const seen: unknown[] = [];
+      watchShellSession('tab-1', (s) => seen.push(s));
+
+      forgetShellSession('tab-1');
+      writeShellSession('tab-1', { currentDb: 'ghost' }, epoch);
+
+      expect(seen).toEqual([]);
     });
   });
 

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -97,6 +97,17 @@ describe('mongosh session registry (#240)', () => {
     );
   });
 
+  it('stamps the owning window on every persisted session', () => {
+    // How the backend finds a window's shells when it is closed with the OS X
+    // button. It cannot go via the workspace: those tab ids are profile-space
+    // while these keys are live-space, so a rebound shell — the only kind with
+    // a child worth stopping — would never be matched.
+    writeShellSession('tab-1', { sessionId: 'sess-1' });
+
+    const call = invokeMock.mock.calls.find((c) => c[0] === 'set_shell_tab_state');
+    expect((call?.[1] as { value: { windowId?: string } }).value.windowId).toBe('main');
+  });
+
   it('follows a tab that is rebound to a new id', () => {
     writeShellSession('old-id', { sessionId: 'sess-1', entries: [{ kind: 'note', text: 'x' }] });
 

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  disposeAllShellSessions,
+  disposeShellSession,
+  readShellSession,
+  resetShellSessions,
+  writeShellSession,
+} from '../mongoshSession';
+
+const invokeMock = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
+
+describe('mongosh session registry (#240)', () => {
+  beforeEach(() => {
+    resetShellSessions();
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+  });
+
+  it('keeps a session and its transcript across an unmount', () => {
+    writeShellSession('tab-1', {
+      sessionId: 'sess-1',
+      entries: [{ kind: 'note', text: 'attached' }],
+      currentDb: 'sales',
+    });
+
+    // Unmounting no longer touches the registry, so a remount finds it intact.
+    expect(readShellSession('tab-1')).toEqual({
+      sessionId: 'sess-1',
+      entries: [{ kind: 'note', text: 'attached' }],
+      currentDb: 'sales',
+    });
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('merges partial writes so one field can be persisted without the others', () => {
+    writeShellSession('tab-1', { sessionId: 'sess-1', currentDb: 'sales' });
+    writeShellSession('tab-1', { entries: [{ kind: 'note', text: 'later' }] });
+
+    expect(readShellSession('tab-1')).toEqual({
+      sessionId: 'sess-1',
+      entries: [{ kind: 'note', text: 'later' }],
+      currentDb: 'sales',
+    });
+  });
+
+  it('stops the backend process only when the tab closes', async () => {
+    writeShellSession('tab-1', { sessionId: 'sess-1', entries: [], currentDb: 'db' });
+
+    await disposeShellSession('tab-1');
+
+    expect(invokeMock).toHaveBeenCalledWith('stop_mongosh_session', { sessionId: 'sess-1' });
+    expect(readShellSession('tab-1')).toBeUndefined();
+  });
+
+  it('disposing a tab that never attached does not call the backend', async () => {
+    writeShellSession('tab-1', { sessionId: null, entries: [], currentDb: 'db' });
+
+    await disposeShellSession('tab-1');
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(readShellSession('tab-1')).toBeUndefined();
+  });
+
+  it('never rejects when the backend refuses — tab teardown must not throw', async () => {
+    invokeMock.mockRejectedValue(new Error('session already gone'));
+    writeShellSession('tab-1', { sessionId: 'sess-1', entries: [], currentDb: 'db' });
+
+    await expect(disposeShellSession('tab-1')).resolves.toBeUndefined();
+    expect(readShellSession('tab-1')).toBeUndefined();
+  });
+
+  it('disposes every session when the workspace is torn down', async () => {
+    writeShellSession('tab-1', { sessionId: 'sess-1', entries: [], currentDb: 'a' });
+    writeShellSession('tab-2', { sessionId: 'sess-2', entries: [], currentDb: 'b' });
+
+    await disposeAllShellSessions();
+
+    expect(invokeMock.mock.calls.map((c) => c[1])).toEqual(
+      expect.arrayContaining([{ sessionId: 'sess-1' }, { sessionId: 'sess-2' }]),
+    );
+    expect(readShellSession('tab-1')).toBeUndefined();
+    expect(readShellSession('tab-2')).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -35,7 +35,9 @@ describe('mongosh session registry (#240)', () => {
       aiOpen: false,
       aiMessages: [],
     });
-    expect(invokeMock).not.toHaveBeenCalled();
+    // Writes now mirror to the backend; what must NOT happen is the child being
+    // killed just because the component went away.
+    expect(invokeMock).not.toHaveBeenCalledWith('stop_mongosh_session', expect.anything());
   });
 
   it('merges partial writes so one field can be persisted without the others', () => {
@@ -66,7 +68,7 @@ describe('mongosh session registry (#240)', () => {
 
     await disposeShellSession('tab-1');
 
-    expect(invokeMock).not.toHaveBeenCalled();
+    expect(invokeMock).not.toHaveBeenCalledWith('stop_mongosh_session', expect.anything());
     expect(readShellSession('tab-1')).toBeUndefined();
   });
 
@@ -83,6 +85,15 @@ describe('mongosh session registry (#240)', () => {
     writeShellSession('tab-1', { entries: [{ kind: 'note', text: 'output' }] });
 
     expect(readShellSession('tab-1')?.autoRanCommand).toBe(true);
+  });
+
+  it('mirrors every write to the backend, which owns the state across reloads', () => {
+    writeShellSession('tab-1', { sessionId: 'sess-1', currentDb: 'sales' });
+
+    expect(invokeMock).toHaveBeenCalledWith(
+      'set_shell_tab_state',
+      expect.objectContaining({ tabId: 'tab-1' }),
+    );
   });
 
   it('follows a tab that is rebound to a new id', () => {

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -127,4 +127,17 @@ describe('mongosh session registry (#240)', () => {
     expect(readShellSession('tab-1')).toBeUndefined();
     expect(readShellSession('tab-2')).toBeUndefined();
   });
+
+  it('keeps its sessions in a store that survives hot module replacement', async () => {
+    // Regression guard for a dev-only failure that looked exactly like a bug in
+    // the feature: editing any file in this module's graph replaced the module,
+    // a plain `new Map()` came back empty, the tab started a second session and
+    // the first mongosh process was orphaned with no id left to stop it.
+    const source = await import('node:fs').then((fs) =>
+      fs.readFileSync('src/lib/mongoshSession.ts', 'utf8'),
+    );
+
+    expect(source).toContain('import.meta.hot?.data?.shellSessions');
+    expect(source).toContain('import.meta.hot?.data) import.meta.hot.data.shellSessions = sessions');
+  });
 });

--- a/src/lib/aiChatRequest.ts
+++ b/src/lib/aiChatRequest.ts
@@ -31,7 +31,13 @@ interface PendingChat {
   settled?: PendingChatReply;
 }
 
-const pending = new Map<string, PendingChat>();
+// Survives Vite hot module replacement for the same reason the shell session
+// registry does: a fresh Map would strand an in-flight request, and the reply
+// would have nowhere to land. No effect in a packaged build.
+const pending: Map<string, PendingChat> =
+  import.meta.hot?.data?.pendingChat ?? new Map<string, PendingChat>();
+// `data` is absent under vitest, where `import.meta.hot` exists but is inert.
+if (import.meta.hot?.data) import.meta.hot.data.pendingChat = pending;
 
 /**
  * Run `task` as the pending request for `key`. The returned promise never

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -185,15 +185,39 @@ export function renameShellSession(oldKey: string, newKey: string): Promise<void
  * Point a retained session at a renamed database and end its process, so the
  * next mount opens a fresh one against the new name with its scrollback intact.
  *
- * Hydrates first, deliberately. If the tab has not mounted since a refresh its
- * state exists only in the backend, and writing `currentDb` straight in would
- * mint a cache entry with a null session id — after which the stop below finds
- * nothing to do and the original child stays attached to the dropped database.
+ * `renamed` is the backend move this follows, and is awaited ONLY on a cache
+ * miss — see below for why the cached path must not await anything.
  */
-export async function retargetShellSessionDatabase(key: string, db: string): Promise<void> {
-  await loadShellSession(key);
-  writeShellSession(key, { currentDb: db });
-  await stopShellSessionProcess(key);
+export function retargetShellSessionDatabase(
+  key: string,
+  db: string,
+  renamed: Promise<void>
+): Promise<void> {
+  const cached = sessions.get(key);
+  if (cached) {
+    const { sessionId } = cached;
+    // Applied synchronously, before returning to the caller. The rename's
+    // `setTabs` re-keys the tab in the same discrete event, so React remounts
+    // MongoShell before any await here could resolve — and the component seeds
+    // itself from the registry once, at mount, without subscribing to later
+    // writes. Deferring this by even a microtask therefore hands the fresh
+    // instance the old database and a session id that is about to be killed:
+    // it would sit on a dead process, and restarting it would `use` the
+    // database the rename just dropped, recreating it on the next write.
+    writeShellSession(key, { currentDb: db, sessionId: null });
+    if (!sessionId) return Promise.resolve();
+    return invoke('stop_mongosh_session', { sessionId })
+      .then(() => undefined)
+      .catch(() => undefined);
+  }
+  // Not cached: the tab has not mounted since a refresh, so its state lives
+  // only in the backend and can only be read back once the rename has landed.
+  // Nothing is mounted under this key, so there is no remount to race.
+  return renamed.then(async () => {
+    await loadShellSession(key);
+    writeShellSession(key, { currentDb: db });
+    await stopShellSessionProcess(key);
+  });
 }
 
 /**

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -151,7 +151,10 @@ export async function disposeShellSession(key: string): Promise<void> {
  * the Restart control uses; `disposeShellSession` is for a tab going away.
  */
 export async function stopShellSessionProcess(key: string): Promise<void> {
-  const session = sessions.get(key);
+  // Hydrate on a miss, like `disposeShellSession`: after a renderer refresh the
+  // tab may not have mounted yet, so its running child is known only to the
+  // backend and a cache-only check would quietly decline to stop it.
+  const session = sessions.get(key) ?? (await loadShellSession(key));
   if (!session?.sessionId) return;
   const { sessionId } = session;
   writeShellSession(key, { sessionId: null });
@@ -162,12 +165,35 @@ export async function stopShellSessionProcess(key: string): Promise<void> {
  *  session belongs to the tab, so it has to move with it — leaving it under the
  *  dead id would strand a live mongosh process that nothing can stop, and the
  *  rebound tab would start a second one. */
-export function renameShellSession(oldKey: string, newKey: string): void {
-  void invoke('rename_shell_tab_state', { oldId: oldKey, newId: newKey }).catch(() => undefined);
+export function renameShellSession(oldKey: string, newKey: string): Promise<void> {
+  // Returns the backend move so a caller that must then READ the new key can
+  // await it. Nothing guarantees a later `get_shell_tab_state` is served after
+  // an unawaited rename, and losing that race would look like an absent
+  // session — i.e. a live mongosh child nothing goes on to stop.
+  const moved = invoke('rename_shell_tab_state', { oldId: oldKey, newId: newKey })
+    .then(() => undefined)
+    .catch(() => undefined);
   const session = sessions.get(oldKey);
-  if (!session) return;
-  sessions.delete(oldKey);
-  sessions.set(newKey, session);
+  if (session) {
+    sessions.delete(oldKey);
+    sessions.set(newKey, session);
+  }
+  return moved;
+}
+
+/**
+ * Point a retained session at a renamed database and end its process, so the
+ * next mount opens a fresh one against the new name with its scrollback intact.
+ *
+ * Hydrates first, deliberately. If the tab has not mounted since a refresh its
+ * state exists only in the backend, and writing `currentDb` straight in would
+ * mint a cache entry with a null session id — after which the stop below finds
+ * nothing to do and the original child stays attached to the dropped database.
+ */
+export async function retargetShellSessionDatabase(key: string, db: string): Promise<void> {
+  await loadShellSession(key);
+  writeShellSession(key, { currentDb: db });
+  await stopShellSessionProcess(key);
 }
 
 /**

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -97,6 +97,93 @@ function endEpoch(key: string): number {
   return next;
 }
 
+/**
+ * Starts that have been issued but have not returned yet, keyed by tab.
+ *
+ * A start is slow (spawn, drain, `use <db>`), and until it returns there is no
+ * session id anywhere — so a component remounting in the middle of one saw an
+ * unattached tab and issued a SECOND start. Both children then wrote their id
+ * over each other, leaving one process with nothing pointing at it and making
+ * the tab's eventual close stop whichever happened to be recorded.
+ *
+ * Keyed on the tab rather than held in the component, because the whole point
+ * is that the second component is a different instance. Survives HMR for the
+ * same reason the sessions map does.
+ */
+const pendingStarts: Map<string, Promise<unknown>> =
+  import.meta.hot?.data?.shellPendingStarts ?? new Map<string, Promise<unknown>>();
+if (import.meta.hot?.data) import.meta.hot.data.shellPendingStarts = pendingStarts;
+
+/**
+ * Run `task` as this tab's start, or join the one already running.
+ *
+ * The joiner gets the same result the original will, so a remount attaches to
+ * the child that is already coming rather than spawning a rival.
+ */
+export function shareShellStart<T extends { session_id: string }>(
+  key: string,
+  task: () => Promise<T>
+): Promise<T> {
+  const existing = pendingStarts.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const startedEpoch = shellSessionEpoch(key);
+  const started = task();
+  pendingStarts.set(key, started);
+  const clear = () => {
+    // Only our own entry: a retry may have replaced it by now.
+    if (pendingStarts.get(key) === started) pendingStarts.delete(key);
+  };
+  // The id is recorded BEFORE the slot is released, and both happen before
+  // anything awaiting `started` resumes. Otherwise there is an instant where
+  // neither the pending map nor the registry says this tab has a session, and
+  // a component re-rendering in that instant starts another child.
+  started.then((result) => {
+    // Still the current attempt, and the tab still ours. A retry calls
+    // `dropPendingShellStart`, which replaces this slot — recording the id then
+    // would hand the tab a child the retrying component is about to stop.
+    const stillCurrent = pendingStarts.get(key) === started;
+    if (stillCurrent && shellSessionEpoch(key) === startedEpoch) {
+      writeShellSession(key, { sessionId: result.session_id });
+    }
+    clear();
+  }, clear);
+  return started;
+}
+
+/** Forget a tab's in-flight start, so the next attempt really starts one. Used
+ *  by Retry, which means "start fresh" rather than "join what is running". */
+export function dropPendingShellStart(key: string): void {
+  pendingStarts.delete(key);
+}
+
+/**
+ * Components watching a key, so a write made by SOMEONE ELSE reaches the
+ * instance currently on screen.
+ *
+ * Without this, output from a command that completes off-screen lands in the
+ * registry and stays invisible until the mounted instance happens to append
+ * something of its own or the tab is switched again.
+ */
+const watchers: Map<string, Set<(session: ShellSession) => void>> = new Map();
+
+/** Subscribe to changes for `key`; returns an unsubscribe. */
+export function watchShellSession(key: string, fn: (session: ShellSession) => void): () => void {
+  const forKey = watchers.get(key) ?? new Set();
+  forKey.add(fn);
+  watchers.set(key, forKey);
+  return () => {
+    forKey.delete(fn);
+    if (forKey.size === 0) watchers.delete(key);
+  };
+}
+
+function notifyWatchers(key: string, session: ShellSession): void {
+  const forKey = watchers.get(key);
+  if (!forKey) return;
+  // Copied first: a watcher may unsubscribe itself while being notified.
+  for (const fn of [...forKey]) fn(session);
+}
+
 /** Read a tab's stored state from the backend WITHOUT caching it. Used by
  *  disposal, which must not resurrect an entry for a key it has just deleted —
  *  or, worse, overwrite the entry a reopened tab has since created. */
@@ -180,6 +267,7 @@ export function writeShellSession(
   };
   sessions.set(key, next);
   persist(key, next);
+  notifyWatchers(key, next);
 }
 
 /**
@@ -198,13 +286,19 @@ export async function disposeShellSession(key: string): Promise<void> {
   endEpoch(key);
   const cached = sessions.get(key);
   sessions.delete(key);
-  void invoke('clear_shell_tab_state', { tabId: key }).catch(() => undefined);
 
-  // Only now, and never back into the cache: an inactive tab's state can live
-  // solely in the backend, so its id has to be read to be stopped.
-  const sessionId = cached?.sessionId ?? (await fetchStoredSession(key))?.sessionId;
-  if (!sessionId) return;
-  await invoke('stop_mongosh_session', { sessionId }).catch(() => undefined);
+  // One backend call takes the entry and stops the child it names. Reading the
+  // id and clearing the entry as two commands is a race the frontend cannot
+  // win — an inactive tab's id exists only in the backend, so a clear that
+  // overtook the read would leave the child running with nothing pointing at
+  // it. The cached id is stopped too, since the mirror is fire-and-forget and
+  // an id written moments ago may not have landed there yet; stopping an
+  // already-stopped session is a no-op.
+  const closing = invoke('close_shell_tab_session', { tabId: key }).catch(() => undefined);
+  if (cached?.sessionId) {
+    await invoke('stop_mongosh_session', { sessionId: cached.sessionId }).catch(() => undefined);
+  }
+  await closing;
 }
 
 /**
@@ -321,6 +415,8 @@ export function forgetShellSession(key: string): void {
 export function resetShellSessions(): void {
   sessions.clear();
   epochs.clear();
+  pendingStarts.clear();
+  watchers.clear();
 }
 
 /** Forget every tab, in the cache and the backend. */

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -46,23 +46,47 @@ export interface ShellSession {
 }
 
 /**
- * Survives Vite hot module replacement.
+ * In-memory cache over the BACKEND's per-tab store.
  *
- * In dev, editing anything in this module's graph replaces the module and a
- * plain `new Map()` would start empty — the tab then finds no stored session,
- * starts a second one, and the ORIGINAL mongosh process is orphaned, because
- * the id that could have stopped it lived only in the map that was just
- * discarded. That shows up as the shell suddenly demanding mongosh again after
- * a code change, with stray processes accumulating behind it.
+ * The backend is the source of truth (`get/set_shell_tab_state`), because
+ * renderer state does not survive a Vite hot reload or a window refresh: the
+ * map came back empty, the tab concluded it had no session and started a second
+ * one, and the original mongosh child was orphaned with no id left to stop it.
+ * The backend already owns those children.
  *
- * Reusing the same Map instance across replacements keeps sessions attached and
- * keeps every process reachable by `disposeShellSession`. No effect on a
- * packaged build, where `import.meta.hot` is undefined.
+ * This cache exists only so the common case stays synchronous — a mounted
+ * component can seed itself without waiting on IPC. After a hot reload it is
+ * empty and `loadShellSession` refills it from the backend.
  */
 const sessions: Map<string, ShellSession> =
   import.meta.hot?.data?.shellSessions ?? new Map<string, ShellSession>();
-// `data` is absent under vitest, where `import.meta.hot` exists but is inert.
+// Reuse the same instance across hot replacements too, so the common path does
+// not even need the backend round trip during development.
 if (import.meta.hot?.data) import.meta.hot.data.shellSessions = sessions;
+
+/** Write-through to the backend. Fire-and-forget: the cache is already updated,
+ *  and a failed mirror must never break the shell. */
+function persist(key: string, session: ShellSession): void {
+  void invoke('set_shell_tab_state', { tabId: key, value: session }).catch(() => undefined);
+}
+
+/**
+ * Read a tab's state from the backend, populating the cache.
+ *
+ * Callers use this when {@link readShellSession} misses — after a hot reload or
+ * a refresh, when the cache is empty but a mongosh child is still running and
+ * must be reattached rather than duplicated.
+ */
+export async function loadShellSession(key: string): Promise<ShellSession | undefined> {
+  const cached = sessions.get(key);
+  if (cached) return cached;
+  const stored = await invoke<ShellSession | null>('get_shell_tab_state', { tabId: key }).catch(
+    () => null,
+  );
+  if (!stored) return undefined;
+  sessions.set(key, stored);
+  return stored;
+}
 
 export function readShellSession(key: string): ShellSession | undefined {
   return sessions.get(key);
@@ -72,14 +96,16 @@ export function readShellSession(key: string): ShellSession | undefined {
  *  field without knowing the rest. */
 export function writeShellSession(key: string, patch: Partial<ShellSession>): void {
   const prev = sessions.get(key);
-  sessions.set(key, {
+  const next: ShellSession = {
     sessionId: patch.sessionId !== undefined ? patch.sessionId : (prev?.sessionId ?? null),
     entries: patch.entries ?? prev?.entries ?? [],
     currentDb: patch.currentDb ?? prev?.currentDb ?? '',
     autoRanCommand: patch.autoRanCommand ?? prev?.autoRanCommand ?? false,
     aiOpen: patch.aiOpen ?? prev?.aiOpen ?? false,
     aiMessages: patch.aiMessages ?? prev?.aiMessages ?? [],
-  });
+  };
+  sessions.set(key, next);
+  persist(key, next);
 }
 
 /**
@@ -91,8 +117,9 @@ export function writeShellSession(key: string, patch: Partial<ShellSession>): vo
  * tab teardown must not be able to throw.
  */
 export async function disposeShellSession(key: string): Promise<void> {
-  const session = sessions.get(key);
+  const session = sessions.get(key) ?? (await loadShellSession(key));
   sessions.delete(key);
+  void invoke('clear_shell_tab_state', { tabId: key }).catch(() => undefined);
   if (!session?.sessionId) return;
   await invoke('stop_mongosh_session', { sessionId: session.sessionId }).catch(() => undefined);
 }
@@ -115,6 +142,7 @@ export async function stopShellSessionProcess(key: string): Promise<void> {
  *  dead id would strand a live mongosh process that nothing can stop, and the
  *  rebound tab would start a second one. */
 export function renameShellSession(oldKey: string, newKey: string): void {
+  void invoke('rename_shell_tab_state', { oldId: oldKey, newId: newKey }).catch(() => undefined);
   const session = sessions.get(oldKey);
   if (!session) return;
   sessions.delete(oldKey);
@@ -129,4 +157,10 @@ export async function disposeAllShellSessions(): Promise<void> {
 /** Test seam: forget everything without touching the backend. */
 export function resetShellSessions(): void {
   sessions.clear();
+}
+
+/** Forget every tab, in the cache and the backend. */
+export async function disposeAllShellTabState(): Promise<void> {
+  sessions.clear();
+  await invoke('clear_all_shell_tab_state').catch(() => undefined);
 }

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -65,6 +65,58 @@ const sessions: Map<string, ShellSession> =
 // not even need the backend round trip during development.
 if (import.meta.hot?.data) import.meta.hot.data.shellSessions = sessions;
 
+/**
+ * Per-key write epoch: how many times THIS renderer has stopped owning a key.
+ *
+ * A command can still be in flight when its tab is closed or moved to another
+ * window, and the unmounted component goes on to persist the result — writing a
+ * transcript built from its own stale snapshot. After a close that resurrects
+ * the session the tab just discarded (deterministic tab ids mean reopening
+ * lands on the same key, inheriting the old scrollback and `autoRanCommand`);
+ * after a move it clobbers the destination window's newer state and, because
+ * every write stamps the owning window, quietly steals ownership back — so
+ * closing the source window would then kill a process the destination is
+ * showing.
+ *
+ * A component captures the epoch when it mounts and passes it with every write.
+ * `disposeShellSession` and `forgetShellSession` bump it, which silences that
+ * component for good without disturbing whoever legitimately owns the key now.
+ */
+const epochs: Map<string, number> = import.meta.hot?.data?.shellEpochs ?? new Map<string, number>();
+if (import.meta.hot?.data) import.meta.hot.data.shellEpochs = epochs;
+
+/** The current write epoch for `key`. Capture this at mount; pass it to
+ *  {@link writeShellSession} so writes that outlive ownership are dropped. */
+export function shellSessionEpoch(key: string): number {
+  return epochs.get(key) ?? 0;
+}
+
+function endEpoch(key: string): number {
+  const next = shellSessionEpoch(key) + 1;
+  epochs.set(key, next);
+  return next;
+}
+
+/**
+ * The epoch at which a key was last DISPOSED, as opposed to merely forgotten.
+ *
+ * Both end an epoch, but they mean opposite things for the mongosh child: a
+ * disposed tab's child should die, a moved tab's child belongs to another
+ * window now and must not be touched. Only the async start path needs to tell
+ * them apart — see {@link wasDisposedSince}.
+ */
+const disposedAt: Map<string, number> =
+  import.meta.hot?.data?.shellDisposedAt ?? new Map<string, number>();
+if (import.meta.hot?.data) import.meta.hot.data.shellDisposedAt = disposedAt;
+
+/** Whether this key was closed outright after `epoch` — i.e. whether a caller
+ *  holding `epoch` is finishing work for a tab that no longer exists. False for
+ *  a tab that merely moved to another window. */
+export function wasDisposedSince(key: string, epoch: number): boolean {
+  const at = disposedAt.get(key);
+  return at !== undefined && at > epoch;
+}
+
 /** Write-through to the backend. Fire-and-forget: the cache is already updated,
  *  and a failed mirror must never break the shell. */
 function persist(key: string, session: ShellSession): void {
@@ -113,9 +165,22 @@ export function readShellSession(key: string): ShellSession | undefined {
   return sessions.get(key);
 }
 
-/** Create or update the stored session. Merges, so a caller can persist one
- *  field without knowing the rest. */
-export function writeShellSession(key: string, patch: Partial<ShellSession>): void {
+/**
+ * Create or update the stored session. Merges, so a caller can persist one
+ * field without knowing the rest.
+ *
+ * `epoch` is the value {@link shellSessionEpoch} returned when the writer
+ * mounted. A mismatch means the writer no longer owns this key — its tab was
+ * closed or moved to another window while a command was in flight — and the
+ * write is dropped. Omitting it writes unconditionally, which is what the
+ * registry's own helpers do.
+ */
+export function writeShellSession(
+  key: string,
+  patch: Partial<ShellSession>,
+  epoch?: number
+): void {
+  if (epoch !== undefined && epoch !== shellSessionEpoch(key)) return;
   const prev = sessions.get(key);
   const next: ShellSession = {
     sessionId: patch.sessionId !== undefined ? patch.sessionId : (prev?.sessionId ?? null),
@@ -139,6 +204,7 @@ export function writeShellSession(key: string, patch: Partial<ShellSession>): vo
  */
 export async function disposeShellSession(key: string): Promise<void> {
   const session = sessions.get(key) ?? (await loadShellSession(key));
+  disposedAt.set(key, endEpoch(key));
   sessions.delete(key);
   void invoke('clear_shell_tab_state', { tabId: key }).catch(() => undefined);
   if (!session?.sessionId) return;
@@ -233,9 +299,27 @@ export async function disposeShellSessionsForTabs(tabIds: string[]): Promise<voi
   await Promise.all(tabIds.map(disposeShellSession));
 }
 
+/**
+ * Drop this renderer's copy of a tab's state WITHOUT ending the session.
+ *
+ * For a tab that moved to another window: the mongosh child and the backend
+ * entry belong to the destination now, so they must survive, but keeping the
+ * cached object here is actively wrong. If the tab ever comes back, this
+ * renderer would seed from a snapshot that predates everything the other window
+ * did — showing the wrong database after a `use` there, and mirroring its stale
+ * transcript over the newer one. Bumping the epoch also silences any command
+ * this renderer still has in flight for the key.
+ */
+export function forgetShellSession(key: string): void {
+  endEpoch(key);
+  sessions.delete(key);
+}
+
 /** Test seam: forget everything without touching the backend. */
 export function resetShellSessions(): void {
   sessions.clear();
+  epochs.clear();
+  disposedAt.clear();
 }
 
 /** Forget every tab, in the cache and the backend. */

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -97,24 +97,24 @@ function endEpoch(key: string): number {
   return next;
 }
 
-/**
- * The epoch at which a key was last DISPOSED, as opposed to merely forgotten.
- *
- * Both end an epoch, but they mean opposite things for the mongosh child: a
- * disposed tab's child should die, a moved tab's child belongs to another
- * window now and must not be touched. Only the async start path needs to tell
- * them apart — see {@link wasDisposedSince}.
- */
-const disposedAt: Map<string, number> =
-  import.meta.hot?.data?.shellDisposedAt ?? new Map<string, number>();
-if (import.meta.hot?.data) import.meta.hot.data.shellDisposedAt = disposedAt;
-
-/** Whether this key was closed outright after `epoch` — i.e. whether a caller
- *  holding `epoch` is finishing work for a tab that no longer exists. False for
- *  a tab that merely moved to another window. */
-export function wasDisposedSince(key: string, epoch: number): boolean {
-  const at = disposedAt.get(key);
-  return at !== undefined && at > epoch;
+/** Read a tab's stored state from the backend WITHOUT caching it. Used by
+ *  disposal, which must not resurrect an entry for a key it has just deleted —
+ *  or, worse, overwrite the entry a reopened tab has since created. */
+async function fetchStoredSession(key: string): Promise<ShellSession | undefined> {
+  const stored = await invoke<unknown>('get_shell_tab_state', { tabId: key }).catch(() => null);
+  // Shape-check rather than trust: this crosses the IPC boundary, and a value
+  // that is merely truthy (an array, say) would otherwise be read for fields it
+  // does not have.
+  if (!stored || typeof stored !== 'object' || Array.isArray(stored)) return undefined;
+  const candidate = stored as Partial<ShellSession>;
+  return {
+    sessionId: candidate.sessionId ?? null,
+    entries: Array.isArray(candidate.entries) ? candidate.entries : [],
+    currentDb: candidate.currentDb ?? '',
+    autoRanCommand: candidate.autoRanCommand ?? false,
+    aiOpen: candidate.aiOpen ?? false,
+    aiMessages: Array.isArray(candidate.aiMessages) ? candidate.aiMessages : [],
+  };
 }
 
 /** Write-through to the backend. Fire-and-forget: the cache is already updated,
@@ -143,20 +143,8 @@ function persist(key: string, session: ShellSession): void {
 export async function loadShellSession(key: string): Promise<ShellSession | undefined> {
   const cached = sessions.get(key);
   if (cached) return cached;
-  const stored = await invoke<unknown>('get_shell_tab_state', { tabId: key }).catch(() => null);
-  // Shape-check rather than trust: this crosses the IPC boundary, and a value
-  // that is merely truthy (an array, say) would otherwise be cached as a
-  // session and read for fields it does not have.
-  if (!stored || typeof stored !== 'object' || Array.isArray(stored)) return undefined;
-  const candidate = stored as Partial<ShellSession>;
-  const session: ShellSession = {
-    sessionId: candidate.sessionId ?? null,
-    entries: Array.isArray(candidate.entries) ? candidate.entries : [],
-    currentDb: candidate.currentDb ?? '',
-    autoRanCommand: candidate.autoRanCommand ?? false,
-    aiOpen: candidate.aiOpen ?? false,
-    aiMessages: Array.isArray(candidate.aiMessages) ? candidate.aiMessages : [],
-  };
+  const session = await fetchStoredSession(key);
+  if (!session) return undefined;
   sessions.set(key, session);
   return session;
 }
@@ -203,12 +191,20 @@ export function writeShellSession(
  * tab teardown must not be able to throw.
  */
 export async function disposeShellSession(key: string): Promise<void> {
-  const session = sessions.get(key) ?? (await loadShellSession(key));
-  disposedAt.set(key, endEpoch(key));
+  // Everything that touches shared state happens BEFORE the first await. Tab
+  // ids are deterministic, so the same key can be reopened while a lookup is in
+  // flight; doing this afterwards would end the epoch of — and delete the cache
+  // entry belonging to — the tab that has since taken the key over.
+  endEpoch(key);
+  const cached = sessions.get(key);
   sessions.delete(key);
   void invoke('clear_shell_tab_state', { tabId: key }).catch(() => undefined);
-  if (!session?.sessionId) return;
-  await invoke('stop_mongosh_session', { sessionId: session.sessionId }).catch(() => undefined);
+
+  // Only now, and never back into the cache: an inactive tab's state can live
+  // solely in the backend, so its id has to be read to be stopped.
+  const sessionId = cached?.sessionId ?? (await fetchStoredSession(key))?.sessionId;
+  if (!sessionId) return;
+  await invoke('stop_mongosh_session', { sessionId }).catch(() => undefined);
 }
 
 /**
@@ -325,7 +321,6 @@ export function forgetShellSession(key: string): void {
 export function resetShellSessions(): void {
   sessions.clear();
   epochs.clear();
-  disposedAt.clear();
 }
 
 /** Forget every tab, in the cache and the backend. */

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import { windowLabel } from '../workspace/workspaceStore';
 import type { ChatMessage } from '../components/AIChatPanel';
 
 /**
@@ -67,7 +68,17 @@ if (import.meta.hot?.data) import.meta.hot.data.shellSessions = sessions;
 /** Write-through to the backend. Fire-and-forget: the cache is already updated,
  *  and a failed mirror must never break the shell. */
 function persist(key: string, session: ShellSession): void {
-  void invoke('set_shell_tab_state', { tabId: key, value: session }).catch(() => undefined);
+  void invoke('set_shell_tab_state', {
+    tabId: key,
+    // Stamp the owning window. Closing a secondary window with its OS button
+    // runs no frontend code, so the backend has to clean up that window's
+    // shells itself — and it cannot do that by looking up the workspace's tab
+    // ids, which are PROFILE-space while these keys are LIVE-space (a tab
+    // rebound to a connection is re-keyed by `renameShellSession`, so the
+    // lookup misses and the child survives the window). Recording ownership
+    // here sidesteps the id-space mismatch entirely.
+    value: { ...session, windowId: windowLabel() },
+  }).catch(() => undefined);
 }
 
 /**

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -32,6 +32,11 @@ export interface ShellSession {
   entries: ShellEntry[];
   /** `use <db>` follows the session, so it has to survive with it. */
   currentDb: string;
+  /** Whether the command that opened this tab has already been auto-run. Lives
+   *  here rather than in a component ref because a ref resets on every mount:
+   *  once the transcript started surviving tab switches, the re-runs became
+   *  visible as the same command executing again on every switch. */
+  autoRanCommand: boolean;
 }
 
 const sessions = new Map<string, ShellSession>();
@@ -48,6 +53,7 @@ export function writeShellSession(key: string, patch: Partial<ShellSession>): vo
     sessionId: patch.sessionId !== undefined ? patch.sessionId : (prev?.sessionId ?? null),
     entries: patch.entries ?? prev?.entries ?? [],
     currentDb: patch.currentDb ?? prev?.currentDb ?? '',
+    autoRanCommand: patch.autoRanCommand ?? prev?.autoRanCommand ?? false,
   });
 }
 

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -80,12 +80,22 @@ function persist(key: string, session: ShellSession): void {
 export async function loadShellSession(key: string): Promise<ShellSession | undefined> {
   const cached = sessions.get(key);
   if (cached) return cached;
-  const stored = await invoke<ShellSession | null>('get_shell_tab_state', { tabId: key }).catch(
-    () => null,
-  );
-  if (!stored) return undefined;
-  sessions.set(key, stored);
-  return stored;
+  const stored = await invoke<unknown>('get_shell_tab_state', { tabId: key }).catch(() => null);
+  // Shape-check rather than trust: this crosses the IPC boundary, and a value
+  // that is merely truthy (an array, say) would otherwise be cached as a
+  // session and read for fields it does not have.
+  if (!stored || typeof stored !== 'object' || Array.isArray(stored)) return undefined;
+  const candidate = stored as Partial<ShellSession>;
+  const session: ShellSession = {
+    sessionId: candidate.sessionId ?? null,
+    entries: Array.isArray(candidate.entries) ? candidate.entries : [],
+    currentDb: candidate.currentDb ?? '',
+    autoRanCommand: candidate.autoRanCommand ?? false,
+    aiOpen: candidate.aiOpen ?? false,
+    aiMessages: Array.isArray(candidate.aiMessages) ? candidate.aiMessages : [],
+  };
+  sessions.set(key, session);
+  return session;
 }
 
 export function readShellSession(key: string): ShellSession | undefined {

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import type { ChatMessage } from '../components/AIChatPanel';
 
 /**
  * Live mongosh sessions and their transcripts, held outside the React tree.
@@ -37,6 +38,11 @@ export interface ShellSession {
    *  once the transcript started surviving tab switches, the re-runs became
    *  visible as the same command executing again on every switch. */
   autoRanCommand: boolean;
+  /** The shell's AI helper, which unmounts with the tab exactly like the chat
+   *  in DocumentViewer does — it just never got the same treatment, so the
+   *  panel collapsed and its transcript vanished on every tab switch. */
+  aiOpen: boolean;
+  aiMessages: ChatMessage[];
 }
 
 const sessions = new Map<string, ShellSession>();
@@ -54,6 +60,8 @@ export function writeShellSession(key: string, patch: Partial<ShellSession>): vo
     entries: patch.entries ?? prev?.entries ?? [],
     currentDb: patch.currentDb ?? prev?.currentDb ?? '',
     autoRanCommand: patch.autoRanCommand ?? prev?.autoRanCommand ?? false,
+    aiOpen: patch.aiOpen ?? prev?.aiOpen ?? false,
+    aiMessages: patch.aiMessages ?? prev?.aiMessages ?? [],
   });
 }
 
@@ -70,6 +78,19 @@ export async function disposeShellSession(key: string): Promise<void> {
   sessions.delete(key);
   if (!session?.sessionId) return;
   await invoke('stop_mongosh_session', { sessionId: session.sessionId }).catch(() => undefined);
+}
+
+/**
+ * Stop the running process but KEEP the tab's transcript and settings, so the
+ * shell can start a fresh session without losing the scrollback. This is what
+ * the Restart control uses; `disposeShellSession` is for a tab going away.
+ */
+export async function stopShellSessionProcess(key: string): Promise<void> {
+  const session = sessions.get(key);
+  if (!session?.sessionId) return;
+  const { sessionId } = session;
+  writeShellSession(key, { sessionId: null });
+  await invoke('stop_mongosh_session', { sessionId }).catch(() => undefined);
 }
 
 /** Follow a tab that was rebound to a new id (App's rebindProfileTabs). The

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -159,9 +159,17 @@ export function renameShellSession(oldKey: string, newKey: string): void {
   sessions.set(newKey, session);
 }
 
-/** Dispose every session — used when the whole workspace is torn down. */
-export async function disposeAllShellSessions(): Promise<void> {
-  await Promise.all(Array.from(sessions.keys(), disposeShellSession));
+/**
+ * Dispose the sessions belonging to a specific set of tabs.
+ *
+ * Deliberately scoped rather than global. Both callers run per-renderer — one
+ * on workspace restore, one when this window is removed by another window's op
+ * — so an app-wide clear would erase the recovery mapping for live shells owned
+ * by OTHER windows without stopping their children, leaving processes that can
+ * no longer be reattached or killed.
+ */
+export async function disposeShellSessionsForTabs(tabIds: string[]): Promise<void> {
+  await Promise.all(tabIds.map(disposeShellSession));
 }
 
 /** Test seam: forget everything without touching the backend. */

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -1,0 +1,77 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Live mongosh sessions and their transcripts, held outside the React tree.
+ *
+ * Inactive tabs are unmounted (PaneView renders only `pane.activeTabId`), and
+ * MongoShell used to stop its mongosh session in an effect cleanup — so
+ * glancing at another tab killed the user's shell process and threw away the
+ * whole scrollback. Coming back spawned a fresh session with an empty
+ * transcript (#240).
+ *
+ * A session is an OS process, not view state: its lifetime belongs to the tab,
+ * not to whether that tab happens to be the one on screen. Keeping it here
+ * means unmounting is free and `disposeShellSession` — called when the tab
+ * actually closes — is the single place a session ends.
+ *
+ * Session-local by design, like `tabChatCache`: not part of the persisted
+ * workspace snapshot, since a mongosh process cannot outlive the app anyway.
+ */
+
+export type ShellEntry =
+  | { kind: 'input'; db: string; text: string }
+  | { kind: 'text'; lines: string[] }
+  | { kind: 'value'; value: unknown }
+  | { kind: 'note'; text: string }
+  | { kind: 'error'; message: string };
+
+export interface ShellSession {
+  /** Backend session id, or null when no session is currently attached. */
+  sessionId: string | null;
+  /** Console scrollback, including the startup banner. */
+  entries: ShellEntry[];
+  /** `use <db>` follows the session, so it has to survive with it. */
+  currentDb: string;
+}
+
+const sessions = new Map<string, ShellSession>();
+
+export function readShellSession(key: string): ShellSession | undefined {
+  return sessions.get(key);
+}
+
+/** Create or update the stored session. Merges, so a caller can persist one
+ *  field without knowing the rest. */
+export function writeShellSession(key: string, patch: Partial<ShellSession>): void {
+  const prev = sessions.get(key);
+  sessions.set(key, {
+    sessionId: patch.sessionId !== undefined ? patch.sessionId : (prev?.sessionId ?? null),
+    entries: patch.entries ?? prev?.entries ?? [],
+    currentDb: patch.currentDb ?? prev?.currentDb ?? '',
+  });
+}
+
+/**
+ * End a tab's session for good: stop the backend process and forget the
+ * transcript. Call this when the TAB closes, never when it merely unmounts.
+ *
+ * Never rejects — a session that is already gone (backend restarted, process
+ * died) is still a successful disposal from the caller's point of view, and
+ * tab teardown must not be able to throw.
+ */
+export async function disposeShellSession(key: string): Promise<void> {
+  const session = sessions.get(key);
+  sessions.delete(key);
+  if (!session?.sessionId) return;
+  await invoke('stop_mongosh_session', { sessionId: session.sessionId }).catch(() => undefined);
+}
+
+/** Dispose every session — used when the whole workspace is torn down. */
+export async function disposeAllShellSessions(): Promise<void> {
+  await Promise.all(Array.from(sessions.keys(), disposeShellSession));
+}
+
+/** Test seam: forget everything without touching the backend. */
+export function resetShellSessions(): void {
+  sessions.clear();
+}

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -72,6 +72,17 @@ export async function disposeShellSession(key: string): Promise<void> {
   await invoke('stop_mongosh_session', { sessionId: session.sessionId }).catch(() => undefined);
 }
 
+/** Follow a tab that was rebound to a new id (App's rebindProfileTabs). The
+ *  session belongs to the tab, so it has to move with it — leaving it under the
+ *  dead id would strand a live mongosh process that nothing can stop, and the
+ *  rebound tab would start a second one. */
+export function renameShellSession(oldKey: string, newKey: string): void {
+  const session = sessions.get(oldKey);
+  if (!session) return;
+  sessions.delete(oldKey);
+  sessions.set(newKey, session);
+}
+
 /** Dispose every session — used when the whole workspace is torn down. */
 export async function disposeAllShellSessions(): Promise<void> {
   await Promise.all(Array.from(sessions.keys(), disposeShellSession));

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -45,7 +45,24 @@ export interface ShellSession {
   aiMessages: ChatMessage[];
 }
 
-const sessions = new Map<string, ShellSession>();
+/**
+ * Survives Vite hot module replacement.
+ *
+ * In dev, editing anything in this module's graph replaces the module and a
+ * plain `new Map()` would start empty — the tab then finds no stored session,
+ * starts a second one, and the ORIGINAL mongosh process is orphaned, because
+ * the id that could have stopped it lived only in the map that was just
+ * discarded. That shows up as the shell suddenly demanding mongosh again after
+ * a code change, with stray processes accumulating behind it.
+ *
+ * Reusing the same Map instance across replacements keeps sessions attached and
+ * keeps every process reachable by `disposeShellSession`. No effect on a
+ * packaged build, where `import.meta.hot` is undefined.
+ */
+const sessions: Map<string, ShellSession> =
+  import.meta.hot?.data?.shellSessions ?? new Map<string, ShellSession>();
+// `data` is absent under vitest, where `import.meta.hot` exists but is inert.
+if (import.meta.hot?.data) import.meta.hot.data.shellSessions = sessions;
 
 export function readShellSession(key: string): ShellSession | undefined {
   return sessions.get(key);

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -239,6 +239,12 @@ export function renameShellSession(oldKey: string, newKey: string): Promise<void
   const moved = invoke('rename_shell_tab_state', { oldId: oldKey, newId: newKey })
     .then(() => undefined)
     .catch(() => undefined);
+  // The rename remounts the shell under `newKey`, so anything the old instance
+  // is still running belongs to a key nothing will read again. Without ending
+  // the old epoch its completion would recreate the obsolete entry — stranding
+  // a session mapping that the renamed tab's close will never clear — and the
+  // output would land there instead of in the tab the user is looking at.
+  endEpoch(oldKey);
   const session = sessions.get(oldKey);
   if (session) {
     sessions.delete(oldKey);

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -221,7 +221,8 @@
       "switchedToDb": "zur Datenbank {{db}} gewechselt",
       "destructiveCancelled": "Destruktiver Befehl abgebrochen.",
       "resultToDataViewer_one": "{{count}} Dokument -> Datenansicht",
-      "resultToDataViewer_other": "{{count}} Dokumente -> Datenansicht"
+      "resultToDataViewer_other": "{{count}} Dokumente -> Datenansicht",
+      "sessionRestarting": "mongosh-Sitzung wird neu gestartet…"
     },
     "errors": {
       "invalidJsonLiteral": "Ungültiges mongosh-JSON-Literal: {{value}}",
@@ -250,7 +251,9 @@
     "toolbar": {
       "run": "Ausführen",
       "aiToggleTitle": "KI-Assistent",
-      "aiToggleLabel": "KI"
+      "aiToggleLabel": "KI",
+      "restartSession": "Neu starten",
+      "restartSessionTitle": "Diese mongosh-Sitzung beenden und eine neue starten"
     },
     "editor": {
       "loading": "Editor wird geladen..."

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -267,12 +267,15 @@
       "resultToDataViewer_one": "{{count}} document -> Data Viewer",
       "resultToDataViewer_other": "{{count}} documents -> Data Viewer",
       "sessionAttached": "mongosh session attached",
+      "sessionRestarting": "restarting mongosh session…",
       "sessionUnavailable": "mongosh session unavailable: {{detail}}",
       "switchedToDb": "switched to db {{db}}"
     },
     "toolbar": {
       "aiToggleLabel": "AI",
       "aiToggleTitle": "AI assistant",
+      "restartSession": "Restart",
+      "restartSessionTitle": "Stop this mongosh session and start a new one",
       "run": "Run"
     }
   },


### PR DESCRIPTION
Phase 1 of #240.

## The bug

Inactive tabs are unmounted — `PaneView.tsx:98` renders only `pane.activeTabId` — and `MongoShell` stopped its mongosh session in an effect cleanup:

```ts
return () => {
  cancelled = true;
  if (openedSessionId) invoke('stop_mongosh_session', { sessionId: openedSessionId });
};
```

So glancing at another tab **terminated the user's shell process** and threw away the entire scrollback. Coming back spawned a fresh session with an empty transcript.

## The fix

A session is an OS process, not view state. Its lifetime belongs to the tab, not to whether that tab happens to be on screen.

The session id, transcript and current database now live in a registry keyed by tab id, outside the React tree. The unmount cleanup no longer stops anything. Teardown happens where the tab actually **closes** — every path that already drops the tab's other caches now ends its session too, plus the workspace-wide resets.

Remounting **reattaches** to the running session instead of starting a second one. Retry is the deliberate exception: it means start fresh, so it still spawns.

`sessionKey` is optional, and without it the old per-mount lifetime is kept — so a shell rendered outside the tab system can't leak a process.

## Tests

Nine. Six over the registry, including that disposal **never rejects** (tab teardown must not be able to throw) and that a tab which never attached doesn't call the backend. Three over the component; the two describing the new behaviour were confirmed red beforehand:

```
× does not kill the mongosh process when the tab is switched away
× reattaches to the running session instead of spawning a second one
```

## Scope

This does **not** change how tabs render. Phase 2 — keeping subtrees mounted with an LRU cap — is deliberately separate, and per the issue shouldn't start until two measurements exist: Monaco's per-instance cost and mongosh's RSS. Neither is measurable in node/jsdom, and mongosh isn't installed on my machine.

Worth stating plainly: **this makes sessions outlive tab switches, so N shell tabs now means N live mongosh processes** where before there was at most one. That's the intended behaviour, but it's also exactly why Phase 2 needs the RSS number before choosing a cap.

## Verification

```
npx tsc --noEmit  → 0 errors
npm run build     → clean
npm run i18n:check→ clean (exit 0)
npx vitest run --coverage → 91 files, 1238 passed, 4 skipped
```
