### PR TITLE
feat(workspace): add Close Tab, Close Others and Close to the Right

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,7 +100,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { FolderCode, KeyRound, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck, ExternalLink, MoveRight, Wand2, Lock, ShieldAlert } from 'lucide-react';
+import { FolderCode, KeyRound, X, ChevronsRight, XSquare, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck, ExternalLink, MoveRight, Wand2, Lock, ShieldAlert } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 
 export interface QueryTab {
@@ -2205,11 +2205,20 @@ function Workspace() {
       // connect, so any stale entries either of those leaves behind
       // permanently fall outside the tab-id space any future tab could
       // ever resolve — harmless, not reachable again. No fix needed there.
+      const closing = new Set(action.tabIds);
       action.tabIds.forEach((id) => {
         generateTaskIdsRef.current.delete(id);
+        tabBuilderStateCache.current.delete(id);
         tabChatCache.current.delete(id);
         clearChatRequest(id);
       });
+      // Prune `tabs[]` here rather than leaving it to the caller. Every
+      // pre-existing call site happened to do its own `setTabs` first, so the
+      // gap was invisible until a new one did not — and the symptom is a
+      // layout/tabs mismatch ("tabs[] contains ids missing from workspace
+      // layout") rather than anything that points at the cause. Filtering twice
+      // is harmless; forgetting to filter is not. `close_tab` already does this.
+      setTabs((prev) => prev.filter((t) => !closing.has(t.id)));
     }
     dispatchLayout(action);
 
@@ -2376,6 +2385,43 @@ function Workspace() {
         icon: <ExternalLink />,
         separatorBefore: items.length > 0,
         onClick: () => handleDetachTab(tabId),
+      });
+    }
+
+    // Close group. Scoped to the pane holding this tab, which is what "others"
+    // and "to the right" mean on a tab strip — a second pane's tabs are a
+    // different strip and are left alone. `close_many` is one op rather than a
+    // loop of `close_tab`, so the pane folds once and the backend sees a single
+    // mirrored action.
+    const paneTabIds = paneOfTab(layout.root, tabId)?.tabIds ?? [];
+    const tabIndex = paneTabIds.indexOf(tabId);
+    // Quick Start is the workspace's home tab, not a document: a bulk close
+    // aimed at query tabs should not sweep it away as collateral. Closing it
+    // deliberately still works — its own X, and Close Tab when it is the tab
+    // that was right-clicked.
+    const isBulkClosable = (id: string) =>
+      id !== tabId && tabs.find((t) => t.id === id)?.type !== 'quickstart';
+    const otherTabIds = paneTabIds.filter(isBulkClosable);
+    const rightTabIds = (tabIndex >= 0 ? paneTabIds.slice(tabIndex + 1) : []).filter(isBulkClosable);
+
+    items.push({
+      label: tShell('workspaceTabBar.contextMenu.closeTab'),
+      icon: <X />,
+      separatorBefore: items.length > 0,
+      onClick: () => closeTabById(tabId),
+    });
+    if (otherTabIds.length > 0) {
+      items.push({
+        label: tShell('workspaceTabBar.contextMenu.closeOthers'),
+        icon: <XSquare />,
+        onClick: () => dispatchWorkspace({ type: 'close_many', tabIds: otherTabIds }),
+      });
+    }
+    if (rightTabIds.length > 0) {
+      items.push({
+        label: tShell('workspaceTabBar.contextMenu.closeToTheRight'),
+        icon: <ChevronsRight />,
+        onClick: () => dispatchWorkspace({ type: 'close_many', tabIds: rightTabIds }),
       });
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2363,15 +2363,17 @@ function Workspace() {
   // backend has no record of them — so both are hidden for them, replaced
   // by a single disabled, explanatory entry.
   const buildTabContextMenuItems = (tabId: string): ContextMenuItem[] => {
-    if (unmirroredTabIdsRef.current.has(tabId)) {
-      const explanation = tShell('workspaceTabBar.contextMenu.unmirroredExplanation');
-      return [{ label: explanation, onClick: () => {}, disabled: true, title: explanation }];
-    }
-
+    // Unmirrored (export/import/generate) tabs exist only in this renderer, so
+    // anything that hands the tab to the BACKEND is unavailable to them. The
+    // close group is not in that category — closing is purely local, and
+    // `dispatchWorkspace` already strips unmirrored ids from what it mirrors,
+    // for `close_many` as well as `close_tab`. Gating the WHOLE menu on this
+    // left an export tab unable to close itself or its neighbours at all.
+    const isUnmirrored = unmirroredTabIdsRef.current.has(tabId);
     const items: ContextMenuItem[] = [];
 
     const dupSource = tabs.find((t) => t.id === tabId && t.type === 'collection');
-    if (dupSource) {
+    if (dupSource && !isUnmirrored) {
       items.push({
         label: tShell('workspaceTabBar.contextMenu.duplicateTab'),
         icon: <Copy />,
@@ -2379,7 +2381,7 @@ function Workspace() {
       });
     }
 
-    if (allTabIds(layout).length > 1) {
+    if (!isUnmirrored && allTabIds(layout).length > 1) {
       items.push({
         label: tShell('workspaceTabBar.contextMenu.detachToNewWindow'),
         icon: <ExternalLink />,
@@ -2431,7 +2433,7 @@ function Workspace() {
     // "Detach to New Window" item was actually pushed) — otherwise the
     // first "Move to" entry would render an orphan divider line at the very
     // top of the menu.
-    otherWindows.forEach((w, i) => {
+    (isUnmirrored ? [] : otherWindows).forEach((w, i) => {
       const hint = activeTabHintFor(w, allTabs, t);
       const target = hint ? `${w.id} (${hint})` : w.id;
       items.push({
@@ -2441,6 +2443,19 @@ function Workspace() {
         onClick: () => handleMoveTab(tabId, w.id),
       });
     });
+
+    // Kept as a trailing note rather than the whole menu: it now explains what
+    // is ABSENT (detach/move) instead of standing in for everything.
+    if (isUnmirrored) {
+      const explanation = tShell('workspaceTabBar.contextMenu.unmirroredExplanation');
+      items.push({
+        label: explanation,
+        onClick: () => {},
+        disabled: true,
+        title: explanation,
+        separatorBefore: items.length > 0,
+      });
+    }
 
     return items;
   };

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -4028,7 +4028,7 @@ describe('App Component', () => {
       expect(screen.getAllByTestId(/^pane-pane-/)).toHaveLength(1);
     });
 
-    it('hides both cross-window items for an unmirrored (export/import) tab, showing a disabled explanatory entry instead', async () => {
+    it('hides both cross-window items for an unmirrored (export/import) tab, but still offers the close actions', async () => {
       mockInvoke.mockImplementation((cmd: string) => {
         if (cmd === 'execute_mql_query') return Promise.resolve([JSON.stringify({ _id: '1', name: 'Ada' })]);
         return Promise.resolve([]);
@@ -4054,6 +4054,16 @@ describe('App Component', () => {
       const placeholder = screen.getByText('Export/import tabs stay in their window');
       expect(placeholder.closest('button')).toBeDisabled();
       expect(placeholder.closest('button')).toHaveAttribute('title', 'Export/import tabs stay in their window');
+
+      // Closing is local — `dispatchWorkspace` drops unmirrored ids from what
+      // it mirrors — so the restriction covers detach/move only. The note now
+      // explains what is missing rather than replacing the entire menu.
+      expect(screen.getByText('Close Tab')).toBeInTheDocument();
+      // Quick Start and the customers tab share this pane; only customers is
+      // bulk-closable, which is enough for the entry to appear.
+      expect(screen.getByText('Close Other Tabs')).toBeInTheDocument();
+      // Nothing sits to the right of the export tab.
+      expect(screen.queryByText('Close Tabs to the Right')).not.toBeInTheDocument();
     });
 
     it('offers only Close Tab for the sole tab when no other windows exist', async () => {

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -3877,6 +3877,69 @@ describe('App Component', () => {
       expect(screen.getByText('Move to win-1 (orders)')).toBeInTheDocument();
     });
 
+    it('offers Close Tab, and Close Others only when there is another tab', async () => {
+      const { fireEvent, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // Only Quick Start: closing it is offered, but there is nothing else to
+      // close and nothing to its right.
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      fireEvent.contextMenu((await within(tabStrip).findByText('Quick Start')).closest('div')!);
+      await screen.findByTestId('context-menu');
+      expect(screen.getByText('Close Tab')).toBeInTheDocument();
+      expect(screen.queryByText('Close Other Tabs')).not.toBeInTheDocument();
+      expect(screen.queryByText('Close Tabs to the Right')).not.toBeInTheDocument();
+    });
+
+    it('leaves Quick Start alone when closing other tabs', async () => {
+      const { fireEvent, within, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // Quick Start + customers. "Close Other Tabs" from customers must not
+      // sweep away the home tab as collateral.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      const customersTab = await within(tabStrip).findByText('customers');
+
+      fireEvent.contextMenu(customersTab.closest('div')!);
+      await screen.findByTestId('context-menu');
+      // Quick Start is the only other tab, and it is excluded — so there is
+      // nothing left to close and the entry is not offered at all.
+      expect(screen.queryByText('Close Other Tabs')).not.toBeInTheDocument();
+
+      // It is still closable on purpose, from its own context menu.
+      fireEvent.keyDown(document, { key: 'Escape' });
+      fireEvent.contextMenu((await within(tabStrip).findByText('Quick Start')).closest('div')!);
+      await screen.findByTestId('context-menu');
+      fireEvent.click(screen.getByText('Close Tab'));
+      await waitFor(() =>
+        expect(within(screen.getByTestId('workspace-tab-strip')).queryByText('Quick Start')).toBeNull()
+      );
+    });
+
+    it('closes the tabs to the right of the clicked tab, and only those', async () => {
+      const { fireEvent, within, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // Quick Start + customers, in that order.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      await within(tabStrip).findByText('customers');
+
+      fireEvent.contextMenu((await within(tabStrip).findByText('Quick Start')).closest('div')!);
+      await screen.findByTestId('context-menu');
+      fireEvent.click(screen.getByText('Close Tabs to the Right'));
+
+      await waitFor(() =>
+        expect(within(screen.getByTestId('workspace-tab-strip')).queryByText('customers')).toBeNull()
+      );
+      // The clicked tab itself survives — "to the right" excludes it.
+      expect(within(screen.getByTestId('workspace-tab-strip')).getByText('Quick Start')).toBeInTheDocument();
+    });
+
     it('hides "Detach to New Window" when this window holds only one tab, but still offers "Move to <window>"', async () => {
       const { fireEvent, within } = await import('@testing-library/react');
       renderWithProviders(<App />);
@@ -3993,19 +4056,24 @@ describe('App Component', () => {
       expect(placeholder.closest('button')).toHaveAttribute('title', 'Export/import tabs stay in their window');
     });
 
-    it('does not open an empty context menu for the sole tab when no other windows exist', async () => {
+    it('offers only Close Tab for the sole tab when no other windows exist', async () => {
       const { fireEvent, within } = await import('@testing-library/react');
       renderWithProviders(<App />);
       await screen.findByTestId('mock-sidebar');
 
-      // Only Quick Start is open, and no other windows were seeded — both
-      // "Detach to New Window" and any "Move to" entries are absent, so
-      // buildTabContextMenuItems returns [] and the menu must not open.
+      // Only Quick Start is open and no other windows were seeded, so
+      // "Detach to New Window" and every "Move to" entry are absent. The menu
+      // used to be empty and therefore suppressed; closing is always available
+      // now — the tab strip's own X offers it for every tab — so it opens with
+      // that single entry.
       const tabStrip = screen.getByTestId('workspace-tab-strip');
       const quickstartTab = await within(tabStrip).findByText('Quick Start');
       fireEvent.contextMenu(quickstartTab.closest('div')!);
 
-      expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+      expect(await screen.findByTestId('context-menu')).toBeInTheDocument();
+      expect(screen.getByText('Close Tab')).toBeInTheDocument();
+      expect(screen.queryByText('Detach to New Window')).not.toBeInTheDocument();
+      expect(screen.queryByText('Close Other Tabs')).not.toBeInTheDocument();
     });
   });
 

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -451,7 +451,10 @@
       "duplicateTab": "Tab duplizieren",
       "detachToNewWindow": "In neues Fenster abdocken",
       "moveToWindow": "Verschieben nach {{target}}",
-      "unmirroredExplanation": "Export-/Import-Tabs bleiben in ihrem Fenster"
+      "unmirroredExplanation": "Export-/Import-Tabs bleiben in ihrem Fenster",
+      "closeTab": "Tab schließen",
+      "closeOthers": "Andere Tabs schließen",
+      "closeToTheRight": "Tabs rechts schließen"
     }
   },
   "emptyWorkspace": {

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -456,6 +456,9 @@
     "closeTab": "Close {{label}}",
     "closeTooltip": "Close tab",
     "contextMenu": {
+      "closeOthers": "Close Other Tabs",
+      "closeTab": "Close Tab",
+      "closeToTheRight": "Close Tabs to the Right",
       "detachToNewWindow": "Detach to New Window",
       "duplicateTab": "Duplicate Tab",
       "moveToWindow": "Move to {{target}}",


### PR DESCRIPTION
The tab context menu offered Duplicate, Detach and Move — but no way to close anything from it.

## What's added

Three entries, scoped to the **pane** holding the clicked tab. That's what "others" and "to the right" mean on a tab strip; a second pane is a different strip and is left alone.

Both bulk entries use the existing `close_many` op rather than a loop of `close_tab`, so the pane folds once and the backend sees a single mirrored action.

## Quick Start is excluded from bulk closes

It's the workspace's home tab, not a document, and a close aimed at query tabs shouldn't sweep it away as collateral. Closing it deliberately still works — its own X, or Close Tab when it's the tab you right-clicked. When Quick Start is the *only* other tab, "Close Other Tabs" isn't offered at all rather than being offered and doing nothing.

## Two things this turned up

**`close_many` never pruned `tabs[]`.** Every pre-existing call site happened to call `setTabs` itself first, so the gap was invisible until a new caller didn't. The symptom is `tabs[] contains ids missing from workspace layout`, which points nowhere near the cause. It now prunes and evicts the builder-state cache, exactly as `close_tab` does. Worth a look in review — it changes behaviour for the three existing callers, though only by making a filter they already performed idempotent.

**One existing test asserted the menu stays shut for a lone tab**, on the grounds it would otherwise be empty. Closing is always available now — the strip's own X already offers it for every tab — so that premise is gone, and the test asserts the single entry instead.

## Tests

Three added: the sole-tab case, "to the right" closing only what's to the right, and Quick Start surviving a bulk close while still being closable on purpose.

## Verification

```
npx tsc --noEmit  → 0 errors
npm run build     → clean
npm run i18n:check→ clean (exit 0)
npx vitest run --coverage → 90 files, 1232 passed, 4 skipped
```
