### PR TITLE
Improve collection tab identification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -336,7 +336,8 @@ const tabIconFor = (tab: QueryTab, isActive: boolean): React.ReactNode => {
 export const tabLabelFor = (
   tab: QueryTab,
   connectionName: (connectionId: string) => string,
-  t: TFunction
+  t: TFunction,
+  openTabs: QueryTab[] = [tab]
 ): string => {
   switch (tab.type) {
     case 'index':
@@ -378,10 +379,28 @@ export const tabLabelFor = (
       return t('tabs.validation', { collection: tab.collection });
     case 'generate':
       return t('tabs.generate', { name: tab.collection || tab.db });
-    default:
-      return tab.collection;
+    default: {
+      const collisions = openTabs.filter(
+        candidate => candidate.type === 'collection' && candidate.collection === tab.collection
+      );
+      if (collisions.length < 2) return tab.collection;
+
+      const namespaceCollides = collisions.some(
+        candidate => candidate.id !== tab.id && candidate.db === tab.db
+      );
+      return namespaceCollides
+        ? `${connectionName(tab.connectionId)} / ${tab.db}:${tab.collection}`
+        : `${tab.db}:${tab.collection}`;
+    }
   }
 };
+
+export const tabTooltipFor = (
+  tab: QueryTab,
+  connectionName: (connectionId: string) => string
+): string | undefined => tab.type === 'collection'
+  ? `${connectionName(tab.connectionId)} / ${tab.db}.${tab.collection}`
+  : undefined;
 
 /**
  * Tab types that operate on a live connection — everything except
@@ -4558,7 +4577,12 @@ function Workspace() {
           pane.tabIds
             .map(id => tabs.find(t => t.id === id))
             .filter((t): t is QueryTab => !!t)
-            .map(tab => ({ id: tab.id, label: tabLabelFor(tab, connectionNameFor, t), icon: tabIconFor(tab, tab.id === pane.activeTabId) }))
+            .map(tab => ({
+              id: tab.id,
+              label: tabLabelFor(tab, connectionNameFor, t, tabs),
+              tooltip: tabTooltipFor(tab, connectionNameFor),
+              icon: tabIconFor(tab, tab.id === pane.activeTabId),
+            }))
         }
         renderTabContent={renderTabContent}
         renderEmptyPane={renderEmptyPane}

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -2,7 +2,39 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/render-with-providers';
 import { resetUpdateTabStateDebounce } from '../../workspace/workspaceStore';
-import App, { tabLabelFor, type QueryTab } from '../../App';
+import App, { tabLabelFor, tabTooltipFor, type QueryTab } from '../../App';
+
+describe('collection tab labels', () => {
+  const t = ((key: string) => key) as any;
+  const connectionName = (id: string) => ({ primary: 'Primary', reporting: 'Reporting' }[id] ?? id);
+  const collectionTab = (id: string, connectionId: string, db: string, collection: string) => ({
+    id,
+    type: 'collection',
+    connectionId,
+    db,
+    collection,
+  } as QueryTab);
+
+  it('shows only the collection name when it is unique', () => {
+    const tab = collectionTab('one', 'primary', 'main', 'rates');
+    expect(tabLabelFor(tab, connectionName, t, [tab])).toBe('rates');
+    expect(tabTooltipFor(tab, connectionName)).toBe('Primary / main.rates');
+  });
+
+  it('prefixes the database when the same collection name is open from different databases', () => {
+    const main = collectionTab('one', 'primary', 'main', 'rates');
+    const test = collectionTab('two', 'primary', 'test', 'rates');
+    expect(tabLabelFor(main, connectionName, t, [main, test])).toBe('main:rates');
+    expect(tabLabelFor(test, connectionName, t, [main, test])).toBe('test:rates');
+  });
+
+  it('also prefixes the connection when database and collection names collide', () => {
+    const primary = collectionTab('one', 'primary', 'main', 'rates');
+    const reporting = collectionTab('two', 'reporting', 'main', 'rates');
+    expect(tabLabelFor(primary, connectionName, t, [primary, reporting])).toBe('Primary / main:rates');
+    expect(tabLabelFor(reporting, connectionName, t, [primary, reporting])).toBe('Reporting / main:rates');
+  });
+});
 
 vi.mock('../../lib/vault', () => ({
   getVaultStatus: vi.fn().mockResolvedValue('unlocked'),

--- a/src/components/layout/WorkspaceTabBar.tsx
+++ b/src/components/layout/WorkspaceTabBar.tsx
@@ -16,6 +16,7 @@ export const TAB_DRAG_MIME = 'application/x-mqlens-tab';
 export interface WorkspaceTab {
   id: string;
   label: string;
+  tooltip?: string;
   icon: React.ReactNode;
   pinned?: boolean;
 }
@@ -88,7 +89,7 @@ export function WorkspaceTabBar({
                   }}
                 >
                   <span className="shrink-0">{tab.icon}</span>
-                  <span className="truncate font-medium">{tab.label}</span>
+                  <span className="truncate font-medium" title={tab.tooltip}>{tab.label}</span>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button

--- a/src/workspace/__tests__/WorkspaceRoot.test.tsx
+++ b/src/workspace/__tests__/WorkspaceRoot.test.tsx
@@ -32,6 +32,26 @@ describe('WorkspaceRoot', () => {
     expect(screen.getByText('B')).toBeInTheDocument();
   });
 
+  it('shows a tab tooltip with the full namespace', () => {
+    const layout = createInitialLayout(['rates'], 'rates');
+    render(
+      <WorkspaceRoot
+        layout={layout}
+        dispatch={vi.fn()}
+        tabsFor={(pane) => pane.tabIds.map(id => ({
+          id,
+          label: 'rates',
+          tooltip: 'Primary / main.rates',
+          icon: null,
+        }))}
+        renderTabContent={() => <div />}
+        renderEmptyPane={() => <div />}
+      />,
+    );
+
+    expect(screen.getByText('rates')).toHaveAttribute('title', 'Primary / main.rates');
+  });
+
   it('renders both panes of a split with their own content simultaneously', () => {
     let l = createInitialLayout(['a', 'b'], 'a');
     l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });


### PR DESCRIPTION
## Summary

Implements the next focused collection-tab UX items from the [issue #260 follow-up](https://github.com/mqlens/mqlens-mongodb/issues/260#issuecomment-5297061440):

- keep unique collection tabs compact (`rates`)
- disambiguate duplicate collection names by database (`main:rates`, `test:rates`)
- include the connection when the same database namespace exists on multiple connections
- expose the full `connection / database.collection` namespace as a tab tooltip

Refs #260

## Verification

- `npm test -- --maxWorkers=1` — 1,408 passed, 4 skipped
- `npm run build`
- backend tests not run locally because Cargo is not installed in the workspace image; this patch changes frontend code only