### PR TITLE
fix(query): accept queries pasted from a browser, chat or document

### DIFF
--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -902,14 +902,22 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   const [isProjectionValid, setIsProjectionValid] = useState(true);
   const [isSortValid, setIsSortValid] = useState(true);
 
+  // The reason, not just the fact. A query that fails on a character the user
+  // cannot see — a smart quote, a zero-width space pasted in from a browser —
+  // reads as correct on screen, and a bare "Invalid JSON" gives them nothing
+  // to act on.
+  const [filterError, setFilterError] = useState<string | null>(null);
+
   useEffect(() => {
     try {
       if (filterQuery.trim()) {
         parseQueryObject(filterQuery);
       }
       setIsFilterValid(true);
-    } catch {
+      setFilterError(null);
+    } catch (err) {
       setIsFilterValid(false);
+      setFilterError(err instanceof Error ? err.message : String(err));
     }
   }, [filterQuery]);
 
@@ -1833,6 +1841,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                   if (isQueryBuilderOpen) syncSortRulesFromInput(v);
                 }}
                 filterInvalid={!isFilterValid}
+                filterError={filterError}
                 projectionInvalid={!isProjectionValid}
                 sortInvalid={!isSortValid}
                 fields={fields}

--- a/src/components/FindQueryBar.tsx
+++ b/src/components/FindQueryBar.tsx
@@ -25,6 +25,10 @@ export interface FindQueryBarProps {
   filterInvalid?: boolean;
   projectionInvalid?: boolean;
   sortInvalid?: boolean;
+  /** Why the filter would not parse. Shown on hover over the badge — the badge
+   *  itself has no room for it, and "Invalid JSON" on its own leaves a user
+   *  staring at a query that looks perfectly correct. */
+  filterError?: string | null;
   fields: string[];
   schema?: SchemaMap;
   /** Emit mongosh-style completions (bare keys + ISODate()/ObjectId()) instead
@@ -83,6 +87,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
   onProjectionChange,
   onSortChange,
   filterInvalid = false,
+  filterError,
   projectionInvalid = false,
   sortInvalid = false,
   fields,
@@ -174,11 +179,15 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
     else onSortChange('');
   };
 
-  const invalidBadge = (
-    <span className="inline-flex shrink-0 items-center gap-1 pr-1.5 font-mono text-[10px] text-destructive whitespace-nowrap">
+  const badge = (reason?: string | null) => (
+    <span
+      className="inline-flex shrink-0 items-center gap-1 pr-1.5 font-mono text-[10px] text-destructive whitespace-nowrap"
+      title={reason ?? undefined}
+    >
       <AlertCircle size={10} /> {t('findQueryBar.errors.invalidJson')}
     </span>
   );
+  const invalidBadge = badge();
 
   return (
     <div className="flex flex-col border-b border-border bg-muted/20">
@@ -197,7 +206,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
             schema={schema}
             data-testid="query-filter-input"
           />
-          {filterInvalid && invalidBadge}
+          {filterInvalid && badge(filterError)}
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -157,6 +157,33 @@ describe('DocumentViewer Component', () => {
     expect(onImport).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts a query pasted with smart quotes, and says why when one will not parse', async () => {
+    // The bug: a query copied out of a browser or a chat arrives with `“ ”`,
+    // which reads as correct on screen and was rejected as "Invalid JSON" with
+    // no reason given.
+    render(
+      <DocumentViewer
+        connectionName="test-conn"
+        databaseName="test-db"
+        collectionName="test-coll"
+        onExecute={mockOnExecute}
+        onExplain={mockOnExplain}
+        loading={false}
+      />
+    );
+
+    const filterInput = screen.getByTestId('query-filter-input');
+    fireEvent.change(filterInput, { target: { value: 'domain: “account.test.com”' } });
+    await waitFor(() => {
+      expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument();
+    });
+
+    // And when something really is wrong, the badge carries the reason.
+    fireEvent.change(filterInput, { target: { value: '{invalid' } });
+    const badge = await screen.findByText('Invalid JSON');
+    await waitFor(() => expect(badge.getAttribute('title')).toBeTruthy());
+  });
+
   it('performs JSON validation on typing', async () => {
     render(
       <DocumentViewer

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -145,3 +145,63 @@ describe('parseShellJson — NumberLong precision (#222 review)', () => {
     expect(parseShellJson('{ a: 1 }')).toEqual({ a: 1 });
   });
 });
+
+describe('parseShellJson — queries pasted from somewhere else', () => {
+  // A query copied out of a browser, a chat window or a document arrives with
+  // characters that look exactly like the ones the user meant. The parser
+  // rejected them with nothing to go on but "Invalid JSON", on a query that
+  // reads as perfectly correct on screen.
+  it('accepts smart double quotes', () => {
+    expect(parseShellJson('domain: “account.test.com”')).toEqual({
+      domain: 'account.test.com',
+    });
+  });
+
+  it('accepts smart single quotes', () => {
+    expect(parseShellJson('domain: ‘account.test.com’')).toEqual({
+      domain: 'account.test.com',
+    });
+  });
+
+  it('accepts a zero-width space, which nobody can see', () => {
+    expect(parseShellJson('domain:​ "account.test.com"')).toEqual({
+      domain: 'account.test.com',
+    });
+  });
+
+  it('accepts a non-breaking space', () => {
+    expect(parseShellJson('domain: "account.test.com"')).toEqual({
+      domain: 'account.test.com',
+    });
+  });
+
+  it('accepts a trailing semicolon, as copied off a JavaScript line', () => {
+    expect(parseShellJson('{ domain: "account.test.com" };')).toEqual({
+      domain: 'account.test.com',
+    });
+  });
+
+  it('leaves a smart quote inside a string alone', () => {
+    // The user is searching for that character. Rewriting it would change what
+    // the query means.
+    expect(parseShellJson('note: "he said “hi”"')).toEqual({
+      note: 'he said “hi”',
+    });
+  });
+
+  it('leaves a lone curly apostrophe alone', () => {
+    // No closing partner, so it is an apostrophe rather than a delimiter —
+    // in a regex here, where inventing a string would corrupt a query that
+    // works today.
+    const parsed = parseShellJson('name: /don’t/');
+    expect(parsed.name.$regularExpression.pattern).toBe('don’t');
+  });
+
+  it('keeps a semicolon that belongs to a value', () => {
+    expect(parseShellJson('sql: "a;"')).toEqual({ sql: 'a;' });
+  });
+
+  it('keeps a straight quote found inside a smart-quoted run', () => {
+    expect(parseShellJson('q: “say "hi"”')).toEqual({ q: 'say "hi"' });
+  });
+});

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -197,6 +197,30 @@ describe('parseShellJson — queries pasted from somewhere else', () => {
     expect(parsed.name.$regularExpression.pattern).toBe('don’t');
   });
 
+  it('keeps an apostrophe inside a smart-quoted value', () => {
+    // The `’` after O is part of the name, not the end of the string. Taking
+    // it produced `"O"Reilly’` and rejected a perfectly ordinary value.
+    expect(parseShellJson('name: ‘O’Reilly’')).toEqual({ name: 'O’Reilly' });
+  });
+
+  it('does not run one smart-quoted value into the next', () => {
+    expect(parseShellJson('{a: ‘x’, b: ‘y’}')).toEqual({ a: 'x', b: 'y' });
+  });
+
+  it('handles a smart-quoted key', () => {
+    expect(parseShellJson('{“domain”: “a.com”}')).toEqual({ domain: 'a.com' });
+  });
+
+  it('keeps escape sequences meaning what they meant', () => {
+    // Only the delimiters were wrong. Re-encoding the body escapes its
+    // backslashes a second time, so `\n` stops being a newline and starts
+    // being two characters — a filter that quietly matches something else.
+    // Source text here is: q: “a\nb”
+    expect(parseShellJson('q: \u201Ca\\nb\u201D')).toEqual({ q: 'a\nb' });
+    // Source text: path: “C:\\temp”, which a shell string reads as one slash.
+    expect(parseShellJson('path: \u201CC:\\\\temp\u201D')).toEqual({ path: 'C:\\temp' });
+  });
+
   it('leaves a regex literal alone, smart quotes and all', () => {
     // `/“ACME”/` is a pattern that really does contain those characters.
     // Rewriting them leaves a filter that still runs and quietly matches

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -197,6 +197,33 @@ describe('parseShellJson — queries pasted from somewhere else', () => {
     expect(parsed.name.$regularExpression.pattern).toBe('don’t');
   });
 
+  it('leaves a regex literal alone, smart quotes and all', () => {
+    // `/“ACME”/` is a pattern that really does contain those characters.
+    // Rewriting them leaves a filter that still runs and quietly matches
+    // different documents, which is worse than refusing to parse.
+    const parsed = parseShellJson('name: /“ACME”/');
+    expect(parsed.name.$regularExpression.pattern).toBe('“ACME”');
+  });
+
+  it('leaves a regex alone inside an array of values', () => {
+    const parsed = parseShellJson('tags: {$in: [/“a”/, "b"]}');
+    expect(parsed.tags.$in[0].$regularExpression.pattern).toBe('“a”');
+    expect(parsed.tags.$in[1]).toBe('b');
+  });
+
+  it('keeps regex flags and escaped slashes', () => {
+    const parsed = parseShellJson('path: /a\\/b/i');
+    expect(parsed.path.$regularExpression.pattern).toBe('a\\/b');
+    expect(parsed.path.$regularExpression.options).toBe('i');
+  });
+
+  it('still fixes smart quotes that are not in a regex', () => {
+    // The regex carve-out must not swallow the rest of the query.
+    expect(parseShellJson('{ name: /x/, domain: “a.com” }')).toMatchObject({
+      domain: 'a.com',
+    });
+  });
+
   it('keeps a semicolon that belongs to a value', () => {
     expect(parseShellJson('sql: "a;"')).toEqual({ sql: 'a;' });
   });

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -221,6 +221,15 @@ describe('parseShellJson — queries pasted from somewhere else', () => {
     expect(parseShellJson('path: \u201CC:\\\\temp\u201D')).toEqual({ path: 'C:\\temp' });
   });
 
+  it('copes with several paste artifacts at once', () => {
+    // A paste brings its damage in combination. The lookahead that finds the
+    // closing quote reads the original text, so it has to skip what the rest
+    // of the normalizer is about to remove.
+    expect(parseShellJson('domain: “x”;')).toEqual({ domain: 'x' });
+    expect(parseShellJson('{domain: “x”​}')).toEqual({ domain: 'x' });
+    expect(parseShellJson('{“domain”​: “x”}')).toEqual({ domain: 'x' });
+  });
+
   it('leaves a regex literal alone, smart quotes and all', () => {
     // `/“ACME”/` is a pattern that really does contain those characters.
     // Rewriting them leaves a filter that still runs and quietly matches

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -198,11 +198,9 @@ export function normalizePastedQuery(text: string): string {
     }
     const closer = CURLY_PAIRS[c];
     if (closer) {
-      const end = text.indexOf(closer, i + 1);
+      const end = closingSmartQuote(text, i + 1, closer);
       if (end !== -1) {
-        // `JSON.stringify` re-quotes and escapes, so a straight quote inside
-        // the smart-quoted run survives instead of ending the string early.
-        out += JSON.stringify(text.slice(i + 1, end));
+        out += asStraightString(text.slice(i + 1, end));
         i = end + 1;
         continue;
       }
@@ -216,6 +214,53 @@ export function normalizePastedQuery(text: string): string {
     i++;
   }
   return stripTrailingSemicolons(out);
+}
+
+/**
+ * Where a smart-quoted run actually ends.
+ *
+ * Not simply the next `’`: in `‘O’Reilly’` that one is an apostrophe, and
+ * taking it would turn a common pasted value into `"O"Reilly’`. Nor the last
+ * one, which would swallow `‘x’, b: ‘y’` whole. A closing delimiter is
+ * followed by something structural — a comma, a closing bracket, a colon when
+ * the run was a key, or nothing at all — where an apostrophe inside a word is
+ * followed by more word.
+ *
+ * -1 when no candidate qualifies, which leaves the text exactly as the user
+ * typed it: a parse error they can see beats a silent change of meaning.
+ */
+function closingSmartQuote(text: string, from: number, closer: string): number {
+  for (let i = text.indexOf(closer, from); i !== -1; i = text.indexOf(closer, i + 1)) {
+    let j = i + 1;
+    while (j < text.length && /\s/.test(text[j])) j++;
+    if (j >= text.length || ',}])'.includes(text[j]) || text[j] === ':') return i;
+  }
+  return -1;
+}
+
+/**
+ * Re-quote a smart-quoted run as a straight-quoted one, changing NOTHING else.
+ *
+ * Only the delimiters were wrong, so only the delimiters are replaced.
+ * Re-encoding the body — `JSON.stringify`, say — escapes its backslashes a
+ * second time, and `“a\nb”` stops meaning a newline and starts meaning the
+ * two characters, which is the same silent change of meaning this whole
+ * function exists to avoid. Escape pairs pass through untouched; only a
+ * straight quote that would end the string early gets escaped.
+ */
+function asStraightString(body: string): string {
+  let out = '"';
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (c === '\\') {
+      // A trailing lone backslash would escape the quote this adds.
+      out += c + (body[i + 1] ?? '\\');
+      i++;
+      continue;
+    }
+    out += c === '"' ? '\\"' : c;
+  }
+  return `${out}"`;
 }
 
 /**

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -154,9 +154,12 @@ const CURLY_PAIRS: Record<string, string> = { '\u201C': '\u201D', '\u2018': '\u2
  *
  * - Straight-quoted strings are copied out verbatim, so a value that contains
  *   a curly quote or an exotic space keeps it.
+ * - Regex literals are copied out verbatim. `/“ACME”/` is a pattern that
+ *   really does contain smart quotes, and rewriting them would leave a filter
+ *   that still runs and quietly matches different documents.
  * - A curly quote is only rewritten when its matching partner appears later.
- *   A lone `’` is an apostrophe — in a regex literal, say — and inventing a
- *   string around it would corrupt a query that works today.
+ *   A lone `’` is an apostrophe, and inventing a string around it would
+ *   corrupt a query that works today.
  * - Trailing semicolons go, because a filter copied off the end of a
  *   JavaScript statement brings one.
  */
