### PR TITLE
chore: back-merge v0.16.1 into dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqlens",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A native desktop GUI for MongoDB, built with Tauri and React.",
   "homepage": "https://mqlens.com",
   "author": "Devesh Kumar <vrshu112@gmail.com>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "0.16.0"
+version = "0.16.1"
 description = "MQLens — a native desktop GUI for MongoDB."
 authors = ["Devesh Kumar <vrshu112@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MQLens",
   "mainBinaryName": "MQLens",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "identifier": "com.mqlens.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Brings `main` back into `dev` after the v0.16.1 release.

Two commits: the version bump `chore(release): mqlens-v0.16.1 [skip ci]` and the merge of #258.

Without it `dev` sits behind `main` by the bump, and the next release cut computes its version from a stale base.