### PR TITLE
fix(shell): keep a moved tab's session, and free its pending start on close

### DIFF
--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -81,6 +81,7 @@ const LOCAL_COMMANDS: &[&str] = &[
     "get_shell_tab_state",
     "set_shell_tab_state",
     "clear_shell_tab_state",
+    "claim_shell_tab_state",
     // Takes a tab's entry and stops the child it named, atomically — same
     // local-only footprint as the two above plus `stop_mongosh_session`.
     "close_shell_tab_session",

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -82,6 +82,7 @@ const LOCAL_COMMANDS: &[&str] = &[
     "set_shell_tab_state",
     "clear_shell_tab_state",
     "claim_shell_tab_state",
+    "disown_shell_tab_state",
     // Takes a tab's entry and stops the child it named, atomically — same
     // local-only footprint as the two above plus `stop_mongosh_session`.
     "close_shell_tab_session",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -739,30 +739,36 @@ pub fn set_shell_tab_state_impl(
     tab_id: &str,
     value: serde_json::Value,
 ) -> Result<Option<String>, String> {
-    // A write from a window that is already gone must not recreate its entry:
-    // the close sweep has run, so nothing would ever stop the child it names.
-    // Rejecting alone would strand that child, so the id comes back for the
-    // caller to stop — this function is sync and holds a lock, and stopping is
-    // neither.
+    // The shell-state lock is taken FIRST and held across the closed-window
+    // check, the ownership check and the insert. Checking whether the window
+    // was closed and then inserting as two steps let a write begin just before
+    // `CloseRequested`, see the window as open, and land after the sweep had
+    // already run — recreating an entry for a window nothing will ever clean up
+    // again. The close path marks the window closed under this same lock, so
+    // the two orderings are now the only ones possible: either the write lands
+    // first and the sweep collects it, or the mark lands first and the write is
+    // refused here. (Lock order is shell state, then closed windows —
+    // everywhere, so the pair cannot deadlock.)
+    let mut map = state.shell_tab_state.lock_safe()?;
+    let submitted_session = value
+        .get("sessionId")
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string());
     if let Some(writer) = value.get("windowId").and_then(|w| w.as_str()) {
-        if window_is_closed(state, writer)? {
-            // Only an id nothing else accounts for is an orphan. If the tab
-            // still HAS an entry, it was claimed by another window and that
-            // window owns the child — the closed writer is simply describing a
-            // session someone else is now using, and stopping it would kill a
-            // live shell in the window that took the tab over.
-            let untracked = state.shell_tab_state.lock_safe()?.get(tab_id).is_none();
-            return Ok(if untracked {
-                value
-                    .get("sessionId")
-                    .and_then(|s| s.as_str())
-                    .map(|s| s.to_string())
-            } else {
-                None
-            });
+        if state.closed_windows.lock_safe()?.contains(writer) {
+            // Refuse it — and hand back the session it names unless the stored
+            // entry already accounts for that exact id. A tab commonly holds a
+            // placeholder with a null or older id, so "an entry exists" is not
+            // evidence that anyone is tracking the child this write describes.
+            let accounted_for = map
+                .get(tab_id)
+                .and_then(|v| v.get("sessionId"))
+                .and_then(|s| s.as_str())
+                .map(|s| Some(s.to_string()) == submitted_session)
+                .unwrap_or(false);
+            return Ok(if accounted_for { None } else { submitted_session });
         }
     }
-    let mut map = state.shell_tab_state.lock_safe()?;
     let recorded_owner = map
         .get(tab_id)
         .and_then(|v| v.get("windowId"))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -746,10 +746,20 @@ pub fn set_shell_tab_state_impl(
     // neither.
     if let Some(writer) = value.get("windowId").and_then(|w| w.as_str()) {
         if window_is_closed(state, writer)? {
-            return Ok(value
-                .get("sessionId")
-                .and_then(|s| s.as_str())
-                .map(|s| s.to_string()));
+            // Only an id nothing else accounts for is an orphan. If the tab
+            // still HAS an entry, it was claimed by another window and that
+            // window owns the child — the closed writer is simply describing a
+            // session someone else is now using, and stopping it would kill a
+            // live shell in the window that took the tab over.
+            let untracked = state.shell_tab_state.lock_safe()?.get(tab_id).is_none();
+            return Ok(if untracked {
+                value
+                    .get("sessionId")
+                    .and_then(|s| s.as_str())
+                    .map(|s| s.to_string())
+            } else {
+                None
+            });
         }
     }
     let mut map = state.shell_tab_state.lock_safe()?;
@@ -807,6 +817,27 @@ pub fn take_shell_tab_state_impl(
     tab_id: &str,
 ) -> Result<Option<serde_json::Value>, String> {
     Ok(state.shell_tab_state.lock_safe()?.remove(tab_id))
+}
+
+/// Take a tab's state only while `window_id` still owns it.
+///
+/// The close sweep enumerates a window's tabs and then takes them one by one;
+/// a destination can claim a moved tab in between, and an unconditional take
+/// would remove state that now belongs to the other window and stop its child.
+/// Checking the owner and removing has to be the same locked operation — making
+/// only the take atomic leaves the enumeration-to-take gap open.
+pub fn take_shell_tab_state_if_owned(
+    state: &AppState,
+    tab_id: &str,
+    window_id: &str,
+) -> Result<Option<serde_json::Value>, String> {
+    let mut map = state.shell_tab_state.lock_safe()?;
+    let owned = map
+        .get(tab_id)
+        .and_then(|v| v.get("windowId"))
+        .and_then(|w| w.as_str())
+        .is_some_and(|owner| owner == window_id);
+    Ok(if owned { map.remove(tab_id) } else { None })
 }
 
 /// Stamp `window_id` as the owner of a tab's state and return the CURRENT

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -895,6 +895,35 @@ pub fn window_is_closed(state: &AppState, window_id: &str) -> Result<bool, Strin
     Ok(state.closed_windows.lock_safe()?.contains(window_id))
 }
 
+/// Give up ownership of a tab, but only if `window_id` still holds it.
+///
+/// A renderer can start hydrating a tab and learn only afterwards that the tab
+/// has moved away from it — its claim is then in flight and lands after the
+/// destination's, stamping the wrong window back. It disowns itself when it
+/// finds out; the tab is left with no owner, and whoever actually has it takes
+/// it again on its next write. Conditional so a renderer cannot disown a tab
+/// that has since been claimed by someone else.
+pub fn disown_shell_tab_state_impl(
+    state: &AppState,
+    tab_id: &str,
+    window_id: &str,
+) -> Result<(), String> {
+    let mut map = state.shell_tab_state.lock_safe()?;
+    let Some(value) = map.get_mut(tab_id) else {
+        return Ok(());
+    };
+    let is_ours = value
+        .get("windowId")
+        .and_then(|w| w.as_str())
+        .is_some_and(|owner| owner == window_id);
+    if is_ours {
+        if let Some(obj) = value.as_object_mut() {
+            obj.remove("windowId");
+        }
+    }
+    Ok(())
+}
+
 /// The tab ids whose stored shell state was written by `window_id`.
 ///
 /// Ownership is read from the state the renderer stamped, not from the
@@ -1226,6 +1255,15 @@ fn claim_shell_tab_state(
     window_id: String,
 ) -> Result<Option<serde_json::Value>, String> {
     claim_shell_tab_state_impl(&state, &tab_id, &window_id)
+}
+
+#[tauri::command]
+fn disown_shell_tab_state(
+    state: tauri::State<'_, AppState>,
+    tab_id: String,
+    window_id: String,
+) -> Result<(), String> {
+    disown_shell_tab_state_impl(&state, &tab_id, &window_id)
 }
 
 /// Close a tab's shell for good: take its state and stop the child it named,
@@ -2400,6 +2438,7 @@ pub fn run() {
             set_shell_tab_state,
             clear_shell_tab_state,
             claim_shell_tab_state,
+            disown_shell_tab_state,
             close_shell_tab_session,
             rename_shell_tab_state,
             disconnect_db,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -735,12 +735,27 @@ pub fn get_shell_tab_state_impl(
 pub fn set_shell_tab_state_impl(
     state: &AppState,
     tab_id: &str,
-    value: serde_json::Value,
+    mut value: serde_json::Value,
 ) -> Result<(), String> {
-    state
-        .shell_tab_state
-        .lock_safe()?
-        .insert(tab_id.to_string(), value);
+    let mut map = state.shell_tab_state.lock_safe()?;
+    // Ownership is NOT the writer's to set. A renderer whose tab has moved can
+    // still have a write in flight — the mirror is fire-and-forget — and it
+    // carries the window it knew about, which would put the departed window
+    // back on the entry and hide the child from its real owner's close sweep.
+    // `claim_shell_tab_state` is the only way ownership changes; an ordinary
+    // write keeps whatever is already recorded, and only a brand-new entry
+    // takes the owner its creator supplies.
+    if let Some(existing_owner) = map
+        .get(tab_id)
+        .and_then(|v| v.get("windowId"))
+        .and_then(|w| w.as_str())
+        .map(|w| w.to_string())
+    {
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert("windowId".to_string(), serde_json::Value::String(existing_owner));
+        }
+    }
+    map.insert(tab_id.to_string(), value);
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -732,11 +732,26 @@ pub fn get_shell_tab_state_impl(
     Ok(state.shell_tab_state.lock_safe()?.get(tab_id).cloned())
 }
 
+/// Applies a tab-state write, returning a session id the CALLER must stop when
+/// the write came from a window that has already closed — see below.
 pub fn set_shell_tab_state_impl(
     state: &AppState,
     tab_id: &str,
     value: serde_json::Value,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
+    // A write from a window that is already gone must not recreate its entry:
+    // the close sweep has run, so nothing would ever stop the child it names.
+    // Rejecting alone would strand that child, so the id comes back for the
+    // caller to stop — this function is sync and holds a lock, and stopping is
+    // neither.
+    if let Some(writer) = value.get("windowId").and_then(|w| w.as_str()) {
+        if window_is_closed(state, writer)? {
+            return Ok(value
+                .get("sessionId")
+                .and_then(|s| s.as_str())
+                .map(|s| s.to_string()));
+        }
+    }
     let mut map = state.shell_tab_state.lock_safe()?;
     let recorded_owner = map
         .get(tab_id)
@@ -760,7 +775,7 @@ pub fn set_shell_tab_state_impl(
     // and it must not be able to lose its own data.
     if let (Some(owner), Some(writer)) = (recorded_owner.as_deref(), writer.as_deref()) {
         if writer != owner {
-            return Ok(());
+            return Ok(None);
         }
     }
     let mut value = value;
@@ -770,7 +785,7 @@ pub fn set_shell_tab_state_impl(
         }
     }
     map.insert(tab_id.to_string(), value);
-    Ok(())
+    Ok(None)
 }
 
 /// Forget a tab's state. Deliberately does NOT stop its mongosh session: the
@@ -1157,12 +1172,15 @@ fn get_shell_tab_state(
 }
 
 #[tauri::command]
-fn set_shell_tab_state(
+async fn set_shell_tab_state(
     state: tauri::State<'_, AppState>,
     tab_id: String,
     value: serde_json::Value,
 ) -> Result<(), String> {
-    set_shell_tab_state_impl(&state, &tab_id, value)
+    if let Some(orphan) = set_shell_tab_state_impl(&state, &tab_id, value)? {
+        let _ = stop_mongosh_session_impl(&state, &orphan).await;
+    }
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -765,6 +765,34 @@ pub fn take_shell_tab_state_impl(
     Ok(state.shell_tab_state.lock_safe()?.remove(tab_id))
 }
 
+/// Stamp `window_id` as the owner of a tab's state and return the CURRENT
+/// value, under one lock.
+///
+/// The renderer that hydrates a session is the one about to display it, so it
+/// has to take ownership — otherwise a moved tab's entry still names the window
+/// it left, hiding the child from the new owner's close sweep. Doing that as a
+/// read followed by a write would race the old renderer's final write and
+/// replay a stale snapshot over it, because `set_shell_tab_state` replaces the
+/// whole value. Only the owner field is touched here, and the caller caches
+/// what is actually stored rather than what it fetched.
+pub fn claim_shell_tab_state_impl(
+    state: &AppState,
+    tab_id: &str,
+    window_id: &str,
+) -> Result<Option<serde_json::Value>, String> {
+    let mut map = state.shell_tab_state.lock_safe()?;
+    let Some(value) = map.get_mut(tab_id) else {
+        return Ok(None);
+    };
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "windowId".to_string(),
+            serde_json::Value::String(window_id.to_string()),
+        );
+    }
+    Ok(Some(value.clone()))
+}
+
 /// Move a tab's state to a new id, for the rebind that renames a restored tab.
 pub fn rename_shell_tab_state_impl(
     state: &AppState,
@@ -1111,6 +1139,15 @@ fn set_shell_tab_state(
 #[tauri::command]
 fn clear_shell_tab_state(state: tauri::State<'_, AppState>, tab_id: String) -> Result<(), String> {
     clear_shell_tab_state_impl(&state, &tab_id)
+}
+
+#[tauri::command]
+fn claim_shell_tab_state(
+    state: tauri::State<'_, AppState>,
+    tab_id: String,
+    window_id: String,
+) -> Result<Option<serde_json::Value>, String> {
+    claim_shell_tab_state_impl(&state, &tab_id, &window_id)
 }
 
 /// Close a tab's shell for good: take its state and stop the child it named,
@@ -2284,6 +2321,7 @@ pub fn run() {
             get_shell_tab_state,
             set_shell_tab_state,
             clear_shell_tab_state,
+            claim_shell_tab_state,
             close_shell_tab_session,
             rename_shell_tab_state,
             disconnect_db,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -735,24 +735,38 @@ pub fn get_shell_tab_state_impl(
 pub fn set_shell_tab_state_impl(
     state: &AppState,
     tab_id: &str,
-    mut value: serde_json::Value,
+    value: serde_json::Value,
 ) -> Result<(), String> {
     let mut map = state.shell_tab_state.lock_safe()?;
-    // Ownership is NOT the writer's to set. A renderer whose tab has moved can
-    // still have a write in flight — the mirror is fire-and-forget — and it
-    // carries the window it knew about, which would put the departed window
-    // back on the entry and hide the child from its real owner's close sweep.
-    // `claim_shell_tab_state` is the only way ownership changes; an ordinary
-    // write keeps whatever is already recorded, and only a brand-new entry
-    // takes the owner its creator supplies.
-    if let Some(existing_owner) = map
+    let recorded_owner = map
         .get(tab_id)
         .and_then(|v| v.get("windowId"))
         .and_then(|w| w.as_str())
-        .map(|w| w.to_string())
-    {
+        .map(|w| w.to_string());
+    let writer = value
+        .get("windowId")
+        .and_then(|w| w.as_str())
+        .map(|w| w.to_string());
+
+    // A write from a renderer that no longer owns this tab is DROPPED, not
+    // merged. The mirror is fire-and-forget, so a window whose tab has moved
+    // can still have one in flight; it carries a whole snapshot taken before
+    // the move, and applying it would put back that window as owner and
+    // overwrite whatever the new owner has since recorded — its transcript, its
+    // database, even a session id that is no longer live.
+    //
+    // A write that names no window at all is trusted and keeps the recorded
+    // owner: that is how a caller with nothing to say about ownership behaves,
+    // and it must not be able to lose its own data.
+    if let (Some(owner), Some(writer)) = (recorded_owner.as_deref(), writer.as_deref()) {
+        if writer != owner {
+            return Ok(());
+        }
+    }
+    let mut value = value;
+    if let (Some(owner), None) = (recorded_owner, writer) {
         if let Some(obj) = value.as_object_mut() {
-            obj.insert("windowId".to_string(), serde_json::Value::String(existing_owner));
+            obj.insert("windowId".to_string(), serde_json::Value::String(owner));
         }
     }
     map.insert(tab_id.to_string(), value);

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4304,6 +4304,30 @@ mod shell_tab_state_tests {
     }
 
     #[test]
+    fn a_write_from_a_closed_window_is_refused_and_hands_back_its_child() {
+        // The close sweep has already run, so recreating the entry would leave
+        // the mongosh child it names with nothing pointing at it. The id comes
+        // back so the caller can stop it.
+        use crate::state::LockExt;
+        let st = state();
+        st.closed_windows.lock_safe().unwrap().insert("win-9".into());
+
+        let orphan = set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-late", "windowId": "win-9" }),
+        )
+        .unwrap();
+
+        assert_eq!(orphan.as_deref(), Some("sess-late"));
+        assert_eq!(
+            get_shell_tab_state_impl(&st, "tab-1").unwrap(),
+            None,
+            "a closed window's write recreated its entry"
+        );
+    }
+
+    #[test]
     fn the_current_owner_keeps_writing_normally() {
         let st = state();
         set_shell_tab_state_impl(

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4228,6 +4228,49 @@ mod shell_tab_state_tests {
     }
 
     #[test]
+    fn claiming_stamps_the_new_owner_and_returns_what_is_actually_stored() {
+        // The claim exists because a moved tab's entry still names the window
+        // it left. It touches only the owner field and hands back the current
+        // value, so the caller never replays a snapshot of its own over a write
+        // the previous owner made in the meantime.
+        use crate::claim_shell_tab_state_impl;
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-1", "windowId": "win-1", "entries": ["kept"] }),
+        )
+        .unwrap();
+
+        let claimed = claim_shell_tab_state_impl(&st, "tab-1", "win-2")
+            .unwrap()
+            .expect("an existing tab is claimable");
+
+        assert_eq!(claimed.get("windowId").unwrap(), "win-2");
+        assert_eq!(claimed.get("sessionId").unwrap(), "sess-1");
+        assert_eq!(
+            claimed.get("entries").unwrap(),
+            &serde_json::json!(["kept"]),
+            "claiming must not drop the rest of the value"
+        );
+        // ...and the change stuck, so the close sweep can find it.
+        assert_eq!(
+            shell_tab_ids_for_window(&st, "win-2").unwrap(),
+            vec!["tab-1".to_string()]
+        );
+        assert!(shell_tab_ids_for_window(&st, "win-1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn claiming_a_tab_with_no_state_is_a_no_op() {
+        use crate::claim_shell_tab_state_impl;
+        assert_eq!(
+            claim_shell_tab_state_impl(&state(), "nope", "win-2").unwrap(),
+            None
+        );
+    }
+
+    #[test]
     fn lists_only_the_tabs_a_given_window_owns() {
         // Closing a secondary window with the OS X button runs no frontend
         // code, so the backend stops that window's shells itself. It has to

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4262,6 +4262,55 @@ mod shell_tab_state_tests {
     }
 
     #[test]
+    fn an_ordinary_write_cannot_take_ownership_back() {
+        // The departed renderer's mirror is fire-and-forget, so a write from it
+        // can land after the destination has claimed the tab. It carries the
+        // window IT knew about; honouring that would hide the child from its
+        // real owner's close sweep and let the old label stop a live session.
+        use crate::claim_shell_tab_state_impl;
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-1", "windowId": "win-1" }),
+        )
+        .unwrap();
+        claim_shell_tab_state_impl(&st, "tab-1", "win-2").unwrap();
+
+        // The old owner's delayed write, still naming itself.
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-1", "entries": ["late"], "windowId": "win-1" }),
+        )
+        .unwrap();
+
+        let stored = get_shell_tab_state_impl(&st, "tab-1").unwrap().unwrap();
+        assert_eq!(stored.get("windowId").unwrap(), "win-2", "ownership was taken back");
+        assert_eq!(
+            stored.get("entries").unwrap(),
+            &serde_json::json!(["late"]),
+            "the write itself must still apply — only the owner field is protected"
+        );
+    }
+
+    #[test]
+    fn a_brand_new_entry_takes_the_owner_its_creator_supplies() {
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "fresh",
+            serde_json::json!({ "sessionId": "s", "windowId": "win-3" }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            shell_tab_ids_for_window(&st, "win-3").unwrap(),
+            vec!["fresh".to_string()]
+        );
+    }
+
+    #[test]
     fn claiming_a_tab_with_no_state_is_a_no_op() {
         use crate::claim_shell_tab_state_impl;
         assert_eq!(

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4387,6 +4387,56 @@ mod shell_tab_state_tests {
     }
 
     #[test]
+    fn a_placeholder_entry_does_not_hide_a_newly_started_child() {
+        // A tab usually holds a placeholder with a null id while its session
+        // starts. If the write carrying the real id arrives after the window is
+        // marked closed, "an entry exists" is not evidence anyone is tracking
+        // that child — the sweep would stop the null (i.e. nothing) and the new
+        // mongosh process would survive to app exit.
+        use crate::state::LockExt;
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": serde_json::Value::Null, "windowId": "win-9" }),
+        )
+        .unwrap();
+        st.closed_windows.lock_safe().unwrap().insert("win-9".into());
+
+        let orphan = set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-new", "windowId": "win-9" }),
+        )
+        .unwrap();
+
+        assert_eq!(orphan.as_deref(), Some("sess-new"));
+    }
+
+    #[test]
+    fn a_closed_window_write_naming_the_recorded_session_is_not_stopped_twice() {
+        use crate::state::LockExt;
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-1", "windowId": "win-9" }),
+        )
+        .unwrap();
+        st.closed_windows.lock_safe().unwrap().insert("win-9".into());
+
+        // The sweep will take this entry and stop sess-1 itself.
+        let orphan = set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-1", "windowId": "win-9" }),
+        )
+        .unwrap();
+
+        assert_eq!(orphan, None);
+    }
+
+    #[test]
     fn the_current_owner_keeps_writing_normally() {
         let st = state();
         set_shell_tab_state_impl(

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4328,6 +4328,65 @@ mod shell_tab_state_tests {
     }
 
     #[test]
+    fn a_closed_window_s_write_is_not_treated_as_an_orphan_once_another_window_owns_the_tab() {
+        // The moved tab was claimed by its destination before the source
+        // window closed, so the source's queued write names a session the
+        // DESTINATION is now using. Stopping it would kill a live shell.
+        use crate::state::LockExt;
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-live", "windowId": "win-2" }),
+        )
+        .unwrap();
+        st.closed_windows.lock_safe().unwrap().insert("win-1".into());
+
+        let orphan = set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-live", "windowId": "win-1" }),
+        )
+        .unwrap();
+
+        assert_eq!(orphan, None, "the destination's live session was stopped");
+        assert_eq!(
+            get_shell_tab_state_impl(&st, "tab-1")
+                .unwrap()
+                .unwrap()
+                .get("windowId")
+                .unwrap(),
+            "win-2"
+        );
+    }
+
+    #[test]
+    fn the_close_sweep_leaves_a_tab_another_window_has_claimed() {
+        // The sweep enumerates a window's tabs and then takes them one by one;
+        // a destination can claim one in between. Taking it anyway would delete
+        // state that now belongs to the other window and stop its child.
+        use crate::{claim_shell_tab_state_impl, take_shell_tab_state_if_owned};
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "s", "windowId": "win-1" }),
+        )
+        .unwrap();
+
+        // Enumerated as win-1's, then claimed by win-2 before the take.
+        claim_shell_tab_state_impl(&st, "tab-1", "win-2").unwrap();
+
+        assert_eq!(take_shell_tab_state_if_owned(&st, "tab-1", "win-1").unwrap(), None);
+        assert!(
+            get_shell_tab_state_impl(&st, "tab-1").unwrap().is_some(),
+            "the new owner's state was swept away"
+        );
+        // The real owner can still take it.
+        assert!(take_shell_tab_state_if_owned(&st, "tab-1", "win-2").unwrap().is_some());
+    }
+
+    #[test]
     fn the_current_owner_keeps_writing_normally() {
         let st = state();
         set_shell_tab_state_impl(

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4443,6 +4443,32 @@ mod shell_tab_state_tests {
     }
 
     #[test]
+    fn disowning_only_gives_up_a_claim_you_still_hold() {
+        use crate::{claim_shell_tab_state_impl, disown_shell_tab_state_impl};
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "s", "windowId": "win-1" }),
+        )
+        .unwrap();
+
+        // Someone else has taken it since; the late disown must not strip them.
+        claim_shell_tab_state_impl(&st, "tab-1", "win-2").unwrap();
+        disown_shell_tab_state_impl(&st, "tab-1", "win-1").unwrap();
+        assert_eq!(
+            shell_tab_ids_for_window(&st, "win-2").unwrap(),
+            vec!["tab-1".to_string()]
+        );
+
+        // The real owner giving it up leaves it unowned, ready to be re-taken.
+        disown_shell_tab_state_impl(&st, "tab-1", "win-2").unwrap();
+        assert!(shell_tab_ids_for_window(&st, "win-2").unwrap().is_empty());
+        let stored = get_shell_tab_state_impl(&st, "tab-1").unwrap().unwrap();
+        assert_eq!(stored.get("sessionId").unwrap(), "s", "the rest of the value survived");
+    }
+
+    #[test]
     fn claiming_a_tab_with_no_state_is_a_no_op() {
         use crate::claim_shell_tab_state_impl;
         assert_eq!(

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4262,11 +4262,12 @@ mod shell_tab_state_tests {
     }
 
     #[test]
-    fn an_ordinary_write_cannot_take_ownership_back() {
+    fn a_write_from_the_previous_owner_is_dropped_whole() {
         // The departed renderer's mirror is fire-and-forget, so a write from it
-        // can land after the destination has claimed the tab. It carries the
-        // window IT knew about; honouring that would hide the child from its
-        // real owner's close sweep and let the old label stop a live session.
+        // can land after the destination has claimed the tab. It carries a
+        // snapshot taken BEFORE the move: merging it would restore the old
+        // window as owner, and overwrite the transcript, database and session
+        // id the new owner has recorded since.
         use crate::claim_shell_tab_state_impl;
         let st = state();
         set_shell_tab_state_impl(
@@ -4276,22 +4277,70 @@ mod shell_tab_state_tests {
         )
         .unwrap();
         claim_shell_tab_state_impl(&st, "tab-1", "win-2").unwrap();
+        // What the new owner has recorded since taking it.
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "sess-2", "entries": ["new"], "windowId": "win-2" }),
+        )
+        .unwrap();
 
         // The old owner's delayed write, still naming itself.
         set_shell_tab_state_impl(
             &st,
             "tab-1",
-            serde_json::json!({ "sessionId": "sess-1", "entries": ["late"], "windowId": "win-1" }),
+            serde_json::json!({ "sessionId": "sess-1", "entries": ["stale"], "windowId": "win-1" }),
         )
         .unwrap();
 
         let stored = get_shell_tab_state_impl(&st, "tab-1").unwrap().unwrap();
-        assert_eq!(stored.get("windowId").unwrap(), "win-2", "ownership was taken back");
+        assert_eq!(stored.get("windowId").unwrap(), "win-2");
+        assert_eq!(stored.get("sessionId").unwrap(), "sess-2");
         assert_eq!(
             stored.get("entries").unwrap(),
-            &serde_json::json!(["late"]),
-            "the write itself must still apply — only the owner field is protected"
+            &serde_json::json!(["new"]),
+            "the stale snapshot overwrote the new owner's transcript"
         );
+    }
+
+    #[test]
+    fn the_current_owner_keeps_writing_normally() {
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "s", "windowId": "win-1" }),
+        )
+        .unwrap();
+
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "s", "entries": ["mine"], "windowId": "win-1" }),
+        )
+        .unwrap();
+
+        let stored = get_shell_tab_state_impl(&st, "tab-1").unwrap().unwrap();
+        assert_eq!(stored.get("entries").unwrap(), &serde_json::json!(["mine"]));
+    }
+
+    #[test]
+    fn a_write_that_names_no_window_keeps_the_recorded_owner() {
+        // How a caller with nothing to say about ownership behaves. It must not
+        // be able to lose its own data to this guard.
+        let st = state();
+        set_shell_tab_state_impl(
+            &st,
+            "tab-1",
+            serde_json::json!({ "sessionId": "s", "windowId": "win-1" }),
+        )
+        .unwrap();
+
+        set_shell_tab_state_impl(&st, "tab-1", serde_json::json!({ "entries": ["anon"] })).unwrap();
+
+        let stored = get_shell_tab_state_impl(&st, "tab-1").unwrap().unwrap();
+        assert_eq!(stored.get("entries").unwrap(), &serde_json::json!(["anon"]));
+        assert_eq!(stored.get("windowId").unwrap(), "win-1");
     }
 
     #[test]

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -86,7 +86,12 @@ use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, Windo
 /// Best-effort: a window closing must never be blocked by shell teardown.
 fn stop_shell_session_for_tab(app: &AppHandle, tab_id: &str) {
     let state = app.state::<AppState>();
-    let session_id = crate::get_shell_tab_state_impl(&state, tab_id)
+    // Taken in one lock rather than read-then-clear. A `set_shell_tab_state`
+    // carrying a session id that has only just started can arrive alongside an
+    // OS window close: between a separate read and clear it would either be
+    // read as absent and then deleted — losing the only pointer to a live
+    // child — or land after the clear and resurrect the closed window's entry.
+    let session_id = crate::take_shell_tab_state_impl(&state, tab_id)
         .ok()
         .flatten()
         .and_then(|v| {
@@ -94,7 +99,6 @@ fn stop_shell_session_for_tab(app: &AppHandle, tab_id: &str) {
                 .and_then(|s| s.as_str())
                 .map(|s| s.to_string())
         });
-    let _ = crate::clear_shell_tab_state_impl(&state, tab_id);
     if let Some(session_id) = session_id {
         let app = app.clone();
         tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -84,14 +84,14 @@ use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, Windo
 
 /// Stop the mongosh child a tab owns, if any, and forget its stored state.
 /// Best-effort: a window closing must never be blocked by shell teardown.
-fn stop_shell_session_for_tab(app: &AppHandle, tab_id: &str) {
+fn stop_shell_session_for_tab(app: &AppHandle, tab_id: &str, window_id: &str) {
     let state = app.state::<AppState>();
     // Taken in one lock rather than read-then-clear. A `set_shell_tab_state`
     // carrying a session id that has only just started can arrive alongside an
     // OS window close: between a separate read and clear it would either be
     // read as absent and then deleted — losing the only pointer to a live
     // child — or land after the clear and resurrect the closed window's entry.
-    let session_id = crate::take_shell_tab_state_impl(&state, tab_id)
+    let session_id = crate::take_shell_tab_state_if_owned(&state, tab_id, window_id)
         .ok()
         .flatten()
         .and_then(|v| {
@@ -173,7 +173,7 @@ fn apply_window_closed_and_broadcast(app: &AppHandle, label: &str, origin: Strin
     }
     let doomed_tabs = crate::shell_tab_ids_for_window(&state, label).unwrap_or_default();
     for tab_id in doomed_tabs {
-        stop_shell_session_for_tab(app, &tab_id);
+        stop_shell_session_for_tab(app, &tab_id, label);
     }
     match workspace::apply_impl(&state, &path, WorkspaceOp::WindowClosed { window_id: label.to_string() }, origin) {
         Ok(Some(payload)) => {

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -168,8 +168,16 @@ fn apply_window_closed_and_broadcast(app: &AppHandle, label: &str, origin: Strin
     // this window has no session id yet, so the sweep below cannot see it and
     // the renderer that would have cancelled it is about to be destroyed. The
     // start itself checks this set and stops the child it spawned.
-    if let Ok(mut closed) = state.closed_windows.lock_safe() {
-        closed.insert(label.to_string());
+    {
+        // Marked under the shell-state lock, which `set_shell_tab_state_impl`
+        // also holds across its own closed-window check. Without that overlap a
+        // write could see the window as open, pause, and land after the sweep
+        // below — recreating an entry nothing would ever clean up. Lock order
+        // is shell state then closed windows, matching every other site.
+        let _state_guard = state.shell_tab_state.lock_safe();
+        if let Ok(mut closed) = state.closed_windows.lock_safe() {
+            closed.insert(label.to_string());
+        }
     }
     let doomed_tabs = crate::shell_tab_ids_for_window(&state, label).unwrap_or_default();
     for tab_id in doomed_tabs {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2906,7 +2906,20 @@ function Workspace() {
           tabBuilderStateCache.current.clear();
           tabChatCache.current.clear();
           resetChatRequests();
-          void disposeShellSessionsForTabs(tabsRef.current.map((t) => t.id));
+          // Not every tab here is gone from the DOCUMENT. This branch also runs
+          // when the last tab of a secondary window is moved elsewhere — that
+          // move is why the window disappeared — and the destination is about
+          // to attach to that tab's mongosh session. Disposing it would kill
+          // the process and delete the state the other window is reaching for.
+          const survivors = new Set(
+            payload.workspace.windows
+              .flatMap((w) => allPanes(w.splitTree).flatMap((p) => p.tabIds))
+              .map((id) => toLiveSpaceId(id, connections))
+          );
+          tabsRef.current.forEach((t) => {
+            if (survivors.has(t.id)) forgetShellSession(t.id);
+            else void disposeShellSession(t.id);
+          });
           dispatchLayout({ type: 'hydrate', layout: createInitialLayout([], null) });
           return;
         }

--- a/src/components/__tests__/AppSecondaryWindow.test.tsx
+++ b/src/components/__tests__/AppSecondaryWindow.test.tsx
@@ -168,4 +168,69 @@ describe('App as a secondary window (windowLabel() === "win-2") — Phase 3 Task
       expect(closeCalls[0].args).toEqual({ label: 'win-2', origin: 'win-2' });
     });
   });
+
+  it('moving this window\'s last tab away keeps that tab\'s shell session alive', async () => {
+    // The window disappears BECAUSE the tab moved, so its tabs are still in the
+    // document — and the destination is about to attach to this very session.
+    // Disposing everything this window listed would kill the mongosh child and
+    // delete the state the other window is reaching for.
+    const { writeShellSession, readShellSession, resetShellSessions } = await import(
+      '../../lib/mongoshSession'
+    );
+    resetShellSessions();
+
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd: string, args: any) => {
+      calls.push({ cmd, args });
+      if (cmd === 'load_app_settings') return Promise.resolve({});
+      if (cmd === 'workspace_get') {
+        return Promise.resolve({
+          revision: 1,
+          windows: [
+            { id: 'main', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: [], activeTabId: null } },
+            { id: 'win-2', focusedPaneId: 'pane-1', splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['conn-1.sales_db.customers'], activeTabId: 'conn-1.sales_db.customers' } },
+          ],
+          tabs: [
+            { id: 'conn-1.sales_db.customers', type: 'collection', profileId: '', profileName: '', db: 'sales_db', collection: 'customers' },
+          ],
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const { act, within } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+    await within(screen.getByTestId('workspace-tab-strip')).findByText('customers');
+
+    writeShellSession('conn-1.sales_db.customers', { sessionId: 'sess-moved' });
+    calls.length = 0;
+
+    // win-2 is gone, but its tab now lives in main.
+    await act(async () => {
+      fireMockEvent('workspace-changed', {
+        revision: 2,
+        origin: 'main',
+        crossWindow: true,
+        workspace: {
+          revision: 2,
+          windows: [
+            {
+              id: 'main',
+              focusedPaneId: 'pane-1',
+              splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['conn-1.sales_db.customers'], activeTabId: 'conn-1.sales_db.customers' },
+            },
+          ],
+          tabs: [
+            { id: 'conn-1.sales_db.customers', type: 'collection', profileId: '', profileName: '', db: 'sales_db', collection: 'customers' },
+          ],
+        },
+      });
+    });
+
+    expect(calls.filter((c) => c.cmd === 'close_shell_tab_session')).toEqual([]);
+    expect(calls.filter((c) => c.cmd === 'stop_mongosh_session')).toEqual([]);
+    // Forgotten here, though: the destination window owns it now.
+    expect(readShellSession('conn-1.sales_db.customers')).toBeUndefined();
+  });
 });

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -453,6 +453,22 @@ describe('mongosh session registry (#240)', () => {
     expect(readShellSession('tab-1')?.sessionId).toBe('sess-live');
   });
 
+  it('claims a session it hydrates, so the new window owns it', async () => {
+    // A moved tab's stored state still names the window it left. Hydrating
+    // without restamping hides the child from the new owner's close sweep, and
+    // lets a window reusing the old label stop a session it does not have.
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === 'get_shell_tab_state'
+        ? Promise.resolve({ sessionId: 'sess-moved', windowId: 'win-9' })
+        : Promise.resolve(undefined),
+    );
+
+    await loadShellSession('tab-1');
+
+    const write = invokeMock.mock.calls.find((c) => c[0] === 'set_shell_tab_state');
+    expect((write?.[1] as { value: { windowId?: string } }).value.windowId).toBe('main');
+  });
+
   it('ignores a backend value that is not a session object', async () => {
     // The payload crosses IPC as opaque JSON; anything merely truthy (an array,
     // say) must not be cached and then read for fields it does not have.

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -475,6 +475,29 @@ describe('mongosh session registry (#240)', () => {
     expect(restored?.sessionId).toBe('sess-moved');
   });
 
+  it('disowns a claim it issued before learning the tab had moved', async () => {
+    // The hydrate began, the tab moved away from this renderer, and the claim
+    // lands after the destination's — stamping this window back over it.
+    let releaseClaim: (v: unknown) => void = () => {};
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === 'claim_shell_tab_state'
+        ? new Promise((res) => { releaseClaim = res; })
+        : Promise.resolve(undefined),
+    );
+
+    const loading = loadShellSession('tab-1');
+    await Promise.resolve();
+    forgetShellSession('tab-1'); // the crossWindow event says the tab left
+    releaseClaim({ sessionId: 'sess-1' });
+
+    expect(await loading).toBeUndefined();
+    expect(invokeMock).toHaveBeenCalledWith('disown_shell_tab_state', {
+      tabId: 'tab-1',
+      windowId: 'main',
+    });
+    expect(readShellSession('tab-1')).toBeUndefined();
+  });
+
   it('ignores a backend value that is not a session object', async () => {
     // The payload crosses IPC as opaque JSON; anything merely truthy (an array,
     // say) must not be cached and then read for fields it does not have.

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -301,6 +301,24 @@ describe('mongosh session registry (#240)', () => {
       );
     });
 
+    it('a reopened tab does not join the closed tab\'s pending start', async () => {
+      // Deterministic ids mean the reopened tab lands on the same key. Joining
+      // the old start would hand it a child the previous mount stops moments
+      // later for failing its own epoch check — a live-looking session id
+      // pointing at nothing.
+      let calls = 0;
+      const task = () => {
+        calls += 1;
+        return new Promise<{ session_id: string }>(() => {}); // still starting
+      };
+      shareShellStart('tab-1', task);
+
+      await disposeShellSession('tab-1');
+      shareShellStart('tab-1', task); // the tab is reopened
+
+      expect(calls).toBe(2);
+    });
+
     it('a reopened tab is not silenced by the previous tab\'s disposal', async () => {
       writeShellSession('tab-1', { sessionId: 'sess-1' });
       await disposeShellSession('tab-1');

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -132,7 +132,7 @@ describe('mongosh session registry (#240)', () => {
     // The tab has not mounted since a refresh, so nothing has hydrated the
     // cache — but the child is running and must still be stoppable.
     invokeMock.mockImplementation((cmd: string) =>
-      cmd === 'get_shell_tab_state'
+      cmd === 'claim_shell_tab_state'
         ? Promise.resolve({ sessionId: 'sess-orphan' })
         : Promise.resolve(undefined),
     );
@@ -172,7 +172,7 @@ describe('mongosh session registry (#240)', () => {
     // then find nothing — leaving mongosh attached to a database the rename
     // has already dropped.
     invokeMock.mockImplementation((cmd: string) =>
-      cmd === 'get_shell_tab_state'
+      cmd === 'claim_shell_tab_state'
         ? Promise.resolve({ sessionId: 'sess-old', currentDb: 'before', entries: [] })
         : Promise.resolve(undefined),
     );
@@ -439,7 +439,7 @@ describe('mongosh session registry (#240)', () => {
     // What a hot reload or a window refresh produces: no cache, but the child
     // is still running and the backend still knows about it.
     invokeMock.mockImplementation((cmd: string) =>
-      cmd === 'get_shell_tab_state'
+      cmd === 'claim_shell_tab_state'
         ? Promise.resolve({ sessionId: 'sess-live', entries: [{ kind: 'note', text: 'kept' }] })
         : Promise.resolve(undefined),
     );
@@ -457,23 +457,29 @@ describe('mongosh session registry (#240)', () => {
     // A moved tab's stored state still names the window it left. Hydrating
     // without restamping hides the child from the new owner's close sweep, and
     // lets a window reusing the old label stop a session it does not have.
-    invokeMock.mockImplementation((cmd: string) =>
-      cmd === 'get_shell_tab_state'
-        ? Promise.resolve({ sessionId: 'sess-moved', windowId: 'win-9' })
+    invokeMock.mockImplementation((cmd: string, args: any) =>
+      cmd === 'claim_shell_tab_state'
+        ? Promise.resolve({ sessionId: 'sess-moved', windowId: args.windowId })
         : Promise.resolve(undefined),
     );
 
-    await loadShellSession('tab-1');
+    const restored = await loadShellSession('tab-1');
 
-    const write = invokeMock.mock.calls.find((c) => c[0] === 'set_shell_tab_state');
-    expect((write?.[1] as { value: { windowId?: string } }).value.windowId).toBe('main');
+    // One atomic call, not a read followed by a write of what was read — that
+    // pair would replay a stale snapshot over the old renderer's final write.
+    expect(invokeMock).toHaveBeenCalledWith('claim_shell_tab_state', {
+      tabId: 'tab-1',
+      windowId: 'main',
+    });
+    expect(invokeMock).not.toHaveBeenCalledWith('get_shell_tab_state', expect.anything());
+    expect(restored?.sessionId).toBe('sess-moved');
   });
 
   it('ignores a backend value that is not a session object', async () => {
     // The payload crosses IPC as opaque JSON; anything merely truthy (an array,
     // say) must not be cached and then read for fields it does not have.
     invokeMock.mockImplementation((cmd: string) =>
-      cmd === 'get_shell_tab_state' ? Promise.resolve([]) : Promise.resolve(undefined),
+      cmd === 'claim_shell_tab_state' ? Promise.resolve([]) : Promise.resolve(undefined),
     );
 
     expect(await loadShellSession('tab-1')).toBeUndefined();

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -187,8 +187,7 @@ function notifyWatchers(key: string, session: ShellSession): void {
 /** Read a tab's stored state from the backend WITHOUT caching it. Used by
  *  disposal, which must not resurrect an entry for a key it has just deleted —
  *  or, worse, overwrite the entry a reopened tab has since created. */
-async function fetchStoredSession(key: string): Promise<ShellSession | undefined> {
-  const stored = await invoke<unknown>('get_shell_tab_state', { tabId: key }).catch(() => null);
+function normalizeStoredSession(stored: unknown): ShellSession | undefined {
   // Shape-check rather than trust: this crosses the IPC boundary, and a value
   // that is merely truthy (an array, say) would otherwise be read for fields it
   // does not have.
@@ -230,15 +229,20 @@ function persist(key: string, session: ShellSession): void {
 export async function loadShellSession(key: string): Promise<ShellSession | undefined> {
   const cached = sessions.get(key);
   if (cached) return cached;
-  const session = await fetchStoredSession(key);
+  // Claims ownership and returns the CURRENT value in one backend call.
+  // Whoever hydrates a session is the renderer about to display it, and the
+  // stored entry still names whichever window wrote it last — after a tab
+  // moves, that is the window it LEFT, which would hide the child from the new
+  // owner's close sweep. Fetching and then writing the fetched value back would
+  // race the old renderer's final write and replay a stale snapshot over it,
+  // since a normal write replaces the whole entry.
+  const stored = await invoke<unknown>('claim_shell_tab_state', {
+    tabId: key,
+    windowId: windowLabel(),
+  }).catch(() => null);
+  const session = normalizeStoredSession(stored);
   if (!session) return undefined;
   sessions.set(key, session);
-  // Claim it. Whoever hydrates a session is the renderer about to display it,
-  // and the stored entry still names whichever window wrote it last — after a
-  // tab moves, that is the window it LEFT. Leaving the stamp alone would hide
-  // the child from the new owner's close sweep, and let the old label's window
-  // stop a session it no longer has.
-  persist(key, session);
   return session;
 }
 

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -236,10 +236,22 @@ export async function loadShellSession(key: string): Promise<ShellSession | unde
   // owner's close sweep. Fetching and then writing the fetched value back would
   // race the old renderer's final write and replay a stale snapshot over it,
   // since a normal write replaces the whole entry.
+  // The epoch before the round trip. If it has moved by the time the claim
+  // lands, this renderer has since been told the tab left it — the claim was
+  // issued before the move and would otherwise stamp this window back over the
+  // destination's. Disown instead; whoever really has the tab takes it again on
+  // its next write.
+  const epochAtClaim = shellSessionEpoch(key);
   const stored = await invoke<unknown>('claim_shell_tab_state', {
     tabId: key,
     windowId: windowLabel(),
   }).catch(() => null);
+  if (shellSessionEpoch(key) !== epochAtClaim) {
+    void invoke('disown_shell_tab_state', { tabId: key, windowId: windowLabel() }).catch(
+      () => undefined
+    );
+    return undefined;
+  }
   const session = normalizeStoredSession(stored);
   if (!session) return undefined;
   sessions.set(key, session);

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -233,6 +233,12 @@ export async function loadShellSession(key: string): Promise<ShellSession | unde
   const session = await fetchStoredSession(key);
   if (!session) return undefined;
   sessions.set(key, session);
+  // Claim it. Whoever hydrates a session is the renderer about to display it,
+  // and the stored entry still names whichever window wrote it last — after a
+  // tab moves, that is the window it LEFT. Leaving the stamp alone would hide
+  // the child from the new owner's close sweep, and let the old label's window
+  // stop a session it no longer has.
+  persist(key, session);
   return session;
 }
 

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -284,6 +284,11 @@ export async function disposeShellSession(key: string): Promise<void> {
   // flight; doing this afterwards would end the epoch of — and delete the cache
   // entry belonging to — the tab that has since taken the key over.
   endEpoch(key);
+  // Drop the shared start too. A reopened tab lands on the same deterministic
+  // key, and joining the previous tab's pending start would hand it a child the
+  // old mount is about to stop for failing ITS epoch check — leaving the
+  // reopened shell attached to a dead session id.
+  dropPendingShellStart(key);
   const cached = sessions.get(key);
   sessions.delete(key);
 


### PR DESCRIPTION
Two bugs surfaced while reviewing #243. Both are already on `dev` — they came in with #241 — so they are fixed here rather than down the #243 → #235 → dev path.

## P1 — moving a secondary window's last tab killed its shell session

When the last tab of a secondary window is moved elsewhere, that move is *why* the window disappears. The reconciliation listener's "this window is gone" branch then ran with the moved tab still in `tabsRef`, and disposed every session it listed — including the one the destination window was about to attach to. The mongosh child was stopped and its state deleted out from under the other window.

Tabs still present anywhere in the updated workspace are now forgotten rather than disposed, which is exactly what the leaving branch a few lines below already does. The id translation matters here too: the workspace stores profile-space ids and the tabs are live-space.

## P2 — a reopened tab could join the closed tab's pending start

`disposeShellSession` ended the key's write epoch but left its shared pending start in place. Tab ids are deterministic, so a tab reopened while that start was still running joined it — and the original mount then stopped the resulting child for failing its own epoch check. The reopened shell was left holding a session id pointing at nothing.

## Verification

- Both tests fail against the unfixed code: the moved-tab one reports the dispose calls it should not have made, the pending-start one counts one start where there should be two.
- `npx tsc --noEmit` clean
- 91 files / 1277 frontend tests passing