@@ -184,6 +187,15 @@ export function normalizePastedQuery(text: string): string {
       }
       continue;
     }
+    // Verbatim: a regex literal's contents are a pattern, not syntax.
+    if (c === '/' && startsRegex(out)) {
+      const end = endOfRegex(text, i);
+      if (end !== -1) {
+        out += text.slice(i, end);
+        i = end;
+        continue;
+      }
+    }
     const closer = CURLY_PAIRS[c];
     if (closer) {
       const end = text.indexOf(closer, i + 1);
@@ -204,6 +216,45 @@ export function normalizePastedQuery(text: string): string {
     i++;
   }
   return stripTrailingSemicolons(out);
+}
+
+/**
+ * Whether a `/` here opens a regex literal rather than divides.
+ *
+ * In a query a regex is always a value, so it follows a key's colon, a comma,
+ * an opening bracket, or nothing at all. Division does not appear in filter
+ * syntax — arithmetic goes through `$divide` — so this cannot mistake one for
+ * the other.
+ */
+function startsRegex(before: string): boolean {
+  const prev = before.replace(/\s+$/, '').slice(-1);
+  return prev === '' || prev === ':' || prev === ',' || prev === '[' || prev === '(' || prev === '{';
+}
+
+/**
+ * The index just past a regex literal's closing `/` and flags, or -1 if it
+ * never closes — in which case the `/` was something else and is left alone.
+ */
+function endOfRegex(text: string, start: number): number {
+  let i = start + 1;
+  let inClass = false;
+  while (i < text.length) {
+    const c = text[i];
+    if (c === '\\') {
+      i += 2;
+      continue;
+    }
+    if (c === '\n') return -1;
+    if (c === '[') inClass = true;
+    else if (c === ']') inClass = false;
+    else if (c === '/' && !inClass) {
+      i++;
+      while (i < text.length && /[a-z]/i.test(text[i])) i++;
+      return i;
+    }
+    i++;
+  }
+  return -1;
 }
 
 /** Drop `;` off the end, but only when it is not inside a string. */

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -134,8 +134,112 @@ export function shellDocErrorKey(err: unknown): string | null {
   return null;
 }
 
