### PR TITLE
fix(i18n): let a catalog carry an exact-zero plural override

### DIFF
--- a/src/lib/i18n/__tests__/catalogs.test.ts
+++ b/src/lib/i18n/__tests__/catalogs.test.ts
@@ -268,9 +268,10 @@ const ALLOWED_IDENTICAL_VALUES = new Set([
  * `_one` form its grammar never selects, and would reject the `_many` French
  * needs, so each locale is asked for its own forms and nothing else.
  */
-function expectedKeys(englishKeys: string[], code: string): string[] {
+function expectedKeys(englishKeys: string[], code: string, localeKeys: string[] = []): string[] {
   const categories = new Intl.PluralRules(code).resolvedOptions().pluralCategories;
   const PLURAL_SUFFIXES = ['zero', 'one', 'two', 'few', 'many', 'other'];
+  const present = new Set(localeKeys);
   const expected = new Set<string>();
   for (const key of englishKeys) {
     const suffix = PLURAL_SUFFIXES.find((s) => key.endsWith(`_${s}`));
@@ -280,6 +281,12 @@ function expectedKeys(englishKeys: string[], code: string): string[] {
     }
     const base = key.slice(0, -(suffix.length + 1));
     for (const category of categories) expected.add(`${base}_${category}`);
+    // `_zero` is not a CLDR category for most languages — German and English
+    // have only `one` and `other` — but i18next checks it first for a count of
+    // exactly 0 whatever the language, and the contributing guide invites
+    // translators to add one. Deriving the set from CLDR alone rejected it as
+    // a stale key. Permitted where a catalog supplies it, never required.
+    if (present.has(`${base}_zero`)) expected.add(`${base}_zero`);
   }
   return [...expected].sort();
 }
@@ -353,6 +360,20 @@ describe('expectedKeys — the plural forms a language actually has', () => {
   it('leaves a language shaped like English alone', () => {
     expect(expectedKeys(en, 'de')).toEqual(['a.count_one', 'a.count_other', 'a.plain']);
   });
+
+  it('permits an exact-zero override without requiring one', () => {
+    // `zero` is not a CLDR category for German, but i18next checks `_zero`
+    // first for a count of exactly 0 in any language, and the contributing
+    // guide invites translators to add one. It is allowed where supplied and
+    // never demanded.
+    expect(expectedKeys(en, 'de', ['a.count_zero'])).toEqual([
+      'a.count_one',
+      'a.count_other',
+      'a.count_zero',
+      'a.plain',
+    ]);
+    expect(expectedKeys(en, 'de', [])).not.toContain('a.count_zero');
+  });
 });
 
 describe('locale catalogs', () => {
@@ -365,7 +386,7 @@ describe('locale catalogs', () => {
         // means a stale entry left behind by a rename — or a plural form the
         // language does not have.
         expect(other, `${code}/${ns}.json does not match the keys en requires`).toEqual(
-          expectedKeys(en, code)
+          expectedKeys(en, code, other)
         );
       }
     }
@@ -491,6 +512,18 @@ describe('locale catalogs', () => {
           const source = englishFor(en, key);
           const otherVal = valueAt(other, key);
           if (source === null || typeof otherVal !== 'string') continue;
+          // An exact-zero override measured against a sibling that counts:
+          // "no documents deleted" is the point of the form, so it may drop
+          // the count English needs. It still may not invent a placeholder
+          // nothing will supply.
+          if (key.endsWith('_zero') && source.key !== key) {
+            const unknown = tokensOf(otherVal).filter((t) => !tokensOf(source.value).includes(t));
+            expect(
+              unknown,
+              `${code}/${ns}.json:${key} uses placeholders en:${source.key} does not supply ("${source.value}" vs "${otherVal}")`,
+            ).toEqual([]);
+            continue;
+          }
           expect(
             tokensOf(otherVal),
             `${code}/${ns}.json:${key} interpolation placeholders don't match en:${source.key} ("${source.value}" vs "${otherVal}")`,


### PR DESCRIPTION
Found in review on #264, resolved there **without an answer**, so it reached `dev`. Picking it back up.

## The gap

`zero` is not a CLDR category for most languages — English, German and French all have only `one` and `other` — but i18next checks `_zero` first for a count of exactly 0 in any language, and `docs/CONTRIBUTING-i18n.md` lists it among the forms a translator may add.

The parity gate built its expected key set from CLDR categories alone, so a catalog that took the guide up on that failed, with the override reported as a stale key.

## Two halves

**Parity** now permits `_zero` where a catalog supplies one, and never requires it.

**Placeholders** needed the other half, which the first fix alone did not give. Measured against its English sibling, a zero override looks like it dropped `{{count}}` — which is the entire point of the form: *no documents deleted* names no number. A `_zero` value may now omit what its sibling interpolates, while still being rejected for inventing a placeholder nothing will supply.

I only found that second half by testing the first against a real catalog rather than trusting the unit test.

## Verification

| Case | Result |
|---|---|
| `de` gains `deletedDocuments_zero` = "Keine Dokumente gelöscht" | passes |
| same key with `{{nonsense}}` in it | fails, naming the unsupplied placeholder |
| no `_zero` anywhere (today's catalogs) | unchanged |

96 files / 1392 tests, tsc, build and i18n extraction clean.