### PR TITLE
feat(documents): redesign query workspace hierarchy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,16 +238,6 @@ interface ActiveConnection {
   mode?: 'normal' | 'read_only' | 'confirm_destructive';
 }
 
-/** Extract the auth username from a MongoDB connection URI; '' when there are no credentials. */
-function usernameFromUri(uri: string): string {
-  try {
-    const { username } = new URL(uri);
-    return username ? decodeURIComponent(username) : '';
-  } catch {
-    return '';
-  }
-}
-
 const QUICK_START_TAB_ID = 'quickstart';
 
 const createQuickStartTab = (): QueryTab => ({
@@ -4008,13 +3998,11 @@ function Workspace() {
         {tab.type === 'collection' && (() => {
           const activeConnection = activeConnections.find(c => c.id === tab.connectionId);
           const connectionName = activeConnection ? activeConnection.name : 'cmi-dev';
-          const connectionUser = activeConnection ? usernameFromUri(activeConnection.uri) : '';
           return (
             <DocumentViewer
               key={tab.id}
               connectionId={tab.connectionId}
               connectionName={connectionName}
-              connectionUser={connectionUser}
               databaseName={tab.db}
               collectionName={tab.collection}
               initialBuilderState={

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect, useContext } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { DocumentViewerContext } from './DocumentViewer';
 import { List } from 'react-window';
-import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, Table2, BarChart3, Lightbulb, GitCompareArrows } from 'lucide-react';
+import { Table, Braces, ChevronRight, ChevronDown, ListFilter, Copy, Check, Edit, Trash2, Plus, BarChart3, Lightbulb, GitCompareArrows } from 'lucide-react';
 import { ChartView } from './ChartView';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { DocumentDiffModal } from './DocumentDiffModal';
@@ -1308,6 +1308,16 @@ export const DataGrid: React.FC<DataGridProps> = ({
       >
 
         <div className="flex items-center gap-0.5 rounded-lg bg-muted/50 p-0.5">
+          {onAnalyzeSchema && (
+            <button
+              type="button"
+              onClick={onAnalyzeSchema}
+              className="rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-all hover:text-foreground"
+              data-testid="analyze-schema-btn"
+            >
+              {t('dataGrid.actions.schema')}
+            </button>
+          )}
           <button
             onClick={() => setActiveTab('results')}
             className={cn(
@@ -1346,6 +1356,17 @@ export const DataGrid: React.FC<DataGridProps> = ({
           )}
         </div>
 
+        {onPageChange && onPageSizeChange && typeof limit === 'number' && (
+          <span className="ml-2 text-[11px] font-semibold text-foreground" data-testid="pager-page-top">
+            {typeof totalCount === 'number'
+              ? t('dataGrid.labels.pageOf', {
+                  page: Math.floor((skip || 0) / (limit || 50)) + 1,
+                  totalPages: Math.max(1, Math.ceil(totalCount / (limit || 50))),
+                })
+              : t('dataGrid.labels.page', { page: Math.floor((skip || 0) / (limit || 50)) + 1 })}
+          </span>
+        )}
+
         {/* Right Side Controls */}
         <div className="flex items-center gap-2">
           {activeTab === 'results' && onInsertDocument && (
@@ -1360,20 +1381,6 @@ export const DataGrid: React.FC<DataGridProps> = ({
             >
               <Plus size={12} />
               {t('dataGrid.actions.insert')}
-            </Button>
-          )}
-          {activeTab === 'results' && onAnalyzeSchema && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={onAnalyzeSchema}
-              className="h-7 gap-1.5 text-[11px]"
-              title={t('dataGrid.tooltips.analyzeSchema')}
-              data-testid="analyze-schema-btn"
-            >
-              <Table2 size={12} />
-              {t('dataGrid.actions.schema')}
             </Button>
           )}
           {activeTab === 'results' && onUpdateMany && (

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -39,23 +39,17 @@ import {
 } from '@/components/ui/resizable';
 import { useDefaultLayout, type Layout } from 'react-resizable-panels';
 import { cn } from '@/lib/utils';
-import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 import {
   Play, 
   AlertCircle,
   Cpu,
-  User,
-  Server,
-  Database,
   ChevronRight,
   ChevronUp,
   FolderOpen,
-  Layers,
   Save, 
   History, 
   Anchor, 
   ExternalLink, 
-  Sparkles, 
   DatabaseZap,
   Trash2,
   Check,
@@ -70,6 +64,7 @@ import {
   Undo2,
   Redo2,
   Heart,
+  MoreHorizontal,
 } from 'lucide-react';
 
 interface VisualRule {
@@ -193,8 +188,6 @@ export function builderStateToQuery(state: BuilderState): GeneratedQuery {
 interface DocumentViewerProps {
   connectionId?: string;
   connectionName: string;
-  /** Auth username parsed from the connection URI; empty when the connection has no credentials. */
-  connectionUser?: string;
   databaseName: string;
   collectionName: string;
   onExecute: (query: { filter: string; sort: string; projection: string; limit: number; skip: number }) => void;
@@ -547,7 +540,6 @@ export const DocumentViewerContext = React.createContext<DocumentViewerContextTy
 export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   connectionId,
   connectionName,
-  connectionUser,
   databaseName,
   collectionName,
   onExecute,
@@ -1470,78 +1462,15 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
 
   return (
     <div className="relative flex h-full min-h-0 flex-col min-w-0">
-      
-      {/* 1. Breadcrumbs Bar */}
-      <div className="flex select-none items-center justify-between border-b border-border bg-muted/30 px-3.5 py-1.5 text-xs text-muted-foreground">
-        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-          <div className={cn('inline-flex items-center gap-1', connectionUser ? 'text-primary' : 'text-muted-foreground')}>
-            <User size={12} className="shrink-0" />
-            <span
-              className={cn('truncate font-semibold', !connectionUser && 'italic')}
-              title={connectionUser ? td('documentViewer.breadcrumbs.authenticatedAs', { user: connectionUser }) : td('documentViewer.breadcrumbs.noAuthentication')}
-            >
-              {connectionUser || td('documentViewer.breadcrumbs.noAuth')}
-            </span>
-          </div>
-          <ChevronRight size={10} className="shrink-0 text-muted-foreground" />
-
-          <div className="inline-flex items-center gap-1 text-foreground">
-            <Server size={12} className="shrink-0 text-primary" />
-            <span className="truncate font-mono font-medium" title={connectionName}>{connectionName}</span>
-          </div>
-          <ChevronRight size={10} className="shrink-0 text-muted-foreground" />
-
-          <div className="inline-flex items-center gap-1 text-foreground">
-            <Database size={12} className="shrink-0 text-warning" />
-            <span className="truncate font-semibold" title={databaseName}>{databaseName}</span>
-          </div>
-          <ChevronRight size={10} className="shrink-0 text-muted-foreground" />
-
-          <div className="inline-flex items-center gap-1 text-foreground">
-            <Layers size={12} className="shrink-0 text-success" />
-            <span className="truncate font-mono font-medium" title={collectionName}>{collectionName}</span>
-          </div>
-        </div>
-      </div>
-
-      {/* 2. Toolbar */}
-      <div className="flex select-none flex-wrap items-center justify-between gap-2 border-b border-border bg-card/50 px-3.5 py-1.5">
+      {/* Infrequent actions live behind one compact menu; the query and AI
+          actions stay beside the editor where they are used. */}
+      <details className="group absolute right-2 top-1 z-40" data-testid="query-more-actions-menu">
+        <summary className="flex h-7 w-fit cursor-pointer list-none select-none items-center gap-1.5 rounded-md border border-border px-2.5 text-[11px] font-medium hover:bg-accent" data-testid="query-more-actions">
+          <MoreHorizontal size={12} />
+          {td('documentViewer.actions.moreActions')}
+        </summary>
+        <div className="absolute right-0 top-9 flex max-h-[70vh] min-w-[280px] flex-col gap-2 overflow-auto rounded-md border border-border bg-popover p-2 shadow-lg">
         <div className="flex flex-wrap items-center gap-1.5">
-          <div className="flex overflow-hidden rounded-md shadow-sm">
-            <Button
-              onClick={handleRun}
-              disabled={loading || explainLoading || !canRun}
-              size="sm"
-              className="h-7 rounded-r-none px-2.5 text-[11px]"
-              title={!canRun ? td('documentViewer.tooltips.runDisabled') : td('documentViewer.tooltips.executeQuery', { shortcut: formatShortcut(shortcutById('run-query')!) })}
-            >
-              <Play size={11} fill="currentColor" />
-              {td('documentViewer.actions.run')}
-            </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  disabled={loading || explainLoading}
-                  size="sm"
-                  variant="default"
-                  className="h-7 rounded-l-none border-l border-primary-foreground/20 px-1.5"
-                >
-                  <ChevronDown size={10} />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="min-w-[120px]">
-                <DropdownMenuItem onClick={handleRun}>
-                  <Play size={11} />
-                  {td('documentViewer.actions.runQuery')}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleExplain}>
-                  <Cpu size={11} />
-                  {td('documentViewer.actions.runExplain')}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm" className="h-7 gap-1.5 text-[11px]">
@@ -1736,21 +1665,6 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
             </Button>
           )}
           <Button
-            variant={isAIHelperOpen ? 'secondary' : 'outline'}
-            size="sm"
-            onClick={() => {
-              const newOpen = !isAIHelperOpen;
-              setIsAIHelperOpen(newOpen);
-              if (newOpen) setIsQueryBuilderOpen(false);
-            }}
-            className={cn('h-7 gap-1.5 text-[11px]', isAIHelperOpen && 'border-primary text-primary')}
-            data-testid="toggle-ai-helper"
-          >
-            <Sparkles size={11} className="text-primary" />
-            <span className="font-semibold text-primary">{td('documentViewer.actions.aiHelper')}</span>
-          </Button>
-
-          <Button
             variant={isQueryBuilderOpen ? 'secondary' : 'outline'}
             size="sm"
             onClick={() => {
@@ -1790,7 +1704,8 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
             {td('documentViewer.actions.visualQueryBuilder')}
           </Button>
         </div>
-      </div>
+        </div>
+      </details>
 
       {/* 3. Main Workspace Split Area */}
       <ResizablePanelGroup
@@ -1803,7 +1718,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         <ResizablePanel id="document-main" minSize="30%" className="flex min-h-0 flex-col">
         <div className="flex h-full min-h-0 min-w-0 flex-col">
             <div className="shrink-0">
-            <div className="flex gap-0.5 border-b border-border bg-muted/20 px-3.5 pt-1.5">
+            <div className="flex gap-0.5 border-b border-border bg-muted/20 px-3.5 pt-1.5 pr-32">
               <button
                 type="button"
                 onClick={() => setQueryMode('find')}
@@ -1856,6 +1771,12 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                 fields={fields}
                 schema={schema}
                 onRun={handleRun}
+                runDisabled={loading || explainLoading || !canRun}
+                onOpenAI={() => {
+                  const newOpen = !isAIHelperOpen;
+                  setIsAIHelperOpen(newOpen);
+                  if (newOpen) setIsQueryBuilderOpen(false);
+                }}
                 onClearFilter={() => handleClearField('filter')}
                 onClearProjection={() => handleClearField('projection')}
                 onClearSort={() => handleClearField('sort')}
@@ -1996,6 +1917,14 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                   );
                 })}
               </div>
+            </div>
+            <div className="flex justify-end gap-1.5 border-t border-border px-2 py-1.5">
+              <Button variant="outline" size="sm" className="h-7 gap-1.5 text-[11px]" onClick={handleExplain} disabled={loading || explainLoading}>
+                <Cpu size={11} /> {td('documentViewer.actions.runExplain')}
+              </Button>
+              <Button size="sm" className="h-7 gap-1.5 text-[11px]" onClick={handleRun} disabled={loading || explainLoading || !canRun}>
+                <Play size={11} fill="currentColor" /> {td('documentViewer.actions.run')}
+              </Button>
             </div>
             </div>
           </div>

--- a/src/components/FindQueryBar.tsx
+++ b/src/components/FindQueryBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertCircle, ArrowUpDown, ChevronDown, ChevronRight, Eraser } from 'lucide-react';
+import { AlertCircle, ArrowUpDown, ChevronDown, ChevronRight, Eraser, Play, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
@@ -44,6 +44,8 @@ export interface FindQueryBarProps {
   onOptionsOpenChange?: (open: boolean) => void;
   /** Run handler (⌘/Ctrl+Enter in the editors, Enter in skip/limit). */
   onRun?: () => void;
+  runDisabled?: boolean;
+  onOpenAI?: () => void;
   /** Clear handlers — default to resetting the field to '{}' when omitted. */
   onClearFilter?: () => void;
   onClearProjection?: () => void;
@@ -97,6 +99,8 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
   optionsOpen: optionsOpenProp,
   onOptionsOpenChange,
   onRun,
+  runDisabled = false,
+  onOpenAI,
   onClearFilter,
   onClearProjection,
   onClearSort,
@@ -190,19 +194,29 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
   const invalidBadge = badge();
 
   return (
-    <div className="flex flex-col border-b border-border bg-muted/20">
-      <div className="flex w-full border-b border-border">
-        <div className={queryColClass(filterInvalid)}>
-          <span
-            className={cn(fieldBadgeClass(filterInvalid), 'self-stretch')}
-            style={queryRowStyle}
-          >
-            {t('findQueryBar.labels.query')}
-          </span>
+    <div className="border-b border-border bg-card/40">
+      <div
+        data-testid={collapsibleOptions ? 'query-composer-body' : undefined}
+        className={cn(collapsibleOptions ? 'flex items-stretch' : 'flex flex-col')}
+      >
+      <div className={cn(collapsibleOptions && 'min-w-0 flex-[7] p-2')}>
+      <div className={cn('flex w-full', !collapsibleOptions && 'border-b border-border')}>
+        <div className={cn(queryColClass(filterInvalid), collapsibleOptions && 'rounded-md border border-border bg-input/60 shadow-sm')}>
+          {!collapsibleOptions && (
+            <span className={cn(fieldBadgeClass(filterInvalid), 'self-stretch')} style={queryRowStyle}>
+              {t('findQueryBar.labels.query')}
+            </span>
+          )}
+          {collapsibleOptions && !filter && (
+            <span className="pointer-events-none absolute left-3 top-2 z-10 text-xs italic text-muted-foreground/60">
+              {t('findQueryBar.labels.query')}
+            </span>
+          )}
           <QueryEditor
             singleLine
             large={collapsibleOptions}
             growWithContent
+            height={collapsibleOptions ? 84 : undefined}
             surface="filter"
             shellSyntax={shellSyntax}
             onRun={onRun}
@@ -223,40 +237,26 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
           >
             <Eraser size={11} />
           </Button>
-          {collapsibleOptions && (
-            <button
-              type="button"
-              data-testid="query-options-toggle"
-              aria-expanded={optionsOpen}
-              aria-controls={optionsRegionId}
-              aria-label={optionsOpen ? t('findQueryBar.tooltips.fewerOptions') : t('findQueryBar.tooltips.moreOptions')}
-              onClick={() => setOptionsOpen(!optionsOpen)}
-              title={optionsOpen ? t('findQueryBar.tooltips.hideOptions') : t('findQueryBar.tooltips.showOptions')}
-              className="mr-1 flex h-6 shrink-0 items-center gap-1 rounded px-1.5 text-[10px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
-            >
-              {optionsOpen ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
-              {t('findQueryBar.labels.options')}
-              {!optionsOpen && hasOptionValues && (
-                <span
-                  data-testid="query-options-dot"
-                  title={t('findQueryBar.tooltips.optionsSet')}
-                  className="ml-0.5 h-1.5 w-1.5 rounded-full bg-primary"
-                />
-              )}
-            </button>
-          )}
         </div>
+      </div>
+
       </div>
 
       <div
         id={optionsRegionId}
         data-testid="query-options-section"
-        className={cn(!optionsVisible && 'hidden')}
+        className={cn(
+          collapsibleOptions && 'min-w-0 flex-[3] space-y-2 border-l border-border bg-muted/15 p-2',
+          !optionsVisible && 'hidden'
+        )}
       >
 
-      <div className="flex w-full border-b border-border">
-        <div className={queryColClass(projectionInvalid)}>
-          <span className={fieldBadgeClass(projectionInvalid)} style={optionRowStyle}>{t('findQueryBar.labels.projection')}</span>
+      <div className={cn('flex w-full', !collapsibleOptions && 'border-b border-border')}>
+        <div
+          data-testid={collapsibleOptions ? 'projection-option-field' : undefined}
+          className={cn(queryColClass(projectionInvalid), collapsibleOptions && 'rounded-md border border-border bg-input/60')}
+        >
+          <span className={cn(fieldBadgeClass(projectionInvalid), collapsibleOptions && 'min-w-[72px] rounded-l-md px-2')} style={optionRowStyle}>{t('findQueryBar.labels.projection')}</span>
           <QueryEditor
             singleLine
             surface="projection"
@@ -281,11 +281,12 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
         </div>
       </div>
 
-      {/* Sort shares a row with skip/limit, the way Compass groups its
-          smaller options after giving `project` a row of its own. */}
       <div className="flex w-full">
-        <div className={queryColClass(sortInvalid)}>
-          <span className={fieldBadgeClass(sortInvalid)} style={optionRowStyle}>{t('findQueryBar.labels.sort')}</span>
+        <div
+          data-testid={collapsibleOptions ? 'sort-option-field' : undefined}
+          className={cn(queryColClass(sortInvalid), collapsibleOptions && 'rounded-md border border-border bg-input/60')}
+        >
+          <span className={cn(fieldBadgeClass(sortInvalid), collapsibleOptions && 'min-w-[72px] rounded-l-md px-2')} style={optionRowStyle}>{t('findQueryBar.labels.sort')}</span>
           <QueryEditor
             singleLine
             surface="sort"
@@ -318,10 +319,12 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
           </Button>
         </div>
 
+      </div>
+
         {showPagination && (
-          <>
-          <div className={queryColClass(false)}>
-            <span className={fieldBadgeClass(false)} style={optionRowStyle}>{t('findQueryBar.labels.skip')}</span>
+          <div className={cn('grid grid-cols-2 gap-2', !collapsibleOptions && 'flex')}>
+          <div className={cn(queryColClass(false), collapsibleOptions && 'rounded-md border border-border bg-input/60')}>
+            <span className={cn(fieldBadgeClass(false), collapsibleOptions && 'min-w-[44px] rounded-l-md px-1.5')} style={optionRowStyle}>{t('findQueryBar.labels.skip')}</span>
             <Input
               type="number"
               value={skip}
@@ -345,8 +348,8 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
             )}
           </div>
 
-          <div className={queryColClass(false)}>
-            <span className={fieldBadgeClass(false)} style={optionRowStyle}>{t('findQueryBar.labels.limit')}</span>
+          <div className={cn(queryColClass(false), collapsibleOptions && 'rounded-md border border-border bg-input/60')}>
+            <span className={cn(fieldBadgeClass(false), collapsibleOptions && 'min-w-[44px] rounded-l-md px-1.5')} style={optionRowStyle}>{t('findQueryBar.labels.limit')}</span>
             <Input
               type="number"
               value={limit}
@@ -369,10 +372,40 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
               </Button>
             )}
           </div>
-          </>
+          </div>
         )}
       </div>
       </div>
+
+      {collapsibleOptions && (
+        <div data-testid="query-composer-footer" className="flex items-center justify-between gap-2 border-t border-border bg-muted/20 px-2 py-1.5">
+          <button
+            type="button"
+            data-testid="query-options-toggle"
+            aria-expanded={optionsOpen}
+            aria-controls={optionsRegionId}
+            aria-label={optionsOpen ? t('findQueryBar.tooltips.fewerOptions') : t('findQueryBar.tooltips.moreOptions')}
+            onClick={() => setOptionsOpen(!optionsOpen)}
+            className="flex h-7 items-center gap-1.5 rounded-md px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            {optionsOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+            {t('findQueryBar.labels.addProjectionSort')}
+            {!optionsOpen && hasOptionValues && <span data-testid="query-options-dot" className="h-1.5 w-1.5 rounded-full bg-primary" />}
+          </button>
+          <div className="flex items-center gap-1.5">
+            {onOpenAI && (
+              <Button type="button" variant="ghost" size="sm" className="h-7 gap-1.5 text-[11px] text-muted-foreground" onClick={onOpenAI} data-testid="toggle-ai-helper">
+                <Sparkles size={11} className="text-primary" />
+                {t('findQueryBar.actions.generateWithAI')}
+              </Button>
+            )}
+            <Button type="button" size="sm" className="h-7 min-w-[64px] gap-1.5 text-[11px]" onClick={onRun} disabled={runDisabled} data-testid="query-run-below">
+              <Play size={11} fill="currentColor" />
+              {t('findQueryBar.actions.run')}
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -306,6 +306,8 @@ describe('DataGrid Component', () => {
     // Page 3 of 27 (skip 100 / limit 50 => page 3; ceil(1312/50)=27)
     expect(screen.getByTestId('pager-page')).toHaveTextContent('3');
     expect(screen.getByTestId('pager-page')).toHaveTextContent('27');
+    expect(screen.getByTestId('pager-page-top')).toHaveTextContent('3');
+    expect(screen.getByTestId('pager-page-top')).toHaveTextContent('27');
     expect(screen.getByTestId('pager-total')).toHaveTextContent('1312');
 
     fireEvent.click(screen.getByTestId('pager-next'));

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -108,11 +108,10 @@ describe('DocumentViewer Component', () => {
     localStorage.clear();
   });
 
-  it('renders breadcrumbs and query inputs correctly', () => {
+  it('uses the tab for namespace context instead of repeating breadcrumbs', () => {
     render(
       <DocumentViewer
         connectionName="test-conn"
-        connectionUser="app-user"
         databaseName="test-db"
         collectionName="test-coll"
         onExecute={mockOnExecute}
@@ -121,11 +120,9 @@ describe('DocumentViewer Component', () => {
       />
     );
 
-    // Verify breadcrumbs — the user crumb is driven by the connectionUser prop
-    expect(screen.getByText('app-user')).toBeInTheDocument();
-    expect(screen.getByText(/test-conn/)).toBeInTheDocument();
-    expect(screen.getByText('test-db')).toBeInTheDocument();
-    expect(screen.getByText('test-coll')).toBeInTheDocument();
+    expect(screen.queryByText('test-conn')).not.toBeInTheDocument();
+    expect(screen.queryByText('test-db')).not.toBeInTheDocument();
+    expect(screen.queryByText('test-coll')).not.toBeInTheDocument();
 
     // Verify labels
     expect(screen.getByText('Query')).toBeInTheDocument();
@@ -133,6 +130,9 @@ describe('DocumentViewer Component', () => {
     expect(screen.getByText('Sort')).toBeInTheDocument();
     expect(screen.getByText('Skip')).toBeInTheDocument();
     expect(screen.getByText('Limit')).toBeInTheDocument();
+    expect(screen.getByTestId('query-more-actions')).toHaveTextContent('More actions');
+    expect(screen.getByTestId('query-more-actions-menu')).toHaveClass('absolute', 'right-2');
+    expect(screen.getByText('Generate query by AI')).toBeInTheDocument();
   });
 
   it('renders Export/Import in the top toolbar and fires their handlers', () => {
@@ -1448,7 +1448,7 @@ describe('page size resync from the pager (#218)', () => {
     expect(row?.className).toContain('focus-within:after:border');
     expect(row?.className).toContain('focus-within:after:absolute');
     expect(row?.className).not.toContain('ring-inset');
-    expect(row?.className).toContain('bg-input/80');
+    expect(row?.className).toContain('bg-input/60');
     expect(editorWrapper?.className ?? '').not.toContain('bg-input');
   });
 

--- a/src/components/__tests__/FindQueryBar.test.tsx
+++ b/src/components/__tests__/FindQueryBar.test.tsx
@@ -48,6 +48,40 @@ describe('FindQueryBar — Options disclosure (#217)', () => {
     expect(screen.getByTestId('projection-query-input')).toBeInTheDocument();
     expect(section()).toHaveClass('hidden');
     expect(screen.getByTestId('query-options-toggle')).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Add Projection/Sort')).toBeInTheDocument();
+  });
+
+  it('places AI generation and Run after the query editor', () => {
+    const onRun = vi.fn();
+    const onOpenAI = vi.fn();
+    renderBar({ onRun, onOpenAI });
+    fireEvent.click(screen.getByText('Generate query by AI'));
+    fireEvent.click(screen.getByTestId('query-run-below'));
+    expect(onOpenAI).toHaveBeenCalledOnce();
+    expect(onRun).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the editor and options in one composer with a full-width action footer', () => {
+    renderBar({ optionsOpen: true, skip: '0', limit: '50', onSkipChange: noop, onLimitChange: noop });
+    expect(screen.getByTestId('query-composer-body')).toHaveClass('flex');
+    expect(screen.getByTestId('query-options-section')).toHaveClass('border-l');
+    expect(screen.getByTestId('query-composer-footer')).toHaveClass('border-t');
+    expect(screen.getByTestId('query-composer-footer').parentElement).toBe(
+      screen.getByTestId('query-composer-body').parentElement,
+    );
+  });
+
+  it('renders expanded options as compact labelled fields instead of badge columns', () => {
+    renderBar({ optionsOpen: true });
+    expect(screen.getByTestId('projection-option-field')).toHaveClass('rounded-md');
+    expect(screen.getByTestId('sort-option-field')).toHaveClass('rounded-md');
+    expect(screen.getByText('Projection')).not.toHaveClass('min-w-[90px]');
+    expect(screen.getByText('Sort')).not.toHaveClass('min-w-[90px]');
+  });
+
+  it('gives the primary query a dominant four-line editing area', () => {
+    renderBar();
+    expect(screen.getByTestId('query-filter-input').parentElement).toHaveStyle({ height: '84px' });
   });
 
   it('reveals the options when the toggle is clicked, and hides them again', () => {
@@ -112,19 +146,18 @@ describe('FindQueryBar — Options disclosure (#217)', () => {
 describe('FindQueryBar — configurable Query height (#217)', () => {
   const heightOf = (label: string) => (screen.getByText(label) as HTMLElement).style.height;
 
-  it('sizes the Query row from the setting', () => {
+  it('uses shadow text instead of a separate Query column in the main editor', () => {
     themeConfig.queryBarHeight = 29;
     renderBar();
     const queryLabel = screen.getByText('Query') as HTMLElement;
-    expect(queryLabel.style.minHeight).toBe(`${29 / 13}rem`);
-    expect(queryLabel.style.height).toBe('');
-    expect(queryLabel).toHaveClass('self-stretch');
+    expect(queryLabel).toHaveClass('pointer-events-none');
+    expect(queryLabel).not.toHaveClass('uppercase');
   });
 
   it('grows only the Query row — option rows stay compact', () => {
     themeConfig.queryBarHeight = 58;
     renderBar();
-    expect((screen.getByText('Query') as HTMLElement).style.minHeight).toBe(`${58 / 13}rem`);
+    expect(screen.getByText('Query')).toHaveClass('pointer-events-none');
     // Projection/sort keep the compact height so the whole bar doesn't inflate.
     const compact = `${22.75 / 13}rem`;
     expect(heightOf('Projection')).toBe(compact);
@@ -144,7 +177,7 @@ describe('FindQueryBar — configurable Query height (#217)', () => {
   it('clamps an out-of-range stored value instead of trusting it', () => {
     themeConfig.queryBarHeight = 9999;
     renderBar();
-    expect((screen.getByText('Query') as HTMLElement).style.minHeight).toBe(`${64 / 13}rem`);
+    expect(screen.getByText('Query')).toHaveClass('pointer-events-none');
     themeConfig.queryBarHeight = 29;
   });
 });
@@ -166,10 +199,10 @@ describe('FindQueryBar — export view is unaffected by the Query height setting
     themeConfig.queryBarHeight = 29;
   });
 
-  it('still sizes the Query label when the field is sized (main query bar)', () => {
+  it('does not render the column-style Query badge in the main query bar', () => {
     themeConfig.queryBarHeight = 64;
     renderBar({ collapsibleOptions: true });
-    expect((screen.getByText('Query') as HTMLElement).style.minHeight).toBe(`${64 / 13}rem`);
+    expect(screen.getByText('Query')).toHaveClass('pointer-events-none');
     themeConfig.queryBarHeight = 29;
   });
 

--- a/src/locales/de/documents.json
+++ b/src/locales/de/documents.json
@@ -5,7 +5,6 @@
       "addRule": "Regel hinzufügen",
       "addSortField": "Sortierfeld hinzufügen",
       "addStage": "Stufe hinzufügen",
-      "aiHelper": "KI-Helfer",
       "apply": "Anwenden",
       "clearAll": "Alles zurücksetzen",
       "clearDefault": "Standard entfernen",
@@ -13,23 +12,18 @@
       "import": "Import",
       "listShortcut": "Liste",
       "loadQuery": "Abfrage laden",
+      "moreActions": "Weitere Aktionen",
       "openInMongosh": "In mongosh öffnen",
       "openQueryIn": "Abfrage öffnen in...",
       "pinAsDefault": "Aktuelle Abfrage als Standard festlegen",
       "queryHistory": "Abfrageverlauf",
       "run": "Ausführen",
       "runExplain": "Explain ausführen",
-      "runQuery": "Abfrage ausführen",
       "saveAndFavorite": "Speichern und zu Favoriten hinzufügen",
       "saveAsNew": "Als neue Abfrage speichern...",
       "saveQuery": "Abfrage speichern",
       "setDefaultQuery": "Standardabfrage festlegen",
       "visualQueryBuilder": "Visueller Abfrage-Builder"
-    },
-    "breadcrumbs": {
-      "authenticatedAs": "Authentifiziert als {{user}}",
-      "noAuth": "keine Auth",
-      "noAuthentication": "Verbindung hat keine Authentifizierung"
     },
     "builder": {
       "ascOption": "Aufsteigend ({{n}})",
@@ -105,7 +99,6 @@
       "deleteSavedQuery": "Gespeicherte Abfrage löschen",
       "disableStage": "Stufe {{n}} deaktivieren",
       "enableStage": "Stufe {{n}} aktivieren",
-      "executeQuery": "Abfrage ausführen ({{shortcut}})",
       "expandStage": "Stufe {{n}} erweitern",
       "importDocuments": "Dokumente aus einer Datei importieren",
       "moveStageDown": "Stufe {{n}} nach unten verschieben",
@@ -115,15 +108,18 @@
       "removeFromFavorites": "Aus Favoriten entfernen",
       "removeRule": "Regel entfernen",
       "removeStage": "Stufe {{n}} entfernen",
-      "runDisabled": "Abfragesyntax korrigieren, um sie auszuführen",
       "runPipelineToStage": "Pipeline bis Stufe {{n}} ausführen",
       "undoPipelineChange": "Pipeline-Änderung rückgängig machen"
     }
   },
   "findQueryBar": {
+    "actions": {
+      "generateWithAI": "Abfrage mit KI erstellen",
+      "run": "Ausführen"
+    },
     "labels": {
+      "addProjectionSort": "Projektion/Sortierung hinzufügen",
       "limit": "Limit",
-      "options": "Optionen",
       "projection": "Projektion",
       "query": "Abfrage",
       "skip": "Skip",
@@ -137,13 +133,10 @@
       "clearProjection": "Projektion leeren",
       "clearSort": "Sortierung leeren",
       "fewerOptions": "Weniger Optionen",
-      "hideOptions": "Projektion, Sortierung, Skip und Limit ausblenden",
       "moreOptions": "Mehr Optionen",
-      "optionsSet": "Projektion, Sortierung, Skip oder Limit ist gesetzt",
       "quickSortDirection": "Sortierrichtung umschalten",
       "resetLimit": "Limit zurücksetzen",
-      "resetSkip": "Skip zurücksetzen",
-      "showOptions": "Projektion, Sortierung, Skip und Limit anzeigen"
+      "resetSkip": "Skip zurücksetzen"
     }
   },
   "diffModal": {
@@ -345,7 +338,6 @@
       "results": "Ergebnisse"
     },
     "tooltips": {
-      "analyzeSchema": "Das Feldschema der Collection analysieren",
       "codeLanguage": "Codesprache",
       "collapse": "Einklappen",
       "copied": "Kopiert",

--- a/src/locales/en/documents.json
+++ b/src/locales/en/documents.json
@@ -152,7 +152,6 @@
       "results": "Results"
     },
     "tooltips": {
-      "analyzeSchema": "Analyze the collection's field schema",
       "codeLanguage": "Code language",
       "collapse": "Collapse",
       "copied": "Copied",
@@ -205,7 +204,6 @@
       "addRule": "Add Rule",
       "addSortField": "Add Sort Field",
       "addStage": "Add Stage",
-      "aiHelper": "AI Helper",
       "apply": "Apply",
       "clearAll": "Clear All",
       "clearDefault": "Clear default",
@@ -213,23 +211,18 @@
       "import": "Import",
       "listShortcut": "List",
       "loadQuery": "Load query",
+      "moreActions": "More actions",
       "openInMongosh": "Open in mongosh",
       "openQueryIn": "Open query in...",
       "pinAsDefault": "Pin current query as default",
       "queryHistory": "Query history",
       "run": "Run",
       "runExplain": "Run Explain",
-      "runQuery": "Run Query",
       "saveAndFavorite": "Save and add to favorites",
       "saveAsNew": "Save as new query...",
       "saveQuery": "Save query",
       "setDefaultQuery": "Set default query",
       "visualQueryBuilder": "Visual Query Builder"
-    },
-    "breadcrumbs": {
-      "authenticatedAs": "Authenticated as {{user}}",
-      "noAuth": "no auth",
-      "noAuthentication": "Connection has no authentication"
     },
     "builder": {
       "ascOption": "Asc ({{n}})",
@@ -305,7 +298,6 @@
       "deleteSavedQuery": "Delete saved query",
       "disableStage": "Disable stage {{n}}",
       "enableStage": "Enable stage {{n}}",
-      "executeQuery": "Execute query ({{shortcut}})",
       "expandStage": "Expand stage {{n}}",
       "importDocuments": "Import documents from a file",
       "moveStageDown": "Move stage {{n}} down",
@@ -315,7 +307,6 @@
       "removeFromFavorites": "Remove from favorites",
       "removeRule": "Remove Rule",
       "removeStage": "Remove stage {{n}}",
-      "runDisabled": "Fix the query syntax to run",
       "runPipelineToStage": "Run pipeline to stage {{n}}",
       "undoPipelineChange": "Undo pipeline change"
     }
@@ -348,12 +339,16 @@
     "loadingDataset": "Error loading dataset: {{detail}}"
   },
   "findQueryBar": {
+    "actions": {
+      "generateWithAI": "Generate query by AI",
+      "run": "Run"
+    },
     "errors": {
       "invalidJson": "Invalid JSON"
     },
     "labels": {
+      "addProjectionSort": "Add Projection/Sort",
       "limit": "Limit",
-      "options": "Options",
       "projection": "Projection",
       "query": "Query",
       "skip": "Skip",
@@ -364,13 +359,10 @@
       "clearProjection": "Clear Projection",
       "clearSort": "Clear Sort",
       "fewerOptions": "Fewer Options",
-      "hideOptions": "Hide projection, sort, skip and limit",
       "moreOptions": "More Options",
-      "optionsSet": "Projection, sort, skip or limit is set",
       "quickSortDirection": "Quick Sort Direction",
       "resetLimit": "Reset Limit",
-      "resetSkip": "Reset Skip",
-      "showOptions": "Show projection, sort, skip and limit"
+      "resetSkip": "Reset Skip"
     }
   },
   "schemaView": {

--- a/src/locales/zh-Hans/documents.json
+++ b/src/locales/zh-Hans/documents.json
@@ -143,7 +143,6 @@
       "results": "结果"
     },
     "tooltips": {
-      "analyzeSchema": "分析该 Collection 的字段结构",
       "codeLanguage": "代码语言",
       "collapse": "折叠",
       "copied": "已复制",
@@ -192,7 +191,6 @@
       "addRule": "添加规则",
       "addSortField": "添加排序字段",
       "addStage": "添加阶段",
-      "aiHelper": "AI 助手",
       "apply": "应用",
       "clearAll": "全部清除",
       "clearDefault": "清除默认",
@@ -200,23 +198,18 @@
       "import": "导入",
       "listShortcut": "列表",
       "loadQuery": "加载查询",
+      "moreActions": "更多操作",
       "openInMongosh": "在 mongosh 中打开",
       "openQueryIn": "在其他工具中打开查询…",
       "pinAsDefault": "将当前查询设为默认",
       "queryHistory": "查询历史",
       "run": "运行",
       "runExplain": "运行 Explain",
-      "runQuery": "运行查询",
       "saveAndFavorite": "保存并加入收藏",
       "saveAsNew": "另存为新查询…",
       "saveQuery": "保存查询",
       "setDefaultQuery": "设置默认查询",
       "visualQueryBuilder": "可视化查询构建器"
-    },
-    "breadcrumbs": {
-      "authenticatedAs": "已以 {{user}} 身份认证",
-      "noAuth": "未认证",
-      "noAuthentication": "该连接未启用身份验证"
     },
     "builder": {
       "ascOption": "升序（{{n}}）",
@@ -290,7 +283,6 @@
       "deleteSavedQuery": "删除已保存的查询",
       "disableStage": "停用第 {{n}} 个阶段",
       "enableStage": "启用第 {{n}} 个阶段",
-      "executeQuery": "执行查询（{{shortcut}}）",
       "expandStage": "展开第 {{n}} 个阶段",
       "importDocuments": "从文件导入文档",
       "moveStageDown": "将第 {{n}} 个阶段下移",
@@ -300,7 +292,6 @@
       "removeFromFavorites": "从收藏中移除",
       "removeRule": "删除规则",
       "removeStage": "删除第 {{n}} 个阶段",
-      "runDisabled": "请先修正查询语法再运行",
       "runPipelineToStage": "运行管道至第 {{n}} 个阶段",
       "undoPipelineChange": "撤销管道更改"
     }
@@ -333,12 +324,16 @@
     "loadingDataset": "加载数据集出错：{{detail}}"
   },
   "findQueryBar": {
+    "actions": {
+      "generateWithAI": "使用 AI 生成查询",
+      "run": "运行"
+    },
     "errors": {
       "invalidJson": "JSON 无效"
     },
     "labels": {
+      "addProjectionSort": "添加投影/排序",
       "limit": "限制",
-      "options": "选项",
       "projection": "投影",
       "query": "查询",
       "skip": "跳过",
@@ -349,13 +344,10 @@
       "clearProjection": "清除投影",
       "clearSort": "清除排序",
       "fewerOptions": "收起选项",
-      "hideOptions": "隐藏投影、排序、跳过和限制",
       "moreOptions": "更多选项",
-      "optionsSet": "已设置投影、排序、跳过或限制",
       "quickSortDirection": "快速切换排序方向",
       "resetLimit": "重置限制",
-      "resetSkip": "重置跳过",
-      "showOptions": "显示投影、排序、跳过和限制"
+      "resetSkip": "重置跳过"
     }
   },
   "schemaView": {


### PR DESCRIPTION
## Summary

Implements the remaining concrete UX hierarchy items from the [issue #260 follow-up](https://github.com/mqlens/mqlens-mongodb/issues/260#issuecomment-5297061440) in one PR:

- removes the duplicate authenticated-user / connection / database / collection header
- places **More actions** on the Find/Aggregation tab strip instead of using a separate toolbar row
- moves infrequent query actions under the compact **More actions** menu
- moves **Generate query by AI** into the query section and keeps the panel branded as AI Assistant
- places **Run** after/below the query workflow; aggregation gets its own Run/Explain footer
- presents query and options as one cohesive 70/30 composer with a full-width action footer
- renders projection, sort, skip, and limit as compact contained fields instead of a spreadsheet-like block
- removes the separate QUERY label column and uses subtle in-editor shadow text
- gives the primary query a dominant four-line editor with scrolling beyond it
- provides an **Add Projection/Sort** disclosure
- moves Schema to the first result control position
- surfaces `Page X / Y` above the result content while retaining paging controls below
- removes dead props, URI username parsing, icons, and translations

The optional Chrome-style tab grouping and the issue's intentionally undefined aggregation redesign are not included; neither has an actionable interaction design. Existing aggregation functionality remains intact and gains the requested action order.

Refs #260

## Verification

- TDD coverage for composer structure, compact option fields, action placement, four-line editor, namespace removal, Schema position, and top page information
- 113 directly affected frontend tests pass
- `tsc --noEmit`
- `npm run build`
- `npm run i18n:check`

The complete GitHub Actions suite is the final gate.