### PR TITLE
feat(tabs): add persistent tab colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,6 +123,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { FolderCode, KeyRound, Radio, X, ChevronsRight, XSquare, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck, ExternalLink, MoveRight, Wand2, Lock, ShieldAlert } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
+import { loadTabColors, saveTabColor, TAB_COLORS, tabColorCss, type TabColorId } from './lib/tabColors';
 
 export interface QueryTab {
   id: string;
@@ -402,6 +403,18 @@ export const tabTooltipFor = (
   ? `${connectionName(tab.connectionId)} / ${tab.db}.${tab.collection}`
   : undefined;
 
+const tabColorLabel = (t: TFunction, color: TabColorId): string => {
+  switch (color) {
+    case 'slate': return t('shell:workspaceTabBar.contextMenu.tabColors.slate');
+    case 'red': return t('shell:workspaceTabBar.contextMenu.tabColors.red');
+    case 'orange': return t('shell:workspaceTabBar.contextMenu.tabColors.orange');
+    case 'amber': return t('shell:workspaceTabBar.contextMenu.tabColors.amber');
+    case 'green': return t('shell:workspaceTabBar.contextMenu.tabColors.green');
+    case 'blue': return t('shell:workspaceTabBar.contextMenu.tabColors.blue');
+    case 'violet': return t('shell:workspaceTabBar.contextMenu.tabColors.violet');
+  }
+};
+
 /**
  * Tab types that operate on a live connection — everything except
  * `settings`/`quickstart`/`tasks`, which render regardless of (or without)
@@ -462,6 +475,7 @@ function Workspace() {
   const isMainWindow = windowLabel() === 'main';
   // Open the Quick Start tab by default so the app never starts on a blank canvas.
   const [tabs, setTabs] = useState<QueryTab[]>([createQuickStartTab()]);
+  const [tabColors, setTabColors] = useState(loadTabColors);
   // Foreign-event reconciliation (below) runs inside a `listen` callback
   // captured once at mount — it can never see a fresh `tabs` STATE value
   // from that closure, same staleness problem `activeConnectionsRef` exists
@@ -2618,6 +2632,30 @@ function Workspace() {
       });
     }
 
+    if (dupSource) {
+      const stableTabId = toProfileSpaceId(tabId, activeConnections);
+      const selected = tabColors[stableTabId];
+      items.push({
+        label: tShell('workspaceTabBar.contextMenu.tabColorDefault'),
+        icon: <span className="size-3 rounded-full border border-current" />,
+        separatorBefore: items.length > 0,
+        onClick: () => setTabColors(saveTabColor(stableTabId, undefined)),
+      });
+      TAB_COLORS.forEach(color => {
+        const colorId = color.id as TabColorId;
+        items.push({
+          label: tabColorLabel(tShell, colorId),
+          icon: (
+            <span
+              className={`size-3 rounded-full ${selected === colorId ? 'ring-2 ring-ring ring-offset-1' : ''}`}
+              style={{ backgroundColor: tabColorCss(colorId) }}
+            />
+          ),
+          onClick: () => setTabColors(saveTabColor(stableTabId, colorId)),
+        });
+      });
+    }
+
     if (!isUnmirrored && allTabIds(layout).length > 1) {
       items.push({
         label: tShell('workspaceTabBar.contextMenu.detachToNewWindow'),
@@ -4581,6 +4619,10 @@ function Workspace() {
               id: tab.id,
               label: tabLabelFor(tab, connectionNameFor, t, tabs),
               tooltip: tabTooltipFor(tab, connectionNameFor),
+              accentColor: (() => {
+                const color = tabColors[toProfileSpaceId(tab.id, activeConnections)];
+                return color ? tabColorCss(color) : undefined;
+              })(),
               icon: tabIconFor(tab, tab.id === pane.activeTabId),
             }))
         }

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -4002,6 +4002,21 @@ describe('App Component', () => {
   });
 
   describe('tab context menu — detach/move (Phase 3 Task 5)', () => {
+    it('sets and persists a subdued collection tab color', async () => {
+      const { fireEvent, within } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      const customersTab = await within(tabStrip).findByText('customers');
+      fireEvent.contextMenu(customersTab.closest('div')!);
+      fireEvent.click(await screen.findByText('Tab color: Blue'));
+
+      expect(within(tabStrip).getByTestId('tab-accent-conn-1.sales_db.customers')).toBeInTheDocument();
+      expect(localStorage.getItem('mqlens-tab-colors')).toContain('"blue"');
+    });
+
     // Seeds lastWorkspaceRef with a second open window (win-1, active tab
     // "orders") via a workspace-changed event — the same seeding technique
     // Task 4's reconciliation tests use. `crossWindow: false` is deliberate:

--- a/src/components/layout/WorkspaceTabBar.tsx
+++ b/src/components/layout/WorkspaceTabBar.tsx
@@ -17,6 +17,7 @@ export interface WorkspaceTab {
   id: string;
   label: string;
   tooltip?: string;
+  accentColor?: string;
   icon: React.ReactNode;
   pinned?: boolean;
 }
@@ -88,6 +89,13 @@ export function WorkspaceTabBar({
                     onTabContextMenu(tab.id, e);
                   }}
                 >
+                  {tab.accentColor && (
+                    <span
+                      data-testid={`tab-accent-${tab.id}`}
+                      className="absolute inset-x-1 top-0 h-0.5 rounded-full"
+                      style={{ backgroundColor: tab.accentColor }}
+                    />
+                  )}
                   <span className="shrink-0">{tab.icon}</span>
                   <span className="truncate font-medium" title={tab.tooltip}>{tab.label}</span>
                   <Tooltip>

--- a/src/lib/__tests__/tabColors.test.ts
+++ b/src/lib/__tests__/tabColors.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadTabColors, saveTabColor, TAB_COLORS } from '../tabColors';
+
+describe('tab colors', () => {
+  it('offers exactly seven subdued colors', () => {
+    expect(TAB_COLORS).toHaveLength(7);
+    expect(TAB_COLORS.every(color => color.saturation <= 50)).toBe(true);
+  });
+
+  it('persists a color by stable tab id and can reset it', () => {
+    const storage = { getItem: vi.fn<() => string | null>(() => null), setItem: vi.fn() };
+    saveTabColor('collection.profile:one.main.rates', 'blue', storage);
+    expect(storage.setItem).toHaveBeenLastCalledWith(
+      'mqlens-tab-colors',
+      JSON.stringify({ 'collection.profile:one.main.rates': 'blue' }),
+    );
+
+    storage.getItem.mockReturnValue(JSON.stringify({ 'collection.profile:one.main.rates': 'blue' }));
+    saveTabColor('collection.profile:one.main.rates', undefined, storage);
+    expect(storage.setItem).toHaveBeenLastCalledWith('mqlens-tab-colors', '{}');
+  });
+
+  it('ignores malformed storage and unknown colors', () => {
+    expect(loadTabColors({ getItem: () => '{bad', setItem: vi.fn() })).toEqual({});
+    expect(loadTabColors({
+      getItem: () => JSON.stringify({ good: 'green', bad: 'neon' }),
+      setItem: vi.fn(),
+    })).toEqual({ good: 'green' });
+  });
+});

--- a/src/lib/tabColors.ts
+++ b/src/lib/tabColors.ts
@@ -1,0 +1,49 @@
+export const TAB_COLORS = [
+  { id: 'slate', hue: 215, saturation: 16, lightness: 47 },
+  { id: 'red', hue: 0, saturation: 45, lightness: 55 },
+  { id: 'orange', hue: 28, saturation: 48, lightness: 52 },
+  { id: 'amber', hue: 45, saturation: 46, lightness: 50 },
+  { id: 'green', hue: 145, saturation: 38, lightness: 45 },
+  { id: 'blue', hue: 210, saturation: 45, lightness: 55 },
+  { id: 'violet', hue: 270, saturation: 38, lightness: 58 },
+] as const;
+
+export type TabColorId = typeof TAB_COLORS[number]['id'];
+export type TabColorMap = Record<string, TabColorId>;
+type StorageLike = Pick<Storage, 'getItem' | 'setItem'>;
+const STORAGE_KEY = 'mqlens-tab-colors';
+const validIds = new Set<string>(TAB_COLORS.map(color => color.id));
+
+export const tabColorCss = (id: TabColorId): string => {
+  const color = TAB_COLORS.find(candidate => candidate.id === id)!;
+  return `hsl(${color.hue}, ${color.saturation}%, ${color.lightness}%)`;
+};
+
+export function loadTabColors(storage: StorageLike = localStorage): TabColorMap {
+  try {
+    const parsed = JSON.parse(storage.getItem(STORAGE_KEY) ?? '{}');
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter((entry): entry is [string, TabColorId] =>
+        typeof entry[1] === 'string' && validIds.has(entry[1]))
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function saveTabColor(
+  stableTabId: string,
+  color: TabColorId | undefined,
+  storage: StorageLike = localStorage,
+): TabColorMap {
+  const next = { ...loadTabColors(storage) };
+  if (color) next[stableTabId] = color;
+  else delete next[stableTabId];
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Keep the in-memory choice when storage is unavailable.
+  }
+  return next;
+}

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -529,6 +529,16 @@
       "detachToNewWindow": "In neues Fenster abdocken",
       "duplicateTab": "Tab duplizieren",
       "moveToWindow": "Verschieben nach {{target}}",
+      "tabColorDefault": "Tab-Farbe: Standard",
+      "tabColors": {
+        "amber": "Tab-Farbe: Bernstein",
+        "blue": "Tab-Farbe: Blau",
+        "green": "Tab-Farbe: Grün",
+        "orange": "Tab-Farbe: Orange",
+        "red": "Tab-Farbe: Rot",
+        "slate": "Tab-Farbe: Schiefergrau",
+        "violet": "Tab-Farbe: Violett"
+      },
       "unmirroredExplanation": "Export-/Import-Tabs bleiben in ihrem Fenster"
     }
   }

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -529,6 +529,16 @@
       "detachToNewWindow": "Detach to New Window",
       "duplicateTab": "Duplicate Tab",
       "moveToWindow": "Move to {{target}}",
+      "tabColorDefault": "Tab color: Default",
+      "tabColors": {
+        "amber": "Tab color: Amber",
+        "blue": "Tab color: Blue",
+        "green": "Tab color: Green",
+        "orange": "Tab color: Orange",
+        "red": "Tab color: Red",
+        "slate": "Tab color: Slate",
+        "violet": "Tab color: Violet"
+      },
       "unmirroredExplanation": "Export/import tabs stay in their window"
     }
   }

--- a/src/locales/zh-Hans/shell.json
+++ b/src/locales/zh-Hans/shell.json
@@ -517,6 +517,16 @@
       "detachToNewWindow": "分离到新窗口",
       "duplicateTab": "复制标签页",
       "moveToWindow": "移动到{{target}}",
+      "tabColorDefault": "标签页颜色：默认",
+      "tabColors": {
+        "amber": "标签页颜色：琥珀色",
+        "blue": "标签页颜色：蓝色",
+        "green": "标签页颜色：绿色",
+        "orange": "标签页颜色：橙色",
+        "red": "标签页颜色：红色",
+        "slate": "标签页颜色：灰色",
+        "violet": "标签页颜色：紫色"
+      },
       "unmirroredExplanation": "导出/导入标签页会保留在各自的窗口中"
     }
   }

--- a/src/workspace/__tests__/WorkspaceRoot.test.tsx
+++ b/src/workspace/__tests__/WorkspaceRoot.test.tsx
@@ -52,6 +52,23 @@ describe('WorkspaceRoot', () => {
     expect(screen.getByText('rates')).toHaveAttribute('title', 'Primary / main.rates');
   });
 
+  it('renders a selected tab accent color', () => {
+    const layout = createInitialLayout(['rates'], 'rates');
+    render(
+      <WorkspaceRoot
+        layout={layout}
+        dispatch={vi.fn()}
+        tabsFor={(pane) => pane.tabIds.map(id => ({ id, label: id, icon: null, accentColor: 'hsl(210, 45%, 55%)' }))}
+        renderTabContent={() => <div />}
+        renderEmptyPane={() => <div />}
+      />,
+    );
+    expect(screen.getByTestId('tab-accent-rates')).toHaveAttribute(
+      'style',
+      'background-color: rgb(89, 140, 192);',
+    );
+  });
+
   it('renders both panes of a split with their own content simultaneously', () => {
     let l = createInitialLayout(['a', 'b'], 'a');
     l = workspaceReducer(l, { type: 'split_pane', paneId: l.root.id, dir: 'row', side: 'end', moveTabId: 'b' });


### PR DESCRIPTION
## Summary

Implements the next tab UX item from the [issue #260 follow-up](https://github.com/mqlens/mqlens-mongodb/issues/260#issuecomment-5297061440):

- adds seven selectable collection-tab colors, all capped at 50% saturation
- renders the selection as a subtle top accent instead of tinting the whole tab
- persists choices by stable profile-space tab ID across restarts and reconnects
- provides a Default option to clear a color
- localizes the menu in English, German, and Simplified Chinese

Refs #260

## Verification

- focused TDD tests: tab palette, persistence/reset, context-menu selection, and accent rendering
- `tsc --noEmit`
- `npm run build`
- `npm run i18n:check`

The workspace environment repeatedly interrupted the complete serial Vitest process; the full suite is therefore left to this PR's CI gate.