### PR TITLE
fix(ai): stop guessing which conversation a tab wants, and keep chats in their own scope

### DIFF
--- a/src-tauri/src/chats.rs
+++ b/src-tauri/src/chats.rs
@@ -131,6 +131,32 @@ impl Chat {
     }
 }
 
+/// Keep messages the stored copy has and the incoming snapshot does not.
+///
+/// A panel saves the whole conversation, from a copy it loaded some time ago.
+/// `append_chat_message` can land in between — a reply parked for a tab that
+/// moved windows — and a blind replace would drop it. Transcripts only grow
+/// within a conversation, so anything stored but missing here is something that
+/// arrived after this caller's snapshot, and belongs at the end.
+pub fn merge_appended(existing: &[Chat], mut incoming: Chat) -> Chat {
+    let Some(stored) = existing.iter().find(|c| c.id == incoming.id) else {
+        return incoming;
+    };
+    let have: std::collections::HashSet<&str> =
+        incoming.messages.iter().map(|m| m.id.as_str()).collect();
+    let missed: Vec<ChatMessage> = stored
+        .messages
+        .iter()
+        .filter(|m| !have.contains(m.id.as_str()))
+        .cloned()
+        .collect();
+    if missed.is_empty() {
+        return incoming;
+    }
+    incoming.messages.extend(missed);
+    incoming
+}
+
 /// Insert or replace `chat`, newest first, capped.
 ///
 /// Replacing by id rather than appending is what makes save idempotent: the
@@ -313,6 +339,7 @@ pub async fn save_chat(
     let path = get_chats_path(&app_handle);
     let mut store = load_store_from_file(&path);
     store.chats = prune_expired(store.chats, cutoff_iso.as_deref().unwrap_or_default());
+    let chat = merge_appended(&store.chats, chat);
     store.chats = upsert_chat(store.chats, chat, MAX_CHATS);
     save_store_to_file(&path, &store)
 }
