### PR TITLE
release: v0.16.2 — MongoDB's object names stay untranslated in German

### DIFF
--- a/src/lib/__tests__/typedNameConfirm.test.ts
+++ b/src/lib/__tests__/typedNameConfirm.test.ts
@@ -25,11 +25,15 @@ describe('confirmByTypedName', () => {
       const t = i18next.getFixedT('de');
       await confirmByTypedName(
         prompt,
-        { title: 'Sammlung löschen', kind: 'collection', expectedName: 'orders' },
+        { title: 'Collection löschen', kind: 'collection', expectedName: 'orders' },
         t,
       );
 
-      expect(capturedOpts?.message).toBe('Gib den Namen der Sammlung ein, um zu bestätigen.');
+      // "Collection", not "Sammlung": MongoDB's object names stay as MongoDB
+      // spells them, in German too.
+      expect(capturedOpts?.message).toBe(
+        'Gib den Namen der Collection ein, um zu bestätigen.'
+      );
       expect(capturedOpts?.validate?.('wrong-name')).toBe('Name stimmt nicht überein');
       // The comparison itself must stay against the raw name, never a
       // translated value — a mistyped guess must fail, and the exact name

--- a/src/lib/i18n/__tests__/catalogs.test.ts
+++ b/src/lib/i18n/__tests__/catalogs.test.ts
@@ -47,7 +47,22 @@ const ALLOWED_IDENTICAL_VALUES = new Set([
   'settings:updates.resultValues.offline', // Offline — established loanword, matches shell:updatePrompt.toast.offline's "offline" usage
   'settings:tools.tabLabel', // Tools
   'shell:watch.status.running', // live — the loanword German uses for a running stream too
-  'shell:watch.columns.collection', // Collection — MongoDB's own term, left untranslated in the German UI
+  // MongoDB's own object names. These are the names of things in the data
+  // model — what `db.createCollection` and `db.createView` make — so they
+  // stay as MongoDB spells them, the way GridFS already does. Translating
+  // them ('Sammlungen', 'Ansichten') left the sidebar naming things the
+  // documentation, the shell and the driver all call something else.
+  'shell:watch.columns.collection', // Collection
+  'sidebar:tree.collectionsLabel', // Collections
+  'sidebar:tree.viewsLabel', // Views
+  'documents:dataGrid.explain.labels.collectionNode', // Collection\n{{namespace}}
+  'documents:dataGrid.explain.labels.collectionFallback', // Collection
+  'admin:statsCards.collStats.collection', // Collection:
+  'admin:statsCards.dbStats.labels.collections', // Collections
+  'admin:statsCards.dbStats.labels.views', // Views
+  'shell:commandPalette.buckets.collections.label', // Collections
+  'transfer:dumpView.labels.collection', // Collection
+  'transfer:dumpView.scope.optionCollection', // Collection
   'settings:updates.tabLabel', // Updates
   'connections:connectionMode.normal.label', // Normal
   'connections:filePicker.textFilter', // Text

--- a/src/locales/de/admin.json
+++ b/src/locales/de/admin.json
@@ -318,7 +318,7 @@
       "defaultOption": "(Standard)"
     },
     "hints": {
-      "leaveEmptyToClear": "Leer lassen und anwenden, um die Validierung für diese Sammlung zu entfernen."
+      "leaveEmptyToClear": "Leer lassen und anwenden, um die Validierung für diese Collection zu entfernen."
     },
     "errors": {
       "invalidValidatorJson": "Ungültiges Validator-JSON: {{message}}",
@@ -334,26 +334,26 @@
     }
   },
   "createViewView": {
-    "title": "Ansicht erstellen — {{database}}",
+    "title": "View erstellen — {{database}}",
     "labels": {
-      "viewName": "Ansichtsname",
-      "sourceCollection": "Quellsammlung",
+      "viewName": "View-Name",
+      "sourceCollection": "Quell-Collection",
       "pipeline": "Aggregationspipeline (JSON-Array)"
     },
-    "loading": "Sammlungen werden geladen…",
+    "loading": "Collections werden geladen…",
     "options": {
-      "noCollections": "(keine Sammlungen)"
+      "noCollections": "(keine Collections)"
     },
     "errors": {
-      "nameRequired": "Ansichtsname ist erforderlich.",
-      "selectSource": "Wähle eine Quellsammlung aus.",
+      "nameRequired": "View-Name ist erforderlich.",
+      "selectSource": "Wähle eine Quell-Collection aus.",
       "pipelineMustBeArray": "Pipeline muss ein JSON-Array von Stufen sein.",
       "invalidPipelineJson": "Ungültiges Pipeline-JSON: {{message}}",
       "syntaxErrorFallback": "Syntaxfehler"
     },
     "actions": {
       "creating": "Wird erstellt…",
-      "createView": "Ansicht erstellen"
+      "createView": "View erstellen"
     }
   },
   "statsCards": {
@@ -364,8 +364,8 @@
       "loading": "Datenbankstatistiken werden geladen…",
       "database": "Datenbank:",
       "labels": {
-        "collections": "Sammlungen",
-        "views": "Ansichten",
+        "collections": "Collections",
+        "views": "Views",
         "objects": "Objekte",
         "avgObjectSize": "Durchschn. Objektgröße",
         "dataSize": "Datengröße",
@@ -375,8 +375,8 @@
       }
     },
     "collStats": {
-      "loading": "Sammlungsstatistiken werden geladen…",
-      "collection": "Sammlung:",
+      "loading": "Collection-Statistiken werden geladen…",
+      "collection": "Collection:",
       "labels": {
         "documents": "Dokumente",
         "avgObjectSize": "Durchschn. Objektgröße",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -12,7 +12,7 @@
   },
   "save": "Speichern",
   "tabs": {
-    "createView": "Neue Ansicht: {{db}}",
+    "createView": "Neue View: {{db}}",
     "dump": "Dump: {{name}}",
     "export": "Export: {{collection}}",
     "generate": "Generieren: {{name}}",
@@ -36,8 +36,8 @@
     "copiedMongoshCommand": "mongosh-Befehl kopiert",
     "copiedToClipboard": "{{what}} kopiert — Rechtsklick auf ein Ziel und „Hier einfügen“ wählen.",
     "copyFailed": "Kopieren fehlgeschlagen: {{detail}}",
-    "copyWhatCollections_one": "{{count}} Sammlung",
-    "copyWhatCollections_other": "{{count}} Sammlungen",
+    "copyWhatCollections_one": "{{count}} Collection",
+    "copyWhatCollections_other": "{{count}} Collections",
     "copyWhatDatabase": "Datenbank {{db}}",
     "couldNotCancelTask": "Abbrechen fehlgeschlagen: {{detail}}",
     "couldNotClearDefault": "Standardabfrage konnte nicht entfernt werden: {{detail}}",
@@ -97,7 +97,7 @@
     "userUpdated": "Benutzer {{name}} aktualisiert"
   },
   "typedNameConfirm": {
-    "messageCollection": "Gib den Namen der Sammlung ein, um zu bestätigen.",
+    "messageCollection": "Gib den Namen der Collection ein, um zu bestätigen.",
     "messageDatabase": "Gib den Namen der Datenbank ein, um zu bestätigen.",
     "validationError": "Name stimmt nicht überein"
   }

--- a/src/locales/de/documents.json
+++ b/src/locales/de/documents.json
@@ -56,8 +56,8 @@
     },
     "dialogs": {
       "runAggregate": {
-        "messageUnknownTarget": "Diese Pipeline schreibt über $out/$merge in eine Sammlung auf einer abgesicherten Verbindung, aber das Ziel konnte nicht automatisch ermittelt werden.\n\nGib CONFIRM ein, um fortzufahren.",
-        "messageWithTarget": "Diese Pipeline schreibt in \"{{target}}\" ($out/$merge) auf einer abgesicherten Verbindung.\n\nGib den Namen der Zielsammlung ein, um zu bestätigen.",
+        "messageUnknownTarget": "Diese Pipeline schreibt über $out/$merge in eine Collection auf einer abgesicherten Verbindung, aber das Ziel konnte nicht automatisch ermittelt werden.\n\nGib CONFIRM ein, um fortzufahren.",
+        "messageWithTarget": "Diese Pipeline schreibt in \"{{target}}\" ($out/$merge) auf einer abgesicherten Verbindung.\n\nGib den Namen der Ziel-Collection ein, um zu bestätigen.",
         "title": "Aggregation ausführen"
       },
       "saveQuery": {
@@ -264,8 +264,8 @@
       "updateMany": "Mehrere aktualisieren"
     },
     "dialogs": {
-      "bulkAllWarning_one": "\n\n⚠ Dies betrifft das einzige Dokument in der Sammlung.",
-      "bulkAllWarning_other": "\n\n⚠ Dies betrifft ALLE {{count}} Dokumente in der Sammlung.",
+      "bulkAllWarning_one": "\n\n⚠ Dies betrifft das einzige Dokument in der Collection.",
+      "bulkAllWarning_other": "\n\n⚠ Dies betrifft ALLE {{count}} Dokumente in der Collection.",
       "copyErrorMessage": "Fehlermeldung kopieren",
       "deleteDocument": {
         "body": "Dieses Dokument löschen? Dies kann nicht rückgängig gemacht werden.",
@@ -277,7 +277,7 @@
         "confirmLabel": "Löschen",
         "title": "Mehrere löschen"
       },
-      "typeCollectionNameSuffix": "\n\nGib den Namen der Sammlung ein, um zu bestätigen.",
+      "typeCollectionNameSuffix": "\n\nGib den Namen der Collection ein, um zu bestätigen.",
       "updateMany": {
         "body_one": "Diese Aktualisierung auf {{count}} Dokument anwenden, das folgendem Filter entspricht?\n{{filter}}",
         "body_other": "Diese Aktualisierung auf {{count}} Dokumente anwenden, die folgendem Filter entsprechen?\n{{filter}}",
@@ -299,13 +299,13 @@
     },
     "explain": {
       "labels": {
-        "collectionFallback": "Sammlung",
-        "collectionNode": "Sammlung\n{{namespace}}",
-        "documentsFromCollection": "Dokumente aus Sammlung",
+        "collectionFallback": "Collection",
+        "collectionNode": "Collection\n{{namespace}}",
+        "documentsFromCollection": "Dokumente aus Collection",
         "indexNode": "Index: {{indexName}}"
       },
       "stage": {
-        "collectionScan": "Sammlungsscan",
+        "collectionScan": "Collection-Scan",
         "fetchDocuments": "Dokumente abrufen",
         "indexIntersection": "Indexschnittmenge",
         "indexScan": "Indexscan",
@@ -345,7 +345,7 @@
       "results": "Ergebnisse"
     },
     "tooltips": {
-      "analyzeSchema": "Das Feldschema der Sammlung analysieren",
+      "analyzeSchema": "Das Feldschema der Collection analysieren",
       "codeLanguage": "Codesprache",
       "collapse": "Einklappen",
       "copied": "Kopiert",
@@ -372,7 +372,7 @@
   },
   "schemaView": {
     "empty": {
-      "title": "Sammlung ist leer — nichts zu analysieren."
+      "title": "Collection ist leer — nichts zu analysieren."
     },
     "labels": {
       "analyzing": "Schema wird analysiert…",
@@ -384,7 +384,7 @@
       "sampledSummary": "{{sampled}} Dokumente untersucht · {{fields}} Felder",
       "schemaPrefix": "Schema:",
       "types": "Typen",
-      "validationComingSoonPrefix": "Der Viewer für Sammlungs-Validierungsschemas folgt in Kürze (#93). Dieser Tab zeigt",
+      "validationComingSoonPrefix": "Der Viewer für Collection-Validierungsschemas folgt in Kürze (#93). Dieser Tab zeigt",
       "validationComingSoonSuffix": "und Validierungsregeln für {{databaseName}}.{{collectionName}}."
     },
     "tabs": {

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -46,7 +46,7 @@
   "commandPalette": {
     "buckets": {
       "collections": {
-        "label": "Sammlungen"
+        "label": "Collections"
       },
       "commands": {
         "label": "Befehle"
@@ -94,7 +94,7 @@
       },
       "exportCollection": {
         "keywords": "herunterladen json csv import download",
-        "title": "Sammlung exportieren…"
+        "title": "Collection exportieren…"
       },
       "focusNextPane": {
         "keywords": "arbeitsbereich bereich layout wechseln workspace pane switch",
@@ -153,9 +153,9 @@
     "results_other": "{{count}} Ergebnisse",
     "scopeFilterTitle": "Seitenleisten-Filter: {{scope}}",
     "scopeLabel": "Bereich der Seitenleiste",
-    "searchPlaceholder": "Befehle, Sammlungen, gespeicherte Abfragen durchsuchen…",
+    "searchPlaceholder": "Befehle, Collections, gespeicherte Abfragen durchsuchen…",
     "title": "Befehlspalette",
-    "typeMoreHint": "Mindestens 2 Zeichen eingeben, um Sammlungen zu durchsuchen"
+    "typeMoreHint": "Mindestens 2 Zeichen eingeben, um Collections zu durchsuchen"
   },
   "connectionCard": {
     "ariaLabel": {
@@ -190,7 +190,7 @@
   },
   "emptyWorkspace": {
     "connectButton": "Mit Datenbank verbinden…",
-    "noConnection": "Keine aktive Verbindung. Verbinde dich mit einem MongoDB-Cluster, um Sammlungen zu durchsuchen und Abfragen auszuführen."
+    "noConnection": "Keine aktive Verbindung. Verbinde dich mit einem MongoDB-Cluster, um Collections zu durchsuchen und Abfragen auszuführen."
   },
   "keyboardShortcuts": {
     "description": "Globale Tastenkürzel für Navigation, Abfragen, die Seitenleiste, Zoom und die Befehlspalette.",
@@ -263,7 +263,7 @@
     "help": {
       "aggregateSyntax": "  db.<coll>.aggregate([{ $match }, { $sort }, { $skip }, { $limit }])",
       "clsClear": "  cls / clear              diese Konsole leeren",
-      "collectionMethodsHeader": "Sammlungsmethoden (werden in der Datenansicht angezeigt)",
+      "collectionMethodsHeader": "Collection-Methoden (werden in der Datenansicht angezeigt)",
       "countDocumentsSyntax": "  db.<coll>.countDocuments(<query>)",
       "findOneSyntax": "  db.<coll>.findOne(<query>)",
       "findSyntax": "  db.<coll>.find(<query>).sort(<sort>).skip(n).limit(n)",
@@ -272,7 +272,7 @@
       "jsMultiline": "  Mehrzeiliges JS schreiben: Variablen, Schleifen, Funktionen, try/catch.",
       "load": "  load(\"script.js\")                       eine .js-Datei ausführen",
       "printjson": "  printjson(db.<coll>.find().toArray())   Ergebnisse ausgeben",
-      "showCollections": "  show collections         Sammlungen der aktuellen Datenbank auflisten",
+      "showCollections": "  show collections         Collections der aktuellen Datenbank auflisten",
       "showDbs": "  show dbs                 Datenbanken auflisten",
       "title": "Shell-Befehle",
       "useDb": "  use <db>                 aktuelle Datenbank wechseln"
@@ -306,12 +306,12 @@
       "viewAllShortcuts": "Alle Tastenkürzel in den Einstellungen ansehen"
     },
     "empty": {
-      "body": "Füge einen MongoDB-Cluster von Atlas oder localhost hinzu oder lade den Beispieldatensatz, um MQLens mit Demo-Sammlungen zu erkunden.",
+      "body": "Füge einen MongoDB-Cluster von Atlas oder localhost hinzu oder lade den Beispieldatensatz, um MQLens mit Demo-Collections zu erkunden.",
       "title": "Noch keine gespeicherten Verbindungen"
     },
     "header": {
       "eyebrow": "Schnellstart",
-      "subtitle": "Deine lokale MongoDB-IDE — verbinde dich mit einem Cluster, erkunde Sammlungen und führe Abfragen aus; alles läuft lokal auf deinem Rechner.",
+      "subtitle": "Deine lokale MongoDB-IDE — verbinde dich mit einem Cluster, erkunde Collections und führe Abfragen aus; alles läuft lokal auf deinem Rechner.",
       "title": "Willkommen bei MQLens"
     },
     "newTile": {
@@ -328,7 +328,7 @@
       "localStorageTitle": "Lokaler Speicher",
       "quickActionsDescription": "Häufige Aufgaben vom Startbildschirm aus.",
       "quickActionsTitle": "Schnellaktionen",
-      "shortcutsHint": "Öffne eine Sammlung für Indizes & Explain-Pläne",
+      "shortcutsHint": "Öffne eine Collection für Indizes & Explain-Pläne",
       "shortcutsTitle": "Tastenkürzel"
     },
     "stats": {
@@ -373,7 +373,7 @@
       "title": "Aufgaben"
     },
     "row": {
-      "itemsProgressSuffix": " · {{processed}}/{{total}} Sammlungen",
+      "itemsProgressSuffix": " · {{processed}}/{{total}} Collections",
       "summary": {
         "copied_one": "{{count}} kopiert",
         "copied_other": "{{count}} kopiert",

--- a/src/locales/de/sidebar.json
+++ b/src/locales/de/sidebar.json
@@ -12,23 +12,23 @@
     "viaMcpBadge": "über MCP"
   },
   "ctx": {
-    "addCollection": "Sammlung hinzufügen",
+    "addCollection": "Collection hinzufügen",
     "addDatabase": "Datenbank hinzufügen",
     "addToFavorites": "Zu Favoriten hinzufügen",
     "analyzeSchema": "Schema analysieren",
     "copy": "Kopieren",
-    "copyCollectionName": "Sammlungsnamen kopieren",
+    "copyCollectionName": "Collection-Namen kopieren",
     "copyDatabase": "Datenbank kopieren",
     "copyDatabaseTo": "Datenbank kopieren nach…",
     "copyIndexName": "Indexnamen kopieren",
     "copyTo": "Kopieren nach…",
     "createIndex": "Index erstellen",
-    "createView": "Ansicht erstellen",
+    "createView": "View erstellen",
     "deleteIndex": "Index löschen",
     "disconnect": "Trennen",
-    "dropCollection": "Sammlung löschen",
+    "dropCollection": "Collection löschen",
     "dropDatabase": "Datenbank löschen",
-    "dropView": "Ansicht löschen",
+    "dropView": "View löschen",
     "dump": "Dump (mongodump)…",
     "generateData": "Daten generieren…",
     "manageConnections": "Verbindungen verwalten",
@@ -36,10 +36,10 @@
     "manageUsersDatabase": "Benutzer verwalten",
     "monitorCluster": "Cluster überwachen",
     "newBucket": "Neuer Bucket",
-    "newCollection": "Neue Sammlung",
+    "newCollection": "Neue Collection",
     "newConnection": "Neue Verbindung",
     "open": "Öffnen",
-    "openCollection": "Sammlung öffnen",
+    "openCollection": "Collection öffnen",
     "openInNewTab": "In neuem Tab öffnen",
     "openShell": "mongosh-Shell öffnen",
     "pasteHere": "Hier einfügen",
@@ -47,7 +47,7 @@
     "refreshDatabase": "Datenbank aktualisieren",
     "refreshDatabases": "Datenbanken aktualisieren",
     "removeFromFavorites": "Aus Favoriten entfernen",
-    "renameCollection": "Sammlung umbenennen",
+    "renameCollection": "Collection umbenennen",
     "renameDatabase": "Datenbank umbenennen",
     "restore": "Wiederherstellung (mongorestore)…",
     "settings": "Einstellungen",
@@ -61,15 +61,15 @@
   "dialogs": {
     "dropCollection": {
       "confirmLabel": "Löschen",
-      "message": "Möchtest du die Sammlung \"{{name}}\" wirklich löschen?",
-      "title": "Sammlung löschen"
+      "message": "Möchtest du die Collection \"{{name}}\" wirklich löschen?",
+      "title": "Collection löschen"
     },
     "dropDatabase": {
       "confirmLabel": "Löschen",
       "message": "Möchtest du die Datenbank \"{{name}}\" wirklich löschen? Dies kann nicht rückgängig gemacht werden.",
       "title": "Datenbank löschen"
     },
-    "enterNewCollectionName": "Neuen Sammlungsnamen eingeben:",
+    "enterNewCollectionName": "Neuen Collection-Namen eingeben:",
     "enterNewDatabaseName": "Neuen Datenbanknamen eingeben:",
     "gridfsBucket": {
       "bucketDefault": "fs",
@@ -79,30 +79,30 @@
         "noSystemPrefix": "Bucket-Name darf nicht mit \"system\" beginnen",
         "required": "Bucket-Name ist erforderlich"
       },
-      "message": "Bucket-Name (Sammlungen werden beim ersten Upload erstellt):",
+      "message": "Bucket-Name (Collections werden beim ersten Upload erstellt):",
       "title": "GridFS-Bucket öffnen"
     },
     "initialCollection": {
       "defaultValue": "collection",
-      "message": "Die Datenbank benötigt eine erste Sammlung. Gib deren Namen ein:",
-      "title": "Erste Sammlung"
+      "message": "Die Datenbank benötigt eine erste Collection. Gib deren Namen ein:",
+      "title": "Erste Collection"
     },
     "nameRequired": "Name ist erforderlich",
     "newCollection": {
-      "placeholder": "Sammlungsname",
-      "title": "Neue Sammlung"
+      "placeholder": "Collection-Name",
+      "title": "Neue Collection"
     },
     "newDatabase": {
       "placeholder": "Datenbankname",
       "title": "Neue Datenbank"
     },
     "renameCollection": {
-      "title": "Sammlung umbenennen"
+      "title": "Collection umbenennen"
     },
     "renameDatabase": {
       "confirmLabel": "Umbenennen",
-      "messagePlain": "Datenbank \"{{oldName}}\" in \"{{newName}}\" umbenennen?\n\nMongoDB unterstützt kein natives Umbenennen von Datenbanken. MQLens kopiert Sammlungen und Indizes, überprüft die Dokumentanzahl und löscht anschließend die Quelldatenbank.",
-      "messageTyped": "Datenbank \"{{oldName}}\" in \"{{newName}}\" umbenennen? MongoDB unterstützt kein natives Umbenennen von Datenbanken. MQLens kopiert Sammlungen und Indizes, überprüft die Dokumentanzahl und löscht anschließend die Quelldatenbank.\n\nGib den Datenbanknamen zur Bestätigung ein.",
+      "messagePlain": "Datenbank \"{{oldName}}\" in \"{{newName}}\" umbenennen?\n\nMongoDB unterstützt kein natives Umbenennen von Datenbanken. MQLens kopiert Collections und Indizes, überprüft die Dokumentanzahl und löscht anschließend die Quelldatenbank.",
+      "messageTyped": "Datenbank \"{{oldName}}\" in \"{{newName}}\" umbenennen? MongoDB unterstützt kein natives Umbenennen von Datenbanken. MQLens kopiert Collections und Indizes, überprüft die Dokumentanzahl und löscht anschließend die Quelldatenbank.\n\nGib den Datenbanknamen zur Bestätigung ein.",
       "promptTitle": "Datenbank umbenennen",
       "title": "Datenbank \"{{name}}\" umbenennen"
     }
@@ -110,10 +110,10 @@
   "empty": {
     "connectAriaLabel": "Mit Datenbank verbinden",
     "connectButton": "Mit Datenbank verbinden...",
-    "favoritesHint": "Rechtsklick auf Elemente im Baum, oder füge eine gespeicherte Abfrage aus einem Sammlungstab zu den Favoriten hinzu",
+    "favoritesHint": "Rechtsklick auf Elemente im Baum, oder füge eine gespeicherte Abfrage aus einem Collection-Tab zu den Favoriten hinzu",
     "foldersHint": "Speichere Verbindungen im Verbindungsmanager",
     "noConnections": "Mit einem MongoDB-Server verbinden, um die Datenbankstruktur zu durchsuchen.",
-    "pinnedHint": "Rechtsklick auf eine Verbindung, Datenbank oder Sammlung → An Seitenleiste anheften"
+    "pinnedHint": "Rechtsklick auf eine Verbindung, Datenbank oder Collection → An Seitenleiste anheften"
   },
   "favorites": {
     "connectionSubtitle": "Verbindung",
@@ -139,7 +139,7 @@
   "search": {
     "ariaLabel": "Seitenleiste durchsuchen",
     "clearAriaLabel": "Suche löschen",
-    "placeholder": "Verbindungen, Datenbanken, Sammlungen durchsuchen…"
+    "placeholder": "Verbindungen, Datenbanken, Collections durchsuchen…"
   },
   "sections": {
     "connections": "VERBINDUNGEN",
@@ -153,32 +153,32 @@
     "couldNotConnect": "Verbindung zu {{name}} fehlgeschlagen",
     "couldNotUpdateFavorites": "Favoriten konnten nicht aktualisiert werden",
     "couldNotUpdatePinned": "Angeheftete Elemente konnten nicht aktualisiert werden",
-    "createCollectionFailed": "Sammlung konnte nicht erstellt werden: {{error}}",
+    "createCollectionFailed": "Collection konnte nicht erstellt werden: {{error}}",
     "createDatabaseFailed": "Datenbank konnte nicht erstellt werden: {{error}}",
-    "dropCollectionFailed": "Sammlung konnte nicht gelöscht werden: {{error}}",
+    "dropCollectionFailed": "Collection konnte nicht gelöscht werden: {{error}}",
     "dropDatabaseFailed": "Datenbank konnte nicht gelöscht werden: {{error}}",
     "noSavedConnection": "Keine gespeicherte Verbindung \"{{name}}\". Füge sie im Verbindungsmanager hinzu und versuche es erneut.",
     "pinned": "An Seitenleiste angeheftet",
     "readOnlyBlocked": "Diese Verbindung ist schreibgeschützt (Produktionsschutz). Ändere den Verbindungsmodus im Verbindungsmanager, um Daten zu bearbeiten.",
     "removedFromFavorites": "Aus Favoriten entfernt",
-    "renameCollectionFailed": "Sammlung konnte nicht umbenannt werden: {{error}}",
+    "renameCollectionFailed": "Collection konnte nicht umbenannt werden: {{error}}",
     "renameDatabaseFailed": "Datenbank konnte nicht umbenannt werden: {{error}}",
     "savedQueryGone": "Gespeicherte Abfrage existiert nicht mehr",
     "unpinned": "Anheftung an Seitenleiste aufgehoben"
   },
   "tree": {
-    "collectionsLabel": "Sammlungen",
+    "collectionsLabel": "Collections",
     "databaseAriaLabel": "Datenbank {{name}}",
     "empty": "Leer",
     "gridfsBucketsLabel": "GridFS-Buckets",
     "indexesLabel": "Indizes",
     "newBucketAriaLabel": "Neuer Bucket",
     "newBucketInline": "Neuer Bucket…",
-    "newCollectionAriaLabel": "Neue Sammlung",
+    "newCollectionAriaLabel": "Neue Collection",
     "offlineSuffix": " · offline",
     "rootLabel": "kein Ordner",
     "systemLabel": "System",
-    "timeseriesAriaLabel": "Time-Series-Sammlung",
-    "viewsLabel": "Ansichten"
+    "timeseriesAriaLabel": "Time-Series-Collection",
+    "viewsLabel": "Views"
   }
 }

--- a/src/locales/de/transfer.json
+++ b/src/locales/de/transfer.json
@@ -62,7 +62,7 @@
       "loadedCount_other": "{{count}} geladene Dokumente"
     },
     "full": {
-      "title": "Vollständige Sammlung",
+      "title": "Vollständige Collection",
       "hint": "Läuft im Hintergrund und schreibt direkt auf die Festplatte."
     },
     "filtered": {
@@ -81,7 +81,7 @@
       "failed": "Vorschau fehlgeschlagen: {{error}}"
     },
     "footer": {
-      "backgroundNote": "Gefilterte und vollständige Sammlungsexporte laufen im Hintergrund. Verfolge ihren Fortschritt im Tab <2>Aufgaben</2>."
+      "backgroundNote": "Gefilterte und vollständige Collection-Exporte laufen im Hintergrund. Verfolge ihren Fortschritt im Tab <2>Aufgaben</2>."
     }
   },
   "generateView": {
@@ -118,7 +118,7 @@
       "syntaxError": "Syntaxfehler"
     },
     "hints": {
-      "chooseTargetCollection": "Wähle zuerst eine Zielsammlung.",
+      "chooseTargetCollection": "Wähle zuerst eine Ziel-Collection.",
       "customTemplateNotice": "Benutzerdefinierte Vorlage — Bearbeitung als Roh-JSON. Korrigiere oder vereinfache sie, um zum Builder zurückzukehren.",
       "runInProgress": "Für diesen Tab läuft bereits ein Generierungsvorgang."
     },
@@ -157,8 +157,8 @@
       "rangeMode": "Von / bis",
       "seedOptional": "Seed (optional)",
       "seedPlaceholder": "zufällig",
-      "targetCollection": "Zielsammlung",
-      "targetCollectionPlaceholder": "Sammlungsname",
+      "targetCollection": "Ziel-Collection",
+      "targetCollectionPlaceholder": "Collection-Name",
       "title": "Daten generieren: {{namespace}}",
       "toIsoPlaceholder": "bis (ISO)",
       "words": "Wörter"
@@ -267,16 +267,16 @@
     },
     "scope": {
       "title": "Umfang",
-      "hint": "Erstelle einen Dump des gesamten Servers, einer einzelnen Datenbank oder einer Sammlung.",
+      "hint": "Erstelle einen Dump des gesamten Servers, einer einzelnen Datenbank oder einer Collection.",
       "optionServer": "Gesamter Server",
       "optionDatabase": "Datenbank",
-      "optionCollection": "Sammlung"
+      "optionCollection": "Collection"
     },
     "labels": {
       "database": "Datenbank",
-      "collection": "Sammlung",
+      "collection": "Collection",
       "selectDatabase": "Datenbank auswählen…",
-      "selectCollection": "Sammlung auswählen…",
+      "selectCollection": "Collection auswählen…",
       "queryFilter": "Abfragefilter (optional)"
     },
     "hints": {
@@ -330,7 +330,7 @@
       "archiveFilterHint": "Lasse beide leer, um alles im Archiv wiederherzustellen, oder filtere nach einer einzelnen Datenbank oder einem Namespace."
     },
     "tree": {
-      "emptySelectionHint": "Wähle mindestens eine Sammlung zum Wiederherstellen aus."
+      "emptySelectionHint": "Wähle mindestens eine Collection zum Wiederherstellen aus."
     },
     "rename": {
       "placeholder": "neuer Name (oder db.name)",
@@ -338,16 +338,16 @@
     },
     "labels": {
       "databaseFilter": "Datenbankfilter",
-      "collectionFilter": "Sammlungsfilter"
+      "collectionFilter": "Collection-Filter"
     },
     "options": {
       "title": "Optionen",
       "hint": "mongorestore-Flags.",
       "flags": {
-        "drop": "Vorhandene Sammlungen vor der Wiederherstellung löschen",
+        "drop": "Vorhandene Collections vor der Wiederherstellung löschen",
         "keepIndexVersion": "Ursprüngliche Indexversion beibehalten",
         "noIndexRestore": "Indizes nicht wiederherstellen",
-        "noOptionsRestore": "Sammlungsoptionen nicht wiederherstellen",
+        "noOptionsRestore": "Collection-Optionen nicht wiederherstellen",
         "maintainInsertionOrder": "Einfügereihenfolge der Dokumente beibehalten",
         "stopOnError": "Bei Fehler anhalten",
         "bypassDocumentValidation": "Dokumentvalidierung umgehen",
@@ -369,30 +369,30 @@
   },
   "copyToDialog": {
     "title": {
-      "collection": "Sammlung \"{{name}}\" kopieren",
-      "collections_one": "{{count}} Sammlung kopieren",
-      "collections_other": "{{count}} Sammlungen kopieren",
+      "collection": "Collection \"{{name}}\" kopieren",
+      "collections_one": "{{count}} Collection kopieren",
+      "collections_other": "{{count}} Collections kopieren",
       "database": "Datenbank \"{{name}}\" kopieren"
     },
     "labels": {
       "targetConnection": "Zielverbindung",
       "targetDatabase": "Zieldatenbank",
-      "targetCollection": "Zielsammlung",
+      "targetCollection": "Ziel-Collection",
       "filter": "Filter (EJSON, optional)",
       "options": "Optionen",
       "includeIndexes": "Indizes einschließen",
-      "includeViews": "Ansichten einschließen",
+      "includeViews": "Views einschließen",
       "conflictResolution": "Konfliktlösung",
       "conflictModeSkip": "Überspringen — vorhandene Zieldokumente unverändert lassen",
       "conflictModeMerge": "Zusammenführen — vorhandene Dokumente behalten, neue hinzufügen (doppelte _ids werden übersprungen)",
-      "conflictModeOverwrite": "Überschreiben — Zielsammlung(en) löschen und ersetzen",
-      "overwriteConfirm": "Mir ist bewusst, dass dies die Zielsammlung(en) ersetzt"
+      "conflictModeOverwrite": "Überschreiben — Ziel-Collection(s) löschen und ersetzen",
+      "overwriteConfirm": "Mir ist bewusst, dass dies die Ziel-Collection(s) ersetzt"
     },
     "placeholders": {
       "selectConnection": "Verbindung auswählen…",
       "newDatabaseName": "Name der neuen Datenbank…",
       "selectDatabase": "Datenbank auswählen…",
-      "collectionName": "Sammlungsname…"
+      "collectionName": "Collection-Name…"
     },
     "actions": {
       "newDatabase": "➕ Neue Datenbank…",
@@ -403,7 +403,7 @@
       "newDatabaseWillBeCreated": "Existiert nicht auf dem Ziel — wird erstellt."
     },
     "errors": {
-      "selfOverwrite": "Quelle und Ziel sind dieselbe Sammlung — Kopieren ist nicht zulässig."
+      "selfOverwrite": "Quelle und Ziel sind dieselbe Collection — Kopieren ist nicht zulässig."
     }
   }
 }


### PR DESCRIPTION
Cuts a patch release from `dev`.

## What ships

**`fix` — MongoDB's object names in the German UI (#261).** The sidebar read *Sammlungen* and *Ansichten*, naming the two things in the tree differently from the documentation, the shell, the driver and `db.createCollection` / `db.createView`.

| Before | After |
|---|---|
| Sammlungen (183) | Collections (183) |
| Ansichten (4) | Views (4) |

Applied across all six German namespaces including compounds — `Collection-Name`, `Time-Series-Collection`, `Ziel-Collection`, `Quell-Collection`. GridFS and the watch panel's `Collection` column were already untranslated; this makes the rest consistent with them.

Left translated on purpose: `Datenbank`, `Dokument`, `Abfrage`, `Index` — ordinary German words MongoDB's own German material uses, rather than names of things in the API. Also untouched: `Datenansicht` / `Dokumentenansicht` (this app's views, not MongoDB's) and the command-palette keywords that deliberately carry both languages.

German-only change; nothing in the English UI moves.

Version is derived from the `fix:` subject, so this lands as **v0.16.2**.