### PR TITLE
feat(i18n): let a locale have its own script and its own plural forms

### DIFF
--- a/src/lib/i18n/__tests__/catalogs.test.ts
+++ b/src/lib/i18n/__tests__/catalogs.test.ts
@@ -284,6 +284,51 @@ function expectedKeys(englishKeys: string[], code: string): string[] {
   return [...expected].sort();
 }
 
+/**
+ * The English value a locale's key should be measured against.
+ *
+ * A locale carries the plural forms ITS language has, so French's `_many` has
+ * no English counterpart of its own. Looking the key up in English and giving
+ * up would quietly exempt exactly those forms from the checks below — the
+ * forms that exist only because this suite started allowing them — and a
+ * `_many` string could drop its `{{count}}`, or stay in English, for the
+ * million-scale counts it is there to serve.
+ */
+function englishFor(
+  en: Record<string, unknown>,
+  key: string
+): { key: string; value: string } | null {
+  const direct = valueAt(en, key);
+  if (typeof direct === 'string') return { key, value: direct };
+  const match = /^(.*)_(zero|one|two|few|many|other)$/.exec(key);
+  if (!match) return null;
+  for (const sibling of ['other', 'one', 'many', 'few', 'two', 'zero']) {
+    const siblingKey = `${match[1]}_${sibling}`;
+    const value = valueAt(en, siblingKey);
+    if (typeof value === 'string') return { key: siblingKey, value };
+  }
+  return null;
+}
+
+describe('englishFor — what a locale-only plural form is measured against', () => {
+  const en = { a: { plain: 'x', count_one: '{{count}} thing', count_other: '{{count}} things' } };
+
+  it('maps a form English does not have onto an English sibling', () => {
+    expect(englishFor(en, 'a.count_many')).toEqual({
+      key: 'a.count_other',
+      value: '{{count}} things',
+    });
+  });
+
+  it('uses the key itself when English has it', () => {
+    expect(englishFor(en, 'a.plain')).toEqual({ key: 'a.plain', value: 'x' });
+  });
+
+  it('gives up on a key that is not a plural form at all', () => {
+    expect(englishFor(en, 'a.unknown')).toBeNull();
+  });
+});
+
 describe('expectedKeys — the plural forms a language actually has', () => {
   const en = ['a.plain', 'a.count_one', 'a.count_other'];
 
@@ -343,13 +388,16 @@ describe('locale catalogs', () => {
       const en = await load('en', ns);
       for (const { code } of OTHER_LOCALES) {
         const other = await load(code, ns);
-        const suspicious = keysOf(en).filter((k) => {
-          const enVal = valueAt(en, k);
+        // The LOCALE's keys, not English's: a plural form only this language
+        // has would otherwise never be looked at.
+        const suspicious = keysOf(other).filter((k) => {
+          const source = englishFor(en, k);
           const otherVal = valueAt(other, k);
           return (
-            typeof enVal === 'string' &&
-            enVal === otherVal &&
-            !ALLOWED_IDENTICAL_VALUES.has(`${ns}:${k}`)
+            source !== null &&
+            source.value === otherVal &&
+            !ALLOWED_IDENTICAL_VALUES.has(`${ns}:${k}`) &&
+            !ALLOWED_IDENTICAL_VALUES.has(`${ns}:${source.key}`)
           );
         });
         expect(
@@ -439,14 +487,14 @@ describe('locale catalogs', () => {
       const en = await load('en', ns);
       for (const { code } of OTHER_LOCALES) {
         const other = await load(code, ns);
-        for (const key of keysOf(en)) {
-          const enVal = valueAt(en, key);
+        for (const key of keysOf(other)) {
+          const source = englishFor(en, key);
           const otherVal = valueAt(other, key);
-          if (typeof enVal !== 'string' || typeof otherVal !== 'string') continue;
+          if (source === null || typeof otherVal !== 'string') continue;
           expect(
             tokensOf(otherVal),
-            `${code}/${ns}.json:${key} interpolation placeholders don't match en ("${enVal}" vs "${otherVal}")`,
-          ).toEqual(tokensOf(enVal));
+            `${code}/${ns}.json:${key} interpolation placeholders don't match en:${source.key} ("${source.value}" vs "${otherVal}")`,
+          ).toEqual(tokensOf(source.value));
         }
       }
     }

--- a/src/lib/i18n/__tests__/catalogs.test.ts
+++ b/src/lib/i18n/__tests__/catalogs.test.ts
@@ -257,15 +257,71 @@ const ALLOWED_IDENTICAL_VALUES = new Set([
   'shell:connectionCard.topology.standalone', // Standalone
 ]);
 
+/**
+ * The key set a locale is expected to carry, given English.
+ *
+ * Not simply English's own keys. A plural key exists once per plural category,
+ * and the categories are a property of the LANGUAGE: English has `one` and
+ * `other`, Japanese and Chinese have only `other`, French additionally has
+ * `many` for counts of a million and up — a count a document total reaches
+ * easily. Demanding English's exact set would force Japanese to carry an
+ * `_one` form its grammar never selects, and would reject the `_many` French
+ * needs, so each locale is asked for its own forms and nothing else.
+ */
+function expectedKeys(englishKeys: string[], code: string): string[] {
+  const categories = new Intl.PluralRules(code).resolvedOptions().pluralCategories;
+  const PLURAL_SUFFIXES = ['zero', 'one', 'two', 'few', 'many', 'other'];
+  const expected = new Set<string>();
+  for (const key of englishKeys) {
+    const suffix = PLURAL_SUFFIXES.find((s) => key.endsWith(`_${s}`));
+    if (!suffix) {
+      expected.add(key);
+      continue;
+    }
+    const base = key.slice(0, -(suffix.length + 1));
+    for (const category of categories) expected.add(`${base}_${category}`);
+  }
+  return [...expected].sort();
+}
+
+describe('expectedKeys — the plural forms a language actually has', () => {
+  const en = ['a.plain', 'a.count_one', 'a.count_other'];
+
+  it('asks a language with one form for one form', () => {
+    // Japanese and Chinese do not inflect for number. An `_one` entry there is
+    // a form the grammar never selects, so demanding it only invents work.
+    expect(expectedKeys(en, 'ja')).toEqual(['a.count_other', 'a.plain']);
+    expect(expectedKeys(en, 'zh-Hans')).toEqual(['a.count_other', 'a.plain']);
+  });
+
+  it('asks French for the many form it needs', () => {
+    // French selects `many` from a million up — a count a document total
+    // reaches easily. Without the form the string falls back to English.
+    expect(expectedKeys(en, 'fr')).toEqual([
+      'a.count_many',
+      'a.count_one',
+      'a.count_other',
+      'a.plain',
+    ]);
+  });
+
+  it('leaves a language shaped like English alone', () => {
+    expect(expectedKeys(en, 'de')).toEqual(['a.count_one', 'a.count_other', 'a.plain']);
+  });
+});
+
 describe('locale catalogs', () => {
-  it('every locale has every namespace with identical key sets', async () => {
+  it('every locale has every namespace with the key set its grammar needs', async () => {
     for (const ns of NAMESPACES) {
       const en = keysOf(await load('en', ns)).sort();
       for (const { code } of OTHER_LOCALES) {
         const other = keysOf(await load(code, ns)).sort();
         // Both directions: a missing key means untranslated copy; an extra key
-        // means a stale entry left behind by a rename.
-        expect(other, `${code}/${ns}.json is missing keys present in en`).toEqual(en);
+        // means a stale entry left behind by a rename — or a plural form the
+        // language does not have.
+        expect(other, `${code}/${ns}.json does not match the keys en requires`).toEqual(
+          expectedKeys(en, code)
+        );
       }
     }
   });

--- a/src/lib/i18n/__tests__/resolve-locale.test.ts
+++ b/src/lib/i18n/__tests__/resolve-locale.test.ts
@@ -66,6 +66,12 @@ describe('matchesFor — what a device tag could match', () => {
     expect(matchesFor('zh-Hans-CN')).toEqual(['zh-hans', 'zh']);
   });
 
+  it('sends a bare zh to simplified rather than to English', () => {
+    // Neither shipped Chinese catalog answers to `zh` alone, so a device set
+    // to plain Chinese would otherwise fall through to English entirely.
+    expect(matchesFor('zh')).toEqual(['zh-hans', 'zh']);
+  });
+
   it('reads the script off the region when the tag omits it', () => {
     // A device that says `zh-TW` has still said which script it wants.
     expect(matchesFor('zh-TW')).toEqual(['zh-hant', 'zh']);

--- a/src/lib/i18n/__tests__/resolve-locale.test.ts
+++ b/src/lib/i18n/__tests__/resolve-locale.test.ts
@@ -97,13 +97,24 @@ describe('matchesFor — what a device tag could match', () => {
     expect(matchesFor('ja')).toEqual(['ja-jpan', 'ja']);
   });
 
-  it('survives a tag with no language at all', () => {
+  it('guesses nothing from a tag with no language at all', () => {
     // `und` is well-formed and its language is absent, so anything that
     // assumes one throws — out of a function that runs while the app is
     // deciding what language to start in.
     expect(() => matchesFor('und')).not.toThrow();
-    expect(matchesFor('und-TW')).toEqual(['zh-hant', 'zh']);
+
+    // And nothing is inferred from what remains. CLDR will maximize any of
+    // these, but every answer is a pick among many: `und-Latn` becomes English
+    // out of the hundreds of languages written in Latin, `und-CH` becomes
+    // German out of Switzerland's four. Matching on that would discard the
+    // real preference sitting behind it.
+    expect(matchesFor('und')).toEqual([]);
+    expect(matchesFor('und-Latn')).toEqual([]);
+    expect(matchesFor('und-CH')).toEqual([]);
+    expect(matchesFor('und-TW')).toEqual([]);
     expect(resolveLocale('system', ['und', 'de-DE'])).toBe('de');
+    expect(resolveLocale('system', ['und-Latn', 'de-DE'])).toBe('de');
+    expect(resolveLocale('system', ['und-CH', 'de-DE'])).toBe('de');
   });
 
   it('is not confused by casing or an empty tag', () => {

--- a/src/lib/i18n/__tests__/resolve-locale.test.ts
+++ b/src/lib/i18n/__tests__/resolve-locale.test.ts
@@ -81,10 +81,20 @@ describe('matchesFor — what a device tag could match', () => {
     expect(matchesFor('zh-SG')).toEqual(['zh-hans', 'zh']);
   });
 
-  it('leaves a language with one script alone', () => {
-    expect(matchesFor('de-AT')).toEqual(['de']);
-    expect(matchesFor('fr-CA')).toEqual(['fr']);
-    expect(matchesFor('ja')).toEqual(['ja']);
+  it('ignores extension subtags rather than reading them as a script', () => {
+    // `zh-TW-u-nu-latn` asks for Traditional Chinese with Latin numerals.
+    // Picking subtags out by length reads that `latn` as the script and sends
+    // a valid preference somewhere that does not exist.
+    expect(matchesFor('zh-TW-u-nu-latn')).toEqual(['zh-hant', 'zh']);
+    expect(matchesFor('zh-Hans-CN-u-ca-chinese')).toEqual(['zh-hans', 'zh']);
+  });
+
+  it('still reaches a single-script language', () => {
+    // CLDR fills in the script these tags omit, so a candidate matching no
+    // shipped catalog comes first and simply falls through.
+    expect(matchesFor('de-AT')).toEqual(['de-latn', 'de']);
+    expect(matchesFor('fr-CA')).toEqual(['fr-latn', 'fr']);
+    expect(matchesFor('ja')).toEqual(['ja-jpan', 'ja']);
   });
 
   it('is not confused by casing or an empty tag', () => {

--- a/src/lib/i18n/__tests__/resolve-locale.test.ts
+++ b/src/lib/i18n/__tests__/resolve-locale.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isLocaleSetting, resolveLocale } from '../locales';
+import { isLocaleSetting, matchesFor, resolveLocale } from '../locales';
 
 describe('resolveLocale', () => {
   it('honours an explicit choice regardless of the device language', () => {
@@ -55,5 +55,34 @@ describe('isLocaleSetting', () => {
     expect(isLocaleSetting(undefined)).toBe(false);
     expect(isLocaleSetting(null)).toBe(false);
     expect(isLocaleSetting(42)).toBe(false);
+  });
+});
+
+describe('matchesFor — what a device tag could match', () => {
+  it('prefers the script over the language', () => {
+    // `zh-Hans` and `zh-Hant` are different catalogs that both start `zh`.
+    // Matching on the language alone would hand a reader of one the other.
+    expect(matchesFor('zh-Hant-HK')).toEqual(['zh-hant', 'zh']);
+    expect(matchesFor('zh-Hans-CN')).toEqual(['zh-hans', 'zh']);
+  });
+
+  it('reads the script off the region when the tag omits it', () => {
+    // A device that says `zh-TW` has still said which script it wants.
+    expect(matchesFor('zh-TW')).toEqual(['zh-hant', 'zh']);
+    expect(matchesFor('zh-HK')).toEqual(['zh-hant', 'zh']);
+    expect(matchesFor('zh-MO')).toEqual(['zh-hant', 'zh']);
+    expect(matchesFor('zh-CN')).toEqual(['zh-hans', 'zh']);
+    expect(matchesFor('zh-SG')).toEqual(['zh-hans', 'zh']);
+  });
+
+  it('leaves a language with one script alone', () => {
+    expect(matchesFor('de-AT')).toEqual(['de']);
+    expect(matchesFor('fr-CA')).toEqual(['fr']);
+    expect(matchesFor('ja')).toEqual(['ja']);
+  });
+
+  it('is not confused by casing or an empty tag', () => {
+    expect(matchesFor('ZH-HANT-tw')).toEqual(['zh-hant', 'zh']);
+    expect(matchesFor('')).toEqual([]);
   });
 });

--- a/src/lib/i18n/__tests__/resolve-locale.test.ts
+++ b/src/lib/i18n/__tests__/resolve-locale.test.ts
@@ -97,6 +97,15 @@ describe('matchesFor — what a device tag could match', () => {
     expect(matchesFor('ja')).toEqual(['ja-jpan', 'ja']);
   });
 
+  it('survives a tag with no language at all', () => {
+    // `und` is well-formed and its language is absent, so anything that
+    // assumes one throws — out of a function that runs while the app is
+    // deciding what language to start in.
+    expect(() => matchesFor('und')).not.toThrow();
+    expect(matchesFor('und-TW')).toEqual(['zh-hant', 'zh']);
+    expect(resolveLocale('system', ['und', 'de-DE'])).toBe('de');
+  });
+
   it('is not confused by casing or an empty tag', () => {
     expect(matchesFor('ZH-HANT-tw')).toEqual(['zh-hant', 'zh']);
     expect(matchesFor('')).toEqual([]);

--- a/src/lib/i18n/locales.ts
+++ b/src/lib/i18n/locales.ts
@@ -88,21 +88,33 @@ export function matchesFor(tag: string): string[] {
     const language = String(tag).split('-')[0]?.toLowerCase();
     return language ? [language] : [];
   }
-  const language = locale.language.toLowerCase();
-  const script = locale.script ?? maximizedScript(locale);
+  // `und` — "undetermined" — is a well-formed tag whose language is absent, so
+  // this cannot assume there is one to lower-case. Reading it off the
+  // maximized locale answers it where CLDR can (`und-TW` is Chinese) and
+  // leaves nothing to match where it cannot, rather than throwing out of a
+  // function that runs while the app is deciding what language to start in.
+  const maximized = maximize(locale);
+  // Only where the tag says something else. A bare `und` maximizes to English,
+  // and letting it match would answer "I don't know" with a language and
+  // swallow the preference listed after it; `und-TW` genuinely does point
+  // somewhere, so its region is allowed to speak.
+  const impliedLanguage = locale.region || locale.script ? maximized?.language : undefined;
+  const language = (locale.language ?? impliedLanguage)?.toLowerCase();
+  if (!language) return [];
+  const script = locale.script ?? maximized?.script;
   const candidates: string[] = [];
   if (script) candidates.push(`${language}-${script.toLowerCase()}`);
   candidates.push(language);
   return candidates;
 }
 
-/** CLDR's likely script for a tag that omits one. Absent where the runtime
- *  ships no likely-subtags data, in which case the language alone has to do. */
-function maximizedScript(locale: Intl.Locale): string | undefined {
+/** The tag with the script and language CLDR considers likely, or null where
+ *  the runtime ships no likely-subtags data. */
+function maximize(locale: Intl.Locale): Intl.Locale | null {
   try {
-    return locale.maximize().script;
+    return locale.maximize();
   } catch {
-    return undefined;
+    return null;
   }
 }
 

--- a/src/lib/i18n/locales.ts
+++ b/src/lib/i18n/locales.ts
@@ -48,11 +48,54 @@ export function resolveLocale(
 ): Locale {
   if (isSupportedLocale(setting)) return setting;
   for (const tag of languages ?? []) {
-    const primary = String(tag).split('-')[0]?.toLowerCase();
-    const hit = SUPPORTED_LOCALES.find((l) => l.code === primary);
-    if (hit) return hit.code;
+    for (const candidate of matchesFor(tag)) {
+      const hit = SUPPORTED_LOCALES.find((l) => l.code.toLowerCase() === candidate);
+      if (hit) return hit.code;
+    }
   }
   return DEFAULT_LOCALE;
+}
+
+/**
+ * Where Chinese is written in traditional characters.
+ *
+ * A device that says `zh-TW` rather than `zh-Hant-TW` has still told us which
+ * script it wants; the region is the only place that information is.
+ */
+const TRADITIONAL_CHINESE_REGIONS = new Set(['TW', 'HK', 'MO']);
+
+/**
+ * What a device language tag could match, most specific first.
+ *
+ * The primary subtag alone is not enough once a language ships in more than one
+ * script: `zh-Hans` and `zh-Hant` are different catalogs and both start `zh`,
+ * so matching on `zh` would hand a Taiwanese user whichever happened to be
+ * registered first. Script beats language, and for Chinese a region implies a
+ * script when the tag omits one.
+ *
+ * Lowercased throughout so the caller can compare without worrying about the
+ * casing conventions of a tag (`zh-Hant-HK`).
+ *
+ * Exported for its tests: the mapping is the whole substance of picking a
+ * locale, and it cannot be exercised through {@link resolveLocale} until the
+ * catalogs it points at exist.
+ */
+export function matchesFor(tag: string): string[] {
+  const parts = String(tag).split('-').filter(Boolean);
+  const language = parts[0]?.toLowerCase();
+  if (!language) return [];
+  const script = parts.slice(1).find((p) => p.length === 4)?.toLowerCase();
+  const region = parts.slice(1).find((p) => p.length === 2)?.toUpperCase();
+  const candidates: string[] = [];
+  if (script) {
+    candidates.push(`${language}-${script}`);
+  } else if (language === 'zh' && region) {
+    candidates.push(
+      `${language}-${TRADITIONAL_CHINESE_REGIONS.has(region) ? 'hant' : 'hans'}`
+    );
+  }
+  candidates.push(language);
+  return candidates;
 }
 
 /** The device's preferred languages, most-preferred first. */

--- a/src/lib/i18n/locales.ts
+++ b/src/lib/i18n/locales.ts
@@ -57,50 +57,53 @@ export function resolveLocale(
 }
 
 /**
- * Where Chinese is written in traditional characters.
- *
- * A device that says `zh-TW` rather than `zh-Hant-TW` has still told us which
- * script it wants; the region is the only place that information is.
- */
-const TRADITIONAL_CHINESE_REGIONS = new Set(['TW', 'HK', 'MO']);
-
-/**
  * What a device language tag could match, most specific first.
  *
  * The primary subtag alone is not enough once a language ships in more than one
  * script: `zh-Hans` and `zh-Hant` are different catalogs and both start `zh`,
- * so matching on `zh` would hand a Taiwanese user whichever happened to be
- * registered first. Script beats language, and for Chinese a region implies a
- * script when the tag omits one.
+ * so matching on `zh` would hand a reader of one the other.
  *
- * Lowercased throughout so the caller can compare without worrying about the
- * casing conventions of a tag (`zh-Hant-HK`).
+ * Parsed with `Intl.Locale` rather than by splitting on dashes. A tag can carry
+ * extensions — `zh-TW-u-nu-latn` asks for Traditional Chinese with Latin
+ * numerals — and picking subtags out by length reads that `latn` as the script,
+ * sending a valid Chinese preference somewhere that does not exist. `Intl` also
+ * knows which script a language and region imply, so `zh-TW` reaches
+ * traditional and a bare `zh` reaches simplified out of CLDR's own data instead
+ * of a table maintained here.
+ *
+ * A candidate that matches no shipped catalog simply falls through, which is
+ * why a single-script language contributes a harmless `de-latn` before `de`.
  *
  * Exported for its tests: the mapping is the whole substance of picking a
  * locale, and it cannot be exercised through {@link resolveLocale} until the
  * catalogs it points at exist.
  */
 export function matchesFor(tag: string): string[] {
-  const parts = String(tag).split('-').filter(Boolean);
-  const language = parts[0]?.toLowerCase();
-  if (!language) return [];
-  const script = parts.slice(1).find((p) => p.length === 4)?.toLowerCase();
-  const region = parts.slice(1).find((p) => p.length === 2)?.toUpperCase();
-  const candidates: string[] = [];
-  if (script) {
-    candidates.push(`${language}-${script}`);
-  } else if (language === 'zh') {
-    // A bare `zh`, or one with only a region, still has to reach a catalog:
-    // neither `zh-Hans` nor `zh-Hant` answers to `zh` alone, so without this a
-    // device set to plain Chinese would fall through to English. Simplified is
-    // the default the region tags point at when they say nothing else, which
-    // is what CLDR's likely-subtags resolve `zh` to as well.
-    candidates.push(
-      `${language}-${region && TRADITIONAL_CHINESE_REGIONS.has(region) ? 'hant' : 'hans'}`
-    );
+  let locale: Intl.Locale;
+  try {
+    locale = new Intl.Locale(String(tag));
+  } catch {
+    // Not a well-formed tag. The leading subtag is the most that can be
+    // salvaged, and an empty tag yields nothing at all.
+    const language = String(tag).split('-')[0]?.toLowerCase();
+    return language ? [language] : [];
   }
+  const language = locale.language.toLowerCase();
+  const script = locale.script ?? maximizedScript(locale);
+  const candidates: string[] = [];
+  if (script) candidates.push(`${language}-${script.toLowerCase()}`);
   candidates.push(language);
   return candidates;
+}
+
+/** CLDR's likely script for a tag that omits one. Absent where the runtime
+ *  ships no likely-subtags data, in which case the language alone has to do. */
+function maximizedScript(locale: Intl.Locale): string | undefined {
+  try {
+    return locale.maximize().script;
+  } catch {
+    return undefined;
+  }
 }
 
 /** The device's preferred languages, most-preferred first. */

--- a/src/lib/i18n/locales.ts
+++ b/src/lib/i18n/locales.ts
@@ -89,9 +89,14 @@ export function matchesFor(tag: string): string[] {
   const candidates: string[] = [];
   if (script) {
     candidates.push(`${language}-${script}`);
-  } else if (language === 'zh' && region) {
+  } else if (language === 'zh') {
+    // A bare `zh`, or one with only a region, still has to reach a catalog:
+    // neither `zh-Hans` nor `zh-Hant` answers to `zh` alone, so without this a
+    // device set to plain Chinese would fall through to English. Simplified is
+    // the default the region tags point at when they say nothing else, which
+    // is what CLDR's likely-subtags resolve `zh` to as well.
     candidates.push(
-      `${language}-${TRADITIONAL_CHINESE_REGIONS.has(region) ? 'hant' : 'hans'}`
+      `${language}-${region && TRADITIONAL_CHINESE_REGIONS.has(region) ? 'hant' : 'hans'}`
     );
   }
   candidates.push(language);

--- a/src/lib/i18n/locales.ts
+++ b/src/lib/i18n/locales.ts
@@ -88,20 +88,16 @@ export function matchesFor(tag: string): string[] {
     const language = String(tag).split('-')[0]?.toLowerCase();
     return language ? [language] : [];
   }
-  // `und` — "undetermined" — is a well-formed tag whose language is absent, so
-  // this cannot assume there is one to lower-case. Reading it off the
-  // maximized locale answers it where CLDR can (`und-TW` is Chinese) and
-  // leaves nothing to match where it cannot, rather than throwing out of a
-  // function that runs while the app is deciding what language to start in.
-  const maximized = maximize(locale);
-  // Only where the tag says something else. A bare `und` maximizes to English,
-  // and letting it match would answer "I don't know" with a language and
-  // swallow the preference listed after it; `und-TW` genuinely does point
-  // somewhere, so its region is allowed to speak.
-  const impliedLanguage = locale.region || locale.script ? maximized?.language : undefined;
-  const language = (locale.language ?? impliedLanguage)?.toLowerCase();
+  // `und` — "undetermined" — is a well-formed tag whose language is absent.
+  // Nothing is guessed from it: CLDR will happily maximize one, but every
+  // answer it gives is a pick among many. `und-Latn` becomes English out of the
+  // hundreds of languages written in Latin, and `und-CH` becomes German out of
+  // Switzerland's four. Either would match here and discard the real
+  // preference listed after it, so an undetermined tag contributes no
+  // candidates and resolution moves on to the next one.
+  const language = locale.language?.toLowerCase();
   if (!language) return [];
-  const script = locale.script ?? maximized?.script;
+  const script = locale.script ?? maximize(locale)?.script;
   const candidates: string[] = [];
   if (script) candidates.push(`${language}-${script.toLowerCase()}`);
   candidates.push(language);


### PR DESCRIPTION
Groundwork for #252 (Chinese Simplified & Traditional, Japanese, French). No new locale here — this is the part that has to be right before one can land, and both gates below would reject those locales today.

## Two assumptions that only hold for German

**Locale matching read the primary subtag only.** `zh-Hans` and `zh-Hant` are different catalogs that both start `zh`, so a reader of one would be handed whichever was registered first. Script now beats language, and for Chinese a region implies a script when the tag omits one:

| Device tag | Matches, in order |
|---|---|
| `zh-Hant-HK` | `zh-hant`, `zh` |
| `zh-TW` / `zh-HK` / `zh-MO` | `zh-hant`, `zh` |
| `zh-CN` / `zh-SG` | `zh-hans`, `zh` |
| `de-AT`, `fr-CA` | `de` / `fr` (unchanged) |

**Catalog parity demanded English's exact key set, plural forms included.** Those forms belong to the language, not to the catalog:

| Language | CLDR categories |
|---|---|
| English, German | `one`, `other` |
| Japanese, Chinese | `other` only |
| French | `one`, `many`, `other` |

So the old gate would have forced Japanese to carry an `_one` form its grammar never selects, and rejected the `_many` French needs — for counts of a million and up, which a document total reaches easily and which would otherwise fall back to English. Each locale is now asked for its own forms and nothing else.

## Verification

- 96 files / 1385 frontend tests, tsc, build, i18n extraction clean
- German is unaffected (its categories match English)
- new tests for both rules, each confirmed to fail with its fix removed

## What follows

One locale per PR, since each is ~1,813 strings: Chinese Simplified, then Traditional, then Japanese, then French. MongoDB's object names stay untranslated in all of them, as they now are in German (#261).