@@ -378,23 +405,28 @@ pub async fn retarget_chat_scope(
     app_handle: tauri::AppHandle,
     connection_name: String,
     database: String,
-    collection: String,
-    variant: String,
+    // `None` means every collection in that database — a database rename moves
+    // conversations whose collection has no open tab too, and the caller cannot
+    // enumerate those from its own tab list.
+    collection: Option<String>,
+    variant: Option<String>,
     new_database: String,
-    new_collection: String,
+    new_collection: Option<String>,
 ) -> Result<(), String> {
     let _guard = store_lock();
     let path = get_chats_path(&app_handle);
     let mut store = load_store_from_file(&path);
     let mut touched = false;
     for chat in store.chats.iter_mut() {
-        if chat.connection_name == connection_name
+        let matches = chat.connection_name == connection_name
             && chat.database == database
-            && chat.collection == collection
-            && chat.variant == variant
-        {
+            && collection.as_ref().is_none_or(|c| &chat.collection == c)
+            && variant.as_ref().is_none_or(|v| &chat.variant == v);
+        if matches {
             chat.database = new_database.clone();
-            chat.collection = new_collection.clone();
+            if let Some(new_collection) = new_collection.as_ref() {
+                chat.collection = new_collection.clone();
+            }
             touched = true;
         }
     }

--- a/src-tauri/src/chats.rs
+++ b/src-tauri/src/chats.rs
@@ -317,6 +317,93 @@ pub async fn save_chat(
     save_store_to_file(&path, &store)
 }
 
+/// The next free `m<N>` id for a transcript.
+///
+/// Assigned backend-side because only a caller holding the store lock can see
+/// what the conversation already uses — the frontend picking one from a copy it
+/// loaded a moment ago can collide with a message appended since, and duplicate
+/// React keys reconcile the wrong bubbles.
+pub fn next_message_id(messages: &[ChatMessage]) -> String {
+    let next = messages
+        .iter()
+        .filter_map(|m| m.id.strip_prefix('m').and_then(|n| n.parse::<u32>().ok()))
+        .max()
+        .map_or(0, |n| n + 1);
+    format!("m{next}")
+}
+
+/// Append one message to a conversation, under the store lock.
+///
+/// The obvious frontend shape — load, push, save — is two commands with the
+/// lock released between them, so a panel saving in that window is either lost
+/// or loses the appended message. The id is assigned here for the same reason:
+/// only a caller holding the lock can see what the transcript already uses.
+#[tauri::command]
+pub async fn append_chat_message(
+    app_handle: tauri::AppHandle,
+    chat_id: String,
+    role: String,
+    text: String,
+    query: Option<Value>,
+    error: Option<bool>,
+    updated_at: String,
+) -> Result<(), String> {
+    let _guard = store_lock();
+    let path = get_chats_path(&app_handle);
+    let mut store = load_store_from_file(&path);
+    let Some(chat) = store.chats.iter_mut().find(|c| c.id == chat_id) else {
+        return Ok(());
+    };
+    let id = next_message_id(&chat.messages);
+    chat.messages.push(ChatMessage {
+        id,
+        role,
+        text,
+        query,
+        error,
+    });
+    if chat.messages.len() > MAX_MESSAGES {
+        let excess = chat.messages.len() - MAX_MESSAGES;
+        chat.messages.drain(0..excess);
+    }
+    chat.updated_at = updated_at;
+    save_store_to_file(&path, &store)
+}
+
+/// Move a conversation to a renamed namespace, under the store lock. A rename
+/// re-keys the tab but leaves the stored chat naming the old database or
+/// collection, after which the panel reads its own conversation as foreign.
+#[tauri::command]
+pub async fn retarget_chat_scope(
+    app_handle: tauri::AppHandle,
+    connection_name: String,
+    database: String,
+    collection: String,
+    variant: String,
+    new_database: String,
+    new_collection: String,
+) -> Result<(), String> {
+    let _guard = store_lock();
+    let path = get_chats_path(&app_handle);
+    let mut store = load_store_from_file(&path);
+    let mut touched = false;
+    for chat in store.chats.iter_mut() {
+        if chat.connection_name == connection_name
+            && chat.database == database
+            && chat.collection == collection
+            && chat.variant == variant
+        {
+            chat.database = new_database.clone();
+            chat.collection = new_collection.clone();
+            touched = true;
+        }
+    }
+    if !touched {
+        return Ok(());
+    }
+    save_store_to_file(&path, &store)
+}
+
 #[tauri::command]
 pub async fn delete_chat(app_handle: tauri::AppHandle, id: String) -> Result<(), String> {
     let _guard = store_lock();

--- a/src-tauri/src/chats.rs
+++ b/src-tauri/src/chats.rs
@@ -281,6 +281,13 @@ pub async fn release_chat(chat_id: String, owner: String) -> Result<(), String> 
     Ok(())
 }
 
+/// Drop every claim held by one owner — a tab that has closed.
+#[tauri::command]
+pub async fn release_owner_chats(owner: String) -> Result<(), String> {
+    open_chats().retain(|_, holder| *holder != owner);
+    Ok(())
+}
+
 /// Drop every claim held by a window — called when that window closes, since
 /// its panels get no chance to release anything.
 pub fn release_window_chats(window_id: &str) {

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -91,6 +91,7 @@ const LOCAL_COMMANDS: &[&str] = &[
     "list_chats",
     "claim_chat",
     "release_chat",
+    "release_owner_chats",
     "load_chat",
     "save_chat",
     "delete_chat",

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -94,6 +94,8 @@ const LOCAL_COMMANDS: &[&str] = &[
     "release_owner_chats",
     "load_chat",
     "save_chat",
+    "append_chat_message",
+    "retarget_chat_scope",
     "delete_chat",
     "clear_chats",
     // Takes a tab's entry and stops the child it named, atomically — same

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2521,6 +2521,7 @@ pub fn run() {
             chats::list_chats,
             chats::claim_chat,
             chats::release_chat,
+            chats::release_owner_chats,
             chats::load_chat,
             chats::save_chat,
             chats::delete_chat,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2524,6 +2524,8 @@ pub fn run() {
             chats::release_owner_chats,
             chats::load_chat,
             chats::save_chat,
+            chats::append_chat_message,
+            chats::retarget_chat_scope,
             chats::delete_chat,
             chats::clear_chats,
             queries::load_collection_queries,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4761,6 +4761,25 @@ mod chat_store_tests {
     }
 
     #[test]
+    fn appending_assigns_an_id_the_transcript_does_not_already_use() {
+        use crate::chats::next_message_id;
+        let msg = |id: &str| ChatMessage {
+            id: id.to_string(),
+            role: "user".to_string(),
+            text: "x".to_string(),
+            query: None,
+            error: None,
+        };
+
+        assert_eq!(next_message_id(&[]), "m0");
+        // Past the HIGHEST, not the count — a transcript is not always dense.
+        assert_eq!(next_message_id(&[msg("m0"), msg("m7")]), "m8");
+        // Ids that are not `m<N>` at all are ignored rather than crashing.
+        assert_eq!(next_message_id(&[msg("weird"), msg("m2")]), "m3");
+        assert_eq!(next_message_id(&[msg("weird")]), "m0");
+    }
+
+    #[test]
     fn retention_drops_only_what_predates_the_cutoff() {
         let existing = vec![
             chat("stale", "users", "2025-01-01T00:00:00Z"),

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4780,6 +4780,63 @@ mod chat_store_tests {
     }
 
     #[test]
+    fn saving_a_snapshot_keeps_messages_appended_since_it_was_taken() {
+        // A panel saves the whole conversation from a copy it loaded earlier.
+        // A reply parked for a tab that moved windows can land in between, and
+        // a blind replace would drop it.
+        use crate::chats::merge_appended;
+        let msg = |id: &str| ChatMessage {
+            id: id.to_string(),
+            role: "assistant".to_string(),
+            text: id.to_string(),
+            query: None,
+            error: None,
+        };
+        let mut stored = chat("c1", "users", "2026-01-01T00:00:00Z");
+        stored.messages = vec![msg("m0"), msg("m1"), msg("m2")];
+        let mut incoming = chat("c1", "users", "2026-01-02T00:00:00Z");
+        incoming.messages = vec![msg("m0"), msg("m1")]; // taken before m2 landed
+
+        let merged = merge_appended(&[stored], incoming);
+
+        assert_eq!(
+            merged.messages.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["m0", "m1", "m2"]
+        );
+    }
+
+    #[test]
+    fn a_snapshot_that_is_already_current_is_left_alone() {
+        use crate::chats::merge_appended;
+        let msg = |id: &str| ChatMessage {
+            id: id.to_string(),
+            role: "user".to_string(),
+            text: "x".to_string(),
+            query: None,
+            error: None,
+        };
+        let mut stored = chat("c1", "users", "2026-01-01T00:00:00Z");
+        stored.messages = vec![msg("m0")];
+        let mut incoming = chat("c1", "users", "2026-01-02T00:00:00Z");
+        incoming.messages = vec![msg("m0"), msg("m1")];
+
+        let merged = merge_appended(&[stored], incoming);
+
+        assert_eq!(
+            merged.messages.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["m0", "m1"],
+            "a longer snapshot must not gain duplicates"
+        );
+    }
+
+    #[test]
+    fn a_conversation_the_store_has_never_seen_merges_to_itself() {
+        use crate::chats::merge_appended;
+        let incoming = chat("brand-new", "users", "2026-01-01T00:00:00Z");
+        assert_eq!(merge_appended(&[], incoming.clone()), incoming);
+    }
+
+    #[test]
     fn retention_drops_only_what_predates_the_cutoff() {
         let existing = vec![
             chat("stale", "users", "2025-01-01T00:00:00Z"),

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4639,6 +4639,27 @@ mod chat_claim_tests {
     }
 
     #[tokio::test]
+    async fn closing_a_tab_frees_everything_that_tab_held() {
+        // Panels do not release on unmount — an inactive tab is unmounted and
+        // still owns its conversation — so the tab closing is where it ends.
+        use crate::chats::release_owner_chats;
+        claim_chat("c9".into(), "main#tab-7".into()).await.unwrap();
+        claim_chat("c10".into(), "main#tab-7".into()).await.unwrap();
+        claim_chat("c11".into(), "main#tab-8".into()).await.unwrap();
+
+        release_owner_chats("main#tab-7".into()).await.unwrap();
+
+        assert!(claim_chat("c9".into(), "main#other".into()).await.unwrap());
+        assert!(claim_chat("c10".into(), "main#other".into()).await.unwrap());
+        assert!(
+            !claim_chat("c11".into(), "main#other".into()).await.unwrap(),
+            "another tab's claim was collateral"
+        );
+        release_owner_chats("main#other".into()).await.unwrap();
+        release_owner_chats("main#tab-8".into()).await.unwrap();
+    }
+
+    #[tokio::test]
     async fn closing_a_window_frees_every_chat_its_panels_held() {
         // Those panels get no chance to release anything themselves.
         claim_chat("c3".into(), "win-9#1".into()).await.unwrap();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2111,21 +2111,15 @@ function Workspace() {
       moveTabChatState(oldId, newId);
       dispatchWorkspace({ type: 'rename_tab', oldId, newId });
     });
-    // Every conversation under the old database name, whichever collection it
-    // was about — otherwise each renamed tab reads its own chat as foreign.
+    // Every conversation under the old database name — including collections
+    // with no open tab, which this renderer cannot enumerate, so the backend
+    // matches on the database alone.
     const renamedConnection = activeConnections.find((c) => c.id === connectionId);
     if (renamedConnection) {
-      const affected = new Set(
-        tabs.filter((t) => t.connectionId === connectionId && t.db === oldName).map((t) => t.collection)
+      void retargetChatScope(
+        { connectionName: renamedConnection.name, database: oldName },
+        { database: newName }
       );
-      for (const collection of affected) {
-        for (const variant of ['editor', 'shell'] as const) {
-          void retargetChatScope(
-            { connectionName: renamedConnection.name, database: oldName, collection, variant },
-            { database: newName, collection }
-          );
-        }
-      }
     }
     invalidatePaletteNamespaceIndex(connectionId);
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,12 @@ import {
   resetChatRequests,
   takeSettledChatRequest,
 } from './lib/aiChatRequest';
-import { appendReplyToChat, releaseChatsForTab, transferChatClaim } from './lib/aiChatStore';
+import {
+  appendReplyToChat,
+  releaseChatsForTab,
+  retargetChatScope,
+  transferChatClaim,
+} from './lib/aiChatStore';
 import {
   disposeShellSession,
   disposeShellSessionsForTabs,
@@ -2025,6 +2030,18 @@ function Workspace() {
       moveTabChatState(oldId, newId);
       dispatchWorkspace({ type: 'rename_tab', oldId, newId });
     });
+    // The stored conversations still name the old collection; without this the
+    // renamed tab reads its own chat as belonging somewhere else and refuses to
+    // continue it.
+    const renamedConnection = activeConnections.find((c) => c.id === connectionId);
+    if (renamedConnection) {
+      for (const variant of ['editor', 'shell'] as const) {
+        void retargetChatScope(
+          { connectionName: renamedConnection.name, database: dbName, collection: oldName, variant },
+          { database: dbName, collection: newName }
+        );
+      }
+    }
     invalidatePaletteNamespaceIndex(connectionId);
   };
 
@@ -2094,6 +2111,22 @@ function Workspace() {
       moveTabChatState(oldId, newId);
       dispatchWorkspace({ type: 'rename_tab', oldId, newId });
     });
+    // Every conversation under the old database name, whichever collection it
+    // was about — otherwise each renamed tab reads its own chat as foreign.
+    const renamedConnection = activeConnections.find((c) => c.id === connectionId);
+    if (renamedConnection) {
+      const affected = new Set(
+        tabs.filter((t) => t.connectionId === connectionId && t.db === oldName).map((t) => t.collection)
+      );
+      for (const collection of affected) {
+        for (const variant of ['editor', 'shell'] as const) {
+          void retargetChatScope(
+            { connectionName: renamedConnection.name, database: oldName, collection, variant },
+            { database: newName, collection }
+          );
+        }
+      }
+    }
     invalidatePaletteNamespaceIndex(connectionId);
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -675,6 +675,11 @@ function Workspace() {
       if (chat) {
         tabChatCache.current.set(newId, chat);
         tabChatCache.current.delete(oldId);
+        // And the open-chat claim, whose owner token is built from the tab id.
+        // Left under the profile-space id it would keep the conversation marked
+        // as open, the rebound tab would be refused it, and closing that tab
+        // would release only the new owner.
+        if (chat.chatId) void transferChatClaim(chat.chatId, oldId, newId);
       }
       // The in-flight request follows the tab; dropping it here would lose a
       // reply that is already on its way.
@@ -3222,6 +3227,11 @@ function Workspace() {
             tabBuilderStateCache.current.delete(id);
             tabChatCache.current.delete(id);
             clearChatRequest(id);
+            // These tabs are going away with their connection. Panels do not
+            // release their conversation on unmount, so without this the chats
+            // stay claimed by tabs that no longer exist and read as open
+            // elsewhere until the window closes.
+            releaseChatsForTab(id);
             void disposeShellSession(id);
             unmirroredTabIdsRef.current.delete(id);
           });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,13 @@ import { Sidebar } from './components/Sidebar';
 import { CommandPalette, type PaletteAction } from './components/CommandPalette';
 import { DocumentViewer, builderStateFromQueryTab, type BuilderState } from './components/DocumentViewer';
 import type { ChatMessage } from './components/AIChatPanel';
-import { clearChatRequest, renameChatRequest, resetChatRequests } from './lib/aiChatRequest';
+import {
+  clearChatRequest,
+  getPendingChatRequest,
+  renameChatRequest,
+  resetChatRequests,
+} from './lib/aiChatRequest';
+import { appendReplyToChat, releaseChatsForTab } from './lib/aiChatStore';
 import {
   disposeShellSession,
   disposeShellSessionsForTabs,
@@ -2247,6 +2253,10 @@ function Workspace() {
       tabBuilderStateCache.current.delete(action.tabId);
       tabChatCache.current.delete(action.tabId);
       clearChatRequest(action.tabId);
+      // The tab held its conversation for as long as it existed — panels do not
+      // release on unmount, because an inactive tab is unmounted and still owns
+      // its chat. Closing is where that ends.
+      releaseChatsForTab(action.tabId);
       void disposeShellSession(action.tabId);
       // #91: forget this tab's generate-task tracking on close (running or
       // finished) — otherwise reopening "Generate Data…" on the same
@@ -2276,6 +2286,7 @@ function Workspace() {
         tabBuilderStateCache.current.delete(id);
         tabChatCache.current.delete(id);
         clearChatRequest(id);
+        releaseChatsForTab(id);
         void disposeShellSession(id);
       });
       // Prune `tabs[]` here rather than leaving it to the caller. Every
@@ -3027,8 +3038,18 @@ function Workspace() {
           );
           leavingIds.forEach((id) => {
             tabBuilderStateCache.current.delete(id);
+            // An answer still in flight cannot follow the tab — the destination
+            // is a different renderer with its own request registry — but the
+            // conversation is backend-stored, so park the reply there and the
+            // other window sees it the moment it opens that chat.
+            const parkIn = tabChatCache.current.get(id)?.chatId;
+            const inFlight = parkIn ? getPendingChatRequest(id) : undefined;
+            if (parkIn && inFlight) {
+              void inFlight.then((reply) => appendReplyToChat(parkIn, reply));
+            }
             tabChatCache.current.delete(id);
             clearChatRequest(id);
+            releaseChatsForTab(id);
             // Gone from the document: end the session. Merely moved to another
             // window: that window owns the child now, so it must keep running —
             // but this renderer's cached copy has to go, or moving the tab back

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,9 @@ import {
   getPendingChatRequest,
   renameChatRequest,
   resetChatRequests,
+  takeSettledChatRequest,
 } from './lib/aiChatRequest';
-import { appendReplyToChat, releaseChatsForTab } from './lib/aiChatStore';
+import { appendReplyToChat, releaseChatsForTab, transferChatClaim } from './lib/aiChatStore';
 import {
   disposeShellSession,
   disposeShellSessionsForTabs,
@@ -1956,8 +1957,33 @@ function Workspace() {
     if (chat) {
       tabChatCache.current.set(newId, chat);
       tabChatCache.current.delete(oldId);
+      // The open-chat claim is held under an owner token built from the tab id,
+      // so a rename has to move it as well. Left behind, the old owner keeps
+      // the conversation marked as open — the remounted tab claims under its
+      // new id, is refused, and nothing releases the stale claim until the
+      // whole window closes.
+      if (chat.chatId) void transferChatClaim(chat.chatId, oldId, newId);
     }
     renameChatRequest(oldId, newId);
+  }, []);
+
+  /** Hand an in-flight or already-settled reply to the stored conversation.
+   *  Used when a tab leaves this renderer: the destination is a different
+   *  window with its own request registry and cannot see ours, but the chat
+   *  store is shared. */
+  const parkPendingReply = useCallback((tabId: string) => {
+    const chatId = tabChatCache.current.get(tabId)?.chatId;
+    if (!chatId) return;
+    // A reply that settled while the tab was inactive is sitting unconsumed in
+    // the registry — `getPendingChatRequest` deliberately reports nothing for
+    // it, so it has to be taken separately or it goes out with the clear.
+    const settled = takeSettledChatRequest(tabId);
+    if (settled) {
+      void appendReplyToChat(chatId, settled);
+      return;
+    }
+    const inFlight = getPendingChatRequest(tabId);
+    if (inFlight) void inFlight.then((reply) => appendReplyToChat(chatId, reply));
   }, []);
 
   const handleCollectionRenamed = (
@@ -2940,6 +2966,10 @@ function Workspace() {
           // call for this same close (see that effect's comment).
           windowClosingRef.current = true;
           closeWorkspaceWindow();
+          // Same reasoning as the leaving branch below: this window is going
+          // away, so park anything still owed to a conversation before the
+          // registries go with it.
+          tabsRef.current.forEach((t) => parkPendingReply(t.id));
           setTabs([]);
           tabBuilderStateCache.current.clear();
           tabChatCache.current.clear();
@@ -3038,15 +3068,7 @@ function Workspace() {
           );
           leavingIds.forEach((id) => {
             tabBuilderStateCache.current.delete(id);
-            // An answer still in flight cannot follow the tab — the destination
-            // is a different renderer with its own request registry — but the
-            // conversation is backend-stored, so park the reply there and the
-            // other window sees it the moment it opens that chat.
-            const parkIn = tabChatCache.current.get(id)?.chatId;
-            const inFlight = parkIn ? getPendingChatRequest(id) : undefined;
-            if (parkIn && inFlight) {
-              void inFlight.then((reply) => appendReplyToChat(parkIn, reply));
-            }
+            parkPendingReply(id);
             tabChatCache.current.delete(id);
             clearChatRequest(id);
             releaseChatsForTab(id);

--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -190,6 +190,12 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
       openScope.collection !== collectionName ||
       openScope.variant !== variant);
 
+  /** The collection a stored command was written against. For a conversation
+   *  from elsewhere that is not this tab's — showing or copying it with the
+   *  local name would hand the user a command for the wrong collection. */
+  const commandCollection = openScope?.collection ?? collectionName;
+
+
   // Identifies this TAB to the shared open-chat claim. Not the mount: an
   // inactive tab unmounts and must be able to re-take the conversation it never
   // stopped pointing at.
@@ -695,7 +701,7 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
                       className="m-0 max-h-[220px] overflow-auto rounded border border-border bg-background p-1.5 font-mono text-[10.5px] text-foreground"
                     >
                       {variant === 'shell'
-                        ? buildRunnableCommand(m.query, collectionName)
+                        ? buildRunnableCommand(m.query, commandCollection)
                         : m.query.queryType === 'aggregate'
                           ? JSON.stringify(m.query.pipeline ?? [], null, 2)
                           : JSON.stringify(
@@ -718,7 +724,7 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
                           size="sm"
                           className="h-7 flex-1 text-xs"
                           onClick={() =>
-                            navigator.clipboard?.writeText(buildRunnableCommand(m.query!, collectionName))
+                            navigator.clipboard?.writeText(buildRunnableCommand(m.query!, commandCollection))
                           }
                           data-testid="chat-copy-btn"
                         >

--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -175,6 +175,10 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
   // the history can be widened past this collection, and a chat picked from
   // there still belongs where it was created.
   const [openScope, setOpenScope] = useState<ChatScope | null>(null);
+  // Whether the scope question has been ANSWERED, which is not the same as
+  // having a scope: a chat that no longer exists resolves to "no foreign
+  // scope", and must not leave persistence blocked forever.
+  const [scopeResolved, setScopeResolved] = useState(!chatId);
 
   /** True when the open conversation belongs to another namespace, so its
    *  queries were written against a different collection. Running one here
@@ -237,13 +241,16 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     if (!chatId) return;
     let active = true;
     void loadChat(chatId).then((stored) => {
-      if (!active || !stored) return;
-      setOpenScope({
-        connectionName: stored.connectionName,
-        database: stored.database,
-        collection: stored.collection,
-        variant: stored.variant,
-      });
+      if (!active) return;
+      if (stored) {
+        setOpenScope({
+          connectionName: stored.connectionName,
+          database: stored.database,
+          collection: stored.collection,
+          variant: stored.variant,
+        });
+      }
+      setScopeResolved(true);
     });
     return () => {
       active = false;
@@ -258,17 +265,26 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
   // closing it again does not litter the history with blank chats.
   useEffect(() => {
     if (chatMessages.length === 0) return;
+    // Not until the recovery below has run for an incoming chat. The scope
+    // lookup is asynchronous, and saving in the meantime would write a foreign
+    // conversation under THIS collection — the very migration the recovery
+    // exists to prevent.
+    if (!scopeResolved) return;
     void saveChat({
       // Its own scope, not the panel's — rewriting a chat under the collection
       // that happens to be showing it would silently move it.
       ...(openScope ?? scope),
-      id: activeChatIdRef.current,
+      // `activeChatId` the state, not the ref. A save queued for one transcript
+      // can execute after New chat has already swapped the ref, and would then
+      // store the old messages under the new id — two conversations with the
+      // same content, one of them a ghost.
+      id: activeChatId,
       title: titleFromMessages(chatMessages, t('aiChatPanel.history.untitled')),
       messages: chatMessages,
       createdAt: createdAtRef.current,
       updatedAt: new Date().toISOString(),
     });
-  }, [chatMessages, scope, t]);
+  }, [chatMessages, activeChatId, openScope, scopeResolved, scope, t]);
 
   // Deliberately NO auto-adoption of the collection's most recent
   // conversation. A tab starts its own chat and the history is an explicit
@@ -280,6 +296,7 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
 
   const startNewChat = () => {
     setOpenScope(null);
+    setScopeResolved(true);
     setActiveChatId(newChatId());
     setChatMessages([]);
     setChatInput('');
@@ -304,6 +321,7 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
       collection: stored.collection,
       variant: stored.variant,
     });
+    setScopeResolved(true);
     releaseOpenChat(activeChatIdRef.current, ownerRef.current);
     setActiveChatId(stored.id, stored.createdAt, false);
     setChatMessages(stored.messages);

--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -218,6 +218,38 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     void claimOpenChat(activeChatIdRef.current, ownerRef.current);
   }, [activeChatId]);
 
+  // Tell the tab which conversation it is on, including the one minted here for
+  // a tab that arrived without any. Without this the tab still has no id after
+  // the first message: the next mount mints another, saves the same transcript
+  // again as a second conversation, and abandons the first claim — once per
+  // tab switch.
+  useEffect(() => {
+    if (!chatId) onChatIdChange?.(activeChatIdRef.current);
+    // Mount only: later changes go through `setActiveChatId`, which notifies.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Recover which namespace the open conversation belongs to. `openScope` is
+  // component state and a tab switch unmounts the panel, so without this a
+  // chat opened from the widened history comes back looking local — and the
+  // persistence effect below would quietly move it to this collection.
+  useEffect(() => {
+    if (!chatId) return;
+    let active = true;
+    void loadChat(chatId).then((stored) => {
+      if (!active || !stored) return;
+      setOpenScope({
+        connectionName: stored.connectionName,
+        database: stored.database,
+        collection: stored.collection,
+        variant: stored.variant,
+      });
+    });
+    return () => {
+      active = false;
+    };
+  }, [chatId]);
+
   useEffect(() => {
     onMessagesChange?.(chatMessages);
   }, [chatMessages, onMessagesChange]);
@@ -372,7 +404,7 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
 
   const handleSendChat = async () => {
     const text = chatInput.trim();
-    if (!text || isChatLoading) return;
+    if (!text || isChatLoading || foreignChat) return;
 
     const history = chatMessages.map((m) => ({
       role: m.role,
@@ -716,7 +748,11 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
         <div className="flex flex-shrink-0 flex-col gap-2 border-t border-border p-2">
           <textarea
             className={composerClassName}
-            placeholder={t('aiChatPanel.composer.placeholder')}
+            placeholder={
+              foreignChat
+                ? t('aiChatPanel.history.viewingOtherScopeShort')
+                : t('aiChatPanel.composer.placeholder')
+            }
             value={chatInput}
             onChange={(e) => setChatInput(e.target.value)}
             onKeyDown={(e) => {
@@ -725,6 +761,7 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
                 handleSendChat();
               }
             }}
+            disabled={foreignChat}
             data-testid="chat-input"
           />
           <Button
@@ -732,7 +769,8 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
             className="w-full"
             size="sm"
             onClick={handleSendChat}
-            disabled={isChatLoading || !chatInput.trim()}
+            disabled={isChatLoading || !chatInput.trim() || foreignChat}
+            title={foreignChat ? t('aiChatPanel.actions.foreignChat') : undefined}
             data-testid="chat-send-btn"
           >
             <Sparkles size={11} />

--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -22,6 +22,7 @@ import {
 import {
   claimOpenChat,
   newPanelOwner,
+  tabChatOwner,
   clearChats,
   deleteChat,
   releaseOpenChat,
@@ -170,9 +171,25 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
   // now rather than at first message, so the id is stable for the whole
   // conversation and the tab can be told about it once.
   const activeChatIdRef = React.useRef(chatId ?? newChatId());
-  // Identifies THIS panel to the shared open-chat claim: two tabs in one window
-  // are two panels, so the window label alone would let both hold a chat.
-  const ownerRef = React.useRef(newPanelOwner());
+  // The scope the OPEN conversation belongs to. Normally the panel's own, but
+  // the history can be widened past this collection, and a chat picked from
+  // there still belongs where it was created.
+  const [openScope, setOpenScope] = useState<ChatScope | null>(null);
+
+  /** True when the open conversation belongs to another namespace, so its
+   *  queries were written against a different collection. Running one here
+   *  would target this collection with someone else's query. */
+  const foreignChat =
+    openScope !== null &&
+    (openScope.connectionName !== (connectionName ?? '') ||
+      openScope.database !== (databaseName ?? '') ||
+      openScope.collection !== collectionName ||
+      openScope.variant !== variant);
+
+  // Identifies this TAB to the shared open-chat claim. Not the mount: an
+  // inactive tab unmounts and must be able to re-take the conversation it never
+  // stopped pointing at.
+  const ownerRef = React.useRef(sessionKey ? tabChatOwner(sessionKey) : newPanelOwner());
   const createdAtRef = React.useRef(new Date().toISOString());
   const [activeChatId, setActiveChatIdState] = useState(activeChatIdRef.current);
   const setActiveChatId = (
@@ -192,13 +209,13 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     onChatIdChange?.(id);
   };
 
-  // Held for as long as this panel is showing the chat, so a second tab on the
-  // same collection knows not to adopt it.
+  // Claimed on mount and NOT released on unmount. An inactive tab is unmounted
+  // but still points at its conversation, so releasing here would let another
+  // tab take one that is still spoken for. The claim ends when the tab stops
+  // pointing at the chat — New chat, opening a different one, or the tab
+  // closing (App and the shell registry release it then).
   useEffect(() => {
-    const held = activeChatIdRef.current;
-    const owner = ownerRef.current;
-    void claimOpenChat(held, owner);
-    return () => releaseOpenChat(held, owner);
+    void claimOpenChat(activeChatIdRef.current, ownerRef.current);
   }, [activeChatId]);
 
   useEffect(() => {
@@ -210,7 +227,9 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
   useEffect(() => {
     if (chatMessages.length === 0) return;
     void saveChat({
-      ...scope,
+      // Its own scope, not the panel's — rewriting a chat under the collection
+      // that happens to be showing it would silently move it.
+      ...(openScope ?? scope),
       id: activeChatIdRef.current,
       title: titleFromMessages(chatMessages, t('aiChatPanel.history.untitled')),
       messages: chatMessages,
@@ -219,39 +238,16 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     });
   }, [chatMessages, scope, t]);
 
-  // Adopt the collection's most recent conversation when this tab has none of
-  // its own — the case that makes the history feel continuous across restarts.
-  // A tab that already has messages is left alone: it is mid-conversation.
-  useEffect(() => {
-    if (chatId || initialMessages.length > 0) return;
-    let active = true;
-    void (async () => {
-      const [recent] = await listChats(scope);
-      if (!active || !recent) return;
-      // Only if nothing else has it. Both panels would otherwise render the
-      // same conversation and then save over each other — including panels in
-      // ANOTHER window, which is why the claim is backend-side. Whoever holds
-      // it is welcome to it; this tab starts fresh.
-      if (!(await claimOpenChat(recent.id, ownerRef.current))) return;
-      const stored = await loadChat(recent.id);
-      if (!active || !stored || stored.messages.length === 0) return;
-      setActiveChatId(stored.id, stored.createdAt);
-      setChatMessages(stored.messages);
-      // From the messages actually adopted, not from `initialMessages`: seeding
-      // the counter from an empty array would hand the next message an id the
-      // restored transcript already uses.
-      chatIdRef.current = maxChatIdNum(stored.messages) + 1;
-    })();
-    return () => {
-      active = false;
-    };
-    // Runs once for this scope; a later scope change means a different panel.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scope]);
+  // Deliberately NO auto-adoption of the collection's most recent
+  // conversation. A tab starts its own chat and the history is an explicit
+  // choice, which removes the whole question of two tabs silently landing on
+  // one transcript and saving over each other — the panel used to guess, and
+  // every guess needed another guard around it.
 
   const refreshChats = async () => setChats(await listChats(scopedOnly ? scope : undefined));
 
   const startNewChat = () => {
+    setOpenScope(null);
     setActiveChatId(newChatId());
     setChatMessages([]);
     setChatInput('');
@@ -270,6 +266,12 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     setClaimFailed(false);
     const stored = await loadChat(id);
     if (!stored) return;
+    setOpenScope({
+      connectionName: stored.connectionName,
+      database: stored.database,
+      collection: stored.collection,
+      variant: stored.variant,
+    });
     releaseOpenChat(activeChatIdRef.current, ownerRef.current);
     setActiveChatId(stored.id, stored.createdAt, false);
     setChatMessages(stored.messages);
@@ -584,6 +586,16 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
           </div>
         </div>
 
+        {foreignChat && openScope && (
+          <div
+            className="border-b border-border bg-muted/50 px-3 py-1.5 text-[10.5px] text-muted-foreground"
+            data-testid="ai-chat-foreign-banner"
+          >
+            {t('aiChatPanel.history.viewingOtherScope', {
+              scope: `${openScope.database}.${openScope.collection}`,
+            })}
+          </div>
+        )}
         <div ref={chatScrollRef} className="flex-1 overflow-y-auto">
           <div className="flex flex-col gap-3 p-3" data-testid="ai-chat-messages">
             {chatMessages.length === 0 && !isChatLoading && (
@@ -669,6 +681,8 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
                         size="sm"
                         className="h-7 flex-1 text-xs"
                         onClick={() => onInsertQuery(m.query!)}
+                        disabled={foreignChat}
+                        title={foreignChat ? t('aiChatPanel.actions.foreignChat') : undefined}
                         data-testid="chat-insert-btn"
                       >
                         {t('aiChatPanel.actions.insert')}
@@ -678,6 +692,8 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
                         size="sm"
                         className="h-7 flex-1 text-xs"
                         onClick={() => onInsertAndRunQuery(m.query!)}
+                        disabled={foreignChat}
+                        title={foreignChat ? t('aiChatPanel.actions.foreignChat') : undefined}
                         data-testid="chat-insert-run-btn"
                       >
                         {t('aiChatPanel.actions.insertAndRun')}

--- a/src/components/__tests__/AIChatPanel.test.tsx
+++ b/src/components/__tests__/AIChatPanel.test.tsx
@@ -437,15 +437,17 @@ JSON.stringify({ explanation: 'x', queryType: 'find', filter: {}, sort: {} })
     expect(screen.queryByTestId('chat-msg-user')).toBeNull();
   });
 
-  it('a second tab does not adopt the conversation another tab is holding', async () => {
-    // Per-tab isolation, which is why the transcript is addressed by chat id
-    // rather than by collection: without this both panels would render the same
-    // conversation and then save over each other.
+  it('starts its own conversation rather than adopting the collection\'s last one', async () => {
+    // The panel used to adopt the most recent chat for the collection when a
+    // tab had none of its own. Two tabs then silently landed on one transcript
+    // and saved over each other, and every guard added around that guessing
+    // needed another guard. A tab starts fresh; the history is an explicit
+    // choice.
     chatStore = [
       {
-        id: 'chat-open-elsewhere',
-        title: 'tab one is using this',
-        messages: [{ id: 'm0', role: 'user', text: 'tab one is using this' }],
+        id: 'chat-earlier',
+        title: 'an earlier conversation',
+        messages: [{ id: 'm0', role: 'user', text: 'an earlier conversation' }],
         connectionName: 'Local',
         database: 'test-db',
         collection: 'users',
@@ -455,15 +457,57 @@ JSON.stringify({ explanation: 'x', queryType: 'find', filter: {}, sort: {} })
       },
     ];
 
-    // Tab one adopts it.
     renderPanel('editor');
-    expect(await screen.findByText('tab one is using this')).toBeInTheDocument();
 
-    // Tab two, same collection, no conversation of its own.
-    renderPanel('editor');
-    await waitFor(() => expect(screen.getAllByTestId('ai-chat-messages')).toHaveLength(2));
-    // Exactly one panel shows it — the one that claimed it.
-    expect(screen.getAllByText('tab one is using this')).toHaveLength(1);
+    await waitFor(() => expect(screen.getByTestId('ai-chat-messages')).toBeInTheDocument());
+    expect(screen.queryByText('an earlier conversation')).toBeNull();
+    // ...and it is still one click away.
+    fireEvent.click(screen.getByTestId('ai-chat-history-btn'));
+    await waitFor(() => expect(screen.getByText('an earlier conversation')).toBeInTheDocument());
+  });
+
+  it('keeps a conversation from another collection read-only and stored where it belongs', async () => {
+    // The history can be widened past this collection. A chat picked from there
+    // must not be rewritten under the namespace that happens to be showing it,
+    // and its query cards were written against a different collection.
+    chatStore = [
+      {
+        id: 'chat-elsewhere',
+        title: 'about orders',
+        messages: [
+          { id: 'm0', role: 'user', text: 'about orders' },
+          {
+            id: 'm1',
+            role: 'assistant',
+            text: 'here',
+            query: { queryType: 'find', filter: {}, sort: {}, pipeline: [], script: '' },
+          },
+        ],
+        connectionName: 'Local',
+        database: 'test-db',
+        collection: 'orders',
+        variant: 'editor',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ];
+
+    renderPanel('editor', { collectionName: 'users' });
+    fireEvent.click(screen.getByTestId('ai-chat-history-btn'));
+    // Widen past this collection.
+    fireEvent.click(screen.getByTestId('ai-chat-history-scope-toggle'));
+    await waitFor(() => expect(screen.getByTestId('ai-chat-history-item-0')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('ai-chat-history-item-0'));
+
+    expect(await screen.findByText('about orders')).toBeInTheDocument();
+    await screen.findByTestId('ai-chat-foreign-banner');
+    // Its query cannot be fired at the collection this tab is showing.
+    expect(screen.getByTestId('chat-insert-run-btn')).toBeDisabled();
+    expect(screen.getByTestId('chat-insert-btn')).toBeDisabled();
+    // And it stays an orders conversation.
+    await waitFor(() =>
+      expect(chatStore.find((c) => c.id === 'chat-elsewhere').collection).toBe('orders')
+    );
   });
 
   it('seeds the conversation from initialMessages', () => {

--- a/src/components/__tests__/AIChatPanel.test.tsx
+++ b/src/components/__tests__/AIChatPanel.test.tsx
@@ -466,6 +466,87 @@ JSON.stringify({ explanation: 'x', queryType: 'find', filter: {}, sort: {} })
     await waitFor(() => expect(screen.getByText('an earlier conversation')).toBeInTheDocument());
   });
 
+  it('tells the tab which conversation it minted, so a remount does not fork it', async () => {
+    // Without this the tab still has no id after the first message: the next
+    // mount mints another, saves the same transcript again as a second
+    // conversation, and abandons the first claim — once per tab switch.
+    const onChatIdChange = vi.fn();
+    render(
+      <AIChatPanel
+        connectionId="c1"
+        connectionName="Local"
+        databaseName="test-db"
+        collectionName="users"
+        variant="editor"
+        isOpen
+        onClose={onClose}
+        onInsertQuery={onInsertQuery}
+        onInsertAndRunQuery={onInsertAndRunQuery}
+        sessionKey="tab-1"
+        onChatIdChange={onChatIdChange}
+      />
+    );
+
+    await waitFor(() => expect(onChatIdChange).toHaveBeenCalled());
+    expect(onChatIdChange.mock.calls[0][0]).toEqual(expect.any(String));
+  });
+
+  it('remembers a foreign conversation is foreign after a tab switch', async () => {
+    // `openScope` is component state and switching tabs unmounts the panel, so
+    // it has to be recovered from the chat itself — otherwise the conversation
+    // comes back looking local and the persistence effect moves it here.
+    chatStore = [
+      {
+        id: 'chat-orders',
+        title: 'about orders',
+        messages: [{ id: 'm0', role: 'user', text: 'about orders' }],
+        connectionName: 'Local',
+        database: 'test-db',
+        collection: 'orders',
+        variant: 'editor',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ];
+
+    // Mounted fresh with that chat already selected, as a remount would be.
+    renderPanel('editor', { collectionName: 'users', chatId: 'chat-orders' });
+
+    await screen.findByTestId('ai-chat-foreign-banner');
+    expect(screen.getByTestId('chat-input')).toBeDisabled();
+    // ...and it is still an orders conversation.
+    await waitFor(() =>
+      expect(chatStore.find((c) => c.id === 'chat-orders').collection).toBe('orders')
+    );
+  });
+
+  it('refuses to continue a foreign conversation rather than answering for the wrong collection', async () => {
+    // The composer would generate against THIS collection and save the answer
+    // under the other one's scope, leaving a query that runs somewhere it was
+    // never written for.
+    chatStore = [
+      {
+        id: 'chat-orders',
+        title: 'about orders',
+        messages: [{ id: 'm0', role: 'user', text: 'about orders' }],
+        connectionName: 'Local',
+        database: 'test-db',
+        collection: 'orders',
+        variant: 'editor',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ];
+
+    renderPanel('editor', { collectionName: 'users', chatId: 'chat-orders' });
+    await screen.findByTestId('ai-chat-foreign-banner');
+
+    expect(screen.getByTestId('chat-send-btn')).toBeDisabled();
+    expect(
+      invokeMock.mock.calls.filter((c) => c[0] === 'generate_mql_query')
+    ).toHaveLength(0);
+  });
+
   it('keeps a conversation from another collection read-only and stored where it belongs', async () => {
     // The history can be widened past this collection. A chat picked from there
     // must not be rewritten under the namespace that happens to be showing it,

--- a/src/components/__tests__/AIChatPanel.test.tsx
+++ b/src/components/__tests__/AIChatPanel.test.tsx
@@ -369,7 +369,14 @@ JSON.stringify({ explanation: 'x', queryType: 'find', filter: {}, sort: {} })
 
     expect(screen.queryByText('first question')).toBeNull();
     expect(screen.queryByText('ok')).toBeNull();
-    // ...and the old conversation is still in the history, not lost.
+    // ...and the old conversation is still in the history, not lost — exactly
+    // once. A save queued for the old transcript can execute after New chat has
+    // swapped the active id, which stored the same messages a second time under
+    // the new one; asserting on the store says so directly, where a DOM query
+    // only reports "multiple elements".
+    await waitFor(() =>
+      expect(chatStore.filter((c) => c.title === 'first question')).toHaveLength(1)
+    );
     fireEvent.click(screen.getByTestId('ai-chat-history-btn'));
     await waitFor(() => expect(screen.getByText('first question')).toBeInTheDocument());
   });

--- a/src/lib/__tests__/aiChatStore.test.ts
+++ b/src/lib/__tests__/aiChatStore.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+  appendReplyToChat,
   claimOpenChat,
   isHeldLocally,
   newPanelOwner,
+  releaseChatsForTab,
+  tabChatOwner,
   listChats,
   newChatId,
   releaseOpenChat,
@@ -78,9 +81,21 @@ describe('AI chat store', () => {
       });
     });
 
-    it('gives each panel its own owner token, since two tabs share a window', () => {
+    it('keys the owner on the TAB, so a remount can re-take its own chat', () => {
+      // Inactive tabs unmount. A per-mount token would leave the tab locked out
+      // of the conversation it never stopped pointing at.
+      expect(tabChatOwner('tab-1')).toBe(tabChatOwner('tab-1'));
+      expect(tabChatOwner('tab-1')).not.toBe(tabChatOwner('tab-2'));
+      expect(tabChatOwner('tab-1').startsWith('main#')).toBe(true);
+      // A panel outside the tab system owns nothing shared.
       expect(newPanelOwner()).not.toBe(newPanelOwner());
-      expect(newPanelOwner().startsWith('main#')).toBe(true);
+    });
+
+    it('releases everything a closed tab held, without needing to know the ids', () => {
+      releaseChatsForTab('tab-1');
+      expect(invokeMock).toHaveBeenCalledWith('release_owner_chats', {
+        owner: tabChatOwner('tab-1'),
+      });
     });
 
     it('keeps working if the backend cannot answer', async () => {
@@ -88,6 +103,32 @@ describe('AI chat store', () => {
       invokeMock.mockRejectedValue(new Error('nope'));
       expect(await claimOpenChat('c1', 'main#1')).toBe(true);
     });
+  });
+
+  it('parks a reply in a conversation nobody is showing', async () => {
+    // The tab moved to another window, whose renderer cannot see this one's
+    // request registry. The store is shared, so the answer waits there.
+    const stored = {
+      id: 'c1',
+      title: 't',
+      messages: [{ id: 'm0', role: 'user' as const, text: 'q' }],
+      connectionName: 'Local',
+      database: 'db',
+      collection: 'coll',
+      variant: 'editor' as const,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === 'load_chat' ? Promise.resolve(stored) : Promise.resolve(undefined),
+    );
+
+    await appendReplyToChat('c1', { text: 'the answer' });
+
+    const saved = invokeMock.mock.calls.find((c) => c[0] === 'save_chat')?.[1] as any;
+    expect(saved.chat.messages.map((m: any) => m.text)).toEqual(['q', 'the answer']);
+    // A fresh id, not one the transcript already uses.
+    expect(saved.chat.messages[1].id).toBe('m1');
   });
 
   it('titles a conversation from its opening question', () => {

--- a/src/lib/__tests__/aiChatStore.test.ts
+++ b/src/lib/__tests__/aiChatStore.test.ts
@@ -5,6 +5,7 @@ import {
   isHeldLocally,
   newPanelOwner,
   releaseChatsForTab,
+  retargetChatScope,
   tabChatOwner,
   transferChatClaim,
   listChats,
@@ -107,30 +108,34 @@ describe('AI chat store', () => {
     });
   });
 
-  it('parks a reply in a conversation nobody is showing', async () => {
-    // The tab moved to another window, whose renderer cannot see this one's
-    // request registry. The store is shared, so the answer waits there.
-    const stored = {
-      id: 'c1',
-      title: 't',
-      messages: [{ id: 'm0', role: 'user' as const, text: 'q' }],
-      connectionName: 'Local',
-      database: 'db',
-      collection: 'coll',
-      variant: 'editor' as const,
-      createdAt: '2026-01-01T00:00:00Z',
-      updatedAt: '2026-01-01T00:00:00Z',
-    };
-    invokeMock.mockImplementation((cmd: string) =>
-      cmd === 'load_chat' ? Promise.resolve(stored) : Promise.resolve(undefined),
-    );
-
+  it('parks a reply through one backend call, not load-then-save', async () => {
+    // Two round trips release the store lock in between: a panel saving in that
+    // window is either lost or loses this message. The id is assigned backend
+    // side for the same reason.
     await appendReplyToChat('c1', { text: 'the answer' });
 
-    const saved = invokeMock.mock.calls.find((c) => c[0] === 'save_chat')?.[1] as any;
-    expect(saved.chat.messages.map((m: any) => m.text)).toEqual(['q', 'the answer']);
-    // A fresh id, not one the transcript already uses.
-    expect(saved.chat.messages[1].id).toBe('m1');
+    expect(invokeMock).toHaveBeenCalledWith(
+      'append_chat_message',
+      expect.objectContaining({ chatId: 'c1', role: 'assistant', text: 'the answer' }),
+    );
+    expect(invokeMock).not.toHaveBeenCalledWith('load_chat', expect.anything());
+    expect(invokeMock).not.toHaveBeenCalledWith('save_chat', expect.anything());
+  });
+
+  it('moves conversations to a renamed namespace', async () => {
+    await retargetChatScope(
+      { connectionName: 'Local', database: 'sales', collection: 'users', variant: 'editor' },
+      { database: 'sales', collection: 'people' },
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith('retarget_chat_scope', {
+      connectionName: 'Local',
+      database: 'sales',
+      collection: 'users',
+      variant: 'editor',
+      newDatabase: 'sales',
+      newCollection: 'people',
+    });
   });
 
   it('titles a conversation from its opening question', () => {

--- a/src/lib/__tests__/aiChatStore.test.ts
+++ b/src/lib/__tests__/aiChatStore.test.ts
@@ -6,7 +6,9 @@ import {
   newPanelOwner,
   releaseChatsForTab,
   tabChatOwner,
+  transferChatClaim,
   listChats,
+  loadChat,
   newChatId,
   releaseOpenChat,
   resetOpenChats,
@@ -174,6 +176,30 @@ describe('AI chat store', () => {
       const call = invokeMock.mock.calls.find((c) => c[0] === cmd);
       expect(call?.[1]?.cutoffIso, `${cmd} carried no cutoff`).toBeTruthy();
     }
+  });
+
+  it('ignores a load result that is not a chat', async () => {
+    // Crosses IPC, so anything merely truthy would otherwise be read for fields
+    // it does not have — and a bogus scope silently puts the panel read-only.
+    for (const bogus of [[], 'nope', { title: 'no id' }]) {
+      invokeMock.mockResolvedValue(bogus);
+      expect(await loadChat('c1')).toBeUndefined();
+    }
+  });
+
+  it('moves a claim when a rename mints a new tab id', async () => {
+    invokeMock.mockResolvedValue(true);
+
+    await transferChatClaim('c1', 'old-tab', 'new-tab');
+
+    expect(invokeMock).toHaveBeenCalledWith('release_chat', {
+      chatId: 'c1',
+      owner: tabChatOwner('old-tab'),
+    });
+    expect(invokeMock).toHaveBeenCalledWith('claim_chat', {
+      chatId: 'c1',
+      owner: tabChatOwner('new-tab'),
+    });
   });
 
   it('reads a backend failure as no history rather than throwing', async () => {

--- a/src/lib/__tests__/aiChatStore.test.ts
+++ b/src/lib/__tests__/aiChatStore.test.ts
@@ -138,6 +138,21 @@ describe('AI chat store', () => {
     });
   });
 
+  it('moves a whole database without naming its collections', async () => {
+    // A database rename has to move conversations about collections with no
+    // open tab, which this renderer cannot enumerate.
+    await retargetChatScope({ connectionName: 'Local', database: 'sales' }, { database: 'revenue' });
+
+    expect(invokeMock).toHaveBeenCalledWith('retarget_chat_scope', {
+      connectionName: 'Local',
+      database: 'sales',
+      collection: null,
+      variant: null,
+      newDatabase: 'revenue',
+      newCollection: null,
+    });
+  });
+
   it('titles a conversation from its opening question', () => {
     expect(
       titleFromMessages(

--- a/src/lib/aiChatStore.ts
+++ b/src/lib/aiChatStore.ts
@@ -240,16 +240,18 @@ export async function appendReplyToChat(
  * continue it.
  */
 export async function retargetChatScope(
-  scope: ChatScope,
-  next: { database: string; collection: string }
+  scope: { connectionName: string; database: string; collection?: string; variant?: 'editor' | 'shell' },
+  next: { database: string; collection?: string }
 ): Promise<void> {
   await invoke('retarget_chat_scope', {
     connectionName: scope.connectionName,
     database: scope.database,
-    collection: scope.collection,
-    variant: scope.variant,
+    // Omitted for a database rename: conversations about collections with no
+    // open tab have to move too, and the caller cannot enumerate those.
+    collection: scope.collection ?? null,
+    variant: scope.variant ?? null,
     newDatabase: next.database,
-    newCollection: next.collection,
+    newCollection: next.collection ?? null,
   }).catch(() => undefined);
 }
 

--- a/src/lib/aiChatStore.ts
+++ b/src/lib/aiChatStore.ts
@@ -184,8 +184,18 @@ export async function listChats(scope?: ChatScope): Promise<ChatSummary[]> {
 }
 
 export async function loadChat(id: string): Promise<StoredChat | undefined> {
-  const chat = await invoke<StoredChat | null>('load_chat', { id }).catch(() => null);
-  return chat ?? undefined;
+  const chat = await invoke<unknown>('load_chat', { id }).catch(() => null);
+  // Shape-checked rather than trusted: this crosses the IPC boundary, and
+  // anything merely truthy — an array, say — would otherwise be read for fields
+  // it does not have. A chat with no id is not a chat, and treating one as a
+  // scope silently puts the panel into read-only mode.
+  if (!chat || typeof chat !== 'object' || Array.isArray(chat)) return undefined;
+  const candidate = chat as Partial<StoredChat>;
+  if (typeof candidate.id !== 'string') return undefined;
+  return {
+    ...(candidate as StoredChat),
+    messages: Array.isArray(candidate.messages) ? candidate.messages : [],
+  };
 }
 
 /** Create or update a conversation. Fire-and-forget at the call sites: the
@@ -230,6 +240,17 @@ export async function appendReplyToChat(
     ],
     updatedAt: new Date().toISOString(),
   });
+}
+
+/** Move a conversation's claim to a tab's new id — renames and profile rebinds
+ *  mint new tab ids, and the owner token is built from one. */
+export async function transferChatClaim(
+  chatId: string,
+  oldTabId: string,
+  newTabId: string
+): Promise<void> {
+  await invoke('release_chat', { chatId, owner: tabChatOwner(oldTabId) }).catch(() => undefined);
+  await claimOpenChat(chatId, tabChatOwner(newTabId));
 }
 
 /** Give up every conversation a tab was holding — called when the tab closes,

--- a/src/lib/aiChatStore.ts
+++ b/src/lib/aiChatStore.ts
@@ -212,34 +212,45 @@ export async function deleteChat(id: string): Promise<void> {
  * Append an assistant reply to a stored conversation the panel is not showing.
  *
  * Used when an answer arrives with nowhere local to land — the tab moved to
- * another window, or the panel has since switched conversations. The store is
- * shared, so parking it here is how the answer reaches wherever that
- * conversation is next opened, rather than being dropped.
+ * another window, or the panel has since switched conversations. One backend
+ * command, because load-then-save is two round trips with the store lock
+ * released between them: a panel saving in that window would either lose this
+ * message or be overwritten by it. The message id is assigned backend-side for
+ * the same reason.
  */
 export async function appendReplyToChat(
   chatId: string,
   reply: { text: string; query?: unknown; error?: boolean }
 ): Promise<void> {
-  const stored = await loadChat(chatId);
-  if (!stored) return;
-  const nextNum =
-    stored.messages.reduce((max, m) => {
-      const match = /^m(\d+)$/.exec(m.id);
-      return match ? Math.max(max, Number(match[1])) : max;
-    }, -1) + 1;
-  await saveChat({
-    ...stored,
-    messages: [
-      ...stored.messages,
-      {
-        id: `m${nextNum}`,
-        role: 'assistant',
-        text: reply.text,
-        ...(reply.error ? { error: true } : { query: reply.query as never }),
-      },
-    ],
+  await invoke('append_chat_message', {
+    chatId,
+    role: 'assistant',
+    text: reply.text,
+    query: reply.query ?? null,
+    error: reply.error ?? null,
     updatedAt: new Date().toISOString(),
-  });
+  }).catch(() => undefined);
+}
+
+/**
+ * Follow a renamed database or collection.
+ *
+ * The rename re-keys the tab but leaves the stored conversations naming the old
+ * namespace, after which the panel reads its own chat as foreign and refuses to
+ * continue it.
+ */
+export async function retargetChatScope(
+  scope: ChatScope,
+  next: { database: string; collection: string }
+): Promise<void> {
+  await invoke('retarget_chat_scope', {
+    connectionName: scope.connectionName,
+    database: scope.database,
+    collection: scope.collection,
+    variant: scope.variant,
+    newDatabase: next.database,
+    newCollection: next.collection,
+  }).catch(() => undefined);
 }
 
 /** Move a conversation's claim to a tab's new id — renames and profile rebinds

--- a/src/lib/aiChatStore.ts
+++ b/src/lib/aiChatStore.ts
@@ -123,16 +123,23 @@ export function newChatId(): string {
 const locallyHeld = new Set<string>();
 
 /**
- * A token identifying one PANEL, not one window.
+ * A token identifying one TAB, not one panel instance and not one window.
  *
- * Two tabs in the same window are two panels and must not both hold a chat, so
- * a window label alone is too coarse; the window prefix is still there because
- * a closing window has to be able to drop everything its panels held.
+ * Two tabs in the same window must not both hold a conversation, so a window
+ * label alone is too coarse. Nor can it be per mount: inactive tabs unmount and
+ * a tab that comes back has to be able to re-take the chat it never stopped
+ * pointing at. The window prefix stays because a closing window drops
+ * everything its tabs held.
  */
-let panelSeq = 0;
+export function tabChatOwner(tabId: string): string {
+  return `${windowLabel()}#${tabId}`;
+}
+
+/** For a panel rendered outside the tab system, which owns nothing shared. */
+let looseSeq = 0;
 export function newPanelOwner(): string {
-  panelSeq += 1;
-  return `${windowLabel()}#${panelSeq}`;
+  looseSeq += 1;
+  return `${windowLabel()}#loose-${looseSeq}`;
 }
 
 /** Take a conversation, or find out that another panel has it. */
@@ -158,7 +165,7 @@ export function isHeldLocally(id: string): boolean {
 /** Test seam. */
 export function resetOpenChats(): void {
   locallyHeld.clear();
-  panelSeq = 0;
+  looseSeq = 0;
 }
 
 /**
@@ -189,6 +196,46 @@ export async function saveChat(chat: StoredChat): Promise<void> {
 
 export async function deleteChat(id: string): Promise<void> {
   await invoke('delete_chat', { id }).catch(() => undefined);
+}
+
+/**
+ * Append an assistant reply to a stored conversation the panel is not showing.
+ *
+ * Used when an answer arrives with nowhere local to land — the tab moved to
+ * another window, or the panel has since switched conversations. The store is
+ * shared, so parking it here is how the answer reaches wherever that
+ * conversation is next opened, rather than being dropped.
+ */
+export async function appendReplyToChat(
+  chatId: string,
+  reply: { text: string; query?: unknown; error?: boolean }
+): Promise<void> {
+  const stored = await loadChat(chatId);
+  if (!stored) return;
+  const nextNum =
+    stored.messages.reduce((max, m) => {
+      const match = /^m(\d+)$/.exec(m.id);
+      return match ? Math.max(max, Number(match[1])) : max;
+    }, -1) + 1;
+  await saveChat({
+    ...stored,
+    messages: [
+      ...stored.messages,
+      {
+        id: `m${nextNum}`,
+        role: 'assistant',
+        text: reply.text,
+        ...(reply.error ? { error: true } : { query: reply.query as never }),
+      },
+    ],
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+/** Give up every conversation a tab was holding — called when the tab closes,
+ *  since nothing else will. */
+export function releaseChatsForTab(tabId: string): void {
+  void invoke('release_owner_chats', { owner: tabChatOwner(tabId) }).catch(() => undefined);
 }
 
 /** Delete every chat, or every chat in one scope. */

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -29,7 +29,8 @@
       "thisCollectionOnly": "Nur diese Collection",
       "title": "Chat-Verlauf",
       "untitled": "Unbenannter Chat",
-      "viewingOtherScope": "Unterhaltung aus {{scope}} — hier nur lesbar"
+      "viewingOtherScope": "Unterhaltung aus {{scope}} — hier nur lesbar",
+      "viewingOtherScopeShort": "Zum Fortsetzen diese Collection öffnen"
     },
     "queryType": {
       "aggregate": "Aggregationspipeline",

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -2,6 +2,7 @@
   "aiChatPanel": {
     "actions": {
       "copy": "Kopieren",
+      "foreignChat": "Diese Unterhaltung gehört zu einer anderen Collection",
       "insert": "Einfügen",
       "insertAndRun": "Einfügen & ausführen"
     },
@@ -27,7 +28,8 @@
       "openElsewhere": "Bereits in einem anderen Tab geöffnet",
       "thisCollectionOnly": "Nur diese Collection",
       "title": "Chat-Verlauf",
-      "untitled": "Unbenannter Chat"
+      "untitled": "Unbenannter Chat",
+      "viewingOtherScope": "Unterhaltung aus {{scope}} — hier nur lesbar"
     },
     "queryType": {
       "aggregate": "Aggregationspipeline",

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -29,7 +29,8 @@
       "thisCollectionOnly": "This collection only",
       "title": "Chat history",
       "untitled": "Untitled chat",
-      "viewingOtherScope": "Viewing a conversation from {{scope}} — read only here"
+      "viewingOtherScope": "Viewing a conversation from {{scope}} — read only here",
+      "viewingOtherScopeShort": "Open this collection to continue it"
     },
     "queryType": {
       "aggregate": "Aggregation pipeline",

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -2,6 +2,7 @@
   "aiChatPanel": {
     "actions": {
       "copy": "Copy",
+      "foreignChat": "This conversation belongs to another collection",
       "insert": "Insert",
       "insertAndRun": "Insert & run"
     },
@@ -27,7 +28,8 @@
       "openElsewhere": "Already open in another tab",
       "thisCollectionOnly": "This collection only",
       "title": "Chat history",
-      "untitled": "Untitled chat"
+      "untitled": "Untitled chat",
+      "viewingOtherScope": "Viewing a conversation from {{scope}} — read only here"
     },
     "queryType": {
       "aggregate": "Aggregation pipeline",


### PR DESCRIPTION
The three findings that merged unresolved with #235. All three come from the same root: the panel adopting a conversation on the tab's behalf.

## Auto-adoption is gone

A tab starts its own chat; the history is an explicit choice. That deletes the case the guards existed for — two tabs silently landing on one transcript and saving over each other — instead of adding another guard around it. The collection's previous conversations are one click away in the history.

This is the simplification agreed after the claim machinery produced a new finding in each of four consecutive review rounds.

## Claims are keyed on the tab, not the mount

Inactive tabs are unmounted and still point at their conversation, so a per-mount token did both wrong things: it released a chat that was still spoken for, and it locked the tab out of retaking its own on remount. The owner is now `<window>#<tabId>`. Panels do not release on unmount; the claim ends when the tab stops pointing at the chat — New chat, opening another, or the tab closing (`release_owner_chats`).

## A conversation from another collection stays that collection's

With the history widened past the current scope, an opened chat was rewritten under whichever namespace happened to be showing it, and its query cards — written against a different collection — could be run here. It now saves under its own scope, Insert and Insert & run are disabled, and a banner names where it came from.

## A reply in flight when its tab moves windows

The destination is a different renderer and cannot see this one's request registry, so the answer was dropped. The chat store is shared, so it is parked in the stored conversation and is waiting the next time that chat is opened.

## Verification

- Both halves of the cross-scope fix fail against the unfixed code: without the scope fix the chat is rewritten as `users` instead of `orders`; without the guard the banner and disabled buttons are absent.
- `cargo test` — 517 passing
- `npx vitest run` — 92 files / 1304 passing
- `npx tsc --noEmit`, `npm run build`, `npm run i18n:check` clean, German alongside English

## Behaviour change worth knowing

A tab no longer reopens its last conversation automatically after a restart — it starts fresh, and the previous one is in the history. That is the deliberate trade for removing the guessing.