### PR TITLE
fix(deps): dompurify 3.4.12 -> 3.4.13 for a DOM-clobbering XSS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mqlens",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mqlens",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
@@ -4843,9 +4843,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "vitest": "^4.1.7"
   },
   "overrides": {
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
     "undici": "7.29.0",
     "@babel/core": "7.29.6",
     "esbuild": "0.28.1",


### PR DESCRIPTION
Closes Dependabot alert 53 (moderate): removing an `IN_PLACE` hook left a detached subtree executable, so sanitized output could still run script.

## The change

One line. dompurify arrives transitively through `monaco-editor`, which asks for `3.2.7`; the `overrides` block was already pinning it — at exactly the version the advisory names — so the pin moves from `3.4.12` to `3.4.13` rather than being added.

`monaco-editor` uses it to sanitize rendered markdown in hovers and suggestion details, which is the path the advisory affects.

## Verified against the version actually installed

Worth stating because the obvious check would have been wrong: after the lockfile changed, `npm install` left `3.4.12` on disk. `npm ls` reported the override correctly, so a test run at that point would have proved nothing about the patched code. The old copy was removed and reinstalled first.

- `node -p` on the installed package: `3.4.13`
- `npm audit`: 0 vulnerabilities
- 92 files / 1311 frontend tests, `tsc --noEmit`, `npm run build`, `npm run i18n:check` all clean