### PR TITLE
fix(query): let the Query field show the whole query

### DIFF
--- a/src/components/FindQueryBar.tsx
+++ b/src/components/FindQueryBar.tsx
@@ -121,7 +121,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
   // to the configured height while its input stayed compact.
   const queryRowStyle = collapsibleOptions
     ? {
-        height: `${
+        minHeight: `${
           clampQueryBarHeight(themeCtx?.config.queryBarHeight ?? QUERY_BAR_HEIGHT_DEFAULT) /
           EDITOR_FONT_BASELINE_PX
         }rem`,
@@ -196,7 +196,12 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
     <div className="flex flex-col border-b border-border bg-muted/20">
       <div className="flex w-full border-b border-border">
         <div className={queryColClass(filterInvalid)}>
-          <span className={fieldBadgeClass(filterInvalid)} style={queryRowStyle}>{t('findQueryBar.labels.query')}</span>
+          <span
+            className={cn(fieldBadgeClass(filterInvalid), collapsibleOptions && 'self-stretch')}
+            style={queryRowStyle}
+          >
+            {t('findQueryBar.labels.query')}
+          </span>
           <QueryEditor
             singleLine
             large={collapsibleOptions}

--- a/src/components/FindQueryBar.tsx
+++ b/src/components/FindQueryBar.tsx
@@ -115,18 +115,15 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
   const optionsRegionId = `additional-query-options-container-${useId()}`;
   // Option rows keep the compact height regardless of the setting.
   const optionRowStyle = { height: `${QUERY_BAR_OPTION_HEIGHT / EDITOR_FONT_BASELINE_PX}rem` };
-  // The configured height applies only where the field itself is sized by it —
-  // QueryEditor keys that off `large`, which is `collapsibleOptions`. Without
-  // this gate the export view (no collapsibleOptions) would grow the QUERY label
-  // to the configured height while its input stayed compact.
-  const queryRowStyle = collapsibleOptions
-    ? {
-        minHeight: `${
-          clampQueryBarHeight(themeCtx?.config.queryBarHeight ?? QUERY_BAR_HEIGHT_DEFAULT) /
-          EDITOR_FONT_BASELINE_PX
-        }rem`,
-      }
-    : optionRowStyle;
+  // The configured height is the main query bar's floor. Export keeps the
+  // compact floor, but either Query field may grow with wrapped content and the
+  // badge stretches with its row.
+  const queryRowDesignPx = collapsibleOptions
+    ? clampQueryBarHeight(themeCtx?.config.queryBarHeight ?? QUERY_BAR_HEIGHT_DEFAULT)
+    : QUERY_BAR_OPTION_HEIGHT;
+  const queryRowStyle = {
+    minHeight: `${queryRowDesignPx / EDITOR_FONT_BASELINE_PX}rem`,
+  };
 
   const showPagination =
     skip !== undefined && limit !== undefined && !!onSkipChange && !!onLimitChange;
@@ -197,7 +194,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
       <div className="flex w-full border-b border-border">
         <div className={queryColClass(filterInvalid)}>
           <span
-            className={cn(fieldBadgeClass(filterInvalid), collapsibleOptions && 'self-stretch')}
+            className={cn(fieldBadgeClass(filterInvalid), 'self-stretch')}
             style={queryRowStyle}
           >
             {t('findQueryBar.labels.query')}
@@ -205,6 +202,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
           <QueryEditor
             singleLine
             large={collapsibleOptions}
+            growWithContent
             surface="filter"
             shellSyntax={shellSyntax}
             onRun={onRun}

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -47,6 +47,8 @@ interface QueryEditorProps {
   /** Roomier single-line field (taller row, larger font) for the primary query
    *  input, which carries almost all of the typing. */
   large?: boolean;
+  /** Wrap and grow this field with its content independently of visual size. */
+  growWithContent?: boolean;
   'data-testid'?: string;
 }
 
@@ -63,6 +65,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   stageOperator,
   shellSyntax,
   large = false,
+  growWithContent = false,
   'data-testid': testid,
 }) => {
   const fieldsRef = useRef(fields); fieldsRef.current = fields;
@@ -113,7 +116,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   const singleLinePadTop = Math.max(0, Math.round((singleLineRowPx - singleLineLineHeight) / 2));
   // Only the primary Query field grows: it carries almost all of the typing,
   // and the compact option rows beside it should not move when it does.
-  const growable = singleLine && large;
+  const growable = singleLine && (large || growWithContent);
   const [grownHeight, setGrownHeight] = useState<number | null>(null);
   const growthEditorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const growthMetricsRef = useRef({

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Editor, { type Monaco } from '@monaco-editor/react';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
 import type { Surface } from '../lib/mongoCompletions';
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils';
 import {
   clampQueryBarHeight,
   EDITOR_FONT_BASELINE_PX,
+  growQueryBarHeight,
   QUERY_BAR_HEIGHT_DEFAULT,
   QUERY_BAR_OPTION_HEIGHT,
 } from '@/lib/themes/ui-scale';
@@ -110,7 +111,12 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   const singleLineLineHeight = Math.round(singleLineFontSize * 1.4);
   // Centre the single line within the full-height box.
   const singleLinePadTop = Math.max(0, Math.round((singleLineRowPx - singleLineLineHeight) / 2));
-  const editorHeight = height ?? (singleLine ? singleLineRowPx : 120);
+  // Only the primary Query field grows: it carries almost all of the typing,
+  // and the compact option rows beside it should not move when it does.
+  const growable = singleLine && large;
+  const [grownHeight, setGrownHeight] = useState<number | null>(null);
+  const editorHeight =
+    height ?? (singleLine ? (growable ? (grownHeight ?? singleLineRowPx) : singleLineRowPx) : 120);
 
   const overflowWidgetsDomNode = getOverflowNode();
 
@@ -133,12 +139,17 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
     glyphMargin: false,
     lineDecorationsWidth: 0,
     lineNumbersMinChars: 0,
-    wordWrap: 'off' as const,
+    // The Query field wraps; the compact option rows stay on one line. Without
+    // this a long filter ran off the right edge with the horizontal scrollbar
+    // hidden, so the only way to read the rest of it was to move the caret.
+    wordWrap: (growable ? 'on' : 'off') as 'on' | 'off',
     scrollbar: {
-      vertical: 'hidden' as const,
+      // Once it has grown as far as it may, it has to be scrollable — a hidden
+      // scrollbar and a fixed height is what made the query unreachable.
+      vertical: (growable ? 'auto' : 'hidden') as 'auto' | 'hidden',
       horizontal: 'hidden' as const,
-      handleMouseWheel: false,
-      verticalScrollbarSize: 0,
+      handleMouseWheel: growable,
+      verticalScrollbarSize: growable ? 8 : 0,
       horizontalScrollbarSize: 0,
     },
     overviewRulerLanes: 0,
@@ -195,6 +206,18 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
             onRunRef.current?.();
           }
         });
+
+        if (growable) {
+          // Follow the wrapped content. `automaticLayout` handles width; height
+          // is ours, because the row it sits in has to grow with it.
+          const followContent = () => {
+            setGrownHeight(
+              growQueryBarHeight(ed.getContentHeight(), singleLineLineHeight, singleLineRowPx)
+            );
+          };
+          ed.onDidContentSizeChange(followContent);
+          followContent();
+        }
 
         if (singleLine) {
           // Let Monaco accept suggestions on Enter when the widget is open; run only when closed.

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
-import Editor, { type Monaco } from '@monaco-editor/react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Editor, { type Monaco, type OnMount } from '@monaco-editor/react';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
 import type { Surface } from '../lib/mongoCompletions';
 import type { SchemaMap } from '../lib/useCollectionSchema';
@@ -115,6 +115,28 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   // and the compact option rows beside it should not move when it does.
   const growable = singleLine && large;
   const [grownHeight, setGrownHeight] = useState<number | null>(null);
+  const growthEditorRef = useRef<Parameters<OnMount>[0] | null>(null);
+  const growthMetricsRef = useRef({ growable, lineHeight: singleLineLineHeight, minHeight: singleLineRowPx });
+  growthMetricsRef.current = { growable, lineHeight: singleLineLineHeight, minHeight: singleLineRowPx };
+  const followGrowableContent = useCallback(() => {
+    const metrics = growthMetricsRef.current;
+    const ed = growthEditorRef.current;
+    if (!metrics.growable || !ed) {
+      setGrownHeight(null);
+      return;
+    }
+    setGrownHeight(
+      growQueryBarHeight(ed.getContentHeight(), metrics.lineHeight, metrics.minHeight)
+    );
+  }, []);
+
+  // Appearance changes do not necessarily produce a Monaco content-size event.
+  // Recompute explicitly so a mounted editor follows query height, zoom and font
+  // scale changes using the current metrics rather than its mount-time values.
+  useEffect(() => {
+    followGrowableContent();
+  }, [followGrowableContent, growable, singleLineLineHeight, singleLineRowPx]);
+
   const editorHeight =
     height ?? (singleLine ? (growable ? (grownHeight ?? singleLineRowPx) : singleLineRowPx) : 120);
 
@@ -207,17 +229,12 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
           }
         });
 
-        if (growable) {
-          // Follow the wrapped content. `automaticLayout` handles width; height
-          // is ours, because the row it sits in has to grow with it.
-          const followContent = () => {
-            setGrownHeight(
-              growQueryBarHeight(ed.getContentHeight(), singleLineLineHeight, singleLineRowPx)
-            );
-          };
-          ed.onDidContentSizeChange(followContent);
-          followContent();
-        }
+        // `automaticLayout` handles width; height is ours, because the row it
+        // sits in has to grow with wrapped content. The callback reads refs so
+        // settings changed after mount cannot leave it using stale metrics.
+        growthEditorRef.current = ed;
+        const contentSizeSubscription = ed.onDidContentSizeChange(followGrowableContent);
+        followGrowableContent();
 
         if (singleLine) {
           // Let Monaco accept suggestions on Enter when the widget is open; run only when closed.
@@ -246,8 +263,12 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
             getStageOperator: () => stageOperatorRef.current,
             getShellSyntax: () => shellSyntaxRef.current,
           });
-          ed.onDidDispose(() => { if (uriRef.current) clearModelMeta(uriRef.current); });
         }
+        ed.onDidDispose(() => {
+          contentSizeSubscription.dispose();
+          if (growthEditorRef.current === ed) growthEditorRef.current = null;
+          if (uriRef.current) clearModelMeta(uriRef.current);
+        });
       }}
       options={singleLine ? singleLineOptions : multiLineOptions}
     />
@@ -270,7 +291,11 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
           '[&_.scroll-decoration]:shadow-none [&_.overflow-guard]:bg-transparent',
           className
         )}
-        style={{ height: `${singleLineRowRem}rem` }}
+        style={{
+          height: growable
+            ? (typeof editorHeight === 'number' ? `${editorHeight}px` : editorHeight)
+            : `${singleLineRowRem}rem`,
+        }}
       >
         {editor}
       </div>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -116,8 +116,18 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   const growable = singleLine && large;
   const [grownHeight, setGrownHeight] = useState<number | null>(null);
   const growthEditorRef = useRef<Parameters<OnMount>[0] | null>(null);
-  const growthMetricsRef = useRef({ growable, lineHeight: singleLineLineHeight, minHeight: singleLineRowPx });
-  growthMetricsRef.current = { growable, lineHeight: singleLineLineHeight, minHeight: singleLineRowPx };
+  const growthMetricsRef = useRef({
+    growable,
+    lineHeight: singleLineLineHeight,
+    minHeight: singleLineRowPx,
+    contentPadding: singleLinePadTop,
+  });
+  growthMetricsRef.current = {
+    growable,
+    lineHeight: singleLineLineHeight,
+    minHeight: singleLineRowPx,
+    contentPadding: singleLinePadTop,
+  };
   const followGrowableContent = useCallback(() => {
     const metrics = growthMetricsRef.current;
     const ed = growthEditorRef.current;
@@ -126,7 +136,12 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
       return;
     }
     setGrownHeight(
-      growQueryBarHeight(ed.getContentHeight(), metrics.lineHeight, metrics.minHeight)
+      growQueryBarHeight(
+        ed.getContentHeight(),
+        metrics.lineHeight,
+        metrics.minHeight,
+        metrics.contentPadding
+      )
     );
   }, []);
 
@@ -135,7 +150,7 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   // scale changes using the current metrics rather than its mount-time values.
   useEffect(() => {
     followGrowableContent();
-  }, [followGrowableContent, growable, singleLineLineHeight, singleLineRowPx]);
+  }, [followGrowableContent, growable, singleLineLineHeight, singleLinePadTop, singleLineRowPx]);
 
   const editorHeight =
     height ?? (singleLine ? (growable ? (grownHeight ?? singleLineRowPx) : singleLineRowPx) : 120);

--- a/src/components/__tests__/FindQueryBar.test.tsx
+++ b/src/components/__tests__/FindQueryBar.test.tsx
@@ -158,7 +158,10 @@ describe('FindQueryBar — export view is unaffected by the Query height setting
     themeConfig.queryBarHeight = 64;
     renderBar({ collapsibleOptions: false });
     const compact = `${22.75 / 13}rem`;
-    expect(heightOf('Query')).toBe(compact);
+    const queryLabel = screen.getByText('Query') as HTMLElement;
+    expect(queryLabel.style.minHeight).toBe(compact);
+    expect(queryLabel.style.height).toBe('');
+    expect(queryLabel).toHaveClass('self-stretch');
     expect(heightOf('Projection')).toBe(compact);
     themeConfig.queryBarHeight = 29;
   });

--- a/src/components/__tests__/FindQueryBar.test.tsx
+++ b/src/components/__tests__/FindQueryBar.test.tsx
@@ -115,13 +115,16 @@ describe('FindQueryBar — configurable Query height (#217)', () => {
   it('sizes the Query row from the setting', () => {
     themeConfig.queryBarHeight = 29;
     renderBar();
-    expect(heightOf('Query')).toBe(`${29 / 13}rem`);
+    const queryLabel = screen.getByText('Query') as HTMLElement;
+    expect(queryLabel.style.minHeight).toBe(`${29 / 13}rem`);
+    expect(queryLabel.style.height).toBe('');
+    expect(queryLabel).toHaveClass('self-stretch');
   });
 
   it('grows only the Query row — option rows stay compact', () => {
     themeConfig.queryBarHeight = 58;
     renderBar();
-    expect(heightOf('Query')).toBe(`${58 / 13}rem`);
+    expect((screen.getByText('Query') as HTMLElement).style.minHeight).toBe(`${58 / 13}rem`);
     // Projection/sort keep the compact height so the whole bar doesn't inflate.
     const compact = `${22.75 / 13}rem`;
     expect(heightOf('Projection')).toBe(compact);
@@ -141,7 +144,7 @@ describe('FindQueryBar — configurable Query height (#217)', () => {
   it('clamps an out-of-range stored value instead of trusting it', () => {
     themeConfig.queryBarHeight = 9999;
     renderBar();
-    expect(heightOf('Query')).toBe(`${64 / 13}rem`);
+    expect((screen.getByText('Query') as HTMLElement).style.minHeight).toBe(`${64 / 13}rem`);
     themeConfig.queryBarHeight = 29;
   });
 });
@@ -163,7 +166,7 @@ describe('FindQueryBar — export view is unaffected by the Query height setting
   it('still sizes the Query label when the field is sized (main query bar)', () => {
     themeConfig.queryBarHeight = 64;
     renderBar({ collapsibleOptions: true });
-    expect(heightOf('Query')).toBe(`${64 / 13}rem`);
+    expect((screen.getByText('Query') as HTMLElement).style.minHeight).toBe(`${64 / 13}rem`);
     themeConfig.queryBarHeight = 29;
   });
 

--- a/src/components/__tests__/QueryEditor.test.tsx
+++ b/src/components/__tests__/QueryEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 type KeyDownHandler = (e: {
   keyCode: number;
@@ -17,6 +17,7 @@ let lastHeight: number | string | undefined;
 let keyDownHandler: KeyDownHandler | undefined;
 let enterRunCommand: (() => void) | undefined;
 let enterRunWhen: string | undefined;
+let firstContentSizeHandler: (() => void) | undefined;
 
 vi.mock('../../lib/monacoMongo', () => ({
   registerMongoCompletionProvider: vi.fn(),
@@ -36,23 +37,25 @@ vi.mock('../../lib/monacoAppTheme', async (importOriginal) => {
 /** What Monaco reports its wrapped content needs. One line by default. */
 let mockContentHeight = 18;
 
-vi.mock('@monaco-editor/react', () => ({
-  default: ({
-    value,
-    onMount,
-    options,
-    height,
-  }: {
-    value: string;
-    options?: Record<string, unknown>;
-    height?: number | string;
-    onMount?: (ed: unknown, monaco: { KeyCode: typeof KeyCode; editor: { defineTheme: () => void; setTheme: () => void } }) => void;
-  }) => {
-    lastOptions = options;
-    lastHeight = height;
-    if (onMount) {
-      onMount(
-        {
+vi.mock('@monaco-editor/react', async () => {
+  const React = await import('react');
+  return {
+    default: ({
+      value,
+      onMount,
+      options,
+      height,
+      wrapperProps,
+    }: {
+      value: string;
+      options?: Record<string, unknown>;
+      height?: number | string;
+      wrapperProps?: Record<string, unknown>;
+      onMount?: (ed: unknown, monaco: { KeyCode: typeof KeyCode; editor: { defineTheme: () => void; setTheme: () => void } }) => void;
+    }) => {
+      lastOptions = options;
+      lastHeight = height;
+      const editorRef = React.useRef({
           onKeyDown: (handler: KeyDownHandler) => {
             keyDownHandler = handler;
           },
@@ -67,7 +70,10 @@ vi.mock('@monaco-editor/react', () => ({
           // The Query field follows its wrapped content height (#260). One
           // line's worth here, so the stock sizing assertions below still
           // describe a field showing a one-line query.
-          onDidContentSizeChange: vi.fn(),
+          onDidContentSizeChange: (handler: () => void) => {
+            firstContentSizeHandler ??= handler;
+            return { dispose: vi.fn() };
+          },
           getContentHeight: () => mockContentHeight,
           getValue: () => value,
           setValue: vi.fn(),
@@ -75,16 +81,25 @@ vi.mock('@monaco-editor/react', () => ({
           setPosition: vi.fn(),
           getModel: () => ({ uri: { toString: () => 'test://model' } }),
           onDidDispose: vi.fn(),
-        },
-        {
-          KeyCode,
-          editor: { defineTheme: vi.fn(), setTheme: vi.fn() },
-        },
+      });
+      React.useEffect(() => {
+        onMount?.(
+          editorRef.current,
+          {
+            KeyCode,
+            editor: { defineTheme: vi.fn(), setTheme: vi.fn() },
+          },
+        );
+      }, []);
+      return (
+        <div
+          data-testid={(wrapperProps?.['data-testid'] as string | undefined) ?? 'monaco'}
+          data-value={value}
+        />
       );
-    }
-    return <div data-testid="monaco" data-value={value} />;
-  },
-}));
+    },
+  };
+});
 
 const themeConfig: Record<string, unknown> = { presetId: 'mqlens-dark', mode: 'dark', fontSize: 13, uiZoom: 1, queryBarHeight: 29 };
 vi.mock('@/hooks/use-theme', () => ({
@@ -115,6 +130,7 @@ describe('QueryEditor', () => {
     keyDownHandler = undefined;
     enterRunCommand = undefined;
     enterRunWhen = undefined;
+    firstContentSizeHandler = undefined;
   });
 
   it('renders a Monaco editor with the given value', () => {
@@ -198,6 +214,7 @@ describe('QueryEditor — the Query field shows the whole query (#260)', () => {
   beforeEach(() => {
     themeConfig.queryBarHeight = 29;
     mockContentHeight = 18;
+    firstContentSizeHandler = undefined;
   });
 
   it('wraps the primary Query field', () => {
@@ -214,8 +231,36 @@ describe('QueryEditor — the Query field shows the whole query (#260)', () => {
 
   it('grows to fit a query that wraps', () => {
     mockContentHeight = 18 * 3;
-    render(<QueryEditor singleLine large surface="filter" value="" onChange={() => {}} fields={[]} />);
+    const { getByTestId } = render(
+      <QueryEditor
+        singleLine
+        large
+        surface="filter"
+        value=""
+        onChange={() => {}}
+        fields={[]}
+        data-testid="query-input"
+      />
+    );
     expect(lastHeight as number).toBeGreaterThan(29);
+    expect(getByTestId('query-input').parentElement).toHaveStyle({ height: `${lastHeight}px` });
+  });
+
+  it('recomputes wrapped height with current appearance metrics', () => {
+    mockContentHeight = 18 * 3;
+    const { rerender } = render(
+      <QueryEditor singleLine large surface="filter" value="" onChange={() => {}} fields={[]} />
+    );
+
+    themeConfig.queryBarHeight = 58;
+    rerender(
+      <QueryEditor singleLine large surface="filter" value="" onChange={() => {}} fields={[]} />
+    );
+    act(() => firstContentSizeHandler?.());
+
+    // At the larger setting the line height is 36px. Monaco's 54px content
+    // therefore occupies two rows, with the new 22px vertical padding retained.
+    expect(lastHeight).toBe(94);
   });
 
   it('stops growing, and can be scrolled from there', () => {

--- a/src/components/__tests__/QueryEditor.test.tsx
+++ b/src/components/__tests__/QueryEditor.test.tsx
@@ -33,6 +33,9 @@ vi.mock('../../lib/monacoAppTheme', async (importOriginal) => {
   };
 });
 
+/** What Monaco reports its wrapped content needs. One line by default. */
+let mockContentHeight = 18;
+
 vi.mock('@monaco-editor/react', () => ({
   default: ({
     value,
@@ -61,6 +64,11 @@ vi.mock('@monaco-editor/react', () => ({
             return 'run-on-enter';
           },
           onDidChangeModelContent: vi.fn(),
+          // The Query field follows its wrapped content height (#260). One
+          // line's worth here, so the stock sizing assertions below still
+          // describe a field showing a one-line query.
+          onDidContentSizeChange: vi.fn(),
+          getContentHeight: () => mockContentHeight,
           getValue: () => value,
           setValue: vi.fn(),
           getPosition: () => null,
@@ -179,5 +187,44 @@ describe('QueryEditor — size follows the query bar height setting', () => {
     // Equal space above and below the line within the 58px row.
     expect(padTop.top).toBe(Math.max(0, Math.round((58 - lineHeight) / 2)));
     themeConfig.queryBarHeight = 29;
+  });
+});
+
+describe('QueryEditor — the Query field shows the whole query (#260)', () => {
+  // Reported as "the height of the query section is locked, so a multiline
+  // query is not fully visible": the field did not wrap, its horizontal
+  // scrollbar was hidden, and raising the height setting only made one line
+  // taller. Nothing could bring the rest of the query on screen.
+  beforeEach(() => {
+    themeConfig.queryBarHeight = 29;
+    mockContentHeight = 18;
+  });
+
+  it('wraps the primary Query field', () => {
+    render(<QueryEditor singleLine large surface="filter" value="" onChange={() => {}} fields={[]} />);
+    expect(lastOptions?.wordWrap).toBe('on');
+  });
+
+  it('leaves the compact option rows on one line', () => {
+    // Projection, sort, skip and limit hold short values and must not move
+    // when the query above them grows.
+    render(<QueryEditor singleLine surface="filter" value="" onChange={() => {}} fields={[]} />);
+    expect(lastOptions?.wordWrap).toBe('off');
+  });
+
+  it('grows to fit a query that wraps', () => {
+    mockContentHeight = 18 * 3;
+    render(<QueryEditor singleLine large surface="filter" value="" onChange={() => {}} fields={[]} />);
+    expect(lastHeight as number).toBeGreaterThan(29);
+  });
+
+  it('stops growing, and can be scrolled from there', () => {
+    mockContentHeight = 18 * 200;
+    render(<QueryEditor singleLine large surface="filter" value="" onChange={() => {}} fields={[]} />);
+    const capped = lastHeight as number;
+    expect(capped).toBeLessThan(18 * 200);
+    // A hidden scrollbar over a fixed height is what made the query
+    // unreachable in the first place.
+    expect((lastOptions?.scrollbar as { vertical: string }).vertical).toBe('auto');
   });
 });

--- a/src/components/__tests__/QueryEditor.test.tsx
+++ b/src/components/__tests__/QueryEditor.test.tsx
@@ -108,6 +108,7 @@ vi.mock('@/hooks/use-theme', () => ({
 }));
 
 import { QueryEditor } from '../QueryEditor';
+import { QUERY_BAR_OPTION_HEIGHT } from '@/lib/themes/ui-scale';
 
 function pressEnter(modifiers: Partial<{ ctrlKey: boolean; metaKey: boolean; shiftKey: boolean }> = {}) {
   const preventDefault = vi.fn();
@@ -220,6 +221,22 @@ describe('QueryEditor — the Query field shows the whole query (#260)', () => {
   it('wraps the primary Query field', () => {
     render(<QueryEditor singleLine large surface="filter" value="" onChange={() => {}} fields={[]} />);
     expect(lastOptions?.wordWrap).toBe('on');
+  });
+
+  it('wraps and grows the primary Query field with compact export styling', () => {
+    mockContentHeight = 18 * 3;
+    render(
+      <QueryEditor
+        singleLine
+        growWithContent
+        surface="filter"
+        value=""
+        onChange={() => {}}
+        fields={[]}
+      />
+    );
+    expect(lastOptions?.wordWrap).toBe('on');
+    expect(lastHeight as number).toBeGreaterThan(QUERY_BAR_OPTION_HEIGHT);
   });
 
   it('does not grow a one-line query just because Monaco includes top padding', () => {

--- a/src/components/__tests__/QueryEditor.test.tsx
+++ b/src/components/__tests__/QueryEditor.test.tsx
@@ -222,6 +222,13 @@ describe('QueryEditor — the Query field shows the whole query (#260)', () => {
     expect(lastOptions?.wordWrap).toBe('on');
   });
 
+  it('does not grow a one-line query just because Monaco includes top padding', () => {
+    // 18px text + the default 6px Monaco top padding still represents one row.
+    mockContentHeight = 24;
+    render(<QueryEditor singleLine large surface="filter" value="" onChange={() => {}} fields={[]} />);
+    expect(lastHeight).toBe(29);
+  });
+
   it('leaves the compact option rows on one line', () => {
     // Projection, sort, skip and limit hold short values and must not move
     // when the query above them grows.

--- a/src/lib/themes/__tests__/ui-scale.test.ts
+++ b/src/lib/themes/__tests__/ui-scale.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   clampUiZoom,
+  growQueryBarHeight,
   computeEffectiveUiScale,
   stepUiZoom,
   UI_ZOOM_DEFAULT,
@@ -26,5 +27,39 @@ describe('ui zoom', () => {
     const base = computeEffectiveUiScale(UI_ZOOM_DEFAULT);
     const zoomed = computeEffectiveUiScale(1.1);
     expect(zoomed).toBeGreaterThan(base);
+  });
+});
+
+describe('growQueryBarHeight — showing the whole query (#260)', () => {
+  // A 29px row with an 18px line: 11px of padding centres one line in the box.
+  const MIN = 29;
+  const LINE = 18;
+
+  it('leaves a query that fits at the configured height', () => {
+    // The setting still sets the floor — a one-line query must not shrink the
+    // bar below what the user asked for.
+    expect(growQueryBarHeight(LINE, LINE, MIN)).toBe(MIN);
+    expect(growQueryBarHeight(4, LINE, MIN)).toBe(MIN);
+  });
+
+  it('grows a row per wrapped line, keeping the padding', () => {
+    // Two wrapped lines need two line-heights plus the padding the single-line
+    // box already carried, or the second line sits against the edge.
+    expect(growQueryBarHeight(LINE * 2, LINE, MIN)).toBe(2 * LINE + (MIN - LINE));
+    expect(growQueryBarHeight(LINE * 3, LINE, MIN)).toBe(3 * LINE + (MIN - LINE));
+  });
+
+  it('stops growing at the cap, so the bar cannot take over the window', () => {
+    const capped = growQueryBarHeight(LINE * 40, LINE, MIN, 6);
+    expect(capped).toBe(6 * LINE + (MIN - LINE));
+    // Past the cap it is the same height whatever else arrives — the editor
+    // scrolls from there.
+    expect(growQueryBarHeight(LINE * 400, LINE, MIN, 6)).toBe(capped);
+  });
+
+  it('falls back to the configured height on nonsense input', () => {
+    // `getContentHeight()` before layout, a zero line-height mid-resize.
+    expect(growQueryBarHeight(Number.NaN, LINE, MIN)).toBe(MIN);
+    expect(growQueryBarHeight(LINE * 3, 0, MIN)).toBe(MIN);
   });
 });

--- a/src/lib/themes/__tests__/ui-scale.test.ts
+++ b/src/lib/themes/__tests__/ui-scale.test.ts
@@ -49,12 +49,20 @@ describe('growQueryBarHeight — showing the whole query (#260)', () => {
     expect(growQueryBarHeight(LINE * 3, LINE, MIN)).toBe(3 * LINE + (MIN - LINE));
   });
 
+  it('does not count Monaco editor padding as another wrapped row', () => {
+    const monacoPadding = 6;
+    expect(growQueryBarHeight(LINE + monacoPadding, LINE, MIN, monacoPadding)).toBe(MIN);
+    expect(growQueryBarHeight(LINE * 2 + monacoPadding, LINE, MIN, monacoPadding)).toBe(
+      2 * LINE + (MIN - LINE)
+    );
+  });
+
   it('stops growing at the cap, so the bar cannot take over the window', () => {
-    const capped = growQueryBarHeight(LINE * 40, LINE, MIN, 6);
+    const capped = growQueryBarHeight(LINE * 40, LINE, MIN, 0, 6);
     expect(capped).toBe(6 * LINE + (MIN - LINE));
     // Past the cap it is the same height whatever else arrives — the editor
     // scrolls from there.
-    expect(growQueryBarHeight(LINE * 400, LINE, MIN, 6)).toBe(capped);
+    expect(growQueryBarHeight(LINE * 400, LINE, MIN, 0, 6)).toBe(capped);
   });
 
   it('falls back to the configured height on nonsense input', () => {

--- a/src/lib/themes/ui-scale.ts
+++ b/src/lib/themes/ui-scale.ts
@@ -13,6 +13,37 @@ export const QUERY_BAR_HEIGHT_DEFAULT = 29;
  *  whatever the query field is set to — like Compass, where only the primary
  *  document editor grows and the small inputs never do. */
 export const QUERY_BAR_OPTION_HEIGHT = 22.75;
+/** How many wrapped rows the Query field grows to before it starts scrolling.
+ *  Enough for a filter that spans a few lines; past that the bar would take
+ *  over the window it sits above. */
+export const QUERY_BAR_GROW_MAX_ROWS = 6;
+
+/**
+ * The height the Query field should take to show what is in it.
+ *
+ * The field wraps, so a long filter occupies several rows; without this it
+ * stayed one row tall and the rest of the query was simply not on screen — no
+ * wrap, no horizontal scrollbar, reachable only by moving the caret. Raising
+ * the height setting could not help, because one line stays one line however
+ * tall the box is.
+ *
+ * Never smaller than the configured row height, so the setting still sets the
+ * floor, and never taller than `QUERY_BAR_GROW_MAX_ROWS` rows.
+ */
+export function growQueryBarHeight(
+  contentHeight: number,
+  lineHeight: number,
+  minHeight: number,
+  maxRows: number = QUERY_BAR_GROW_MAX_ROWS
+): number {
+  if (!Number.isFinite(contentHeight) || !Number.isFinite(lineHeight) || lineHeight <= 0) {
+    return minHeight;
+  }
+  const rows = Math.max(1, Math.min(maxRows, Math.ceil(contentHeight / lineHeight)));
+  const padding = Math.max(0, minHeight - lineHeight);
+  return Math.max(minHeight, Math.round(rows * lineHeight + padding));
+}
+
 export function clampQueryBarHeight(px: number): number {
   if (!Number.isFinite(px)) return QUERY_BAR_HEIGHT_DEFAULT;
   return Math.round(Math.min(Math.max(px, QUERY_BAR_HEIGHT_MIN), QUERY_BAR_HEIGHT_MAX));

--- a/src/lib/themes/ui-scale.ts
+++ b/src/lib/themes/ui-scale.ts
@@ -34,12 +34,19 @@ export function growQueryBarHeight(
   contentHeight: number,
   lineHeight: number,
   minHeight: number,
+  contentPadding: number = 0,
   maxRows: number = QUERY_BAR_GROW_MAX_ROWS
 ): number {
   if (!Number.isFinite(contentHeight) || !Number.isFinite(lineHeight) || lineHeight <= 0) {
     return minHeight;
   }
-  const rows = Math.max(1, Math.min(maxRows, Math.ceil(contentHeight / lineHeight)));
+  // Monaco includes its configured editor padding in getContentHeight(). That
+  // padding positions the text inside the row; it is not another visual line.
+  const paddingInsideContent = Number.isFinite(contentPadding)
+    ? Math.max(0, contentPadding)
+    : 0;
+  const textHeight = Math.max(0, contentHeight - paddingInsideContent);
+  const rows = Math.max(1, Math.min(maxRows, Math.ceil(textHeight / lineHeight)));
   const padding = Math.max(0, minHeight - lineHeight);
   return Math.max(minHeight, Math.round(rows * lineHeight + padding));
 }


### PR DESCRIPTION
Fixes #260.

## Why nothing could bring the query on screen

Three things compounded in the Find query field:

| | |
|---|---|
| newlines flattened on paste | a multi-line query becomes one long line |
| `wordWrap: 'off'` | that line never wraps |
| `scrollbar.horizontal: 'hidden'`, size `0` | and there is no scrollbar to reach the rest of it |

So the remainder was reachable only by moving the caret. The reporter read it as a locked height, and the reason that reading is natural is that **the one available control cannot help**: Settings → Appearance → Query bar height is clamped 23–64px, and without wrapping a taller box is just one taller line.

**Not a regression.** The field has been single-line since long before the height setting arrived in v0.15.0; that change made the bar roomier, not more locked.

## What changes

The primary Query field wraps and follows its content — a row at a time, up to six, scrolling past that. The height setting keeps its job as the floor.

The compact option rows (projection, sort, skip, limit) are untouched: they hold short values and should not move when the query above them grows. That is the same split the code already documents, where only the primary editor is sized by the setting.

Enter still runs the query, and newlines are still flattened on paste — which is exactly what keeps that binding unambiguous. A pasted pretty-printed filter therefore becomes one wrapped query rather than several lines; it is readable, but its indentation is not preserved. Say the word if it should keep the formatting instead, since that means moving to Shift+Enter for newlines.

## Verification

- 96 files / 1400 tests, tsc, build, i18n clean
- the height rule is a pure function with its own tests (floor, per-row growth, cap, garbage input), each confirmed to fail with the fix removed
- component tests that the Query field wraps and grows, that option rows do not, and that it becomes scrollable at the cap

**What I could not verify:** how it looks. There is no way for me to run the GUI here, so the growing row against the QUERY badge and the eraser button — both vertically centred — wants an eyeball before merge.