+/** Invisible characters that ride along with pasted text. */
+const ZERO_WIDTH = /[\u200B-\u200D\uFEFF]/;
+/** Spaces that are not the space character: NBSP and the typographic run. */
+const UNICODE_SPACE = /[\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]/;
+const CURLY_PAIRS: Record<string, string> = { '\u201C': '\u201D', '\u2018': '\u2019' };
+
+/**
+ * Undo what copying a query out of a browser, a chat window or a document does
+ * to it.
+ *
+ * A query pasted from anywhere that applies smart quotes arrives with `“ ”`
+ * instead of `" "`, and text copied out of a web page routinely carries a
+ * zero-width space. Both read as perfectly ordinary queries on screen — the
+ * zero-width one is literally invisible — and both made the parser fail with
+ * nothing to go on but "Invalid JSON".
+ *
+ * Conservative on purpose:
+ *
+ * - Straight-quoted strings are copied out verbatim, so a value that contains
+ *   a curly quote or an exotic space keeps it.
+ * - A curly quote is only rewritten when its matching partner appears later.
+ *   A lone `’` is an apostrophe — in a regex literal, say — and inventing a
+ *   string around it would corrupt a query that works today.
+ * - Trailing semicolons go, because a filter copied off the end of a
+ *   JavaScript statement brings one.
+ */
+export function normalizePastedQuery(text: string): string {
+  let out = '';
+  let i = 0;
+  while (i < text.length) {
+    const c = text[i];
+    // Verbatim: whatever is inside a straight-quoted string is the user's data.
+    if (c === '"' || c === "'") {
+      out += c;
+      i++;
+      while (i < text.length) {
+        if (text[i] === '\\') {
+          out += text[i] + (text[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += text[i];
+        if (text[i] === c) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    const closer = CURLY_PAIRS[c];
+    if (closer) {
+      const end = text.indexOf(closer, i + 1);
+      if (end !== -1) {
+        // `JSON.stringify` re-quotes and escapes, so a straight quote inside
+        // the smart-quoted run survives instead of ending the string early.
+        out += JSON.stringify(text.slice(i + 1, end));
+        i = end + 1;
+        continue;
+      }
+      // No partner: an apostrophe, not a delimiter. Leave it exactly as it is.
+    }
+    if (ZERO_WIDTH.test(c)) {
+      i++;
+      continue;
+    }
+    out += UNICODE_SPACE.test(c) ? ' ' : c;
+    i++;
+  }
+  return stripTrailingSemicolons(out);
+}
+
+/** Drop `;` off the end, but only when it is not inside a string. */
+function stripTrailingSemicolons(text: string): string {
+  let cut = text.length;
+  let i = 0;
+  while (i < text.length) {
+    const c = text[i];
+    if (c === '"' || c === "'") {
+      i++;
+      while (i < text.length) {
+        if (text[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (text[i] === c) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      cut = text.length;
+      continue;
+    }
+    if (c === ';' || /\s/.test(c)) {
+      if (c === ';' && cut === text.length) cut = i;
+    } else {
+      cut = text.length;
+    }
+    i++;
+  }
+  return cut === text.length ? text : text.slice(0, cut);
+}
+
 export function parseShellJson(text: string): any {
-  const trimmed = text.trim();
+  const trimmed = normalizePastedQuery(text).trim();
   if (!trimmed) return {};
   // parseFilter signals "unparseable / not a valid query" by returning an empty
   // string rather than throwing (e.g. `{ _id }`, a half-typed field). Surface

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -226,14 +226,23 @@ export function normalizePastedQuery(text: string): string {
  * the run was a key, or nothing at all — where an apostrophe inside a word is
  * followed by more word.
  *
+ * The lookahead reads the ORIGINAL text, so it has to skip what the rest of
+ * this normalizer is about to remove: a paste carries its damage in
+ * combination, and `“x”;` or `“x”<zero-width>}` would otherwise keep its curly
+ * quotes because the closer was followed by something not yet cleaned up.
+ *
  * -1 when no candidate qualifies, which leaves the text exactly as the user
  * typed it: a parse error they can see beats a silent change of meaning.
  */
 function closingSmartQuote(text: string, from: number, closer: string): number {
   for (let i = text.indexOf(closer, from); i !== -1; i = text.indexOf(closer, i + 1)) {
     let j = i + 1;
-    while (j < text.length && /\s/.test(text[j])) j++;
-    if (j >= text.length || ',}])'.includes(text[j]) || text[j] === ':') return i;
+    // `\s` already covers the non-breaking and typographic spaces, but not the
+    // zero-width run, which this normalizer drops outright.
+    while (j < text.length && (/\s/.test(text[j]) || ZERO_WIDTH.test(text[j]))) j++;
+    if (j >= text.length || ',}])'.includes(text[j]) || text[j] === ':' || text[j] === ';') {
+      return i;
+    }
   }
   return -1;
 }


### PR DESCRIPTION
## The bug

Reported against v0.15.0: a query that reads as perfectly correct is rejected as `Invalid JSON`.

`domain: "account.test.com"` is fine. `domain: “account.test.com”` — the same query copied out of a browser, a chat window or a document — is not, and looks identical at the query bar's font size. A zero-width space, which web pages hand out freely, is invisible at any size.

## What changes

Input is normalized before parsing, deliberately conservatively:

| Input | Before | After |
|---|---|---|
| `domain: “account.test.com”` | Invalid JSON | parses |
| `domain: ‘account.test.com’` | Invalid JSON | parses |
| zero-width space outside a string | Invalid JSON | parses |
| trailing `;` off a JS line | Invalid JSON | parses |
| `note: "he said “hi”"` | parses | parses, smart quotes kept |
| `name: /don’t/` | parses | parses, apostrophe kept |
| `sql: "a;"` | parses | parses, semicolon kept |

A smart quote is only rewritten when its closing partner appears later — a lone `’` is an apostrophe, not a delimiter, and inventing a string around it would corrupt a query that works today. Straight-quoted strings are copied verbatim, so values keep whatever they contain.

The badge also gained the parse reason on hover. `Invalid JSON` on its own, over a query that looks right, is what made this need a screenshot to diagnose.

## Verification

- 10 parser cases, including every "leave it alone" case above
- a component test that the pasted form clears the badge, and that a genuinely broken query gets a reason
- confirmed each test fails with the fix removed
- full suite, tsc, build, i18n catalogs clean

Applies to every field that goes through `parseShellJson` — filter, sort, projection, aggregation stages, update-many, export.

Unrelated, noticed while verifying: `MongoShell > shows output that another instance finished off-screen` fails about one full-suite run in three, on `dev` without these changes too. Pre-existing, not touched here.