### PR TITLE
feat(audit): durable local activity logging (#272)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -44,6 +44,11 @@ services you connect to.
 - **No account** — there is no MQLens backend.
 - **Credentials encrypted at rest** with AES-256-GCM and Argon2id key
   derivation, behind a master password (with optional biometric unlock).
+- **Activity / audit log (local only)** — optional operation history is stored
+  as vault-encrypted SQLite (`audit.db.enc`). It may include collection names,
+  filters, and (if enabled in Settings) document fragments. Protect the vault
+  password. **Export** is an explicit user action that writes **plaintext**
+  outside the vault envelope — treat exported files as sensitive.
 - **Signed builds** — macOS notarized, Windows signed, and GPG-signed Linux
   artifacts; updater artifacts are signed and verified before install.
 - **Apache-2.0** — the source is open for review.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -58,6 +58,12 @@ services you connect to.
   file instead of writing over it. A crash mid-write is distinguished from
   tampering: only when the recorded count confirms the trailing bytes were an
   interrupted write is that partial record discarded and logging continued.
+- **The activity log cannot be erased from the app** — there is no "clear"
+  action for an intact log; the retention setting is the only thing that removes
+  events, on the schedule you choose. A log that has *failed* verification can be
+  discarded so recording can resume, and that always leaves a permanent record
+  of the discard which retention will not remove. So a discarded log can never be
+  made to look like one that was never discarded.
   Note the limit: the log is encrypted with your own master password on your own
   machine, so it is tamper-**evident**, not tamper-**proof** — anyone holding
   that password can delete it and start fresh.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -52,10 +52,12 @@ services you connect to.
   explicit user action that writes **plaintext** outside the vault envelope —
   treat exported files as sensitive.
 - **Audit log integrity** — every record carries its sequence number and the
-  hash of the record before it, so deleting, reordering or editing entries is
+  hash of the record before it, and a companion file records how many events the
+  log should hold, so deleting, reordering, editing or truncating entries is
   detected when the log is opened; MQLens then stops recording and preserves the
   file instead of writing over it. A crash mid-write is distinguished from
-  tampering: the partial trailing record is discarded and logging continues.
+  tampering: only when the recorded count confirms the trailing bytes were an
+  interrupted write is that partial record discarded and logging continued.
   Note the limit: the log is encrypted with your own master password on your own
   machine, so it is tamper-**evident**, not tamper-**proof** — anyone holding
   that password can delete it and start fresh.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -45,10 +45,20 @@ services you connect to.
 - **Credentials encrypted at rest** with AES-256-GCM and Argon2id key
   derivation, behind a master password (with optional biometric unlock).
 - **Activity / audit log (local only)** — optional operation history is stored
-  as vault-encrypted SQLite (`audit.db.enc`). It may include collection names,
-  filters, and (if enabled in Settings) document fragments. Protect the vault
-  password. **Export** is an explicit user action that writes **plaintext**
-  outside the vault envelope — treat exported files as sensitive.
+  in `audit.log.enc` as an append-only log whose records are each encrypted
+  individually with the vault key; the decrypted log never touches the
+  filesystem. It may include collection names, filters, and (if enabled in
+  Settings) document fragments. Protect the vault password. **Export** is an
+  explicit user action that writes **plaintext** outside the vault envelope —
+  treat exported files as sensitive.
+- **Audit log integrity** — every record carries its sequence number and the
+  hash of the record before it, so deleting, reordering or editing entries is
+  detected when the log is opened; MQLens then stops recording and preserves the
+  file instead of writing over it. A crash mid-write is distinguished from
+  tampering: the partial trailing record is discarded and logging continues.
+  Note the limit: the log is encrypted with your own master password on your own
+  machine, so it is tamper-**evident**, not tamper-**proof** — anyone holding
+  that password can delete it and start fresh.
 - **Signed builds** — macOS notarized, Windows signed, and GPG-signed Linux
   artifacts; updater artifacts are signed and verified before install.
 - **Apache-2.0** — the source is open for review.

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ dist-ssr
 # Local-only: internal design/process docs + AI-assistant tooling
 # (kept on disk, intentionally not published)
 docs/superpowers/
+docs/specs/
+docs/plans/
 .superpowers/
 GO-LIVE.md
 .claude/

--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -110,6 +110,8 @@ export default defineConfig({
       'settings:shortcuts.tabDescription',
       'settings:security.tabLabel',
       'settings:security.tabDescription',
+      'settings:audit.tabLabel',
+      'settings:audit.tabDescription',
       'settings:language.tabLabel',
       'settings:language.tabDescription',
       'connections:tabs.server',

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2230,6 +2230,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6538,6 +6548,7 @@ dependencies = [
  "csv",
  "fake",
  "flate2",
+ "fs4",
  "futures",
  "mongodb",
  "rand 0.8.6",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2096,6 +2096,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2710,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2710,6 +2731,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -3534,6 +3564,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5300,6 +5341,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "russh"
 version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6488,6 +6543,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest 0.12.28",
  "rmcp",
+ "rusqlite",
  "russh",
  "rust_xlsxwriter",
  "serde",
@@ -7476,6 +7532,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,7 +64,7 @@ rmcp = { version = "=2.2.0", features = ["server", "transport-streamable-http-se
 # proven-compatible pairing rather than a guess.
 axum = { version = "=0.8.9", default-features = false, features = ["http1", "tokio"] }
 # Bundled SQLite for local audit log (#272) — no system libsqlite required.
-rusqlite = { version = "0.32", features = ["bundled", "backup"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [dev-dependencies]
 tiny_http = "0.12.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,7 +64,7 @@ rmcp = { version = "=2.2.0", features = ["server", "transport-streamable-http-se
 # proven-compatible pairing rather than a guess.
 axum = { version = "=0.8.9", default-features = false, features = ["http1", "tokio"] }
 # Bundled SQLite for local audit log (#272) — no system libsqlite required.
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.32", features = ["bundled", "backup"] }
 
 [dev-dependencies]
 tiny_http = "0.12.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,6 +65,9 @@ rmcp = { version = "=2.2.0", features = ["server", "transport-streamable-http-se
 axum = { version = "=0.8.9", default-features = false, features = ["http1", "tokio"] }
 # Bundled SQLite for local audit log (#272) — no system libsqlite required.
 rusqlite = { version = "0.32", features = ["bundled"] }
+# Cross-process advisory lock on the audit log so two MQLens instances cannot
+# interleave appends and break its hash chain.
+fs4 = "0.13"
 
 [dev-dependencies]
 tiny_http = "0.12.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,6 +63,8 @@ rmcp = { version = "=2.2.0", features = ["server", "transport-streamable-http-se
 # server transport (rmcp-2.2.0/Cargo.toml `[dev-dependencies.axum]`), so it's a
 # proven-compatible pairing rather than a guess.
 axum = { version = "=0.8.9", default-features = false, features = ["http1", "tokio"] }
+# Bundled SQLite for local audit log (#272) — no system libsqlite required.
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [dev-dependencies]
 tiny_http = "0.12.0"

--- a/src-tauri/src/audit/classify.rs
+++ b/src-tauri/src/audit/classify.rs
@@ -1,0 +1,70 @@
+//! Map Tauri command / op names to [`OpClass`] for audit level gating (#272).
+
+use super::level::OpClass;
+
+/// Classify a registered command (or logical op name) for audit level gating.
+///
+/// Unknown names default to [`OpClass::Write`] so new mutating commands are
+/// never silently skipped at level A.
+pub fn classify_op(op: &str) -> OpClass {
+    match op {
+        "run_mongosh_command" | "mongosh" => OpClass::Shell,
+
+        "execute_mql_query"
+        | "find"
+        | "count_documents"
+        | "explain_mql_query"
+        | "explain_aggregate_query"
+        | "list_databases"
+        | "list_collections"
+        | "list_indexes"
+        | "execute_aggregate_read" => OpClass::ReadHigh,
+
+        "db_stats"
+        | "coll_stats"
+        | "index_stats"
+        | "server_status"
+        | "current_ops"
+        | "repl_set_status"
+        | "get_profiling_status"
+        | "read_profile"
+        | "list_users"
+        | "list_roles"
+        | "analyze_schema" => OpClass::ReadOther,
+
+        _ => OpClass::Write,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_and_shell() {
+        assert_eq!(classify_op("delete_many"), OpClass::Write);
+        assert_eq!(classify_op("drop_collection"), OpClass::Write);
+        assert_eq!(classify_op("drop_database"), OpClass::Write);
+        assert_eq!(classify_op("insert_document"), OpClass::Write);
+        assert_eq!(classify_op("run_mongosh_command"), OpClass::Shell);
+        assert_eq!(classify_op("mongosh"), OpClass::Shell);
+    }
+
+    #[test]
+    fn finds_are_read_high() {
+        assert_eq!(classify_op("execute_mql_query"), OpClass::ReadHigh);
+        assert_eq!(classify_op("find"), OpClass::ReadHigh);
+        assert_eq!(classify_op("count_documents"), OpClass::ReadHigh);
+    }
+
+    #[test]
+    fn stats_are_read_other() {
+        assert_eq!(classify_op("db_stats"), OpClass::ReadOther);
+        assert_eq!(classify_op("server_status"), OpClass::ReadOther);
+    }
+
+    #[test]
+    fn unknown_defaults_to_write() {
+        assert_eq!(classify_op("brand_new_mutating_op"), OpClass::Write);
+    }
+}

--- a/src-tauri/src/audit/classify.rs
+++ b/src-tauri/src/audit/classify.rs
@@ -2,6 +2,35 @@
 
 use super::level::OpClass;
 
+/// Every op name this module classifies as a read, i.e. the activity levels B
+/// and C advertise. `audit_records_every_classified_read` asserts each one has
+/// a real recorder call site — classifying a read without instrumenting it made
+/// level C silently record far less than "every database operation".
+///
+/// `find` is deliberately absent: it is an alias of `execute_mql_query`, not a
+/// command of its own.
+pub const CLASSIFIED_READ_OPS: &[&str] = &[
+    "execute_mql_query",
+    "count_documents",
+    "explain_mql_query",
+    "explain_aggregate_query",
+    "list_databases",
+    "list_collections",
+    "list_indexes",
+    "execute_aggregate_read",
+    "db_stats",
+    "coll_stats",
+    "index_stats",
+    "server_status",
+    "current_ops",
+    "repl_set_status",
+    "get_profiling_status",
+    "read_profile",
+    "list_users",
+    "list_roles",
+    "analyze_schema",
+];
+
 /// Classify a registered command (or logical op name) for audit level gating.
 ///
 /// Unknown names default to [`OpClass::Write`] so new mutating commands are
@@ -61,6 +90,47 @@ mod tests {
     fn stats_are_read_other() {
         assert_eq!(classify_op("db_stats"), OpClass::ReadOther);
         assert_eq!(classify_op("server_status"), OpClass::ReadOther);
+    }
+
+    /// Source of every module that owns a read entry point, so the coverage
+    /// test below sees the actual recorder call sites.
+    const AUDITED_READ_SOURCES: &[(&str, &str)] = &[
+        ("db/query.rs", include_str!("../db/query.rs")),
+        ("db/metadata.rs", include_str!("../db/metadata.rs")),
+        ("db/aggregate.rs", include_str!("../db/aggregate.rs")),
+        ("db/stats.rs", include_str!("../db/stats.rs")),
+        ("db/users.rs", include_str!("../db/users.rs")),
+        ("db/schema.rs", include_str!("../db/schema.rs")),
+        ("monitoring.rs", include_str!("../monitoring.rs")),
+    ];
+
+    #[test]
+    fn every_classified_read_op_is_actually_recorded() {
+        let missing: Vec<&str> = CLASSIFIED_READ_OPS
+            .iter()
+            .copied()
+            .filter(|op| {
+                let needle = format!("\"{op}\",");
+                !AUDITED_READ_SOURCES
+                    .iter()
+                    .any(|(_, src)| src.contains(&needle))
+            })
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "op(s) classified as a read but never passed to a recorder, so levels \
+             B/C would not log them: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn classified_read_ops_all_classify_as_reads() {
+        for op in CLASSIFIED_READ_OPS {
+            assert!(
+                matches!(classify_op(op), OpClass::ReadHigh | OpClass::ReadOther),
+                "{op} is listed as a read but classify_op says otherwise"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -109,6 +109,32 @@ impl AuditSession {
             None => Err("audit session is closed".into()),
         }
     }
+
+    pub fn prune_before(&self, ts_ms: i64) -> Result<u64, String> {
+        let guard = self.store.lock().map_err(|e| e.to_string())?;
+        match guard.as_ref() {
+            Some(store) => store.prune_before(ts_ms),
+            None => Ok(0),
+        }
+    }
+
+    pub fn clear_all(&self) -> Result<u64, String> {
+        let guard = self.store.lock().map_err(|e| e.to_string())?;
+        match guard.as_ref() {
+            Some(store) => store.clear_all(),
+            None => Err("audit session is closed".into()),
+        }
+    }
+
+    /// Close without sealing (used on vault reset when the enc file is deleted).
+    pub fn discard(&self) {
+        if let Ok(mut g) = self.store.lock() {
+            *g = None;
+        }
+        if let Ok(mut k) = self.key.lock() {
+            *k = None;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -1,23 +1,15 @@
-//! Vault AES-GCM envelope for the audit SQLite DB (#272).
+//! Vault-backed audit session: policy, the durable log, and the query index (#272).
+//!
+//! Encryption itself lives in [`super::log`], which encrypts each record
+//! individually. This module owns the session lifecycle around it.
 
-use crate::vault;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use super::level::AuditLevel;
+use super::log::{AuditLog, LoadReport};
 use super::store::{AuditEvent, AuditFilter, AuditStore};
-
-/// Encrypt raw SQLite DB bytes with the vault key.
-pub fn seal(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, String> {
-    vault::encrypt(key, plaintext)
-}
-
-/// Decrypt an `audit.db.enc` blob back to SQLite bytes.
-pub fn unseal(key: &[u8; 32], blob: &[u8]) -> Result<Vec<u8>, String> {
-    vault::decrypt(key, blob)
-}
 
 /// Cached audit settings for the open vault session (refreshed on unlock / save).
 #[derive(Clone, Copy, Debug)]
@@ -39,31 +31,37 @@ impl Default for AuditPolicy {
     }
 }
 
-/// Open audit session while vault is unlocked; sealed on close/lock.
+/// Open audit session while the vault is unlocked.
+///
+/// Holds two things: the append-only encrypted log, which is the durable source
+/// of truth, and an in-memory SQLite index rebuilt from it for querying. Every
+/// recorded event is appended and fsynced immediately — there is no snapshot to
+/// batch and no window in which a crash loses recent events.
 pub struct AuditSession {
-    enc_path: PathBuf,
+    log: AuditLog,
     store: Mutex<Option<AuditStore>>,
     key: Mutex<Option<[u8; 32]>>,
     dropped: AtomicU64,
     policy: Mutex<AuditPolicy>,
+    /// Set when the log failed verification on load: the file is preserved and
+    /// appends refused, so the UI must say auditing has stopped.
+    integrity_error: Mutex<Option<String>>,
 }
 
 impl AuditSession {
-    pub fn new(enc_path: PathBuf) -> Self {
+    pub fn new(log_path: PathBuf) -> Self {
         Self {
-            enc_path,
+            log: AuditLog::new(log_path),
             store: Mutex::new(None),
             key: Mutex::new(None),
             dropped: AtomicU64::new(0),
             policy: Mutex::new(AuditPolicy::default()),
+            integrity_error: Mutex::new(None),
         }
     }
 
     pub fn policy(&self) -> AuditPolicy {
-        self.policy
-            .lock()
-            .map(|g| *g)
-            .unwrap_or_default()
+        self.policy.lock().map(|g| *g).unwrap_or_default()
     }
 
     pub fn set_policy(&self, policy: AuditPolicy) {
@@ -72,85 +70,74 @@ impl AuditSession {
         }
     }
 
-    pub fn enc_path(&self) -> &Path {
-        &self.enc_path
+    pub fn log_path(&self) -> &Path {
+        self.log.path()
     }
 
     pub fn dropped_count(&self) -> u64 {
         self.dropped.load(Ordering::Relaxed)
     }
 
+    /// Why the log stopped accepting events, if it has.
+    pub fn integrity_error(&self) -> Option<String> {
+        self.integrity_error.lock().ok().and_then(|g| g.clone())
+    }
+
     pub fn is_open(&self) -> bool {
         self.store.lock().map(|g| g.is_some()).unwrap_or(false)
     }
 
-    /// Decrypt envelope (or create empty store) and hold it unlocked.
-    pub fn open(&self, key: [u8; 32]) -> Result<(), String> {
-        let store = if self.enc_path.exists() {
-            let blob = fs::read(&self.enc_path)
-                .map_err(|e| format!("read {}: {e}", self.enc_path.display()))?;
-            if blob.is_empty() {
-                AuditStore::open_memory()?
-            } else {
-                let plain = unseal(&key, &blob)?;
-                AuditStore::from_bytes(&plain)?
+    /// Recover the log and rebuild the query index from it.
+    pub fn open(&self, key: [u8; 32]) -> Result<LoadReport, String> {
+        let (events, report) = self.log.open(&key)?;
+        let store = AuditStore::open_memory()?;
+        // Replay in write order: `insert` replaces by id, so a task's terminal
+        // record supersedes the `running` one it wrote when it was queued.
+        for event in &events {
+            if let Err(e) = store.insert(event) {
+                eprintln!("audit index rebuild skipped {}: {e}", event.id);
             }
-        } else {
-            AuditStore::open_memory()?
-        };
+        }
         *self.store.lock().map_err(|e| e.to_string())? = Some(store);
         *self.key.lock().map_err(|e| e.to_string())? = Some(key);
-        Ok(())
-    }
-
-    /// Encrypt the live store to `enc_path` without closing the session.
-    /// Called after every mutation so a crash or `process::exit` cannot lose events.
-    pub fn persist(&self) -> Result<(), String> {
-        let (plain, key) = {
-            let store_guard = self.store.lock().map_err(|e| e.to_string())?;
-            let key_guard = self.key.lock().map_err(|e| e.to_string())?;
-            let Some(store) = store_guard.as_ref() else {
-                return Ok(());
-            };
-            let Some(key) = key_guard.as_ref() else {
-                return Ok(());
-            };
-            (store.to_bytes()?, *key)
-        };
-        let blob = seal(&key, &plain)?;
-        if let Some(parent) = self.enc_path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("create {}: {e}", parent.display()))?;
+        if let Ok(mut slot) = self.integrity_error.lock() {
+            *slot = report.integrity_error.clone();
         }
-        let tmp = self.enc_path.with_extension("enc.tmp");
-        fs::write(&tmp, &blob).map_err(|e| format!("write {}: {e}", tmp.display()))?;
-        fs::rename(&tmp, &self.enc_path)
-            .map_err(|e| format!("rename {} → {}: {e}", tmp.display(), self.enc_path.display()))?;
-        Ok(())
+        if report.truncated_tail {
+            eprintln!(
+                "audit log: discarded a partial trailing record after an unclean exit ({} kept)",
+                report.records
+            );
+        }
+        Ok(report)
     }
 
-    /// Seal store to `enc_path`, drop plaintext store, clear key.
-    pub fn close(&self) -> Result<(), String> {
-        self.persist()?;
-        self.discard();
-        Ok(())
-    }
-
-    /// Insert when open; otherwise increment dropped and return Ok(false).
+    /// Append when open; otherwise count the event as dropped and return `Ok(false)`.
     pub fn try_insert(&self, event: &AuditEvent) -> Result<bool, String> {
-        {
-            let guard = self.store.lock().map_err(|e| e.to_string())?;
+        let key = {
+            let guard = self.key.lock().map_err(|e| e.to_string())?;
             match guard.as_ref() {
-                Some(store) => store.insert(event)?,
+                Some(k) => *k,
                 None => {
                     self.dropped.fetch_add(1, Ordering::Relaxed);
                     return Ok(false);
                 }
             }
-        }
-        if let Err(e) = self.persist() {
-            eprintln!("audit persist after insert: {e}");
+        };
+        // Durable first: the log is the record of truth, the index is derived.
+        // Indexing an event the log rejected would show history that cannot
+        // survive a restart.
+        if let Err(e) = self.log.append(&key, event) {
             self.dropped.fetch_add(1, Ordering::Relaxed);
+            return Err(e);
+        }
+        let guard = self.store.lock().map_err(|e| e.to_string())?;
+        match guard.as_ref() {
+            Some(store) => store.insert(event)?,
+            None => {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+                return Ok(false);
+            }
         }
         Ok(true)
     }
@@ -172,7 +159,8 @@ impl AuditSession {
             }
         };
         if n > 0 {
-            self.persist()?;
+            // Retention must reach the durable log too, not just the index.
+            self.compact_log_from_index()?;
         }
         Ok(n)
     }
@@ -185,12 +173,43 @@ impl AuditSession {
                 None => return Err("audit session is closed".into()),
             }
         };
-        self.persist()?;
+        // Also the way out of a sealed log: compaction writes a fresh chain.
+        self.compact_log_from_index()?;
+        if let Ok(mut slot) = self.integrity_error.lock() {
+            *slot = None;
+        }
         Ok(n)
     }
 
-    /// Close without sealing (used on vault reset when the enc file is deleted).
+    /// Rewrite the log to match the index exactly.
+    fn compact_log_from_index(&self) -> Result<(), String> {
+        let key = {
+            let guard = self.key.lock().map_err(|e| e.to_string())?;
+            match guard.as_ref() {
+                Some(k) => *k,
+                None => return Ok(()),
+            }
+        };
+        let events = {
+            let guard = self.store.lock().map_err(|e| e.to_string())?;
+            match guard.as_ref() {
+                Some(store) => store.all_chronological()?,
+                None => return Ok(()),
+            }
+        };
+        self.log.compact(&key, &events)
+    }
+
+    /// Close the session. Every event is already durable, so this only releases
+    /// the file handle and forgets the key.
+    pub fn close(&self) -> Result<(), String> {
+        self.discard();
+        Ok(())
+    }
+
+    /// Drop the in-memory index, the key and the file handle.
     pub fn discard(&self) {
+        self.log.close();
         if let Ok(mut g) = self.store.lock() {
             *g = None;
         }
@@ -201,14 +220,8 @@ impl AuditSession {
 }
 
 impl Drop for AuditSession {
-    /// Seal to disk if the vault session is still open — covers app quit and
-    /// dev reload without an explicit `vault_lock`.
     fn drop(&mut self) {
-        if self.is_open() {
-            if let Err(e) = self.close() {
-                eprintln!("audit session drop: failed to seal: {e}");
-            }
-        }
+        self.discard();
     }
 }
 
@@ -218,6 +231,8 @@ mod tests {
     use crate::audit::store::SCHEMA_VERSION;
     use tempfile::tempdir;
 
+    const KEY: [u8; 32] = [9u8; 32];
+
     fn sample(id: &str, ts: i64) -> AuditEvent {
         AuditEvent {
             id: id.into(),
@@ -226,101 +241,127 @@ mod tests {
             profile_name: None,
             database: Some("db".into()),
             collection: Some("c".into()),
-            op: "dropCollection".into(),
+            op: "drop_collection".into(),
             source: "ui".into(),
             ok: true,
             error: None,
             duration_ms: None,
-            summary: "dropCollection db.c".into(),
+            summary: format!("dropCollection db.c {id}"),
             args_json: None,
             level_at_record: "A".into(),
             schema_version: SCHEMA_VERSION,
         }
     }
 
-    #[test]
-    fn seal_unseal_round_trip() {
-        let key = [7u8; 32];
-        let plain = b"sqlite-bytes-not-real-but-fine";
-        let blob = seal(&key, plain).expect("seal");
-        assert_ne!(&blob[..], &plain[..]);
-        let back = unseal(&key, &blob).expect("unseal");
-        assert_eq!(back, plain);
+    fn ids(session: &AuditSession) -> Vec<String> {
+        let mut rows = session.query(&AuditFilter::default()).expect("query");
+        rows.sort_by_key(|e| e.ts);
+        rows.into_iter().map(|e| e.id).collect()
     }
 
     #[test]
-    fn session_close_writes_enc_and_blocks_insert() {
+    fn events_survive_a_hard_exit_with_no_close() {
         let dir = tempdir().unwrap();
-        let enc = dir.path().join("audit.db.enc");
-        let session = AuditSession::new(enc.clone());
-        let key = [9u8; 32];
-        session.open(key).expect("open");
-        assert!(session
-            .try_insert(&sample("e1", 100))
-            .expect("insert while open"));
-        session.close().expect("close");
-        assert!(enc.exists(), "envelope file must exist after close");
-        assert!(!session.is_open());
-        let inserted = session
-            .try_insert(&sample("e2", 200))
-            .expect("soft-fail insert");
-        assert!(!inserted);
-        assert_eq!(session.dropped_count(), 1);
-
-        session.open(key).expect("reopen");
-        let rows = session.query(&AuditFilter::default()).expect("query");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].id, "e1");
-    }
-
-    #[test]
-    fn drop_seals_without_explicit_close() {
-        let dir = tempdir().unwrap();
-        let enc = dir.path().join("audit.db.enc");
-        let key = [9u8; 32];
-        {
-            let session = AuditSession::new(enc.clone());
-            session.open(key).expect("open");
-            assert!(session
-                .try_insert(&sample("e1", 100))
-                .expect("insert while open"));
-        }
-        assert!(enc.exists(), "envelope file must exist after drop");
-        let session2 = AuditSession::new(enc);
-        session2.open(key).expect("reopen");
-        let rows = session2.query(&AuditFilter::default()).expect("query");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].id, "e1");
-    }
-
-    #[test]
-    fn insert_persists_without_close() {
-        let dir = tempdir().unwrap();
-        let enc = dir.path().join("audit.db.enc");
-        let key = [9u8; 32];
-        let session = AuditSession::new(enc.clone());
-        session.open(key).expect("open");
-        assert!(session
-            .try_insert(&sample("e1", 100))
-            .expect("insert"));
-        assert!(
-            enc.exists(),
-            "envelope must exist after insert, before close"
-        );
-        // Simulate a hard process exit: the live session is abandoned without close().
+        let path = dir.path().join("audit.log.enc");
+        let session = AuditSession::new(path.clone());
+        session.open(KEY).expect("open");
+        assert!(session.try_insert(&sample("e1", 100)).expect("insert"));
+        assert!(session.try_insert(&sample("e2", 200)).expect("insert"));
+        // No close(): every append was already fsynced.
         std::mem::forget(session);
-        let session2 = AuditSession::new(enc);
-        session2.open(key).expect("reopen after crash");
-        let rows = session2.query(&AuditFilter::default()).expect("query");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].id, "e1");
+
+        let reopened = AuditSession::new(path);
+        let report = reopened.open(KEY).expect("reopen");
+        assert_eq!(report.records, 2);
+        assert!(report.integrity_error.is_none());
+        assert_eq!(ids(&reopened), ["e1", "e2"]);
     }
 
     #[test]
-    fn wrong_key_fails_unseal() {
-        let key = [1u8; 32];
-        let other = [2u8; 32];
-        let blob = seal(&key, b"data").expect("seal");
-        assert!(unseal(&other, &blob).is_err());
+    fn insert_is_refused_and_counted_after_close() {
+        let dir = tempdir().unwrap();
+        let session = AuditSession::new(dir.path().join("audit.log.enc"));
+        session.open(KEY).expect("open");
+        assert!(session.try_insert(&sample("e1", 100)).expect("insert"));
+        session.close().expect("close");
+        assert!(!session.is_open());
+
+        assert!(!session.try_insert(&sample("e2", 200)).expect("soft-fail"));
+        assert_eq!(session.dropped_count(), 1);
+    }
+
+    #[test]
+    fn prune_reaches_the_durable_log_not_just_the_index() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.log.enc");
+        let session = AuditSession::new(path.clone());
+        session.open(KEY).expect("open");
+        session.try_insert(&sample("old", 1_000)).expect("insert");
+        session.try_insert(&sample("new", 5_000)).expect("insert");
+        assert_eq!(session.prune_before(3_000).expect("prune"), 1);
+        session.close().expect("close");
+
+        // The pruned event must not come back from the log on the next unlock.
+        let reopened = AuditSession::new(path);
+        reopened.open(KEY).expect("reopen");
+        assert_eq!(ids(&reopened), ["new"]);
+    }
+
+    #[test]
+    fn clear_all_does_not_come_back_from_the_log() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.log.enc");
+        let session = AuditSession::new(path.clone());
+        session.open(KEY).expect("open");
+        session.try_insert(&sample("e1", 100)).expect("insert");
+        session.try_insert(&sample("e2", 200)).expect("insert");
+        assert_eq!(session.clear_all().expect("clear"), 2);
+        session.close().expect("close");
+
+        let reopened = AuditSession::new(path);
+        let report = reopened.open(KEY).expect("reopen");
+        assert_eq!(report.records, 0);
+        assert!(ids(&reopened).is_empty());
+    }
+
+    #[test]
+    fn a_tampered_log_surfaces_an_integrity_error_and_stops_recording() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.log.enc");
+        let session = AuditSession::new(path.clone());
+        session.open(KEY).expect("open");
+        session.try_insert(&sample("e1", 100)).expect("insert");
+        session.try_insert(&sample("e2", 200)).expect("insert");
+        session.close().expect("close");
+
+        let mut bytes = std::fs::read(&path).unwrap();
+        let len = bytes.len();
+        bytes[24] ^= 0xff; // inside the first record's ciphertext
+        std::fs::write(&path, &bytes).unwrap();
+
+        let reopened = AuditSession::new(path.clone());
+        let report = reopened.open(KEY).expect("open a damaged log");
+        assert!(report.integrity_error.is_some(), "{report:?}");
+        assert!(reopened.integrity_error().is_some());
+
+        // Recording stops rather than overwriting the evidence.
+        assert!(reopened.try_insert(&sample("e3", 300)).is_err());
+        assert_eq!(std::fs::read(&path).unwrap().len(), len);
+
+        // Clearing is the documented way back to a working log.
+        reopened.clear_all().expect("clear");
+        assert!(reopened.integrity_error().is_none());
+        assert!(reopened.try_insert(&sample("e4", 400)).expect("insert"));
+    }
+
+    #[test]
+    fn policy_defaults_to_level_a_without_payloads() {
+        let dir = tempdir().unwrap();
+        let session = AuditSession::new(dir.path().join("audit.log.enc"));
+        let policy = session.policy();
+        assert!(policy.enabled);
+        assert_eq!(policy.level, AuditLevel::A);
+        assert!(!policy.include_payloads);
+        assert_eq!(policy.retention_days, 30);
     }
 }

--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use super::level::AuditLevel;
-use super::log::{AuditLog, LoadReport};
+use super::log::{AuditLog, LoadReport, RetainedLock};
 use super::store::{AuditEvent, AuditFilter, AuditStore};
 
 /// Cached audit settings for the open vault session (refreshed on unlock / save).
@@ -90,6 +90,17 @@ impl AuditSession {
     /// Recover the log and rebuild the query index from it.
     pub fn open(&self, key: [u8; 32]) -> Result<LoadReport, String> {
         let (events, report) = self.log.open(&key)?;
+        self.seed_index(key, events, &report)?;
+        Ok(report)
+    }
+
+    /// Build the in-memory query index from recovered records.
+    fn seed_index(
+        &self,
+        key: [u8; 32],
+        events: Vec<AuditEvent>,
+        report: &LoadReport,
+    ) -> Result<(), String> {
         let store = AuditStore::open_memory()?;
         // Replay in write order: `insert` replaces by id, so a task's terminal
         // record supersedes the `running` one it wrote when it was queued.
@@ -109,7 +120,7 @@ impl AuditSession {
                 report.records
             );
         }
-        Ok(report)
+        Ok(())
     }
 
     /// Append when open; otherwise count the event as dropped and return `Ok(false)`.
@@ -150,7 +161,14 @@ impl AuditSession {
         }
     }
 
+    /// Apply retention. A no-op on a sealed log: pruning compacts, and
+    /// compaction would replace the very file being preserved as evidence and
+    /// clear its seal. Only an explicit [`Self::clear_all`] may do that.
     pub fn prune_before(&self, ts_ms: i64) -> Result<u64, String> {
+        if let Some(reason) = self.integrity_error() {
+            eprintln!("audit: skipping retention prune, log is sealed: {reason}");
+            return Ok(0);
+        }
         let n = {
             let guard = self.store.lock().map_err(|e| e.to_string())?;
             match guard.as_ref() {
@@ -205,6 +223,27 @@ impl AuditSession {
     pub fn close(&self) -> Result<(), String> {
         self.discard();
         Ok(())
+    }
+
+    /// Close the session but keep the log's cross-process lock held, so a key
+    /// rotation can replace the file with no window for another instance to
+    /// take it and append under the old key.
+    pub fn close_retaining_lock(&self) -> Option<RetainedLock> {
+        let retained = self.log.close_retaining_lock();
+        if let Ok(mut g) = self.store.lock() {
+            *g = None;
+        }
+        if let Ok(mut k) = self.key.lock() {
+            *k = None;
+        }
+        retained
+    }
+
+    /// Reopen using a lock handed over by [`Self::close_retaining_lock`].
+    pub fn open_retaining(&self, key: [u8; 32], lock: RetainedLock) -> Result<LoadReport, String> {
+        let (events, report) = self.log.open_retaining(&key, lock)?;
+        self.seed_index(key, events, &report)?;
+        Ok(report)
     }
 
     /// Drop the in-memory index, the key and the file handle.
@@ -355,6 +394,35 @@ mod tests {
         reopened.clear_all().expect("clear");
         assert!(reopened.integrity_error().is_none());
         assert!(reopened.try_insert(&sample("e4", 400)).expect("insert"));
+    }
+
+    #[test]
+    fn retention_never_prunes_a_sealed_log() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.log.enc");
+        let session = AuditSession::new(path.clone());
+        session.open(KEY).expect("open");
+        session.try_insert(&sample("old", 1_000)).expect("insert");
+        session.try_insert(&sample("new", 5_000)).expect("insert");
+        session.close().expect("close");
+
+        // Tamper, then reopen: the log seals.
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes[24] ^= 0xff;
+        std::fs::write(&path, &bytes).unwrap();
+        let reopened = AuditSession::new(path.clone());
+        let report = reopened.open(KEY).expect("open damaged");
+        assert!(report.integrity_error.is_some(), "{report:?}");
+
+        // Pruning compacts, and compaction would replace the file and clear the
+        // seal — destroying the evidence sealing exists to keep.
+        assert_eq!(
+            reopened.prune_before(9_999).expect("prune"),
+            0,
+            "a sealed log must not be pruned"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), bytes, "file must be untouched");
+        assert!(reopened.integrity_error().is_some(), "seal must remain");
     }
 
     #[test]

--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
+use super::level::AuditLevel;
 use super::store::{AuditEvent, AuditFilter, AuditStore};
 
 /// Encrypt raw SQLite DB bytes with the vault key.
@@ -18,12 +19,31 @@ pub fn unseal(key: &[u8; 32], blob: &[u8]) -> Result<Vec<u8>, String> {
     vault::decrypt(key, blob)
 }
 
+/// Cached audit settings for the open vault session (refreshed on unlock / save).
+#[derive(Clone, Copy, Debug)]
+pub struct AuditPolicy {
+    pub enabled: bool,
+    pub level: AuditLevel,
+    pub include_payloads: bool,
+}
+
+impl Default for AuditPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            level: AuditLevel::A,
+            include_payloads: false,
+        }
+    }
+}
+
 /// Open audit session while vault is unlocked; sealed on close/lock.
 pub struct AuditSession {
     enc_path: PathBuf,
     store: Mutex<Option<AuditStore>>,
     key: Mutex<Option<[u8; 32]>>,
     dropped: AtomicU64,
+    policy: Mutex<AuditPolicy>,
 }
 
 impl AuditSession {
@@ -33,6 +53,20 @@ impl AuditSession {
             store: Mutex::new(None),
             key: Mutex::new(None),
             dropped: AtomicU64::new(0),
+            policy: Mutex::new(AuditPolicy::default()),
+        }
+    }
+
+    pub fn policy(&self) -> AuditPolicy {
+        self.policy
+            .lock()
+            .map(|g| *g)
+            .unwrap_or_default()
+    }
+
+    pub fn set_policy(&self, policy: AuditPolicy) {
+        if let Ok(mut g) = self.policy.lock() {
+            *g = policy;
         }
     }
 

--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 
 use super::level::AuditLevel;
 use super::log::{AuditLog, LoadReport, RetainedLock};
-use super::store::{AuditEvent, AuditFilter, AuditStore};
+use super::store::{AuditEvent, AuditFilter, AuditStore, SCHEMA_VERSION, TOMBSTONE_OP};
 
 /// Cached audit settings for the open vault session (refreshed on unlock / save).
 #[derive(Clone, Copy, Debug)]
@@ -28,6 +28,45 @@ impl Default for AuditPolicy {
             include_payloads: false,
             retention_days: 30,
         }
+    }
+}
+
+/// Build the record left behind when a damaged log is discarded.
+///
+/// Everything that matters goes in `summary` and `error`, which are stored at
+/// every level and under any payload setting — unlike `args_json`, which the
+/// payload gate can drop.
+fn tombstone(
+    discarded: u64,
+    verified_count: u64,
+    verified_head: Option<&str>,
+    reason: &str,
+) -> AuditEvent {
+    let head = verified_head
+        .map(|h| &h[..h.len().min(16)])
+        .unwrap_or("unknown");
+    AuditEvent {
+        id: uuid::Uuid::new_v4().to_string(),
+        ts: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0),
+        connection_id: None,
+        profile_name: None,
+        database: None,
+        collection: None,
+        op: TOMBSTONE_OP.to_string(),
+        source: "ui".into(),
+        ok: false,
+        error: Some(reason.to_string()),
+        duration_ms: None,
+        summary: format!(
+            "damaged activity log discarded — {discarded} readable event(s) removed, \
+             the rest unverifiable; verified {verified_count} record(s) up to chain {head}"
+        ),
+        args_json: None,
+        level_at_record: "-".into(),
+        schema_version: SCHEMA_VERSION,
     }
 }
 
@@ -79,8 +118,16 @@ impl AuditSession {
     }
 
     /// Why the log stopped accepting events, if it has.
+    ///
+    /// Falls through to the log's own seal so a seal created *after* load — a
+    /// compaction that replaced the file but could not update its counter —
+    /// cannot leave status reporting healthy while every append is refused.
     pub fn integrity_error(&self) -> Option<String> {
-        self.integrity_error.lock().ok().and_then(|g| g.clone())
+        self.integrity_error
+            .lock()
+            .ok()
+            .and_then(|g| g.clone())
+            .or_else(|| self.log.sealed_reason())
     }
 
     pub fn is_open(&self) -> bool {
@@ -163,7 +210,7 @@ impl AuditSession {
 
     /// Apply retention. A no-op on a sealed log: pruning compacts, and
     /// compaction would replace the very file being preserved as evidence and
-    /// clear its seal. Only an explicit [`Self::clear_all`] may do that.
+    /// clear its seal. Only an explicit [`Self::discard_damaged_log`] may do that.
     pub fn prune_before(&self, ts_ms: i64) -> Result<u64, String> {
         if let Some(reason) = self.integrity_error() {
             eprintln!("audit: skipping retention prune, log is sealed: {reason}");
@@ -183,20 +230,54 @@ impl AuditSession {
         Ok(n)
     }
 
-    pub fn clear_all(&self) -> Result<u64, String> {
-        let n = {
-            let guard = self.store.lock().map_err(|e| e.to_string())?;
-            match guard.as_ref() {
-                Some(store) => store.clear_all()?,
-                None => return Err("audit session is closed".into()),
-            }
+    /// Discard a *damaged* log and resume recording, leaving a permanent record
+    /// that it happened.
+    ///
+    /// Deliberately not a general "clear": retention is the only way a healthy
+    /// log shrinks. An audit trail with a one-click erase button defeats every
+    /// integrity check around it — those checks would then only defend against
+    /// someone *without* access to the app, which is the wrong adversary. So this
+    /// refuses unless the log is already sealed, and even then it writes a
+    /// tombstone as the first record of the new chain. Retention skips tombstones
+    /// and a discard preserves any that are still readable.
+    ///
+    /// The guarantee is therefore: a discard always leaves a record of itself, so
+    /// a discarded log can never be made to look like one that never was. It is
+    /// *not* that the full history of discards survives — damaging the file can
+    /// destroy earlier tombstones along with everything else, though doing so
+    /// seals the log again and so leaves a fresh one.
+    pub fn discard_damaged_log(&self) -> Result<u64, String> {
+        let Some(reason) = self.integrity_error() else {
+            return Err("the activity log is intact, so there is nothing to discard. \
+                        Old events are removed automatically by the retention setting."
+                .into());
         };
-        // Also the way out of a sealed log: compaction writes a fresh chain.
+
+        let verified_head = self.log.chain_head_hex();
+        let verified_count = self.log.record_count().unwrap_or(0);
+
+        let discarded = {
+            let guard = self.store.lock().map_err(|e| e.to_string())?;
+            let Some(store) = guard.as_ref() else {
+                return Err("audit session is closed".into());
+            };
+            let discarded = store.retain_tombstones_only()?;
+            store.insert(&tombstone(
+                discarded,
+                verified_count,
+                verified_head.as_deref(),
+                &reason,
+            ))?;
+            discarded
+        };
+
+        // Compaction is what actually replaces the sealed file, and it clears the
+        // log's own seal; the session's copy is cleared alongside it.
         self.compact_log_from_index()?;
         if let Ok(mut slot) = self.integrity_error.lock() {
             *slot = None;
         }
-        Ok(n)
+        Ok(discarded)
     }
 
     /// Rewrite the log to match the index exactly.
@@ -350,20 +431,17 @@ mod tests {
     }
 
     #[test]
-    fn clear_all_does_not_come_back_from_the_log() {
+    fn an_intact_log_cannot_be_erased() {
         let dir = tempdir().unwrap();
-        let path = dir.path().join("audit.log.enc");
-        let session = AuditSession::new(path.clone());
+        let session = AuditSession::new(dir.path().join("audit.log.enc"));
         session.open(KEY).expect("open");
         session.try_insert(&sample("e1", 100)).expect("insert");
-        session.try_insert(&sample("e2", 200)).expect("insert");
-        assert_eq!(session.clear_all().expect("clear"), 2);
-        session.close().expect("close");
 
-        let reopened = AuditSession::new(path);
-        let report = reopened.open(KEY).expect("reopen");
-        assert_eq!(report.records, 0);
-        assert!(ids(&reopened).is_empty());
+        // The whole point of the split: retention removes events, a human cannot.
+        let err = session.discard_damaged_log().expect_err("must refuse");
+        assert!(err.contains("intact"), "{err}");
+        assert!(err.contains("retention"), "{err}");
+        assert_eq!(ids(&session), ["e1"], "the event must survive");
     }
 
     #[test]
@@ -376,9 +454,11 @@ mod tests {
         session.try_insert(&sample("e2", 200)).expect("insert");
         session.close().expect("close");
 
+        // Damage the *last* record: earlier ones stay readable, which is the
+        // interesting case — a partial recovery followed by a discard.
         let mut bytes = std::fs::read(&path).unwrap();
         let len = bytes.len();
-        bytes[24] ^= 0xff; // inside the first record's ciphertext
+        *bytes.last_mut().unwrap() ^= 0xff;
         std::fs::write(&path, &bytes).unwrap();
 
         let reopened = AuditSession::new(path.clone());
@@ -390,39 +470,76 @@ mod tests {
         assert!(reopened.try_insert(&sample("e3", 300)).is_err());
         assert_eq!(std::fs::read(&path).unwrap().len(), len);
 
-        // Clearing is the documented way back to a working log.
-        reopened.clear_all().expect("clear");
-        assert!(reopened.integrity_error().is_none());
+        // Discarding is the documented way back to a working log — and it must
+        // leave a permanent record that it happened.
+        let discarded = reopened.discard_damaged_log().expect("discard");
+        assert_eq!(discarded, 1, "the readable event is removed with the rest");
+        assert!(reopened.integrity_error().is_none(), "seal must be cleared");
         assert!(reopened.try_insert(&sample("e4", 400)).expect("insert"));
+
+        let rows = reopened.query(&AuditFilter::default()).expect("query");
+        let tomb: Vec<_> = rows
+            .iter()
+            .filter(|e| e.op == crate::audit::store::TOMBSTONE_OP)
+            .collect();
+        assert_eq!(tomb.len(), 1, "exactly one tombstone");
+        assert!(!tomb[0].ok, "a discard is not a success");
+        assert!(tomb[0].summary.contains("discarded"), "{}", tomb[0].summary);
+        assert!(
+            tomb[0].error.as_deref().unwrap_or("").len() > 0,
+            "the tombstone must carry why the log was unverifiable"
+        );
     }
 
     #[test]
-    fn retention_never_prunes_a_sealed_log() {
+    fn a_tombstone_survives_retention_and_accumulates_across_discards() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("audit.log.enc");
+
+        let damage_last_record = || {
+            let mut bytes = std::fs::read(&path).unwrap();
+            *bytes.last_mut().unwrap() ^= 0xff;
+            std::fs::write(&path, &bytes).unwrap();
+        };
+
         let session = AuditSession::new(path.clone());
         session.open(KEY).expect("open");
-        session.try_insert(&sample("old", 1_000)).expect("insert");
-        session.try_insert(&sample("new", 5_000)).expect("insert");
+        session.try_insert(&sample("e1", 100)).expect("insert");
         session.close().expect("close");
+        damage_last_record();
 
-        // Tamper, then reopen: the log seals.
-        let mut bytes = std::fs::read(&path).unwrap();
-        bytes[24] ^= 0xff;
-        std::fs::write(&path, &bytes).unwrap();
-        let reopened = AuditSession::new(path.clone());
-        let report = reopened.open(KEY).expect("open damaged");
-        assert!(report.integrity_error.is_some(), "{report:?}");
+        let s1 = AuditSession::new(path.clone());
+        s1.open(KEY).expect("open damaged");
+        s1.discard_damaged_log().expect("discard");
 
-        // Pruning compacts, and compaction would replace the file and clear the
-        // seal — destroying the evidence sealing exists to keep.
+        // Retention must not put a deadline on the record that a discard happened.
         assert_eq!(
-            reopened.prune_before(9_999).expect("prune"),
+            s1.prune_before(i64::MAX).expect("prune"),
             0,
-            "a sealed log must not be pruned"
+            "a tombstone must not be pruned away"
         );
-        assert_eq!(std::fs::read(&path).unwrap(), bytes, "file must be untouched");
-        assert!(reopened.integrity_error().is_some(), "seal must remain");
+        assert_eq!(
+            s1.query(&AuditFilter::default()).expect("query").len(),
+            1,
+            "the tombstone remains"
+        );
+
+        // Record again, damage the new record, discard again: the earlier
+        // tombstone is still readable, so the two accumulate.
+        s1.try_insert(&sample("e2", 200)).expect("insert");
+        s1.close().expect("close");
+        damage_last_record();
+
+        let s2 = AuditSession::new(path);
+        s2.open(KEY).expect("open damaged again");
+        s2.discard_damaged_log().expect("second discard");
+
+        let rows = s2.query(&AuditFilter::default()).expect("query");
+        let tombs = rows
+            .iter()
+            .filter(|e| e.op == crate::audit::store::TOMBSTONE_OP)
+            .count();
+        assert_eq!(tombs, 2, "a readable earlier discard must stay on record");
     }
 
     #[test]

--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -103,39 +103,56 @@ impl AuditSession {
         Ok(())
     }
 
+    /// Encrypt the live store to `enc_path` without closing the session.
+    /// Called after every mutation so a crash or `process::exit` cannot lose events.
+    pub fn persist(&self) -> Result<(), String> {
+        let (plain, key) = {
+            let store_guard = self.store.lock().map_err(|e| e.to_string())?;
+            let key_guard = self.key.lock().map_err(|e| e.to_string())?;
+            let Some(store) = store_guard.as_ref() else {
+                return Ok(());
+            };
+            let Some(key) = key_guard.as_ref() else {
+                return Ok(());
+            };
+            (store.to_bytes()?, *key)
+        };
+        let blob = seal(&key, &plain)?;
+        if let Some(parent) = self.enc_path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("create {}: {e}", parent.display()))?;
+        }
+        let tmp = self.enc_path.with_extension("enc.tmp");
+        fs::write(&tmp, &blob).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+        fs::rename(&tmp, &self.enc_path)
+            .map_err(|e| format!("rename {} → {}: {e}", tmp.display(), self.enc_path.display()))?;
+        Ok(())
+    }
+
     /// Seal store to `enc_path`, drop plaintext store, clear key.
     pub fn close(&self) -> Result<(), String> {
-        let mut store_guard = self.store.lock().map_err(|e| e.to_string())?;
-        let mut key_guard = self.key.lock().map_err(|e| e.to_string())?;
-        let key = key_guard
-            .take()
-            .ok_or_else(|| "audit session has no key".to_string())?;
-        if let Some(store) = store_guard.take() {
-            let plain = store.to_bytes()?;
-            let blob = seal(&key, &plain)?;
-            if let Some(parent) = self.enc_path.parent() {
-                fs::create_dir_all(parent)
-                    .map_err(|e| format!("create {}: {e}", parent.display()))?;
-            }
-            fs::write(&self.enc_path, blob)
-                .map_err(|e| format!("write {}: {e}", self.enc_path.display()))?;
-        }
+        self.persist()?;
+        self.discard();
         Ok(())
     }
 
     /// Insert when open; otherwise increment dropped and return Ok(false).
     pub fn try_insert(&self, event: &AuditEvent) -> Result<bool, String> {
-        let guard = self.store.lock().map_err(|e| e.to_string())?;
-        match guard.as_ref() {
-            Some(store) => {
-                store.insert(event)?;
-                Ok(true)
-            }
-            None => {
-                self.dropped.fetch_add(1, Ordering::Relaxed);
-                Ok(false)
+        {
+            let guard = self.store.lock().map_err(|e| e.to_string())?;
+            match guard.as_ref() {
+                Some(store) => store.insert(event)?,
+                None => {
+                    self.dropped.fetch_add(1, Ordering::Relaxed);
+                    return Ok(false);
+                }
             }
         }
+        if let Err(e) = self.persist() {
+            eprintln!("audit persist after insert: {e}");
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(true)
     }
 
     pub fn query(&self, filter: &AuditFilter) -> Result<Vec<AuditEvent>, String> {
@@ -147,19 +164,29 @@ impl AuditSession {
     }
 
     pub fn prune_before(&self, ts_ms: i64) -> Result<u64, String> {
-        let guard = self.store.lock().map_err(|e| e.to_string())?;
-        match guard.as_ref() {
-            Some(store) => store.prune_before(ts_ms),
-            None => Ok(0),
+        let n = {
+            let guard = self.store.lock().map_err(|e| e.to_string())?;
+            match guard.as_ref() {
+                Some(store) => store.prune_before(ts_ms)?,
+                None => return Ok(0),
+            }
+        };
+        if n > 0 {
+            self.persist()?;
         }
+        Ok(n)
     }
 
     pub fn clear_all(&self) -> Result<u64, String> {
-        let guard = self.store.lock().map_err(|e| e.to_string())?;
-        match guard.as_ref() {
-            Some(store) => store.clear_all(),
-            None => Err("audit session is closed".into()),
-        }
+        let n = {
+            let guard = self.store.lock().map_err(|e| e.to_string())?;
+            match guard.as_ref() {
+                Some(store) => store.clear_all()?,
+                None => return Err("audit session is closed".into()),
+            }
+        };
+        self.persist()?;
+        Ok(n)
     }
 
     /// Close without sealing (used on vault reset when the enc file is deleted).
@@ -261,6 +288,29 @@ mod tests {
         assert!(enc.exists(), "envelope file must exist after drop");
         let session2 = AuditSession::new(enc);
         session2.open(key).expect("reopen");
+        let rows = session2.query(&AuditFilter::default()).expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "e1");
+    }
+
+    #[test]
+    fn insert_persists_without_close() {
+        let dir = tempdir().unwrap();
+        let enc = dir.path().join("audit.db.enc");
+        let key = [9u8; 32];
+        let session = AuditSession::new(enc.clone());
+        session.open(key).expect("open");
+        assert!(session
+            .try_insert(&sample("e1", 100))
+            .expect("insert"));
+        assert!(
+            enc.exists(),
+            "envelope must exist after insert, before close"
+        );
+        // Simulate a hard process exit: the live session is abandoned without close().
+        std::mem::forget(session);
+        let session2 = AuditSession::new(enc);
+        session2.open(key).expect("reopen after crash");
         let rows = session2.query(&AuditFilter::default()).expect("query");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].id, "e1");

--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -267,8 +267,11 @@ mod tests {
         session.open(KEY).expect("open");
         assert!(session.try_insert(&sample("e1", 100)).expect("insert"));
         assert!(session.try_insert(&sample("e2", 200)).expect("insert"));
-        // No close(): every append was already fsynced.
-        std::mem::forget(session);
+        // Dropped without close(): every append was already fsynced, so nothing
+        // depends on an orderly shutdown. Dropping rather than `mem::forget`ing
+        // because a dying process releases the log's advisory lock, and a leaked
+        // handle would not.
+        drop(session);
 
         let reopened = AuditSession::new(path);
         let report = reopened.open(KEY).expect("reopen");

--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -25,6 +25,7 @@ pub struct AuditPolicy {
     pub enabled: bool,
     pub level: AuditLevel,
     pub include_payloads: bool,
+    pub retention_days: u32,
 }
 
 impl Default for AuditPolicy {
@@ -33,6 +34,7 @@ impl Default for AuditPolicy {
             enabled: true,
             level: AuditLevel::A,
             include_payloads: false,
+            retention_days: 30,
         }
     }
 }
@@ -171,6 +173,18 @@ impl AuditSession {
     }
 }
 
+impl Drop for AuditSession {
+    /// Seal to disk if the vault session is still open — covers app quit and
+    /// dev reload without an explicit `vault_lock`.
+    fn drop(&mut self) {
+        if self.is_open() {
+            if let Err(e) = self.close() {
+                eprintln!("audit session drop: failed to seal: {e}");
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,6 +242,26 @@ mod tests {
 
         session.open(key).expect("reopen");
         let rows = session.query(&AuditFilter::default()).expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "e1");
+    }
+
+    #[test]
+    fn drop_seals_without_explicit_close() {
+        let dir = tempdir().unwrap();
+        let enc = dir.path().join("audit.db.enc");
+        let key = [9u8; 32];
+        {
+            let session = AuditSession::new(enc.clone());
+            session.open(key).expect("open");
+            assert!(session
+                .try_insert(&sample("e1", 100))
+                .expect("insert while open"));
+        }
+        assert!(enc.exists(), "envelope file must exist after drop");
+        let session2 = AuditSession::new(enc);
+        session2.open(key).expect("reopen");
+        let rows = session2.query(&AuditFilter::default()).expect("query");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].id, "e1");
     }

--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -1,0 +1,182 @@
+//! Vault AES-GCM envelope for the audit SQLite DB (#272).
+
+use crate::vault;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use super::store::{AuditEvent, AuditFilter, AuditStore};
+
+/// Encrypt raw SQLite DB bytes with the vault key.
+pub fn seal(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, String> {
+    vault::encrypt(key, plaintext)
+}
+
+/// Decrypt an `audit.db.enc` blob back to SQLite bytes.
+pub fn unseal(key: &[u8; 32], blob: &[u8]) -> Result<Vec<u8>, String> {
+    vault::decrypt(key, blob)
+}
+
+/// Open audit session while vault is unlocked; sealed on close/lock.
+pub struct AuditSession {
+    enc_path: PathBuf,
+    store: Mutex<Option<AuditStore>>,
+    key: Mutex<Option<[u8; 32]>>,
+    dropped: AtomicU64,
+}
+
+impl AuditSession {
+    pub fn new(enc_path: PathBuf) -> Self {
+        Self {
+            enc_path,
+            store: Mutex::new(None),
+            key: Mutex::new(None),
+            dropped: AtomicU64::new(0),
+        }
+    }
+
+    pub fn enc_path(&self) -> &Path {
+        &self.enc_path
+    }
+
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.store.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
+
+    /// Decrypt envelope (or create empty store) and hold it unlocked.
+    pub fn open(&self, key: [u8; 32]) -> Result<(), String> {
+        let store = if self.enc_path.exists() {
+            let blob = fs::read(&self.enc_path)
+                .map_err(|e| format!("read {}: {e}", self.enc_path.display()))?;
+            if blob.is_empty() {
+                AuditStore::open_memory()?
+            } else {
+                let plain = unseal(&key, &blob)?;
+                AuditStore::from_bytes(&plain)?
+            }
+        } else {
+            AuditStore::open_memory()?
+        };
+        *self.store.lock().map_err(|e| e.to_string())? = Some(store);
+        *self.key.lock().map_err(|e| e.to_string())? = Some(key);
+        Ok(())
+    }
+
+    /// Seal store to `enc_path`, drop plaintext store, clear key.
+    pub fn close(&self) -> Result<(), String> {
+        let mut store_guard = self.store.lock().map_err(|e| e.to_string())?;
+        let mut key_guard = self.key.lock().map_err(|e| e.to_string())?;
+        let key = key_guard
+            .take()
+            .ok_or_else(|| "audit session has no key".to_string())?;
+        if let Some(store) = store_guard.take() {
+            let plain = store.to_bytes()?;
+            let blob = seal(&key, &plain)?;
+            if let Some(parent) = self.enc_path.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|e| format!("create {}: {e}", parent.display()))?;
+            }
+            fs::write(&self.enc_path, blob)
+                .map_err(|e| format!("write {}: {e}", self.enc_path.display()))?;
+        }
+        Ok(())
+    }
+
+    /// Insert when open; otherwise increment dropped and return Ok(false).
+    pub fn try_insert(&self, event: &AuditEvent) -> Result<bool, String> {
+        let guard = self.store.lock().map_err(|e| e.to_string())?;
+        match guard.as_ref() {
+            Some(store) => {
+                store.insert(event)?;
+                Ok(true)
+            }
+            None => {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+                Ok(false)
+            }
+        }
+    }
+
+    pub fn query(&self, filter: &AuditFilter) -> Result<Vec<AuditEvent>, String> {
+        let guard = self.store.lock().map_err(|e| e.to_string())?;
+        match guard.as_ref() {
+            Some(store) => store.query(filter),
+            None => Err("audit session is closed".into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::store::SCHEMA_VERSION;
+    use tempfile::tempdir;
+
+    fn sample(id: &str, ts: i64) -> AuditEvent {
+        AuditEvent {
+            id: id.into(),
+            ts,
+            connection_id: None,
+            profile_name: None,
+            database: Some("db".into()),
+            collection: Some("c".into()),
+            op: "dropCollection".into(),
+            source: "ui".into(),
+            ok: true,
+            error: None,
+            duration_ms: None,
+            summary: "dropCollection db.c".into(),
+            args_json: None,
+            level_at_record: "A".into(),
+            schema_version: SCHEMA_VERSION,
+        }
+    }
+
+    #[test]
+    fn seal_unseal_round_trip() {
+        let key = [7u8; 32];
+        let plain = b"sqlite-bytes-not-real-but-fine";
+        let blob = seal(&key, plain).expect("seal");
+        assert_ne!(&blob[..], &plain[..]);
+        let back = unseal(&key, &blob).expect("unseal");
+        assert_eq!(back, plain);
+    }
+
+    #[test]
+    fn session_close_writes_enc_and_blocks_insert() {
+        let dir = tempdir().unwrap();
+        let enc = dir.path().join("audit.db.enc");
+        let session = AuditSession::new(enc.clone());
+        let key = [9u8; 32];
+        session.open(key).expect("open");
+        assert!(session
+            .try_insert(&sample("e1", 100))
+            .expect("insert while open"));
+        session.close().expect("close");
+        assert!(enc.exists(), "envelope file must exist after close");
+        assert!(!session.is_open());
+        let inserted = session
+            .try_insert(&sample("e2", 200))
+            .expect("soft-fail insert");
+        assert!(!inserted);
+        assert_eq!(session.dropped_count(), 1);
+
+        session.open(key).expect("reopen");
+        let rows = session.query(&AuditFilter::default()).expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "e1");
+    }
+
+    #[test]
+    fn wrong_key_fails_unseal() {
+        let key = [1u8; 32];
+        let other = [2u8; 32];
+        let blob = seal(&key, b"data").expect("seal");
+        assert!(unseal(&other, &blob).is_err());
+    }
+}

--- a/src-tauri/src/audit/level.rs
+++ b/src-tauri/src/audit/level.rs
@@ -14,6 +14,24 @@ pub enum AuditLevel {
     C,
 }
 
+impl AuditLevel {
+    pub fn parse(s: &str) -> Self {
+        match s.trim() {
+            "B" | "b" => Self::B,
+            "C" | "c" => Self::C,
+            _ => Self::A,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::A => "A",
+            Self::B => "B",
+            Self::C => "C",
+        }
+    }
+}
+
 /// Coarse class of a MongoDB-facing operation for level gating.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OpClass {
@@ -65,5 +83,14 @@ mod tests {
         assert!(should_record(AuditLevel::C, OpClass::Shell));
         assert!(should_record(AuditLevel::C, OpClass::ReadHigh));
         assert!(should_record(AuditLevel::C, OpClass::ReadOther));
+    }
+
+    #[test]
+    fn parse_level_defaults_unknown_to_a() {
+        assert_eq!(AuditLevel::parse("A"), AuditLevel::A);
+        assert_eq!(AuditLevel::parse("b"), AuditLevel::B);
+        assert_eq!(AuditLevel::parse("C"), AuditLevel::C);
+        assert_eq!(AuditLevel::parse("nope"), AuditLevel::A);
+        assert_eq!(AuditLevel::A.as_str(), "A");
     }
 }

--- a/src-tauri/src/audit/level.rs
+++ b/src-tauri/src/audit/level.rs
@@ -1,0 +1,69 @@
+//! Audit logging level gate (#272).
+//!
+//! Decides whether an operation class is recorded at the configured
+//! [`AuditLevel`].
+
+/// User-selectable audit verbosity (Settings → Activity / Audit).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuditLevel {
+    /// Writes + mongosh (default).
+    A,
+    /// A + high-level reads (find/aggregate/count/explain/list summaries).
+    B,
+    /// All DB-facing commands (READ ∪ GUARDED_WRITE) + mongosh.
+    C,
+}
+
+/// Coarse class of a MongoDB-facing operation for level gating.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpClass {
+    /// Insert/update/delete/drop/rename/import/restore/generate/$out/$merge, etc.
+    Write,
+    /// Embedded mongosh command text.
+    Shell,
+    /// find / aggregate (read) / count / explain / namespace list-shaped reads.
+    ReadHigh,
+    /// Other DB reads covered only at level C (stats, profiler read, etc.).
+    ReadOther,
+}
+
+/// Returns true when `op` should be persisted at the given settings level.
+pub fn should_record(level: AuditLevel, op: OpClass) -> bool {
+    match level {
+        AuditLevel::A => matches!(op, OpClass::Write | OpClass::Shell),
+        AuditLevel::B => matches!(
+            op,
+            OpClass::Write | OpClass::Shell | OpClass::ReadHigh
+        ),
+        AuditLevel::C => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn level_a_records_writes_and_shell_skips_find() {
+        assert!(should_record(AuditLevel::A, OpClass::Write));
+        assert!(should_record(AuditLevel::A, OpClass::Shell));
+        assert!(!should_record(AuditLevel::A, OpClass::ReadHigh));
+        assert!(!should_record(AuditLevel::A, OpClass::ReadOther));
+    }
+
+    #[test]
+    fn level_b_includes_high_reads() {
+        assert!(should_record(AuditLevel::B, OpClass::Write));
+        assert!(should_record(AuditLevel::B, OpClass::Shell));
+        assert!(should_record(AuditLevel::B, OpClass::ReadHigh));
+        assert!(!should_record(AuditLevel::B, OpClass::ReadOther));
+    }
+
+    #[test]
+    fn level_c_includes_all_db_ops() {
+        assert!(should_record(AuditLevel::C, OpClass::Write));
+        assert!(should_record(AuditLevel::C, OpClass::Shell));
+        assert!(should_record(AuditLevel::C, OpClass::ReadHigh));
+        assert!(should_record(AuditLevel::C, OpClass::ReadOther));
+    }
+}

--- a/src-tauri/src/audit/log.rs
+++ b/src-tauri/src/audit/log.rs
@@ -452,8 +452,44 @@ impl AuditLog {
             .map_err(|e| format!("read {}: {e}", self.path.display()))?;
 
         if bytes.is_empty() {
-            // A brand new (or zero-length) log: lay down the header in place,
-            // keeping the handle and its lock.
+            // An empty file is only "brand new" if nothing was ever recorded.
+            // Deleting or truncating the log to zero would otherwise be the one
+            // way to erase history without detection, since there are no frames
+            // left to fail a check.
+            let sealed = match self.read_state(key) {
+                RecordedState::Known(expected, _) if expected > 0 => Some(format!(
+                    "the audit log is empty but {expected} event(s) were recorded — the file \
+                     was deleted or truncated. Discard the damaged log from Activity to \
+                     resume recording."
+                )),
+                RecordedState::Unreadable(why) => Some(format!(
+                    "the audit log is empty and its state file could not be read ({why}), so \
+                     it cannot be verified. Discard the damaged log from Activity to resume \
+                     recording."
+                )),
+                _ => None,
+            };
+            if let Some(reason) = sealed {
+                // Write nothing: the state file is the surviving evidence.
+                *slot = Some(Open {
+                    lock,
+                    file,
+                    seq: 0,
+                    head: GENESIS,
+                    sealed_reason: Some(reason.clone()),
+                });
+                return Ok((
+                    Vec::new(),
+                    LoadReport {
+                        records: 0,
+                        truncated_tail: false,
+                        integrity_error: Some(reason),
+                    },
+                ));
+            }
+
+            // Genuinely new: lay down the header in place, keeping the handle
+            // and its lock.
             let header = header_bytes();
             file.write_all(&header)
                 .map_err(|e| format!("write {}: {e}", self.path.display()))?;
@@ -500,15 +536,15 @@ impl AuditLog {
             RecordedState::Missing => {
                 decoded.report.integrity_error = Some(
                     "the audit log's state file is missing, so the log cannot be verified \
-                     against the number of events it should hold. Clear the log to start a \
-                     new one."
+                     against the number of events it should hold. Discard the damaged log \
+                     from Activity to resume recording."
                         .into(),
                 );
             }
             RecordedState::Unreadable(why) => {
                 decoded.report.integrity_error = Some(format!(
                     "the audit log's state file could not be read ({why}), so the log cannot \
-                     be verified. Clear the log to start a new one."
+                     be verified. Discard the damaged log from Activity to resume recording."
                 ));
             }
         }
@@ -628,8 +664,8 @@ impl AuditLog {
             if let Err(e) = self.write_state(key, seq, &head) {
                 sealed_reason = Some(format!(
                     "the audit log was compacted but its state file could not be updated \
-                     ({e}), so the log can no longer be verified. Clear the log to start a \
-                     new one."
+                     ({e}), so the log can no longer be verified. Discard the damaged log \
+                     from Activity to resume recording."
                 ));
                 state_error = Some(e);
             }
@@ -646,6 +682,14 @@ impl AuditLog {
             Some(e) => Err(e),
             None => replaced,
         }
+    }
+
+    /// Hex chain head, for recording what a discarded log was verified up to.
+    pub fn chain_head_hex(&self) -> Option<String> {
+        self.open
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().map(|o| hex32(&o.head)))
     }
 
     /// Records written so far, or `None` when closed.

--- a/src-tauri/src/audit/log.rs
+++ b/src-tauri/src/audit/log.rs
@@ -608,15 +608,33 @@ impl AuditLog {
         drop(file);
 
         let replaced = durable::write_atomic(&self.path, &bytes);
-        // Restore the session either way, so a failed compaction leaves a
-        // usable log rather than a closed one — with the chain state that
-        // matches whichever file is actually on disk.
-        let (seq, head, sealed_reason) = if replaced.is_ok() {
-            self.write_state(key, seq, &head)?;
+
+        // Restore the session on every path. Returning early here would leave
+        // the slot empty and drop the cross-process lock while the in-memory
+        // index stayed populated, so `audit_status` would claim auditing was
+        // active while every append failed with "audit log is closed".
+        let (seq, head, mut sealed_reason) = if replaced.is_ok() {
             (seq, head, None)
         } else {
             (prev_seq, prev_head, prev_sealed)
         };
+
+        // The counter must follow the data file. If it cannot be written, the
+        // compacted log no longer matches the count on disk and the next unlock
+        // would read that as missing records — so seal now rather than report
+        // healthy and fail later.
+        let mut state_error = None;
+        if replaced.is_ok() {
+            if let Err(e) = self.write_state(key, seq, &head) {
+                sealed_reason = Some(format!(
+                    "the audit log was compacted but its state file could not be updated \
+                     ({e}), so the log can no longer be verified. Clear the log to start a \
+                     new one."
+                ));
+                state_error = Some(e);
+            }
+        }
+
         *slot = Some(Open {
             lock,
             file: self.open_handle()?,
@@ -624,7 +642,10 @@ impl AuditLog {
             head,
             sealed_reason,
         });
-        replaced
+        match state_error {
+            Some(e) => Err(e),
+            None => replaced,
+        }
     }
 
     /// Records written so far, or `None` when closed.
@@ -1070,6 +1091,38 @@ mod tests {
             events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
             ["e3", "e4", "e5"]
         );
+    }
+
+    #[test]
+    fn a_failed_state_write_seals_but_never_closes_the_session() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+
+        // Block only the state sidecar's staging path, so the data file is
+        // replaced but the counter cannot follow it.
+        let state_tmp = dir.path().join("audit.log.enc.state.tmp");
+        fs::create_dir(&state_tmp).unwrap();
+
+        let err = log
+            .compact(&KEY, &[event("e3", 1_003)])
+            .expect_err("state write must fail");
+        assert!(err.contains("state"), "{err}");
+
+        // The session must not be left closed: that would drop the lock while the
+        // in-memory index stayed populated, so status would claim auditing works.
+        assert!(log.is_open(), "session must stay open");
+        assert!(
+            log.sealed_reason().is_some(),
+            "an unverifiable log must report itself sealed rather than healthy"
+        );
+        assert!(
+            log.append(&KEY, &event("e4", 1_004)).is_err(),
+            "a sealed log must refuse appends"
+        );
+
+        // And the lock is still held, so no second instance can step in.
+        let other = AuditLog::new(path);
+        assert!(other.open(&KEY).is_err(), "lock must still be held");
     }
 
     #[test]

--- a/src-tauri/src/audit/log.rs
+++ b/src-tauri/src/audit/log.rs
@@ -24,7 +24,9 @@
 //!
 //! `vault::encrypt` emits a self-contained 12-byte random nonce plus AES-256-GCM
 //! ciphertext and tag, so every record stands alone and carries its own
-//! authentication tag.
+//! authentication tag. The length prefix is passed as additional authenticated
+//! data, so editing that unencrypted header breaks authentication rather than
+//! passing as a short append.
 //!
 //! # Integrity
 //!
@@ -66,6 +68,11 @@ const LEN_PREFIX: usize = 4;
 const MAX_RECORD_BYTES: u32 = 8 * 1024 * 1024;
 
 const GENESIS: [u8; 32] = [0u8; 32];
+
+/// AES-256-GCM framing overhead in a `vault::encrypt` blob: random nonce, then
+/// ciphertext (same length as the plaintext), then the authentication tag.
+const NONCE_BYTES: usize = 12;
+const TAG_BYTES: usize = 16;
 
 /// One log record: the event plus its position in the hash chain.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -129,14 +136,20 @@ fn encode_record(
         event: event.clone(),
     };
     let json = serde_json::to_vec(&record).map_err(|e| format!("encode audit record: {e}"))?;
-    let blob = vault::encrypt(key, &json)?;
-    let len: u32 = blob
-        .len()
+    // The length prefix is stored unencrypted, so bind it into the record's
+    // authentication tag. Editing the prefix then fails to decrypt instead of
+    // looking indistinguishable from a partial append.
+    //
+    // The ciphertext length is fixed by the plaintext length (AES-GCM adds a
+    // constant nonce + tag), so it can be computed before encrypting.
+    let len: u32 = (NONCE_BYTES + json.len() + TAG_BYTES)
         .try_into()
         .map_err(|_| "audit record exceeds u32 length".to_string())?;
     if len > MAX_RECORD_BYTES {
         return Err(format!("audit record too large ({len} bytes)"));
     }
+    let blob = vault::encrypt_with_aad(key, &json, &len.to_be_bytes())?;
+    debug_assert_eq!(blob.len(), len as usize, "framed length must match the blob");
     let mut framed = Vec::with_capacity(LEN_PREFIX + blob.len());
     framed.extend_from_slice(&len.to_be_bytes());
     framed.extend_from_slice(&blob);
@@ -195,9 +208,23 @@ fn decode_file(key: &[u8; 32], bytes: &[u8]) -> Result<Decoded, String> {
             bytes[off + 2],
             bytes[off + 3],
         ]);
-        // A length that does not fit the remaining file can only be a partial
-        // append; the same is true of an absurd length written into a torn prefix.
-        if len == 0 || len > MAX_RECORD_BYTES || remaining - LEN_PREFIX < len as usize {
+        // A length no real record could have means the prefix itself was edited,
+        // not that an append was cut short — never truncate on those, or the
+        // record and everything after it would be deleted silently.
+        let minimum = (NONCE_BYTES + TAG_BYTES) as u32;
+        if len < minimum || len > MAX_RECORD_BYTES {
+            decoded.report.integrity_error = Some(format!(
+                "audit log record {} declares an impossible length ({len} bytes) — \
+                 the file was modified outside MQLens",
+                decoded.seq + 1
+            ));
+            break;
+        }
+        // Declared longer than the bytes actually present. Only the final frame
+        // can be in this state, and it is what an interrupted append leaves
+        // behind. An edited prefix on a complete record is caught instead by the
+        // authentication tag below, which covers the prefix as AAD.
+        if remaining - LEN_PREFIX < len as usize {
             decoded.report.truncated_tail = true;
             break;
         }
@@ -208,7 +235,7 @@ fn decode_file(key: &[u8; 32], bytes: &[u8]) -> Result<Decoded, String> {
         // reached the disk, so failing to authenticate means it was altered (or
         // the key is wrong) — never truncate it away, or the last record of a
         // tampered log would be silently erased.
-        let plain = match vault::decrypt(key, body) {
+        let plain = match vault::decrypt_with_aad(key, body, &len.to_be_bytes()) {
             Ok(p) => p,
             Err(e) => {
                 decoded.report.integrity_error = Some(format!(
@@ -265,6 +292,13 @@ struct Decoded {
 
 /// Open state: the append handle plus the chain position it continues from.
 struct Open {
+    /// Held for the whole session. Kept on a sidecar path rather than the log
+    /// itself because compaction *replaces* the log file: locking the data file
+    /// would release the lock the moment its inode is swapped, letting a second
+    /// process lock the new file while the first still appends to the unlinked
+    /// old one. The sidecar inode is stable, so the exclusion holds across
+    /// compaction. Released when this handle drops.
+    lock: fs::File,
     file: fs::File,
     seq: u64,
     head: [u8; 32],
@@ -276,14 +310,46 @@ struct Open {
 /// Append-only encrypted audit log.
 pub struct AuditLog {
     path: PathBuf,
+    lock_path: PathBuf,
     open: Mutex<Option<Open>>,
 }
 
 impl AuditLog {
     pub fn new(path: PathBuf) -> Self {
+        let mut lock_path = path.clone().into_os_string();
+        lock_path.push(".lock");
         Self {
             path,
+            lock_path: PathBuf::from(lock_path),
             open: Mutex::new(None),
+        }
+    }
+
+    /// Path of the sidecar lock file, so vault reset can clean it up.
+    pub fn lock_path(&self) -> &Path {
+        &self.lock_path
+    }
+
+    /// Take the cross-process exclusive lock for this session.
+    fn acquire_lock(&self) -> Result<fs::File, String> {
+        if let Some(parent) = self.lock_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+        }
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&self.lock_path)
+            .map_err(|e| format!("open {}: {e}", self.lock_path.display()))?;
+        match file.try_lock_exclusive() {
+            Ok(true) => Ok(file),
+            Ok(false) => Err(format!(
+                "another MQLens instance is already recording to the activity log ({}) — \
+                 only one instance can record at a time",
+                self.path.display()
+            )),
+            Err(e) => Err(format!("lock {}: {e}", self.lock_path.display())),
         }
     }
 
@@ -302,6 +368,7 @@ impl AuditLog {
 
         // Take the lock before reading, so no other instance can be appending
         // while recovery decides what is a torn tail and what is tampering.
+        let lock = self.acquire_lock()?;
         let mut file = self.open_handle()?;
         let mut bytes = Vec::new();
         file.read_to_end(&mut bytes)
@@ -316,6 +383,7 @@ impl AuditLog {
             file.sync_all()
                 .map_err(|e| format!("fsync {}: {e}", self.path.display()))?;
             *slot = Some(Open {
+                lock,
                 file,
                 seq: 0,
                 head: GENESIS,
@@ -336,6 +404,7 @@ impl AuditLog {
         }
 
         *slot = Some(Open {
+            lock,
             file,
             seq: decoded.seq,
             head: decoded.head,
@@ -344,34 +413,20 @@ impl AuditLog {
         Ok((decoded.events, decoded.report))
     }
 
-    /// Open the log and take an exclusive advisory lock on it.
-    ///
-    /// The lock is what keeps a second MQLens process from interleaving appends:
-    /// each process caches its own `seq` and `head`, so concurrent writers would
-    /// duplicate sequence numbers and break the hash chain, sealing the log on
-    /// the next unlock. There is no single-instance enforcement in the app, so
-    /// this has to be handled here. The lock is released when the handle drops.
+    /// Open the log data file for reading and appending. Exclusion is the
+    /// sidecar lock's job, not this handle's.
     fn open_handle(&self) -> Result<fs::File, String> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
         }
-        let file = fs::OpenOptions::new()
+        fs::OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             // Never truncate: the whole point is to append to existing history.
             .truncate(false)
             .open(&self.path)
-            .map_err(|e| format!("open {}: {e}", self.path.display()))?;
-        match file.try_lock_exclusive() {
-            Ok(true) => Ok(file),
-            Ok(false) => Err(format!(
-                "another MQLens instance is already recording to the activity log ({}) — \
-                 only one instance can record at a time",
-                self.path.display()
-            )),
-            Err(e) => Err(format!("lock {}: {e}", self.path.display())),
-        }
+            .map_err(|e| format!("open {}: {e}", self.path.display()))
     }
 
     /// Append one event and fsync it. O(1) in the size of the existing log.
@@ -405,20 +460,41 @@ impl AuditLog {
     /// the only O(total history) operations, and none of them per-event.
     pub fn compact(&self, key: &[u8; 32], events: &[AuditEvent]) -> Result<(), String> {
         let mut slot = self.open.lock().map_err(|e| e.to_string())?;
-        if slot.is_none() {
+        let Some(open) = slot.take() else {
             return Err("audit log is closed".into());
-        }
+        };
         let (bytes, head, seq) = encode_file(key, events)?;
-        // Drop the handle before replacing the file so Windows can rename over it.
-        *slot = None;
-        durable::write_atomic(&self.path, &bytes)?;
+
+        // Carry the sidecar lock across untouched: it must stay held for the
+        // whole replacement, or another instance could lock the new file while
+        // this one still holds the unlinked old inode. Only the *data* handle is
+        // closed, because Windows cannot rename over an open file.
+        let Open {
+            lock,
+            file,
+            seq: prev_seq,
+            head: prev_head,
+            sealed_reason: prev_sealed,
+        } = open;
+        drop(file);
+
+        let replaced = durable::write_atomic(&self.path, &bytes);
+        // Restore the session either way, so a failed compaction leaves a
+        // usable log rather than a closed one — with the chain state that
+        // matches whichever file is actually on disk.
+        let (seq, head, sealed_reason) = if replaced.is_ok() {
+            (seq, head, None)
+        } else {
+            (prev_seq, prev_head, prev_sealed)
+        };
         *slot = Some(Open {
+            lock,
             file: self.open_handle()?,
             seq,
             head,
-            sealed_reason: None,
+            sealed_reason,
         });
-        Ok(())
+        replaced
     }
 
     /// Records written so far, or `None` when closed.
@@ -675,6 +751,64 @@ mod tests {
         assert_eq!(fs::read(&path).unwrap().len(), before, "file must be intact");
     }
 
+    /// Overwrite the first record's 4-byte length prefix with `len`.
+    fn set_first_length(path: &Path, len: u32) -> Vec<u8> {
+        let mut bytes = fs::read(path).unwrap();
+        bytes[HEADER_LEN..HEADER_LEN + LEN_PREFIX].copy_from_slice(&len.to_be_bytes());
+        fs::write(path, &bytes).unwrap();
+        bytes
+    }
+
+    #[test]
+    fn an_edited_length_prefix_seals_the_log_rather_than_truncating_it() {
+        // The prefix is stored unencrypted, so it is the one field an attacker
+        // can edit without touching ciphertext. Each of these used to be read as
+        // "partial append" and deleted the record and everything after it.
+        for bogus in [0u32, 1, 27, MAX_RECORD_BYTES + 1] {
+            let dir = tempdir().unwrap();
+            let (log, path) = log_with(dir.path(), 3);
+            log.close();
+            let tampered = set_first_length(&path, bogus);
+
+            let reopened = AuditLog::new(path.clone());
+            let (events, report) = reopened.open(&KEY).expect("load");
+            assert!(
+                report.integrity_error.is_some(),
+                "length {bogus} must be reported as tampering: {report:?}"
+            );
+            assert!(events.is_empty());
+            assert_eq!(
+                fs::read(&path).unwrap(),
+                tampered,
+                "length {bogus} must not truncate the file"
+            );
+        }
+    }
+
+    #[test]
+    fn a_plausible_but_wrong_length_prefix_fails_authentication() {
+        // Big enough to look real and still fit inside the file, so only the
+        // AAD binding over the prefix can catch it.
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.close();
+        let real_len = u32::from_be_bytes([
+            fs::read(&path).unwrap()[HEADER_LEN],
+            fs::read(&path).unwrap()[HEADER_LEN + 1],
+            fs::read(&path).unwrap()[HEADER_LEN + 2],
+            fs::read(&path).unwrap()[HEADER_LEN + 3],
+        ]);
+        let tampered = set_first_length(&path, real_len + 1);
+
+        let reopened = AuditLog::new(path.clone());
+        let (_, report) = reopened.open(&KEY).expect("load");
+        assert!(
+            report.integrity_error.is_some(),
+            "a fitting but altered prefix must fail authentication: {report:?}"
+        );
+        assert_eq!(fs::read(&path).unwrap(), tampered, "file must be intact");
+    }
+
     #[test]
     fn deleting_a_record_breaks_the_hash_chain() {
         let dir = tempdir().unwrap();
@@ -787,18 +921,36 @@ mod tests {
     }
 
     #[test]
-    fn compaction_keeps_the_lock_held_afterwards() {
+    fn the_lock_is_never_released_during_compaction() {
         let dir = tempdir().unwrap();
         let (log, path) = log_with(dir.path(), 3);
-        log.compact(&KEY, &[event("e3", 1_003)]).expect("compact");
+        let other = AuditLog::new(path.clone());
 
-        // Compaction replaces the file, so it must re-acquire the lock.
-        let other = AuditLog::new(path);
-        assert!(
-            other.open(&KEY).is_err(),
-            "the lock must still be held after compaction"
-        );
+        // Compaction replaces the data file's inode. The lock lives on a stable
+        // sidecar path precisely so this window does not exist — otherwise a
+        // second instance could take the new file while this one appends to the
+        // unlinked old one, losing those events silently.
+        assert!(other.open(&KEY).is_err(), "locked before compaction");
+        log.compact(&KEY, &[event("e3", 1_003)]).expect("compact");
+        assert!(other.open(&KEY).is_err(), "must still be locked after compaction");
+
         log.append(&KEY, &event("e4", 1_004)).expect("append after compact");
+        log.close();
+
+        let (events, report) = other.open(&KEY).expect("open once released");
+        assert!(report.integrity_error.is_none(), "{report:?}");
+        assert_eq!(
+            events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["e3", "e4"]
+        );
+    }
+
+    #[test]
+    fn the_lock_lives_on_a_sidecar_path_not_the_log_itself() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 1);
+        assert_eq!(log.lock_path(), path.with_extension("enc.lock"));
+        assert!(log.lock_path().exists(), "sidecar lock file must exist");
     }
 
     #[test]

--- a/src-tauri/src/audit/log.rs
+++ b/src-tauri/src/audit/log.rs
@@ -1,0 +1,735 @@
+//! Append-only encrypted record log for the audit trail (#272).
+//!
+//! # Why not a whole-image envelope
+//!
+//! The first cut sealed the entire SQLite database into `audit.db.enc` on every
+//! change. That made per-event durability cost O(total history): each recorded
+//! operation re-serialized, re-encrypted and rewrote the whole log, so latency
+//! grew with retained history and a partial write could lose *everything*. The
+//! only way to bound that was to batch, which reopened a window where a crash
+//! lost recent events — exactly the events an audit log exists for.
+//!
+//! This module removes the trade-off. Each event is one independently encrypted
+//! record appended to `audit.log.enc`, so a write is O(1) in history size and
+//! can be fsynced on every single event. The in-memory SQLite store becomes a
+//! pure query index, rebuilt from this file on unlock.
+//!
+//! # Format
+//!
+//! ```text
+//! header: b"MQLAUDIT" | u32 BE format version | u32 BE reserved   (16 bytes)
+//! record: u32 BE ciphertext length | vault::encrypt(key, record_json)
+//! record: ...
+//! ```
+//!
+//! `vault::encrypt` emits a self-contained 12-byte random nonce plus AES-256-GCM
+//! ciphertext and tag, so every record stands alone and carries its own
+//! authentication tag.
+//!
+//! # Integrity
+//!
+//! Each record embeds its sequence number and the chain hash of the record
+//! before it, where `chain(i) = sha256(chain(i-1) || record_json(i))`. Deleting,
+//! reordering or editing a record therefore breaks verification at load time.
+//!
+//! A *torn tail* — a crash midway through an append — is a different thing from
+//! tampering and is handled differently: the trailing partial record is
+//! discarded and logging continues. Corruption anywhere earlier seals the log
+//! (see [`LoadReport::integrity_error`]): the file is left untouched as evidence
+//! and appends are refused rather than overwriting it.
+//!
+//! Note the honest limit: this log is encrypted with the user's own vault key on
+//! the user's own machine. It is tamper-*evident*, not tamper-*proof* — whoever
+//! holds the master password can always delete the file and start fresh.
+
+use crate::durable;
+use crate::vault;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use super::store::AuditEvent;
+
+const MAGIC: &[u8; 8] = b"MQLAUDIT";
+const FORMAT_VERSION: u32 = 1;
+const HEADER_LEN: usize = 16;
+const LEN_PREFIX: usize = 4;
+
+/// Reject absurd record lengths so a corrupt prefix cannot make us allocate
+/// gigabytes. Comfortably above one event (64 KiB args + 2 KiB error + fields).
+const MAX_RECORD_BYTES: u32 = 8 * 1024 * 1024;
+
+const GENESIS: [u8; 32] = [0u8; 32];
+
+/// One log record: the event plus its position in the hash chain.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Record {
+    /// 1-based position in the log.
+    seq: u64,
+    /// Hex chain hash of the preceding record; 64 zeros for the first.
+    prev: String,
+    event: AuditEvent,
+}
+
+/// What [`AuditLog::open`] found in the file.
+#[derive(Clone, Debug, Default)]
+pub struct LoadReport {
+    /// Records recovered and verified.
+    pub records: u64,
+    /// A trailing partial record was discarded — a crash mid-append, not tampering.
+    pub truncated_tail: bool,
+    /// Verification failed at or before the last record. The log is sealed
+    /// against further appends and the file is preserved as evidence.
+    pub integrity_error: Option<String>,
+}
+
+fn hex32(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for b in bytes {
+        out.push(char::from_digit((b >> 4) as u32, 16).unwrap_or('0'));
+        out.push(char::from_digit((b & 0x0f) as u32, 16).unwrap_or('0'));
+    }
+    out
+}
+
+fn chain_next(prev: &[u8; 32], record_json: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(prev);
+    hasher.update(record_json);
+    let digest = hasher.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}
+
+fn header_bytes() -> Vec<u8> {
+    let mut out = Vec::with_capacity(HEADER_LEN);
+    out.extend_from_slice(MAGIC);
+    out.extend_from_slice(&FORMAT_VERSION.to_be_bytes());
+    out.extend_from_slice(&0u32.to_be_bytes());
+    out
+}
+
+/// Serialize one record and its framed, encrypted on-disk form.
+fn encode_record(
+    key: &[u8; 32],
+    seq: u64,
+    prev: &[u8; 32],
+    event: &AuditEvent,
+) -> Result<(Vec<u8>, [u8; 32]), String> {
+    let record = Record {
+        seq,
+        prev: hex32(prev),
+        event: event.clone(),
+    };
+    let json = serde_json::to_vec(&record).map_err(|e| format!("encode audit record: {e}"))?;
+    let blob = vault::encrypt(key, &json)?;
+    let len: u32 = blob
+        .len()
+        .try_into()
+        .map_err(|_| "audit record exceeds u32 length".to_string())?;
+    if len > MAX_RECORD_BYTES {
+        return Err(format!("audit record too large ({len} bytes)"));
+    }
+    let mut framed = Vec::with_capacity(LEN_PREFIX + blob.len());
+    framed.extend_from_slice(&len.to_be_bytes());
+    framed.extend_from_slice(&blob);
+    Ok((framed, chain_next(prev, &json)))
+}
+
+/// Build a whole log file from scratch — used for compaction and key rotation.
+fn encode_file(key: &[u8; 32], events: &[AuditEvent]) -> Result<(Vec<u8>, [u8; 32], u64), String> {
+    let mut out = header_bytes();
+    let mut head = GENESIS;
+    let mut seq = 0u64;
+    for event in events {
+        seq += 1;
+        let (framed, next) = encode_record(key, seq, &head, event)?;
+        out.extend_from_slice(&framed);
+        head = next;
+    }
+    Ok((out, head, seq))
+}
+
+/// Decode every record in `bytes`, verifying the chain.
+///
+/// `Ok((events, report))` — a torn tail sets `report.truncated_tail` and
+/// `report.valid_len` worth of bytes are the ones worth keeping; interior
+/// corruption sets `report.integrity_error` and stops the scan.
+fn decode_file(key: &[u8; 32], bytes: &[u8]) -> Result<Decoded, String> {
+    if bytes.len() < HEADER_LEN {
+        return Err("audit log is shorter than its header".to_string());
+    }
+    if &bytes[..8] != MAGIC {
+        return Err("audit log has an unrecognized header".to_string());
+    }
+    let version = u32::from_be_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+    if version != FORMAT_VERSION {
+        return Err(format!("unsupported audit log format version {version}"));
+    }
+
+    let mut decoded = Decoded {
+        events: Vec::new(),
+        head: GENESIS,
+        seq: 0,
+        valid_len: HEADER_LEN,
+        report: LoadReport::default(),
+    };
+    let mut off = HEADER_LEN;
+
+    while off < bytes.len() {
+        let remaining = bytes.len() - off;
+        if remaining < LEN_PREFIX {
+            decoded.report.truncated_tail = true;
+            break;
+        }
+        let len = u32::from_be_bytes([
+            bytes[off],
+            bytes[off + 1],
+            bytes[off + 2],
+            bytes[off + 3],
+        ]);
+        // A length that does not fit the remaining file can only be a partial
+        // append; the same is true of an absurd length written into a torn prefix.
+        if len == 0 || len > MAX_RECORD_BYTES || remaining - LEN_PREFIX < len as usize {
+            decoded.report.truncated_tail = true;
+            break;
+        }
+        let body = &bytes[off + LEN_PREFIX..off + LEN_PREFIX + len as usize];
+        let is_last = off + LEN_PREFIX + len as usize == bytes.len();
+
+        let plain = match vault::decrypt(key, body) {
+            Ok(p) => p,
+            Err(e) => {
+                // Only the final record can be a torn write; anything earlier
+                // means the file was altered.
+                if is_last {
+                    decoded.report.truncated_tail = true;
+                    break;
+                }
+                decoded.report.integrity_error =
+                    Some(format!("record {} failed to decrypt: {e}", decoded.seq + 1));
+                break;
+            }
+        };
+        let record: Record = match serde_json::from_slice(&plain) {
+            Ok(r) => r,
+            Err(e) => {
+                if is_last {
+                    decoded.report.truncated_tail = true;
+                    break;
+                }
+                decoded.report.integrity_error =
+                    Some(format!("record {} is malformed: {e}", decoded.seq + 1));
+                break;
+            }
+        };
+
+        let expected_seq = decoded.seq + 1;
+        if record.seq != expected_seq {
+            decoded.report.integrity_error = Some(format!(
+                "audit log records are out of order: expected sequence {expected_seq}, found {}",
+                record.seq
+            ));
+            break;
+        }
+        if record.prev != hex32(&decoded.head) {
+            decoded.report.integrity_error = Some(format!(
+                "audit log hash chain broken at record {expected_seq} — \
+                 the file was modified outside MQLens"
+            ));
+            break;
+        }
+
+        decoded.head = chain_next(&decoded.head, &plain);
+        decoded.seq = record.seq;
+        decoded.events.push(record.event);
+        off += LEN_PREFIX + len as usize;
+        decoded.valid_len = off;
+    }
+
+    decoded.report.records = decoded.seq;
+    Ok(decoded)
+}
+
+struct Decoded {
+    events: Vec<AuditEvent>,
+    head: [u8; 32],
+    seq: u64,
+    valid_len: usize,
+    report: LoadReport,
+}
+
+/// Open state: the append handle plus the chain position it continues from.
+struct Open {
+    file: fs::File,
+    seq: u64,
+    head: [u8; 32],
+    /// Set when the load found interior corruption. Appends are refused so the
+    /// damaged file survives for inspection instead of being written over.
+    sealed_reason: Option<String>,
+}
+
+/// Append-only encrypted audit log.
+pub struct AuditLog {
+    path: PathBuf,
+    open: Mutex<Option<Open>>,
+}
+
+impl AuditLog {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            open: Mutex::new(None),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Recover the log and hold it open for appends.
+    ///
+    /// Returns every verified event in write order so the caller can rebuild the
+    /// query index, plus a report describing what recovery had to do.
+    pub fn open(&self, key: &[u8; 32]) -> Result<(Vec<AuditEvent>, LoadReport), String> {
+        let mut slot = self.open.lock().map_err(|e| e.to_string())?;
+        *slot = None;
+
+        if !self.path.exists() {
+            durable::write_atomic(&self.path, &header_bytes())?;
+            *slot = Some(Open {
+                file: self.open_handle()?,
+                seq: 0,
+                head: GENESIS,
+                sealed_reason: None,
+            });
+            return Ok((Vec::new(), LoadReport::default()));
+        }
+
+        let bytes =
+            fs::read(&self.path).map_err(|e| format!("read {}: {e}", self.path.display()))?;
+        if bytes.is_empty() {
+            durable::write_atomic(&self.path, &header_bytes())?;
+            *slot = Some(Open {
+                file: self.open_handle()?,
+                seq: 0,
+                head: GENESIS,
+                sealed_reason: None,
+            });
+            return Ok((Vec::new(), LoadReport::default()));
+        }
+
+        let decoded = decode_file(key, &bytes)?;
+        let file = self.open_handle()?;
+
+        if decoded.report.integrity_error.is_none() && decoded.report.truncated_tail {
+            // Drop the partial record so the next append starts on a clean
+            // boundary. Safe: it never decrypted, so it was never a whole event.
+            file.set_len(decoded.valid_len as u64)
+                .map_err(|e| format!("truncate {}: {e}", self.path.display()))?;
+            file.sync_all()
+                .map_err(|e| format!("fsync {}: {e}", self.path.display()))?;
+        }
+
+        *slot = Some(Open {
+            file,
+            seq: decoded.seq,
+            head: decoded.head,
+            sealed_reason: decoded.report.integrity_error.clone(),
+        });
+        Ok((decoded.events, decoded.report))
+    }
+
+    fn open_handle(&self) -> Result<fs::File, String> {
+        fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&self.path)
+            .map_err(|e| format!("open {}: {e}", self.path.display()))
+    }
+
+    /// Append one event and fsync it. O(1) in the size of the existing log.
+    pub fn append(&self, key: &[u8; 32], event: &AuditEvent) -> Result<(), String> {
+        let mut slot = self.open.lock().map_err(|e| e.to_string())?;
+        let open = slot.as_mut().ok_or("audit log is closed")?;
+        if let Some(reason) = &open.sealed_reason {
+            return Err(format!("audit log is sealed: {reason}"));
+        }
+
+        let (framed, next) = encode_record(key, open.seq + 1, &open.head, event)?;
+        open.file
+            .seek(SeekFrom::End(0))
+            .map_err(|e| format!("seek {}: {e}", self.path.display()))?;
+        open.file
+            .write_all(&framed)
+            .map_err(|e| format!("append {}: {e}", self.path.display()))?;
+        // The point of the whole design: durability per event, not per batch.
+        open.file
+            .sync_data()
+            .map_err(|e| format!("fsync {}: {e}", self.path.display()))?;
+
+        open.seq += 1;
+        open.head = next;
+        Ok(())
+    }
+
+    /// Rewrite the log to contain exactly `events`, in order.
+    ///
+    /// Used for retention pruning, clearing, and unsealing after corruption —
+    /// the only O(total history) operations, and none of them per-event.
+    pub fn compact(&self, key: &[u8; 32], events: &[AuditEvent]) -> Result<(), String> {
+        let mut slot = self.open.lock().map_err(|e| e.to_string())?;
+        if slot.is_none() {
+            return Err("audit log is closed".into());
+        }
+        let (bytes, head, seq) = encode_file(key, events)?;
+        // Drop the handle before replacing the file so Windows can rename over it.
+        *slot = None;
+        durable::write_atomic(&self.path, &bytes)?;
+        *slot = Some(Open {
+            file: self.open_handle()?,
+            seq,
+            head,
+            sealed_reason: None,
+        });
+        Ok(())
+    }
+
+    /// Records written so far, or `None` when closed.
+    pub fn record_count(&self) -> Option<u64> {
+        self.open.lock().ok().and_then(|g| g.as_ref().map(|o| o.seq))
+    }
+
+    /// Why appends are being refused, if they are.
+    pub fn sealed_reason(&self) -> Option<String> {
+        self.open
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().and_then(|o| o.sealed_reason.clone()))
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.open.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
+
+    /// Release the file handle. Every append is already durable, so there is
+    /// nothing to flush.
+    pub fn close(&self) {
+        if let Ok(mut slot) = self.open.lock() {
+            *slot = None;
+        }
+    }
+}
+
+/// Re-encrypt a whole log from `old_key` to `new_key`, returning the new file
+/// bytes without writing them.
+///
+/// Records are individually encrypted, so a password change cannot just
+/// re-encrypt one blob: every record is decrypted and the chain rebuilt. Kept
+/// separate from writing so `vault_change_password` can prepare every vault file
+/// before overwriting any of them.
+pub fn prepare_reencrypted(
+    old_key: &[u8; 32],
+    new_key: &[u8; 32],
+    path: &Path,
+) -> Result<Option<Vec<u8>>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    let decoded = decode_file(old_key, &bytes)?;
+    if let Some(reason) = decoded.report.integrity_error {
+        return Err(format!("cannot re-encrypt a damaged audit log: {reason}"));
+    }
+    let (out, _, _) = encode_file(new_key, &decoded.events)?;
+    Ok(Some(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::store::SCHEMA_VERSION;
+    use tempfile::tempdir;
+
+    fn event(id: &str, ts: i64) -> AuditEvent {
+        AuditEvent {
+            id: id.into(),
+            ts,
+            connection_id: Some("c1".into()),
+            profile_name: Some("prod".into()),
+            database: Some("shop".into()),
+            collection: Some("orders".into()),
+            op: "drop_collection".into(),
+            source: "ui".into(),
+            ok: true,
+            error: None,
+            duration_ms: Some(3),
+            summary: format!("dropCollection shop.orders #{id}"),
+            args_json: None,
+            level_at_record: "A".into(),
+            schema_version: SCHEMA_VERSION,
+        }
+    }
+
+    const KEY: [u8; 32] = [7u8; 32];
+
+    fn log_with(dir: &Path, n: usize) -> (AuditLog, PathBuf) {
+        let path = dir.join("audit.log.enc");
+        let log = AuditLog::new(path.clone());
+        log.open(&KEY).expect("open");
+        for i in 1..=n {
+            log.append(&KEY, &event(&format!("e{i}"), 1_000 + i as i64))
+                .expect("append");
+        }
+        (log, path)
+    }
+
+    #[test]
+    fn appends_survive_reopen_in_order() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.close();
+
+        let reopened = AuditLog::new(path);
+        let (events, report) = reopened.open(&KEY).expect("reopen");
+        assert_eq!(report.records, 3);
+        assert!(!report.truncated_tail);
+        assert!(report.integrity_error.is_none());
+        let ids: Vec<&str> = events.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, ["e1", "e2", "e3"]);
+    }
+
+    #[test]
+    fn every_append_is_durable_without_close() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 2);
+        // Simulate a hard kill: abandon the live handle without closing.
+        std::mem::forget(log);
+
+        let reopened = AuditLog::new(path);
+        let (events, report) = reopened.open(&KEY).expect("reopen after crash");
+        assert_eq!(events.len(), 2, "both events must already be on disk");
+        assert!(!report.truncated_tail);
+    }
+
+    #[test]
+    fn append_cost_does_not_grow_the_rewritten_bytes() {
+        // Regression guard for the whole-image design: appending the 50th event
+        // must not rewrite the earlier 49. The file grows by one record only.
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 49);
+        let before = fs::metadata(&path).unwrap().len();
+        log.append(&KEY, &event("e50", 9_999)).expect("append");
+        let after = fs::metadata(&path).unwrap().len();
+        let one_record = after - before;
+        assert!(
+            one_record < before / 4,
+            "one append grew the file by {one_record} bytes against {before} existing"
+        );
+    }
+
+    #[test]
+    fn torn_tail_is_discarded_and_logging_continues() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.close();
+
+        // Chop the final record in half, as a crash mid-append would.
+        let bytes = fs::read(&path).unwrap();
+        fs::write(&path, &bytes[..bytes.len() - 20]).unwrap();
+
+        let reopened = AuditLog::new(path.clone());
+        let (events, report) = reopened.open(&KEY).expect("recover");
+        assert!(report.truncated_tail, "torn tail must be reported");
+        assert!(
+            report.integrity_error.is_none(),
+            "a torn tail is a crash, not tampering: {report:?}"
+        );
+        assert_eq!(events.len(), 2, "the two whole records survive");
+
+        // And the log is usable again: the partial record was truncated away.
+        reopened.append(&KEY, &event("e4", 4_000)).expect("append");
+        reopened.close();
+        let again = AuditLog::new(path);
+        let (events, report) = again.open(&KEY).expect("reopen");
+        assert!(report.integrity_error.is_none(), "{report:?}");
+        assert_eq!(
+            events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["e1", "e2", "e4"]
+        );
+    }
+
+    #[test]
+    fn interior_tampering_is_detected_and_seals_the_log() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.close();
+
+        // Flip a byte inside the *first* record's ciphertext.
+        let mut bytes = fs::read(&path).unwrap();
+        let target = HEADER_LEN + LEN_PREFIX + 4;
+        bytes[target] ^= 0xff;
+        fs::write(&path, &bytes).unwrap();
+
+        let reopened = AuditLog::new(path.clone());
+        let (events, report) = reopened.open(&KEY).expect("load");
+        assert!(
+            report.integrity_error.is_some(),
+            "interior corruption must be reported, not silently truncated"
+        );
+        assert!(events.is_empty(), "nothing before the damage to recover");
+
+        // Sealed: appending must refuse rather than overwrite the evidence.
+        let err = reopened.append(&KEY, &event("e4", 4_000)).unwrap_err();
+        assert!(err.contains("sealed"), "{err}");
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            bytes,
+            "the damaged file must be preserved untouched"
+        );
+    }
+
+    #[test]
+    fn deleting_a_record_breaks_the_hash_chain() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.close();
+
+        // Splice out the first record entirely — lengths stay self-consistent,
+        // so only the chain and sequence numbers can catch this.
+        let bytes = fs::read(&path).unwrap();
+        let first_len = u32::from_be_bytes([
+            bytes[HEADER_LEN],
+            bytes[HEADER_LEN + 1],
+            bytes[HEADER_LEN + 2],
+            bytes[HEADER_LEN + 3],
+        ]) as usize;
+        let mut spliced = bytes[..HEADER_LEN].to_vec();
+        spliced.extend_from_slice(&bytes[HEADER_LEN + LEN_PREFIX + first_len..]);
+        fs::write(&path, &spliced).unwrap();
+
+        let reopened = AuditLog::new(path);
+        let (_, report) = reopened.open(&KEY).expect("load");
+        let err = report.integrity_error.expect("deletion must be detected");
+        assert!(
+            err.contains("out of order") || err.contains("chain broken"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn compact_rewrites_the_log_and_clears_a_seal() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 4);
+        // Keep only the two newest, as retention pruning would.
+        let keep = vec![event("e3", 1_003), event("e4", 1_004)];
+        log.compact(&KEY, &keep).expect("compact");
+        log.append(&KEY, &event("e5", 1_005)).expect("append after compact");
+        log.close();
+
+        let reopened = AuditLog::new(path);
+        let (events, report) = reopened.open(&KEY).expect("reopen");
+        assert!(report.integrity_error.is_none(), "{report:?}");
+        assert_eq!(
+            events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["e3", "e4", "e5"]
+        );
+    }
+
+    #[test]
+    fn compact_to_empty_produces_a_valid_empty_log() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.compact(&KEY, &[]).expect("clear");
+        log.close();
+
+        let reopened = AuditLog::new(path);
+        let (events, report) = reopened.open(&KEY).expect("reopen");
+        assert!(events.is_empty());
+        assert_eq!(report.records, 0);
+        assert!(report.integrity_error.is_none());
+    }
+
+    #[test]
+    fn wrong_key_fails_to_load() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 2);
+        log.close();
+        let reopened = AuditLog::new(path);
+        // The first record fails to authenticate and is not the last one.
+        let (events, report) = reopened.open(&[9u8; 32]).expect("load");
+        assert!(events.is_empty());
+        assert!(report.integrity_error.is_some());
+    }
+
+    #[test]
+    fn rejects_a_foreign_header() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.log.enc");
+        fs::write(&path, b"NOTMQLENS\0\0\0\0\0\0\0").unwrap();
+        let log = AuditLog::new(path);
+        let err = log.open(&KEY).unwrap_err();
+        assert!(err.contains("unrecognized header"), "{err}");
+    }
+
+    #[test]
+    fn reencrypt_preserves_every_event_under_the_new_key() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.close();
+
+        let new_key = [4u8; 32];
+        let bytes = prepare_reencrypted(&KEY, &new_key, &path)
+            .expect("prepare")
+            .expect("some bytes");
+        fs::write(&path, &bytes).unwrap();
+
+        let reopened = AuditLog::new(path);
+        let (events, report) = reopened.open(&new_key).expect("open with new key");
+        assert!(report.integrity_error.is_none(), "{report:?}");
+        assert_eq!(
+            events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["e1", "e2", "e3"]
+        );
+    }
+
+    #[test]
+    fn reencrypt_refuses_a_damaged_log() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.close();
+        let mut bytes = fs::read(&path).unwrap();
+        bytes[HEADER_LEN + LEN_PREFIX + 4] ^= 0xff;
+        fs::write(&path, &bytes).unwrap();
+
+        let err = prepare_reencrypted(&KEY, &[4u8; 32], &path).unwrap_err();
+        assert!(err.contains("damaged"), "{err}");
+    }
+
+    #[test]
+    fn missing_file_reencrypts_to_nothing() {
+        let dir = tempdir().unwrap();
+        let absent = dir.path().join("nope.log.enc");
+        assert!(prepare_reencrypted(&KEY, &[4u8; 32], &absent)
+            .expect("prepare")
+            .is_none());
+    }
+
+    #[test]
+    fn hex32_is_lowercase_and_64_chars() {
+        assert_eq!(hex32(&GENESIS), "0".repeat(64));
+        let mut b = [0u8; 32];
+        b[0] = 0xab;
+        b[31] = 0x0f;
+        let h = hex32(&b);
+        assert_eq!(h.len(), 64);
+        assert!(h.starts_with("ab"));
+        assert!(h.ends_with("0f"));
+    }
+}

--- a/src-tauri/src/audit/log.rs
+++ b/src-tauri/src/audit/log.rs
@@ -34,9 +34,12 @@
 //!
 //! A *torn tail* — a crash midway through an append — is a different thing from
 //! tampering and is handled differently: the trailing partial record is
-//! discarded and logging continues. Corruption anywhere earlier seals the log
-//! (see [`LoadReport::integrity_error`]): the file is left untouched as evidence
-//! and appends are refused rather than overwriting it.
+//! discarded and logging continues. The distinction is whether the frame is
+//! physically complete, not where it sits: an incomplete frame is a torn append,
+//! while any fully present frame that fails to authenticate means the file was
+//! altered, including the very last one. Tampering seals the log (see
+//! [`LoadReport::integrity_error`]): the file is left untouched as evidence and
+//! appends are refused rather than overwriting it.
 //!
 //! Note the honest limit: this log is encrypted with the user's own vault key on
 //! the user's own machine. It is tamper-*evident*, not tamper-*proof* — whoever
@@ -46,7 +49,8 @@ use crate::durable;
 use crate::vault;
 use sha2::{Digest, Sha256};
 use std::fs;
-use std::io::{Seek, SeekFrom, Write};
+use fs4::fs_std::FileExt;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -198,31 +202,28 @@ fn decode_file(key: &[u8; 32], bytes: &[u8]) -> Result<Decoded, String> {
             break;
         }
         let body = &bytes[off + LEN_PREFIX..off + LEN_PREFIX + len as usize];
-        let is_last = off + LEN_PREFIX + len as usize == bytes.len();
 
+        // Only an *incomplete* frame is a torn append, and that is already
+        // handled by the length checks above. A frame that is entirely present
+        // reached the disk, so failing to authenticate means it was altered (or
+        // the key is wrong) — never truncate it away, or the last record of a
+        // tampered log would be silently erased.
         let plain = match vault::decrypt(key, body) {
             Ok(p) => p,
             Err(e) => {
-                // Only the final record can be a torn write; anything earlier
-                // means the file was altered.
-                if is_last {
-                    decoded.report.truncated_tail = true;
-                    break;
-                }
-                decoded.report.integrity_error =
-                    Some(format!("record {} failed to decrypt: {e}", decoded.seq + 1));
+                decoded.report.integrity_error = Some(format!(
+                    "audit log record {} failed to authenticate ({e}) — the file was \
+                     modified outside MQLens, or the vault key does not match",
+                    decoded.seq + 1
+                ));
                 break;
             }
         };
         let record: Record = match serde_json::from_slice(&plain) {
             Ok(r) => r,
             Err(e) => {
-                if is_last {
-                    decoded.report.truncated_tail = true;
-                    break;
-                }
                 decoded.report.integrity_error =
-                    Some(format!("record {} is malformed: {e}", decoded.seq + 1));
+                    Some(format!("audit log record {} is malformed: {e}", decoded.seq + 1));
                 break;
             }
         };
@@ -296,25 +297,26 @@ impl AuditLog {
     /// query index, plus a report describing what recovery had to do.
     pub fn open(&self, key: &[u8; 32]) -> Result<(Vec<AuditEvent>, LoadReport), String> {
         let mut slot = self.open.lock().map_err(|e| e.to_string())?;
+        // Drop any previous handle first, releasing its lock.
         *slot = None;
 
-        if !self.path.exists() {
-            durable::write_atomic(&self.path, &header_bytes())?;
-            *slot = Some(Open {
-                file: self.open_handle()?,
-                seq: 0,
-                head: GENESIS,
-                sealed_reason: None,
-            });
-            return Ok((Vec::new(), LoadReport::default()));
-        }
+        // Take the lock before reading, so no other instance can be appending
+        // while recovery decides what is a torn tail and what is tampering.
+        let mut file = self.open_handle()?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)
+            .map_err(|e| format!("read {}: {e}", self.path.display()))?;
 
-        let bytes =
-            fs::read(&self.path).map_err(|e| format!("read {}: {e}", self.path.display()))?;
         if bytes.is_empty() {
-            durable::write_atomic(&self.path, &header_bytes())?;
+            // A brand new (or zero-length) log: lay down the header in place,
+            // keeping the handle and its lock.
+            let header = header_bytes();
+            file.write_all(&header)
+                .map_err(|e| format!("write {}: {e}", self.path.display()))?;
+            file.sync_all()
+                .map_err(|e| format!("fsync {}: {e}", self.path.display()))?;
             *slot = Some(Open {
-                file: self.open_handle()?,
+                file,
                 seq: 0,
                 head: GENESIS,
                 sealed_reason: None,
@@ -323,7 +325,6 @@ impl AuditLog {
         }
 
         let decoded = decode_file(key, &bytes)?;
-        let file = self.open_handle()?;
 
         if decoded.report.integrity_error.is_none() && decoded.report.truncated_tail {
             // Drop the partial record so the next append starts on a clean
@@ -343,12 +344,34 @@ impl AuditLog {
         Ok((decoded.events, decoded.report))
     }
 
+    /// Open the log and take an exclusive advisory lock on it.
+    ///
+    /// The lock is what keeps a second MQLens process from interleaving appends:
+    /// each process caches its own `seq` and `head`, so concurrent writers would
+    /// duplicate sequence numbers and break the hash chain, sealing the log on
+    /// the next unlock. There is no single-instance enforcement in the app, so
+    /// this has to be handled here. The lock is released when the handle drops.
     fn open_handle(&self) -> Result<fs::File, String> {
-        fs::OpenOptions::new()
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+        }
+        let file = fs::OpenOptions::new()
             .read(true)
             .write(true)
+            .create(true)
+            // Never truncate: the whole point is to append to existing history.
+            .truncate(false)
             .open(&self.path)
-            .map_err(|e| format!("open {}: {e}", self.path.display()))
+            .map_err(|e| format!("open {}: {e}", self.path.display()))?;
+        match file.try_lock_exclusive() {
+            Ok(true) => Ok(file),
+            Ok(false) => Err(format!(
+                "another MQLens instance is already recording to the activity log ({}) — \
+                 only one instance can record at a time",
+                self.path.display()
+            )),
+            Err(e) => Err(format!("lock {}: {e}", self.path.display())),
+        }
     }
 
     /// Append one event and fsync it. O(1) in the size of the existing log.
@@ -509,13 +532,25 @@ mod tests {
     fn every_append_is_durable_without_close() {
         let dir = tempdir().unwrap();
         let (log, path) = log_with(dir.path(), 2);
-        // Simulate a hard kill: abandon the live handle without closing.
-        std::mem::forget(log);
 
+        // Read the bytes straight off disk while the log is still open. A crash
+        // at this instant would leave exactly this file, because every append is
+        // fsynced — so decoding it is the durability guarantee.
+        //
+        // Deliberately not `mem::forget`: that would leak the handle and hold the
+        // advisory lock forever, which a dying process does not do — the OS
+        // releases it, the same way dropping the handle does below.
+        let on_disk = fs::read(&path).unwrap();
+        let decoded = decode_file(&KEY, &on_disk).expect("decode the on-disk image");
+        assert_eq!(decoded.events.len(), 2, "both events must already be on disk");
+        assert!(!decoded.report.truncated_tail, "{:?}", decoded.report);
+        assert!(decoded.report.integrity_error.is_none(), "{:?}", decoded.report);
+
+        drop(log);
         let reopened = AuditLog::new(path);
-        let (events, report) = reopened.open(&KEY).expect("reopen after crash");
-        assert_eq!(events.len(), 2, "both events must already be on disk");
-        assert!(!report.truncated_tail);
+        let (events, report) = reopened.open(&KEY).expect("reopen");
+        assert_eq!(events.len(), 2);
+        assert!(report.integrity_error.is_none(), "{report:?}");
     }
 
     #[test]
@@ -596,6 +631,51 @@ mod tests {
     }
 
     #[test]
+    fn a_modified_final_record_seals_the_log_instead_of_being_truncated_away() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.close();
+
+        // Flip a byte inside the *last* record. Its frame is complete and
+        // reaches EOF, so length checks cannot tell it apart from a good record
+        // — only the auth tag can, and it must not be mistaken for a torn write.
+        let mut bytes = fs::read(&path).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xff;
+        fs::write(&path, &bytes).unwrap();
+
+        let reopened = AuditLog::new(path.clone());
+        let (_, report) = reopened.open(&KEY).expect("load");
+        assert!(
+            report.integrity_error.is_some(),
+            "a complete-but-unauthentic final record is tampering, not a torn tail: {report:?}"
+        );
+        assert!(!report.truncated_tail, "{report:?}");
+        assert_eq!(
+            fs::read(&path).unwrap().len(),
+            bytes.len(),
+            "the evidence must not be truncated away"
+        );
+    }
+
+    #[test]
+    fn a_single_record_log_opened_with_the_wrong_key_is_not_silently_emptied() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 1);
+        log.close();
+        let before = fs::read(&path).unwrap().len();
+
+        let reopened = AuditLog::new(path.clone());
+        let (events, report) = reopened.open(&[42u8; 32]).expect("load");
+        assert!(events.is_empty());
+        assert!(
+            report.integrity_error.is_some(),
+            "the only record must not be written off as a torn append: {report:?}"
+        );
+        assert_eq!(fs::read(&path).unwrap().len(), before, "file must be intact");
+    }
+
+    #[test]
     fn deleting_a_record_breaks_the_hash_chain() {
         let dir = tempdir().unwrap();
         let (log, path) = log_with(dir.path(), 3);
@@ -666,6 +746,59 @@ mod tests {
         let (events, report) = reopened.open(&[9u8; 32]).expect("load");
         assert!(events.is_empty());
         assert!(report.integrity_error.is_some());
+    }
+
+    #[test]
+    fn a_second_instance_cannot_open_the_same_log() {
+        let dir = tempdir().unwrap();
+        let (first, path) = log_with(dir.path(), 1);
+
+        // Concurrent appenders would each cache their own seq/head and break the
+        // chain, so the second must be refused outright rather than corrupting it.
+        let second = AuditLog::new(path.clone());
+        let err = second.open(&KEY).unwrap_err();
+        assert!(
+            err.contains("another MQLens instance"),
+            "expected a clear lock message, got: {err}"
+        );
+
+        // The first instance keeps working while it holds the lock.
+        first.append(&KEY, &event("e2", 2_000)).expect("append");
+
+        // Releasing the lock hands the log over cleanly.
+        first.close();
+        let (events, report) = second.open(&KEY).expect("open after release");
+        assert!(report.integrity_error.is_none(), "{report:?}");
+        assert_eq!(
+            events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["e1", "e2"]
+        );
+    }
+
+    #[test]
+    fn reopening_in_the_same_instance_does_not_deadlock_on_its_own_lock() {
+        let dir = tempdir().unwrap();
+        let (log, _path) = log_with(dir.path(), 2);
+        // `open` must release the previous handle before taking the lock again.
+        let (events, report) = log.open(&KEY).expect("reopen in place");
+        assert!(report.integrity_error.is_none(), "{report:?}");
+        assert_eq!(events.len(), 2);
+        log.append(&KEY, &event("e3", 3_000)).expect("append after reopen");
+    }
+
+    #[test]
+    fn compaction_keeps_the_lock_held_afterwards() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.compact(&KEY, &[event("e3", 1_003)]).expect("compact");
+
+        // Compaction replaces the file, so it must re-acquire the lock.
+        let other = AuditLog::new(path);
+        assert!(
+            other.open(&KEY).is_err(),
+            "the lock must still be held after compaction"
+        );
+        log.append(&KEY, &event("e4", 1_004)).expect("append after compact");
     }
 
     #[test]

--- a/src-tauri/src/audit/log.rs
+++ b/src-tauri/src/audit/log.rs
@@ -69,6 +69,9 @@ const MAX_RECORD_BYTES: u32 = 8 * 1024 * 1024;
 
 const GENESIS: [u8; 32] = [0u8; 32];
 
+/// Size of the plaintext in the state sidecar: `u64` record count + chain head.
+const STATE_PLAINTEXT_LEN: usize = 8 + 32;
+
 /// AES-256-GCM framing overhead in a `vault::encrypt` blob: random nonce, then
 /// ciphertext (same length as the plaintext), then the authentication tag.
 const NONCE_BYTES: usize = 12;
@@ -290,6 +293,16 @@ struct Decoded {
     report: LoadReport,
 }
 
+/// What the state sidecar says the log should contain.
+enum RecordedState {
+    /// No sidecar on disk.
+    Missing,
+    /// Present but unreadable under this key.
+    Unreadable(String),
+    /// Records written, and the chain head after them.
+    Known(u64, [u8; 32]),
+}
+
 /// Open state: the append handle plus the chain position it continues from.
 struct Open {
     /// Held for the whole session. Kept on a sidecar path rather than the log
@@ -311,6 +324,7 @@ struct Open {
 pub struct AuditLog {
     path: PathBuf,
     lock_path: PathBuf,
+    state_path: PathBuf,
     open: Mutex<Option<Open>>,
 }
 
@@ -318,11 +332,61 @@ impl AuditLog {
     pub fn new(path: PathBuf) -> Self {
         let mut lock_path = path.clone().into_os_string();
         lock_path.push(".lock");
+        let mut state_path = path.clone().into_os_string();
+        state_path.push(".state");
         Self {
             path,
             lock_path: PathBuf::from(lock_path),
+            state_path: PathBuf::from(state_path),
             open: Mutex::new(None),
         }
+    }
+
+    /// Path of the state sidecar, so vault reset and rotation can handle it.
+    pub fn state_path(&self) -> &Path {
+        &self.state_path
+    }
+
+    /// Record the number of events the log should contain, and the chain head
+    /// after them.
+    ///
+    /// This is what makes recovery unambiguous. The leading length prefix is
+    /// unauthenticated, so an edited prefix and a genuinely interrupted append
+    /// look identical from the file alone — and truncating on that ambiguity
+    /// would delete real records. Comparing against a durably recorded count
+    /// separates the two: fewer records than expected means removal, the same
+    /// count means the trailing bytes really were a partial append. It closes
+    /// tail truncation for the same reason. Encrypted under the vault key so it
+    /// cannot be forged without it.
+    fn write_state(&self, key: &[u8; 32], seq: u64, head: &[u8; 32]) -> Result<(), String> {
+        let mut plain = Vec::with_capacity(STATE_PLAINTEXT_LEN);
+        plain.extend_from_slice(&seq.to_be_bytes());
+        plain.extend_from_slice(head);
+        let blob = vault::encrypt(key, &plain)?;
+        durable::write_atomic(&self.state_path, &blob)
+    }
+
+    fn read_state(&self, key: &[u8; 32]) -> RecordedState {
+        if !self.state_path.exists() {
+            return RecordedState::Missing;
+        }
+        let blob = match fs::read(&self.state_path) {
+            Ok(b) if !b.is_empty() => b,
+            Ok(_) => return RecordedState::Missing,
+            Err(e) => return RecordedState::Unreadable(e.to_string()),
+        };
+        let plain = match vault::decrypt(key, &blob) {
+            Ok(p) => p,
+            Err(e) => return RecordedState::Unreadable(e),
+        };
+        if plain.len() != STATE_PLAINTEXT_LEN {
+            return RecordedState::Unreadable("unexpected length".into());
+        }
+        let mut seq_bytes = [0u8; 8];
+        seq_bytes.copy_from_slice(&plain[..8]);
+        let mut head = [0u8; 32];
+        head.copy_from_slice(&plain[8..]);
+        RecordedState::Known(u64::from_be_bytes(seq_bytes), head)
     }
 
     /// Path of the sidecar lock file, so vault reset can clean it up.
@@ -362,13 +426,26 @@ impl AuditLog {
     /// Returns every verified event in write order so the caller can rebuild the
     /// query index, plus a report describing what recovery had to do.
     pub fn open(&self, key: &[u8; 32]) -> Result<(Vec<AuditEvent>, LoadReport), String> {
+        self.open_inner(key, None)
+    }
+
+    fn open_inner(
+        &self,
+        key: &[u8; 32],
+        held: Option<RetainedLock>,
+    ) -> Result<(Vec<AuditEvent>, LoadReport), String> {
         let mut slot = self.open.lock().map_err(|e| e.to_string())?;
         // Drop any previous handle first, releasing its lock.
-        *slot = None;
+        if held.is_none() {
+            *slot = None;
+        }
 
         // Take the lock before reading, so no other instance can be appending
         // while recovery decides what is a torn tail and what is tampering.
-        let lock = self.acquire_lock()?;
+        let lock = match held {
+            Some(RetainedLock(file)) => file,
+            None => self.acquire_lock()?,
+        };
         let mut file = self.open_handle()?;
         let mut bytes = Vec::new();
         file.read_to_end(&mut bytes)
@@ -382,6 +459,7 @@ impl AuditLog {
                 .map_err(|e| format!("write {}: {e}", self.path.display()))?;
             file.sync_all()
                 .map_err(|e| format!("fsync {}: {e}", self.path.display()))?;
+            self.write_state(key, 0, &GENESIS)?;
             *slot = Some(Open {
                 lock,
                 file,
@@ -392,15 +470,63 @@ impl AuditLog {
             return Ok((Vec::new(), LoadReport::default()));
         }
 
-        let decoded = decode_file(key, &bytes)?;
+        let recorded = self.read_state(key);
+        let mut decoded = decode_file(key, &bytes)?;
+
+        // The framing alone cannot tell an edited length prefix from an
+        // interrupted append, so trust the durable count instead of guessing.
+        // Only when decoding found nothing wrong itself — a broken chain or a
+        // failed tag is a more specific diagnosis than a count mismatch.
+        if decoded.report.integrity_error.is_none() {
+        match recorded {
+            RecordedState::Known(expected_seq, expected_head) => {
+                if decoded.seq < expected_seq {
+                    decoded.report.integrity_error = Some(format!(
+                        "audit log is missing records: {} readable, {expected_seq} expected — \
+                         records were removed, or a frame header was altered",
+                        decoded.seq
+                    ));
+                } else if decoded.seq == expected_seq && decoded.head != expected_head {
+                    decoded.report.integrity_error = Some(
+                        "audit log contents do not match their recorded hash — the file was \
+                         modified outside MQLens"
+                            .into(),
+                    );
+                }
+                // `decoded.seq > expected_seq` is the ordinary crash between an
+                // append and its state write: those records authenticated and
+                // chained, so they are genuine and the state is refreshed below.
+            }
+            RecordedState::Missing => {
+                decoded.report.integrity_error = Some(
+                    "the audit log's state file is missing, so the log cannot be verified \
+                     against the number of events it should hold. Clear the log to start a \
+                     new one."
+                        .into(),
+                );
+            }
+            RecordedState::Unreadable(why) => {
+                decoded.report.integrity_error = Some(format!(
+                    "the audit log's state file could not be read ({why}), so the log cannot \
+                     be verified. Clear the log to start a new one."
+                ));
+            }
+        }
+        }
 
         if decoded.report.integrity_error.is_none() && decoded.report.truncated_tail {
-            // Drop the partial record so the next append starts on a clean
-            // boundary. Safe: it never decrypted, so it was never a whole event.
+            // Confirmed a partial append rather than a removal, so dropping it is
+            // safe and leaves the next append on a clean boundary.
             file.set_len(decoded.valid_len as u64)
                 .map_err(|e| format!("truncate {}: {e}", self.path.display()))?;
             file.sync_all()
                 .map_err(|e| format!("fsync {}: {e}", self.path.display()))?;
+        }
+
+        if decoded.report.integrity_error.is_none() {
+            // Re-anchor the counter to what the log actually holds, covering both
+            // a truncated tail and records that outran their state write.
+            self.write_state(key, decoded.seq, &decoded.head)?;
         }
 
         *slot = Some(Open {
@@ -451,6 +577,9 @@ impl AuditLog {
 
         open.seq += 1;
         open.head = next;
+        // After the record, so a crash between the two leaves the log ahead of
+        // the counter — which recovery treats as genuine, not as removal.
+        self.write_state(key, open.seq, &open.head)?;
         Ok(())
     }
 
@@ -483,6 +612,7 @@ impl AuditLog {
         // usable log rather than a closed one — with the chain state that
         // matches whichever file is actually on disk.
         let (seq, head, sealed_reason) = if replaced.is_ok() {
+            self.write_state(key, seq, &head)?;
             (seq, head, None)
         } else {
             (prev_seq, prev_head, prev_sealed)
@@ -521,6 +651,22 @@ impl AuditLog {
             *slot = None;
         }
     }
+
+    /// Close the log but keep its cross-process lock held, for handing to
+    /// [`Self::open_retaining`].
+    pub fn close_retaining_lock(&self) -> Option<RetainedLock> {
+        let mut slot = self.open.lock().ok()?;
+        slot.take().map(|open| RetainedLock(open.lock))
+    }
+
+    /// Recover the log using a lock that is already held.
+    pub fn open_retaining(
+        &self,
+        key: &[u8; 32],
+        lock: RetainedLock,
+    ) -> Result<(Vec<AuditEvent>, LoadReport), String> {
+        self.open_inner(key, Some(lock))
+    }
 }
 
 /// Re-encrypt a whole log from `old_key` to `new_key`, returning the new file
@@ -533,22 +679,44 @@ impl AuditLog {
 pub fn prepare_reencrypted(
     old_key: &[u8; 32],
     new_key: &[u8; 32],
-    path: &Path,
-) -> Result<Option<Vec<u8>>, String> {
-    if !path.exists() {
-        return Ok(None);
+    log_path: &Path,
+) -> Result<Vec<(PathBuf, Vec<u8>)>, String> {
+    if !log_path.exists() {
+        return Ok(Vec::new());
     }
-    let bytes = fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let bytes = fs::read(log_path).map_err(|e| format!("read {}: {e}", log_path.display()))?;
     if bytes.is_empty() {
-        return Ok(None);
+        return Ok(Vec::new());
     }
     let decoded = decode_file(old_key, &bytes)?;
     if let Some(reason) = decoded.report.integrity_error {
         return Err(format!("cannot re-encrypt a damaged audit log: {reason}"));
     }
-    let (out, _, _) = encode_file(new_key, &decoded.events)?;
-    Ok(Some(out))
+    let (log_bytes, head, seq) = encode_file(new_key, &decoded.events)?;
+
+    // The state sidecar is encrypted under the same key, so it has to be
+    // rotated in the same transaction — otherwise the new-key log would be
+    // checked against an old-key counter and seal itself on the next unlock.
+    let mut state_plain = Vec::with_capacity(STATE_PLAINTEXT_LEN);
+    state_plain.extend_from_slice(&seq.to_be_bytes());
+    state_plain.extend_from_slice(&head);
+    let state_bytes = vault::encrypt(new_key, &state_plain)?;
+
+    let mut state_path = log_path.to_path_buf().into_os_string();
+    state_path.push(".state");
+    Ok(vec![
+        (log_path.to_path_buf(), log_bytes),
+        (PathBuf::from(state_path), state_bytes),
+    ])
 }
+
+/// A held cross-process lock, kept alive across a close/reopen cycle.
+///
+/// Key rotation must read and replace the log while no other instance can touch
+/// it, but it also has to close the session to get a consistent snapshot.
+/// Handing the lock through instead of dropping it removes the window where a
+/// second instance could take the log and append under the old key.
+pub struct RetainedLock(fs::File);
 
 #[cfg(test)]
 mod tests {
@@ -648,16 +816,21 @@ mod tests {
     #[test]
     fn torn_tail_is_discarded_and_logging_continues() {
         let dir = tempdir().unwrap();
-        let (log, path) = log_with(dir.path(), 3);
+        let (log, path) = log_with(dir.path(), 2);
         log.close();
 
-        // Chop the final record in half, as a crash mid-append would.
-        let bytes = fs::read(&path).unwrap();
-        fs::write(&path, &bytes[..bytes.len() - 20]).unwrap();
+        // A real interrupted append leaves partial bytes *and* a counter that
+        // still reads 2, because the counter is written after the record. Appending
+        // a truncated frame by hand reproduces that; rewriting the file after a
+        // successful append would not, and would correctly look like removal.
+        let mut partial = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        partial.write_all(&[0, 0, 1, 0]).unwrap(); // declares 256 bytes...
+        partial.write_all(&[7u8; 40]).unwrap(); // ...but only 40 are present
+        drop(partial);
 
         let reopened = AuditLog::new(path.clone());
         let (events, report) = reopened.open(&KEY).expect("recover");
-        assert!(report.truncated_tail, "torn tail must be reported");
+        assert!(report.truncated_tail, "torn tail must be reported: {report:?}");
         assert!(
             report.integrity_error.is_none(),
             "a torn tail is a crash, not tampering: {report:?}"
@@ -673,6 +846,49 @@ mod tests {
         assert_eq!(
             events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
             ["e1", "e2", "e4"]
+        );
+    }
+
+    #[test]
+    fn inflating_the_last_records_length_seals_instead_of_dropping_it() {
+        // The one case framing alone cannot classify: a complete record whose
+        // prefix is changed to more than the bytes remaining looks exactly like
+        // an interrupted append. The durable count is what separates them.
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 3);
+        log.close();
+
+        let mut bytes = fs::read(&path).unwrap();
+        let last_start = {
+            let mut off = HEADER_LEN;
+            let mut prev = off;
+            while off < bytes.len() {
+                let len = u32::from_be_bytes([
+                    bytes[off],
+                    bytes[off + 1],
+                    bytes[off + 2],
+                    bytes[off + 3],
+                ]) as usize;
+                prev = off;
+                off += LEN_PREFIX + len;
+            }
+            prev
+        };
+        bytes[last_start..last_start + LEN_PREFIX]
+            .copy_from_slice(&(MAX_RECORD_BYTES - 1).to_be_bytes());
+        fs::write(&path, &bytes).unwrap();
+
+        let reopened = AuditLog::new(path.clone());
+        let (events, report) = reopened.open(&KEY).expect("load");
+        assert!(
+            report.integrity_error.is_some(),
+            "dropping a record must not pass as a torn append: {report:?}"
+        );
+        assert_eq!(events.len(), 2, "the intact prefix is still readable");
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            bytes,
+            "the altered record must be preserved as evidence"
         );
     }
 
@@ -970,10 +1186,12 @@ mod tests {
         log.close();
 
         let new_key = [4u8; 32];
-        let bytes = prepare_reencrypted(&KEY, &new_key, &path)
-            .expect("prepare")
-            .expect("some bytes");
-        fs::write(&path, &bytes).unwrap();
+        let files = prepare_reencrypted(&KEY, &new_key, &path).expect("prepare");
+        // The state sidecar is keyed too, so it must rotate alongside the log.
+        assert_eq!(files.len(), 2, "log and state sidecar");
+        for (target, bytes) in files {
+            fs::write(target, bytes).unwrap();
+        }
 
         let reopened = AuditLog::new(path);
         let (events, report) = reopened.open(&new_key).expect("open with new key");
@@ -981,6 +1199,27 @@ mod tests {
         assert_eq!(
             events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
             ["e1", "e2", "e3"]
+        );
+    }
+
+    #[test]
+    fn reencrypting_only_the_log_and_not_its_state_would_seal_it() {
+        // Guards the pairing: rotating one without the other leaves a new-key log
+        // checked against an old-key counter.
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 2);
+        log.close();
+
+        let new_key = [4u8; 32];
+        let files = prepare_reencrypted(&KEY, &new_key, &path).expect("prepare");
+        let (log_target, log_bytes) = files.into_iter().next().unwrap();
+        fs::write(log_target, log_bytes).unwrap();
+
+        let reopened = AuditLog::new(path);
+        let (_, report) = reopened.open(&new_key).expect("load");
+        assert!(
+            report.integrity_error.is_some(),
+            "a stale state sidecar must be caught: {report:?}"
         );
     }
 
@@ -1003,7 +1242,7 @@ mod tests {
         let absent = dir.path().join("nope.log.enc");
         assert!(prepare_reencrypted(&KEY, &[4u8; 32], &absent)
             .expect("prepare")
-            .is_none());
+            .is_empty());
     }
 
     #[test]

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -1,14 +1,18 @@
 //! Local operation audit log (#272).
 //!
-//! Level gating, redaction, SQLite store, and vault envelope session.
+//! Level gating, redaction, SQLite store, vault envelope, and soft-fail recording.
 
+pub mod classify;
 pub mod envelope;
 pub mod level;
+pub mod record;
 pub mod redact;
 pub mod store;
 
-pub use envelope::{seal, unseal, AuditSession};
+pub use classify::classify_op;
+pub use envelope::{seal, unseal, AuditPolicy, AuditSession};
 pub use level::{should_record, AuditLevel, OpClass};
+pub use record::{maybe_record, maybe_record_result, RecordInput};
 pub use redact::{redact_text, truncate_args, MAX_ARGS_BYTES};
 pub use store::{AuditEvent, AuditFilter, AuditStore, SCHEMA_VERSION};
 
@@ -34,13 +38,20 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
+fn policy_from_settings(settings: &AppSettings) -> AuditPolicy {
+    AuditPolicy {
+        enabled: settings.audit_enabled,
+        level: AuditLevel::parse(&settings.audit_level),
+        include_payloads: settings.audit_include_payloads,
+    }
+}
+
 /// Open (or replace) the audit session after a successful vault unlock.
 pub fn open_on_unlock(
     app: &tauri::AppHandle,
     state: &AppState,
     key: [u8; 32],
 ) -> Result<(), String> {
-    // Soft-fail: audit must never block unlock.
     if let Err(e) = open_on_unlock_inner(app, state, key) {
         eprintln!("audit open_on_unlock: {e}");
     }
@@ -61,6 +72,7 @@ fn open_on_unlock_inner(
         &key,
     )
     .unwrap_or_default();
+    session.set_policy(policy_from_settings(&settings));
     let cutoff = retention_cutoff_ms(settings.audit_retention_days, now_ms());
     let _ = session.prune_before(cutoff);
 
@@ -97,6 +109,15 @@ pub fn reset_store(app: &tauri::AppHandle, state: &AppState) -> Result<(), Strin
             .map_err(|e| format!("remove {}: {e}", path.display()))?;
     }
     Ok(())
+}
+
+/// Refresh in-memory audit policy after settings are saved (vault unlocked).
+pub fn refresh_policy_from_settings(state: &AppState, settings: &AppSettings) {
+    if let Ok(guard) = state.audit.lock_safe() {
+        if let Some(session) = guard.as_ref() {
+            session.set_policy(policy_from_settings(settings));
+        }
+    }
 }
 
 /// Current settings snapshot for audit decisions (defaults if locked/unloadable).

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -1,0 +1,10 @@
+//! Local operation audit log (#272).
+//!
+//! Level gating and redaction live here; SQLite store and vault envelope
+//! land in follow-up tasks.
+
+pub mod level;
+pub mod redact;
+
+pub use level::{should_record, AuditLevel, OpClass};
+pub use redact::{redact_text, truncate_args, MAX_ARGS_BYTES};

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -12,7 +12,7 @@ pub mod store;
 
 pub use classify::classify_op;
 pub use envelope::{AuditPolicy, AuditSession};
-pub use log::{AuditLog, LoadReport};
+pub use log::{AuditLog, LoadReport, RetainedLock};
 pub use level::{should_record, AuditLevel, OpClass};
 pub use record::{
     flush_pending, maybe_record, maybe_record_result, maybe_record_task_start, with_source,
@@ -120,7 +120,12 @@ fn open_on_unlock_inner(
     )
     .unwrap_or_default();
     session.set_policy(policy_from_settings(&settings));
-    prune_for_policy(&session, session.policy());
+    // Never prune a sealed log: retention compacts, and compaction rewrites the
+    // file and clears the seal, destroying the corrupted frame and everything
+    // after it — exactly what sealing exists to preserve.
+    if report.integrity_error.is_none() {
+        prune_for_policy(&session, session.policy());
+    }
 
     *slot = Some(session);
     drop(slot);
@@ -132,6 +137,50 @@ fn open_on_unlock_inner(
         eprintln!("audit: wrote {flushed} task outcome(s) recorded while the vault was locked");
     }
     Ok(())
+}
+
+/// Close the session for a key rotation, keeping the log's cross-process lock.
+///
+/// Releasing it would let a second instance take the log and append under the
+/// old key while rotation swaps in the new-key file — on Unix that second
+/// process keeps writing to the unlinked old inode, so those events vanish.
+pub fn suspend_for_rotation(state: &AppState) -> Option<RetainedLock> {
+    set_degraded(state, None);
+    let mut slot = state.audit.lock_safe().ok()?;
+    let session = slot.take()?;
+    session.close_retaining_lock()
+}
+
+/// Reopen after a rotation, reusing the lock held throughout it.
+pub fn resume_after_rotation(
+    app: &tauri::AppHandle,
+    state: &AppState,
+    key: [u8; 32],
+    lock: RetainedLock,
+) -> Result<(), String> {
+    let result = (|| -> Result<(), String> {
+        let mut slot = state.audit.lock_safe()?;
+        let session = AuditSession::new(connections::get_audit_log_path(app));
+        let report = session.open_retaining(key, lock)?;
+        if let Some(err) = &report.integrity_error {
+            eprintln!("audit log integrity: {err}");
+        }
+        let settings = load_settings_for_key(app, &key);
+        session.set_policy(policy_from_settings(&settings));
+        if report.integrity_error.is_none() {
+            prune_for_policy(&session, session.policy());
+        }
+        *slot = Some(session);
+        Ok(())
+    })();
+    match &result {
+        Ok(()) => set_degraded(state, None),
+        Err(e) => {
+            eprintln!("audit resume_after_rotation: {e}");
+            set_degraded(state, Some(e.clone()));
+        }
+    }
+    result
 }
 
 /// Seal and drop the audit session on vault lock.
@@ -179,8 +228,35 @@ pub fn reset_store(app: &tauri::AppHandle, state: &AppState) -> Result<(), Strin
             session.discard();
         }
     }
+
+    // A reset destroys the vault this history belonged to. Anything still parked
+    // from it must not be flushed into the *next* vault's log — including errors
+    // that were sanitized under the old vault's payload policy. Bumping the
+    // generation also stops background tasks still holding an old
+    // `TaskAuditContext` from parking their outcome after the reset.
+    if let Ok(mut pending) = state.audit_pending.lock_safe() {
+        let dropped = pending.len();
+        pending.clear();
+        if dropped > 0 {
+            eprintln!("audit: discarded {dropped} parked event(s) belonging to the reset vault");
+        }
+    }
+    state
+        .audit_generation
+        .fetch_add(1, std::sync::atomic::Ordering::Release);
+
+    let log_path = connections::get_audit_log_path(app);
+    let sidecar = |suffix: &str| {
+        let mut p = log_path.clone().into_os_string();
+        p.push(suffix);
+        std::path::PathBuf::from(p)
+    };
     for path in [
-        connections::get_audit_log_path(app),
+        log_path.clone(),
+        // The state sidecar holds the expected record count; leaving it behind
+        // would make the next vault's fresh log look like records were removed.
+        sidecar(".state"),
+        sidecar(".lock"),
         connections::get_audit_enc_path(app),
     ] {
         if path.exists() {
@@ -197,6 +273,8 @@ pub fn refresh_policy_from_settings(state: &AppState, settings: &AppSettings) {
     if let Ok(guard) = state.audit.lock_safe() {
         if let Some(session) = guard.as_ref() {
             session.set_policy(policy);
+            // `prune_before` refuses on a sealed log; saving a shorter retention
+            // window must not become a way to overwrite preserved evidence.
             prune_for_policy(session, policy);
         }
     }

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -2,10 +2,12 @@
 //!
 //! Level gating, redaction, and SQLite store. Vault envelope is Task 3.
 
+pub mod envelope;
 pub mod level;
 pub mod redact;
 pub mod store;
 
+pub use envelope::{seal, unseal, AuditSession};
 pub use level::{should_record, AuditLevel, OpClass};
 pub use redact::{redact_text, truncate_args, MAX_ARGS_BYTES};
 pub use store::{AuditEvent, AuditFilter, AuditStore, SCHEMA_VERSION};

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -5,15 +5,20 @@
 pub mod classify;
 pub mod envelope;
 pub mod level;
+pub mod log;
 pub mod record;
 pub mod redact;
 pub mod store;
 
 pub use classify::classify_op;
-pub use envelope::{seal, unseal, AuditPolicy, AuditSession};
+pub use envelope::{AuditPolicy, AuditSession};
+pub use log::{AuditLog, LoadReport};
 pub use level::{should_record, AuditLevel, OpClass};
-pub use record::{maybe_record, maybe_record_result, RecordInput};
-pub use redact::{redact_text, truncate_args, MAX_ARGS_BYTES};
+pub use record::{
+    maybe_record, maybe_record_result, maybe_record_task_start, with_source, RecordInput,
+    TaskAuditContext,
+};
+pub use redact::{redact_error, redact_text, truncate_args, MAX_ARGS_BYTES, MAX_ERROR_BYTES};
 pub use store::{AuditEvent, AuditFilter, AuditStore, SCHEMA_VERSION};
 
 use crate::connections::{self, AppSettings};
@@ -52,16 +57,40 @@ fn prune_for_policy(session: &AuditSession, policy: AuditPolicy) {
     let _ = session.prune_before(cutoff);
 }
 
+/// Record (or clear) the reason auditing is inactive while the vault is unlocked.
+fn set_degraded(state: &AppState, reason: Option<String>) {
+    if let Ok(mut slot) = state.audit_degraded.lock_safe() {
+        *slot = reason;
+    }
+}
+
+/// Why auditing is inactive despite an unlocked vault, if it is.
+pub fn degraded_reason(state: &AppState) -> Option<String> {
+    state.audit_degraded.lock_safe().ok().and_then(|g| g.clone())
+}
+
 /// Open (or replace) the audit session after a successful vault unlock.
+///
+/// A failure here must not block the unlock itself — a corrupt `audit.log.enc`
+/// would otherwise lock the user out of their own vault. Instead the reason is
+/// stored so [`degraded_reason`] can surface it and the error is returned for
+/// callers that want to react.
 pub fn open_on_unlock(
     app: &tauri::AppHandle,
     state: &AppState,
     key: [u8; 32],
 ) -> Result<(), String> {
-    if let Err(e) = open_on_unlock_inner(app, state, key) {
-        eprintln!("audit open_on_unlock: {e}");
+    match open_on_unlock_inner(app, state, key) {
+        Ok(()) => {
+            set_degraded(state, None);
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("audit open_on_unlock: {e}");
+            set_degraded(state, Some(e.clone()));
+            Err(e)
+        }
     }
-    Ok(())
 }
 
 fn open_on_unlock_inner(
@@ -76,9 +105,14 @@ fn open_on_unlock_inner(
         }
     }
 
-    let path = connections::get_audit_enc_path(app);
+    supersede_legacy_envelope(app);
+
+    let path = connections::get_audit_log_path(app);
     let session = AuditSession::new(path);
-    session.open(key)?;
+    let report = session.open(key)?;
+    if let Some(err) = &report.integrity_error {
+        eprintln!("audit log integrity: {err}");
+    }
 
     let settings = connections::load_settings_encrypted(
         &connections::get_settings_enc_path(app),
@@ -101,6 +135,7 @@ pub fn close_on_lock(state: &AppState) -> Result<(), String> {
 }
 
 fn close_on_lock_inner(state: &AppState) -> Result<(), String> {
+    set_degraded(state, None);
     let mut slot = state.audit.lock_safe()?;
     if let Some(session) = slot.take() {
         session.close()?;
@@ -108,17 +143,42 @@ fn close_on_lock_inner(state: &AppState) -> Result<(), String> {
     Ok(())
 }
 
-/// Discard session and delete `audit.db.enc` on vault reset.
+/// Move a pre-append-log `audit.db.enc` out of the way.
+///
+/// The whole-image envelope was replaced by `audit.log.enc` before this feature
+/// shipped, so there is no released format to migrate. The old file is renamed
+/// rather than deleted so a developer's local history is not silently destroyed.
+fn supersede_legacy_envelope(app: &tauri::AppHandle) {
+    let legacy = connections::get_audit_enc_path(app);
+    if !legacy.exists() {
+        return;
+    }
+    let superseded = legacy.with_extension("enc.superseded");
+    match std::fs::rename(&legacy, &superseded) {
+        Ok(()) => eprintln!(
+            "audit: {} predates the append-only log format; renamed to {}",
+            legacy.display(),
+            superseded.display()
+        ),
+        Err(e) => eprintln!("audit: could not set aside {}: {e}", legacy.display()),
+    }
+}
+
+/// Discard session and delete the audit log on vault reset.
 pub fn reset_store(app: &tauri::AppHandle, state: &AppState) -> Result<(), String> {
     if let Ok(mut slot) = state.audit.lock_safe() {
         if let Some(session) = slot.take() {
             session.discard();
         }
     }
-    let path = connections::get_audit_enc_path(app);
-    if path.exists() {
-        std::fs::remove_file(&path)
-            .map_err(|e| format!("remove {}: {e}", path.display()))?;
+    for path in [
+        connections::get_audit_log_path(app),
+        connections::get_audit_enc_path(app),
+    ] {
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .map_err(|e| format!("remove {}: {e}", path.display()))?;
+        }
     }
     Ok(())
 }

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -1,6 +1,6 @@
 //! Local operation audit log (#272).
 //!
-//! Level gating, redaction, and SQLite store. Vault envelope is Task 3.
+//! Level gating, redaction, SQLite store, and vault envelope session.
 
 pub mod envelope;
 pub mod level;
@@ -11,3 +11,110 @@ pub use envelope::{seal, unseal, AuditSession};
 pub use level::{should_record, AuditLevel, OpClass};
 pub use redact::{redact_text, truncate_args, MAX_ARGS_BYTES};
 pub use store::{AuditEvent, AuditFilter, AuditStore, SCHEMA_VERSION};
+
+use crate::connections::{self, AppSettings};
+use crate::state::{AppState, LockExt};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Clamp retention days to a sane range (1..=365).
+pub fn clamp_retention_days(days: u32) -> u32 {
+    days.clamp(1, 365)
+}
+
+/// Unix-ms cutoff for pruning given retention days and "now".
+pub fn retention_cutoff_ms(retention_days: u32, now_ms: i64) -> i64 {
+    let days = clamp_retention_days(retention_days) as i64;
+    now_ms.saturating_sub(days.saturating_mul(86_400_000))
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Open (or replace) the audit session after a successful vault unlock.
+pub fn open_on_unlock(
+    app: &tauri::AppHandle,
+    state: &AppState,
+    key: [u8; 32],
+) -> Result<(), String> {
+    // Soft-fail: audit must never block unlock.
+    if let Err(e) = open_on_unlock_inner(app, state, key) {
+        eprintln!("audit open_on_unlock: {e}");
+    }
+    Ok(())
+}
+
+fn open_on_unlock_inner(
+    app: &tauri::AppHandle,
+    state: &AppState,
+    key: [u8; 32],
+) -> Result<(), String> {
+    let path = connections::get_audit_enc_path(app);
+    let session = AuditSession::new(path);
+    session.open(key)?;
+
+    let settings = connections::load_settings_encrypted(
+        &connections::get_settings_enc_path(app),
+        &key,
+    )
+    .unwrap_or_default();
+    let cutoff = retention_cutoff_ms(settings.audit_retention_days, now_ms());
+    let _ = session.prune_before(cutoff);
+
+    *state.audit.lock_safe()? = Some(session);
+    Ok(())
+}
+
+/// Seal and drop the audit session on vault lock.
+pub fn close_on_lock(state: &AppState) -> Result<(), String> {
+    if let Err(e) = close_on_lock_inner(state) {
+        eprintln!("audit close_on_lock: {e}");
+    }
+    Ok(())
+}
+
+fn close_on_lock_inner(state: &AppState) -> Result<(), String> {
+    let mut slot = state.audit.lock_safe()?;
+    if let Some(session) = slot.take() {
+        session.close()?;
+    }
+    Ok(())
+}
+
+/// Discard session and delete `audit.db.enc` on vault reset.
+pub fn reset_store(app: &tauri::AppHandle, state: &AppState) -> Result<(), String> {
+    if let Ok(mut slot) = state.audit.lock_safe() {
+        if let Some(session) = slot.take() {
+            session.discard();
+        }
+    }
+    let path = connections::get_audit_enc_path(app);
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .map_err(|e| format!("remove {}: {e}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Current settings snapshot for audit decisions (defaults if locked/unloadable).
+pub fn load_settings_for_key(app: &tauri::AppHandle, key: &[u8; 32]) -> AppSettings {
+    connections::load_settings_encrypted(&connections::get_settings_enc_path(app), key)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod retention_tests {
+    use super::*;
+
+    #[test]
+    fn clamp_and_cutoff() {
+        assert_eq!(clamp_retention_days(0), 1);
+        assert_eq!(clamp_retention_days(400), 365);
+        assert_eq!(clamp_retention_days(30), 30);
+        let cutoff = retention_cutoff_ms(1, 86_400_000 * 10);
+        assert_eq!(cutoff, 86_400_000 * 9);
+    }
+}

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -15,8 +15,8 @@ pub use envelope::{AuditPolicy, AuditSession};
 pub use log::{AuditLog, LoadReport};
 pub use level::{should_record, AuditLevel, OpClass};
 pub use record::{
-    maybe_record, maybe_record_result, maybe_record_task_start, with_source, RecordInput,
-    TaskAuditContext,
+    flush_pending, maybe_record, maybe_record_result, maybe_record_task_start, with_source,
+    RecordInput, TaskAuditContext,
 };
 pub use redact::{redact_error, redact_text, truncate_args, MAX_ARGS_BYTES, MAX_ERROR_BYTES};
 pub use store::{AuditEvent, AuditFilter, AuditStore, SCHEMA_VERSION};
@@ -123,6 +123,14 @@ fn open_on_unlock_inner(
     prune_for_policy(&session, session.policy());
 
     *slot = Some(session);
+    drop(slot);
+
+    // Background tasks that finished while the vault was locked parked their
+    // terminal events; write them now so nothing stays marked `running`.
+    let flushed = record::flush_pending(&state.audit, &state.audit_pending);
+    if flushed > 0 {
+        eprintln!("audit: wrote {flushed} task outcome(s) recorded while the vault was locked");
+    }
     Ok(())
 }
 

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -1,10 +1,11 @@
 //! Local operation audit log (#272).
 //!
-//! Level gating and redaction live here; SQLite store and vault envelope
-//! land in follow-up tasks.
+//! Level gating, redaction, and SQLite store. Vault envelope is Task 3.
 
 pub mod level;
 pub mod redact;
+pub mod store;
 
 pub use level::{should_record, AuditLevel, OpClass};
 pub use redact::{redact_text, truncate_args, MAX_ARGS_BYTES};
+pub use store::{AuditEvent, AuditFilter, AuditStore, SCHEMA_VERSION};

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -43,7 +43,13 @@ fn policy_from_settings(settings: &AppSettings) -> AuditPolicy {
         enabled: settings.audit_enabled,
         level: AuditLevel::parse(&settings.audit_level),
         include_payloads: settings.audit_include_payloads,
+        retention_days: settings.audit_retention_days,
     }
+}
+
+fn prune_for_policy(session: &AuditSession, policy: AuditPolicy) {
+    let cutoff = retention_cutoff_ms(policy.retention_days, now_ms());
+    let _ = session.prune_before(cutoff);
 }
 
 /// Open (or replace) the audit session after a successful vault unlock.
@@ -63,6 +69,13 @@ fn open_on_unlock_inner(
     state: &AppState,
     key: [u8; 32],
 ) -> Result<(), String> {
+    let mut slot = state.audit.lock_safe()?;
+    if let Some(existing) = slot.take() {
+        if let Err(e) = existing.close() {
+            eprintln!("audit close before reopen: {e}");
+        }
+    }
+
     let path = connections::get_audit_enc_path(app);
     let session = AuditSession::new(path);
     session.open(key)?;
@@ -73,10 +86,9 @@ fn open_on_unlock_inner(
     )
     .unwrap_or_default();
     session.set_policy(policy_from_settings(&settings));
-    let cutoff = retention_cutoff_ms(settings.audit_retention_days, now_ms());
-    let _ = session.prune_before(cutoff);
+    prune_for_policy(&session, session.policy());
 
-    *state.audit.lock_safe()? = Some(session);
+    *slot = Some(session);
     Ok(())
 }
 
@@ -113,9 +125,11 @@ pub fn reset_store(app: &tauri::AppHandle, state: &AppState) -> Result<(), Strin
 
 /// Refresh in-memory audit policy after settings are saved (vault unlocked).
 pub fn refresh_policy_from_settings(state: &AppState, settings: &AppSettings) {
+    let policy = policy_from_settings(settings);
     if let Ok(guard) = state.audit.lock_safe() {
         if let Some(session) = guard.as_ref() {
-            session.set_policy(policy_from_settings(settings));
+            session.set_policy(policy);
+            prune_for_policy(session, policy);
         }
     }
 }

--- a/src-tauri/src/audit/record.rs
+++ b/src-tauri/src/audit/record.rs
@@ -74,15 +74,14 @@ fn maybe_record_inner(state: &AppState, input: RecordInput<'_>) -> Result<(), St
         .unwrap_or(inferred_source.as_str())
         .to_string();
 
-    let args_json = input.args.map(|raw| {
-        let redacted = redact_text(raw);
-        let cap = if policy.include_payloads {
-            MAX_ARGS_BYTES
-        } else {
-            2_048
-        };
-        truncate_args(&redacted, cap)
-    });
+    let args_json = if policy.include_payloads {
+        input.args.map(|raw| {
+            let redacted = redact_text(raw);
+            truncate_args(&redacted, MAX_ARGS_BYTES)
+        })
+    } else {
+        None
+    };
 
     let event = AuditEvent {
         id: Uuid::new_v4().to_string(),
@@ -103,6 +102,8 @@ fn maybe_record_inner(state: &AppState, input: RecordInput<'_>) -> Result<(), St
     };
 
     let _ = session.try_insert(&event)?;
+    let cutoff = super::retention_cutoff_ms(policy.retention_days, now_ms());
+    let _ = session.prune_before(cutoff);
     Ok(())
 }
 

--- a/src-tauri/src/audit/record.rs
+++ b/src-tauri/src/audit/record.rs
@@ -296,6 +296,10 @@ pub struct TaskAuditContext {
     slot: SessionSlot,
     /// Where a terminal event goes if the vault locked before the task finished.
     pending: PendingSlot,
+    /// Vault generation this task belongs to, and the live counter to compare
+    /// against. A reset bumps the counter, which invalidates this context.
+    generation: u64,
+    generation_now: Arc<std::sync::atomic::AtomicU64>,
     /// Policy in force when the task was queued. `None` means the `running`
     /// event was never recorded (auditing off, or the level excluded it), and
     /// the terminal event is skipped for the same reason.
@@ -340,6 +344,10 @@ impl TaskAuditContext {
         let ctx = Self {
             slot: Arc::clone(&state.audit),
             pending: Arc::clone(&state.audit_pending),
+            generation: state
+                .audit_generation
+                .load(std::sync::atomic::Ordering::Acquire),
+            generation_now: Arc::clone(&state.audit_generation),
             policy,
             event_id: Uuid::new_v4().to_string(),
             ts: now_ms(),
@@ -366,6 +374,15 @@ impl TaskAuditContext {
         let Some(policy) = self.policy else {
             return;
         };
+        // The vault this task belonged to was reset; its history is gone and this
+        // event must not land in the replacement vault's log.
+        if self
+            .generation_now
+            .load(std::sync::atomic::Ordering::Acquire)
+            != self.generation
+        {
+            return;
+        }
         let summary = format!("{} ({outcome})", self.summary);
         let input = RecordInput {
             event_id: Some(&self.event_id),
@@ -817,6 +834,34 @@ mod tests {
         assert!(
             state.audit_pending.lock().unwrap().is_empty(),
             "a skipped event must not be parked either"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reset_vault_discards_a_parked_outcome() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        let ctx = TaskAuditContext::capture(
+            &state,
+            Some("c1"),
+            Some("shop"),
+            Some("orders"),
+            "start_import_task",
+            "import shop.orders (json, skip)",
+        );
+
+        // The vault is reset while the task is still running: its history is gone.
+        let session = state.audit.lock().unwrap().take().unwrap();
+        session.close().expect("close");
+        state.audit_pending.lock().unwrap().clear();
+        state
+            .audit_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
+
+        ctx.record_terminal("completed", None, Some(5));
+        assert!(
+            state.audit_pending.lock().unwrap().is_empty(),
+            "an outcome from the reset vault must not be parked for the next one"
         );
     }
 

--- a/src-tauri/src/audit/record.rs
+++ b/src-tauri/src/audit/record.rs
@@ -236,6 +236,12 @@ pub fn maybe_record_task_start(
     );
 }
 
+/// Apply the policy's retention window immediately.
+fn prune_now(session: &AuditSession, policy: AuditPolicy) {
+    let cutoff = super::retention_cutoff_ms(policy.retention_days, now_ms());
+    let _ = session.prune_before(cutoff);
+}
+
 /// Hold a terminal event until the audit session reopens.
 fn park_pending(pending: &PendingSlot, event: AuditEvent, outcome: &str) {
     let Ok(mut queue) = pending.lock() else {
@@ -270,9 +276,14 @@ pub fn flush_pending(slot: &SessionSlot, pending: &PendingSlot) -> usize {
     let Some(session) = guard.as_ref() else {
         return 0;
     };
+    let policy = session.policy();
     let mut written = 0;
     queue.retain(|event| match session.try_insert(event) {
         Ok(true) => {
+            // Same reason as `TaskAuditContext::write`: these inserts skip
+            // `record_into`, and a parked event's timestamp can already be past
+            // the retention cutoff by the time the vault reopens.
+            prune_now(session, policy);
             written += 1;
             false
         }
@@ -413,7 +424,15 @@ impl TaskAuditContext {
         let inserted = match self.slot.lock() {
             Ok(guard) => match guard.as_ref() {
                 Some(session) => match session.try_insert(&event) {
-                    Ok(done) => done,
+                    Ok(done) => {
+                        // This path bypasses `record_into`, so retention has to be
+                        // applied here too: a task queued before the cutoff — or
+                        // parked through a long lock — keeps its original
+                        // timestamp and would otherwise sit past its window until
+                        // some unrelated operation pruned it.
+                        prune_now(session, policy);
+                        done
+                    }
                     Err(e) => {
                         eprintln!("audit task record ({outcome}): {e}");
                         false

--- a/src-tauri/src/audit/record.rs
+++ b/src-tauri/src/audit/record.rs
@@ -2,14 +2,50 @@
 
 use super::classify::classify_op;
 use super::level::{should_record, OpClass};
-use super::redact::{redact_text, truncate_args, MAX_ARGS_BYTES};
+use super::redact::{redact_error, redact_text, truncate_args, MAX_ARGS_BYTES};
 use super::store::{AuditEvent, SCHEMA_VERSION};
+use super::envelope::AuditSession;
 use crate::state::{AppState, LockExt};
+use std::sync::{Arc, Mutex};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
+/// Shared handle to the audit session slot in `AppState`.
+pub type SessionSlot = Arc<Mutex<Option<AuditSession>>>;
+
+tokio::task_local! {
+    /// Invoking surface for audit attribution, scoped around one tool call.
+    static AUDIT_SOURCE: &'static str;
+}
+
+/// Run `fut` with the audit source pinned to `source` (e.g. `"mcp"`).
+///
+/// The MCP tools share the same `_impl`s as the UI, and a connection's
+/// `via_mcp` flag records who *opened* it, not who is calling now —
+/// `require_mcp_connection` deliberately accepts any live opted-in connection.
+/// Without this scope an agent's reads and destructive writes on a UI-opened
+/// connection were attributed to the human UI.
+pub async fn with_source<F>(source: &'static str, fut: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    AUDIT_SOURCE.scope(source, fut).await
+}
+
+/// The source pinned by an enclosing [`with_source`] scope, if any.
+fn scoped_source() -> Option<&'static str> {
+    AUDIT_SOURCE.try_with(|s| *s).ok()
+}
+
 /// Inputs for a single audit attempt. Never causes the Mongo op to fail.
 pub struct RecordInput<'a> {
+    /// Reuse an existing event id to *supersede* that event instead of adding a
+    /// row. Used by background tasks to replace their `running` event with the
+    /// real outcome. `None` mints a fresh id.
+    pub event_id: Option<&'a str>,
+    /// Pin the event's timestamp. A superseding record keeps the original time
+    /// so the row does not jump around the listing when a long task finishes.
+    pub ts: Option<i64>,
     pub connection_id: Option<&'a str>,
     pub database: Option<&'a str>,
     pub collection: Option<&'a str>,
@@ -55,7 +91,28 @@ pub fn maybe_record(state: &AppState, input: RecordInput<'_>) {
 }
 
 fn maybe_record_inner(state: &AppState, input: RecordInput<'_>) -> Result<(), String> {
-    let guard = state.audit.lock_safe()?;
+    let (profile_name, inferred_source) = profile_and_source(state, input.connection_id);
+    // Explicit override wins, then the invoking surface pinned by the caller's
+    // `with_source` scope, and only then the connection's provenance.
+    let source = input
+        .source
+        .map(|s| s.to_string())
+        .or_else(|| scoped_source().map(|s| s.to_string()))
+        .unwrap_or(inferred_source);
+    record_into(&state.audit, profile_name, source, input)
+}
+
+/// Build and insert the event against an already-resolved profile and source.
+///
+/// Split out of [`maybe_record_inner`] so [`TaskAuditContext`] can record from a
+/// spawned task that no longer has an `&AppState` to resolve them from.
+fn record_into(
+    slot: &SessionSlot,
+    profile_name: Option<String>,
+    source: String,
+    input: RecordInput<'_>,
+) -> Result<(), String> {
+    let guard = slot.lock().map_err(|e| e.to_string())?;
     let Some(session) = guard.as_ref() else {
         return Ok(());
     };
@@ -68,12 +125,6 @@ fn maybe_record_inner(state: &AppState, input: RecordInput<'_>) -> Result<(), St
         return Ok(());
     }
 
-    let (profile_name, inferred_source) = profile_and_source(state, input.connection_id);
-    let source = input
-        .source
-        .unwrap_or(inferred_source.as_str())
-        .to_string();
-
     let args_json = if policy.include_payloads {
         input.args.map(|raw| {
             let redacted = redact_text(raw);
@@ -84,8 +135,11 @@ fn maybe_record_inner(state: &AppState, input: RecordInput<'_>) -> Result<(), St
     };
 
     let event = AuditEvent {
-        id: Uuid::new_v4().to_string(),
-        ts: now_ms(),
+        id: input
+            .event_id
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| Uuid::new_v4().to_string()),
+        ts: input.ts.unwrap_or_else(now_ms),
         connection_id: input.connection_id.map(|s| s.to_string()),
         profile_name,
         database: input.database.map(|s| s.to_string()),
@@ -93,10 +147,15 @@ fn maybe_record_inner(state: &AppState, input: RecordInput<'_>) -> Result<(), St
         op: input.op.to_string(),
         source,
         ok: input.ok,
-        error: input.error.map(|s| s.to_string()),
+        // Errors carry payload values of their own (dup-key / validation
+        // errors embed rejected documents), so they are sanitized against the
+        // same payload gate as `args_json` rather than stored verbatim.
+        error: input
+            .error
+            .map(|s| redact_error(s, policy.include_payloads)),
         duration_ms: input.duration_ms,
         summary: input.summary.to_string(),
-        args_json: args_json,
+        args_json,
         level_at_record: policy.level.as_str().to_string(),
         schema_version: SCHEMA_VERSION,
     };
@@ -105,6 +164,149 @@ fn maybe_record_inner(state: &AppState, input: RecordInput<'_>) -> Result<(), St
     let cutoff = super::retention_cutoff_ms(policy.retention_days, now_ms());
     let _ = session.prune_before(cutoff);
     Ok(())
+}
+
+/// Record a background task's start only when no background task will record it.
+///
+/// A queued task writes its own `running` event and later supersedes it with the
+/// terminal outcome, so recording queue acceptance here as well would put two
+/// rows in the listing for every import, copy, generate and restore. Two cases
+/// still have to be recorded at this level, because nothing runs in the
+/// background to do it:
+///
+/// - a **rejected** start (read-only connection, invalid mode) — exactly the
+///   blocked destructive attempt an audit log needs;
+/// - a task that **completed inline**, as mock/demo connections do.
+#[allow(clippy::too_many_arguments)]
+pub fn maybe_record_task_start(
+    state: &AppState,
+    connection_id: Option<&str>,
+    database: Option<&str>,
+    collection: Option<&str>,
+    op: &str,
+    started: Instant,
+    summary: &str,
+    args: Option<&str>,
+    result: &Result<crate::TaskInfo, String>,
+) {
+    let (outcome, ok, error) = match result {
+        Err(e) => ("rejected", false, Some(e.clone())),
+        // Still running: the spawned task owns this event from here on.
+        Ok(task) if task.status == "running" => return,
+        Ok(task) => (
+            task.status.as_str(),
+            task.status == "completed",
+            task.error.clone(),
+        ),
+    };
+    maybe_record(
+        state,
+        RecordInput {
+            event_id: None,
+            ts: None,
+            connection_id,
+            database,
+            collection,
+            op,
+            class: Some(OpClass::Write),
+            source: None,
+            ok,
+            error: error.as_deref(),
+            duration_ms: Some(started.elapsed().as_millis() as i64),
+            summary: &format!("{summary} ({outcome})"),
+            args,
+        },
+    );
+}
+
+/// Audit context captured when a background task is queued, so the task can
+/// record its own terminal outcome after the queuing command has returned.
+///
+/// Queue acceptance and the task's real result are separate facts: recording only
+/// the former logged `ok: true` for imports/copies/restores that later failed,
+/// were cancelled, or wrote only partially.
+#[derive(Clone)]
+pub struct TaskAuditContext {
+    slot: SessionSlot,
+    /// Stable across the `running` record and the terminal one, so the second
+    /// replaces the first instead of adding a row.
+    event_id: String,
+    /// Time the task was queued; kept on the terminal record too.
+    ts: i64,
+    connection_id: Option<String>,
+    profile_name: Option<String>,
+    database: Option<String>,
+    collection: Option<String>,
+    op: String,
+    source: String,
+    summary: String,
+}
+
+impl TaskAuditContext {
+    /// Capture the context and record the task as `running`.
+    ///
+    /// Recording immediately matters: if the app dies mid-import the log still
+    /// shows the operation was started, which a terminal-only event would miss.
+    pub fn capture(
+        state: &AppState,
+        connection_id: Option<&str>,
+        database: Option<&str>,
+        collection: Option<&str>,
+        op: &str,
+        summary: &str,
+    ) -> Self {
+        let (profile_name, inferred_source) = profile_and_source(state, connection_id);
+        let source = scoped_source()
+            .map(|s| s.to_string())
+            .unwrap_or(inferred_source);
+        let ctx = Self {
+            slot: Arc::clone(&state.audit),
+            event_id: Uuid::new_v4().to_string(),
+            ts: now_ms(),
+            connection_id: connection_id.map(|s| s.to_string()),
+            profile_name,
+            database: database.map(|s| s.to_string()),
+            collection: collection.map(|s| s.to_string()),
+            op: op.to_string(),
+            source,
+            summary: summary.to_string(),
+        };
+        ctx.write("running", true, None, None);
+        ctx
+    }
+
+    /// Record the task's terminal state, replacing its `running` event.
+    /// `outcome` is `completed`, `failed` or `cancelled`.
+    pub fn record_terminal(&self, outcome: &str, error: Option<&str>, duration_ms: Option<i64>) {
+        self.write(outcome, outcome == "completed", error, duration_ms);
+    }
+
+    fn write(&self, outcome: &str, ok: bool, error: Option<&str>, duration_ms: Option<i64>) {
+        let summary = format!("{} ({outcome})", self.summary);
+        let input = RecordInput {
+            event_id: Some(&self.event_id),
+            ts: Some(self.ts),
+            connection_id: self.connection_id.as_deref(),
+            database: self.database.as_deref(),
+            collection: self.collection.as_deref(),
+            op: &self.op,
+            class: Some(OpClass::Write),
+            source: None,
+            ok,
+            error,
+            duration_ms,
+            summary: &summary,
+            args: None,
+        };
+        if let Err(e) = record_into(
+            &self.slot,
+            self.profile_name.clone(),
+            self.source.clone(),
+            input,
+        ) {
+            eprintln!("audit task record ({outcome}): {e}");
+        }
+    }
 }
 
 /// Record from a `Result`, capturing ok/error and elapsed time.
@@ -125,6 +327,8 @@ pub fn maybe_record_result<T, E: std::fmt::Display>(
     maybe_record(
         state,
         RecordInput {
+            event_id: None,
+            ts: None,
             connection_id,
             database,
             collection,
@@ -138,4 +342,332 @@ pub fn maybe_record_result<T, E: std::fmt::Display>(
             args,
         },
     );
+}
+
+/// Record a background task's *rejected* start, and nothing on success.
+///
+/// A queued task records its own `running` event and then its terminal outcome
+/// under the same id, so also recording queue acceptance here would put two rows
+/// in the listing for every import, copy, generate and restore. A rejection —
+/// a read-only connection, an invalid mode — never reaches the task, so it has
+/// to be recorded at this level or it is lost.
+#[allow(clippy::too_many_arguments)]
+pub fn maybe_record_rejection<T, E: std::fmt::Display>(
+    state: &AppState,
+    connection_id: Option<&str>,
+    database: Option<&str>,
+    collection: Option<&str>,
+    op: &str,
+    started: Instant,
+    summary: &str,
+    args: Option<&str>,
+    result: &Result<T, E>,
+) {
+    let Err(err) = result else {
+        return;
+    };
+    let err = err.to_string();
+    maybe_record(
+        state,
+        RecordInput {
+            event_id: None,
+            ts: None,
+            connection_id,
+            database,
+            collection,
+            op,
+            class: Some(OpClass::Write),
+            source: None,
+            ok: false,
+            error: Some(&err),
+            duration_ms: Some(started.elapsed().as_millis() as i64),
+            summary: &format!("{summary} (rejected)"),
+            args,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::envelope::AuditPolicy;
+    use crate::audit::level::AuditLevel;
+    use crate::audit::store::AuditFilter;
+
+    fn state_with_open_session(dir: &std::path::Path) -> AppState {
+        let state = AppState::new();
+        let session = AuditSession::new(dir.join("audit.log.enc"));
+        session.open([5u8; 32]).expect("open session");
+        session.set_policy(AuditPolicy {
+            enabled: true,
+            level: AuditLevel::C,
+            include_payloads: false,
+            retention_days: 30,
+        });
+        *state.audit.lock().unwrap() = Some(session);
+        state
+    }
+
+    fn drop_input<'a>(source: Option<&'a str>) -> RecordInput<'a> {
+        RecordInput {
+            event_id: None,
+            ts: None,
+            connection_id: Some("c1"),
+            database: Some("shop"),
+            collection: Some("orders"),
+            op: "drop_collection",
+            class: None,
+            source,
+            ok: true,
+            error: None,
+            duration_ms: None,
+            summary: "dropCollection shop.orders",
+            args: None,
+        }
+    }
+
+    fn only_source(state: &AppState) -> String {
+        let guard = state.audit.lock().unwrap();
+        let rows = guard
+            .as_ref()
+            .unwrap()
+            .query(&AuditFilter::default())
+            .expect("query");
+        assert_eq!(rows.len(), 1, "expected exactly one recorded event");
+        rows[0].source.clone()
+    }
+
+    #[tokio::test]
+    async fn scoped_source_overrides_connection_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        // No `connection_meta` entry, so provenance inference would say "ui".
+        with_source("mcp", async {
+            maybe_record(&state, drop_input(None));
+        })
+        .await;
+        assert_eq!(only_source(&state), "mcp");
+    }
+
+    #[tokio::test]
+    async fn explicit_source_wins_over_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        with_source("mcp", async {
+            maybe_record(&state, drop_input(Some("shell")));
+        })
+        .await;
+        assert_eq!(only_source(&state), "shell");
+    }
+
+    #[tokio::test]
+    async fn without_a_scope_source_falls_back_to_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        maybe_record(&state, drop_input(None));
+        assert_eq!(only_source(&state), "ui");
+    }
+
+    #[tokio::test]
+    async fn task_context_captures_the_scoped_source_and_records_terminal_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        let ctx = with_source("mcp", async {
+            TaskAuditContext::capture(
+                &state,
+                Some("c1"),
+                Some("shop"),
+                Some("orders"),
+                "start_import_task",
+                "import shop.orders (json, skip)",
+            )
+        })
+        .await;
+        ctx.record_terminal("failed", Some("boom"), Some(7));
+
+        let guard = state.audit.lock().unwrap();
+        let rows = guard
+            .as_ref()
+            .unwrap()
+            .query(&AuditFilter::default())
+            .expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].source, "mcp");
+        assert!(!rows[0].ok, "a failed task must not be recorded as ok");
+        assert!(rows[0].summary.ends_with("(failed)"), "{}", rows[0].summary);
+        assert_eq!(rows[0].error.as_deref(), Some("boom"));
+    }
+
+    #[tokio::test]
+    async fn a_task_produces_exactly_one_row_not_two() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        let ctx = TaskAuditContext::capture(
+            &state,
+            Some("c1"),
+            Some("shop"),
+            Some("orders"),
+            "start_collection_copy",
+            "copy shop.orders → shop.orders_copy",
+        );
+        // Queued: visible immediately, so a mid-task crash still leaves a trace.
+        {
+            let guard = state.audit.lock().unwrap();
+            let rows = guard
+                .as_ref()
+                .unwrap()
+                .query(&AuditFilter::default())
+                .expect("query");
+            assert_eq!(rows.len(), 1);
+            assert!(rows[0].summary.ends_with("(running)"), "{}", rows[0].summary);
+        }
+
+        ctx.record_terminal("completed", None, Some(50));
+
+        let guard = state.audit.lock().unwrap();
+        let rows = guard
+            .as_ref()
+            .unwrap()
+            .query(&AuditFilter::default())
+            .expect("query");
+        assert_eq!(
+            rows.len(),
+            1,
+            "the terminal record must supersede the running one, not add a row"
+        );
+        assert!(rows[0].summary.ends_with("(completed)"), "{}", rows[0].summary);
+        assert_eq!(rows[0].duration_ms, Some(50));
+    }
+
+    #[tokio::test]
+    async fn a_superseding_record_keeps_the_original_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        let ctx = TaskAuditContext::capture(
+            &state,
+            Some("c1"),
+            Some("shop"),
+            None,
+            "start_database_copy",
+            "copy database a → shop",
+        );
+        let queued_ts = {
+            let guard = state.audit.lock().unwrap();
+            guard.as_ref().unwrap().query(&AuditFilter::default()).unwrap()[0].ts
+        };
+        ctx.record_terminal("failed", Some("boom"), Some(9));
+
+        let guard = state.audit.lock().unwrap();
+        let rows = guard.as_ref().unwrap().query(&AuditFilter::default()).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].ts, queued_ts,
+            "a long task finishing must not reorder its row in the listing"
+        );
+        assert!(!rows[0].ok);
+    }
+
+    fn task(status: &str, error: Option<&str>) -> crate::TaskInfo {
+        crate::TaskInfo {
+            id: "t1".into(),
+            kind: "import".into(),
+            label: "Import".into(),
+            status: status.into(),
+            processed: 0,
+            total: None,
+            message: String::new(),
+            path: None,
+            error: error.map(|e| e.to_string()),
+            created_at_ms: 0,
+            finished_at_ms: None,
+            sub_label: None,
+            items_processed: None,
+            items_total: None,
+            summary: None,
+        }
+    }
+
+    fn rows(state: &AppState) -> Vec<AuditEvent> {
+        let guard = state.audit.lock().unwrap();
+        guard
+            .as_ref()
+            .unwrap()
+            .query(&AuditFilter::default())
+            .expect("query")
+    }
+
+    fn record_start(state: &AppState, result: &Result<crate::TaskInfo, String>) {
+        maybe_record_task_start(
+            state,
+            Some("c1"),
+            Some("shop"),
+            Some("orders"),
+            "start_import_task",
+            Instant::now(),
+            "import shop.orders (json, skip)",
+            None,
+            result,
+        );
+    }
+
+    #[tokio::test]
+    async fn a_queued_task_start_is_left_for_the_task_itself_to_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        record_start(&state, &Ok(task("running", None)));
+        assert!(
+            rows(&state).is_empty(),
+            "queue acceptance must not be recorded — it would double-log every task"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rejected_start_is_recorded_as_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        record_start(&state, &Err("connection is read-only".into()));
+        let rows = rows(&state);
+        assert_eq!(rows.len(), 1, "a blocked destructive attempt must be logged");
+        assert!(!rows[0].ok);
+        assert!(rows[0].summary.ends_with("(rejected)"), "{}", rows[0].summary);
+        assert_eq!(rows[0].error.as_deref(), Some("connection is read-only"));
+    }
+
+    #[tokio::test]
+    async fn a_task_that_finished_inline_is_recorded_here() {
+        // Mock/demo connections complete without spawning anything, so nothing
+        // else would ever record them.
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        record_start(&state, &Ok(task("completed", None)));
+        let rows = rows(&state);
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].ok);
+        assert!(rows[0].summary.ends_with("(completed)"), "{}", rows[0].summary);
+    }
+
+    #[tokio::test]
+    async fn completed_task_is_recorded_as_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        let ctx = TaskAuditContext::capture(
+            &state,
+            Some("c1"),
+            Some("shop"),
+            None,
+            "start_database_copy",
+            "copy database a → shop",
+        );
+        ctx.record_terminal("completed", None, Some(12));
+
+        let guard = state.audit.lock().unwrap();
+        let rows = guard
+            .as_ref()
+            .unwrap()
+            .query(&AuditFilter::default())
+            .expect("query");
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].ok);
+        assert!(rows[0].summary.ends_with("(completed)"), "{}", rows[0].summary);
+    }
 }

--- a/src-tauri/src/audit/record.rs
+++ b/src-tauri/src/audit/record.rs
@@ -1,0 +1,140 @@
+//! Soft-fail audit recording from DB / mongosh `_impl`s (#272).
+
+use super::classify::classify_op;
+use super::level::{should_record, OpClass};
+use super::redact::{redact_text, truncate_args, MAX_ARGS_BYTES};
+use super::store::{AuditEvent, SCHEMA_VERSION};
+use crate::state::{AppState, LockExt};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+/// Inputs for a single audit attempt. Never causes the Mongo op to fail.
+pub struct RecordInput<'a> {
+    pub connection_id: Option<&'a str>,
+    pub database: Option<&'a str>,
+    pub collection: Option<&'a str>,
+    /// Logical op / command name (e.g. `delete_many`, `mongosh`).
+    pub op: &'a str,
+    /// Override class; when `None`, derived via [`classify_op`].
+    pub class: Option<OpClass>,
+    /// `ui` | `mcp` | `shell` | `tools` — when `None`, inferred from connection meta.
+    pub source: Option<&'a str>,
+    pub ok: bool,
+    pub error: Option<&'a str>,
+    pub duration_ms: Option<i64>,
+    pub summary: &'a str,
+    pub args: Option<&'a str>,
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn profile_and_source(state: &AppState, connection_id: Option<&str>) -> (Option<String>, String) {
+    let Some(id) = connection_id else {
+        return (None, "ui".into());
+    };
+    if let Ok(meta) = state.connection_meta.lock_safe() {
+        if let Some(m) = meta.get(id) {
+            let source = if m.via_mcp { "mcp" } else { "ui" };
+            return (Some(m.name.clone()), source.into());
+        }
+    }
+    (None, "ui".into())
+}
+
+/// Record an audit event if enabled, level matches, and vault session is open.
+/// Swallows all errors — never fails the caller.
+pub fn maybe_record(state: &AppState, input: RecordInput<'_>) {
+    if let Err(e) = maybe_record_inner(state, input) {
+        eprintln!("audit maybe_record: {e}");
+    }
+}
+
+fn maybe_record_inner(state: &AppState, input: RecordInput<'_>) -> Result<(), String> {
+    let guard = state.audit.lock_safe()?;
+    let Some(session) = guard.as_ref() else {
+        return Ok(());
+    };
+    let policy = session.policy();
+    if !policy.enabled {
+        return Ok(());
+    }
+    let class = input.class.unwrap_or_else(|| classify_op(input.op));
+    if !should_record(policy.level, class) {
+        return Ok(());
+    }
+
+    let (profile_name, inferred_source) = profile_and_source(state, input.connection_id);
+    let source = input
+        .source
+        .unwrap_or(inferred_source.as_str())
+        .to_string();
+
+    let args_json = input.args.map(|raw| {
+        let redacted = redact_text(raw);
+        let cap = if policy.include_payloads {
+            MAX_ARGS_BYTES
+        } else {
+            2_048
+        };
+        truncate_args(&redacted, cap)
+    });
+
+    let event = AuditEvent {
+        id: Uuid::new_v4().to_string(),
+        ts: now_ms(),
+        connection_id: input.connection_id.map(|s| s.to_string()),
+        profile_name,
+        database: input.database.map(|s| s.to_string()),
+        collection: input.collection.map(|s| s.to_string()),
+        op: input.op.to_string(),
+        source,
+        ok: input.ok,
+        error: input.error.map(|s| s.to_string()),
+        duration_ms: input.duration_ms,
+        summary: input.summary.to_string(),
+        args_json: args_json,
+        level_at_record: policy.level.as_str().to_string(),
+        schema_version: SCHEMA_VERSION,
+    };
+
+    let _ = session.try_insert(&event)?;
+    Ok(())
+}
+
+/// Record from a `Result`, capturing ok/error and elapsed time.
+pub fn maybe_record_result<T, E: std::fmt::Display>(
+    state: &AppState,
+    connection_id: Option<&str>,
+    database: Option<&str>,
+    collection: Option<&str>,
+    op: &str,
+    class: OpClass,
+    source: Option<&str>,
+    started: Instant,
+    summary: &str,
+    args: Option<&str>,
+    result: &Result<T, E>,
+) {
+    let err_owned = result.as_ref().err().map(|e| e.to_string());
+    maybe_record(
+        state,
+        RecordInput {
+            connection_id,
+            database,
+            collection,
+            op,
+            class: Some(class),
+            source,
+            ok: result.is_ok(),
+            error: err_owned.as_deref(),
+            duration_ms: Some(started.elapsed().as_millis() as i64),
+            summary,
+            args,
+        },
+    );
+}

--- a/src-tauri/src/audit/record.rs
+++ b/src-tauri/src/audit/record.rs
@@ -4,7 +4,7 @@ use super::classify::classify_op;
 use super::level::{should_record, OpClass};
 use super::redact::{redact_error, redact_text, truncate_args, MAX_ARGS_BYTES};
 use super::store::{AuditEvent, SCHEMA_VERSION};
-use super::envelope::AuditSession;
+use super::envelope::{AuditPolicy, AuditSession};
 use crate::state::{AppState, LockExt};
 use std::sync::{Arc, Mutex};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -12,6 +12,13 @@ use uuid::Uuid;
 
 /// Shared handle to the audit session slot in `AppState`.
 pub type SessionSlot = Arc<Mutex<Option<AuditSession>>>;
+
+/// Terminal task events waiting for the audit session to reopen.
+pub type PendingSlot = Arc<Mutex<Vec<AuditEvent>>>;
+
+/// Cap the parked queue so a long-locked vault cannot grow it without bound.
+/// Far above any plausible number of background tasks in one lock window.
+const MAX_PENDING_EVENTS: usize = 1024;
 
 tokio::task_local! {
     /// Invoking surface for audit attribution, scoped around one tool call.
@@ -125,6 +132,21 @@ fn record_into(
         return Ok(());
     }
 
+    let event = build_event(&input, profile_name, source, policy);
+
+    let _ = session.try_insert(&event)?;
+    let cutoff = super::retention_cutoff_ms(policy.retention_days, now_ms());
+    let _ = session.prune_before(cutoff);
+    Ok(())
+}
+
+/// Assemble the stored row, applying the payload gate to both args and errors.
+fn build_event(
+    input: &RecordInput<'_>,
+    profile_name: Option<String>,
+    source: String,
+    policy: AuditPolicy,
+) -> AuditEvent {
     let args_json = if policy.include_payloads {
         input.args.map(|raw| {
             let redacted = redact_text(raw);
@@ -134,7 +156,7 @@ fn record_into(
         None
     };
 
-    let event = AuditEvent {
+    AuditEvent {
         id: input
             .event_id
             .map(|s| s.to_string())
@@ -158,12 +180,7 @@ fn record_into(
         args_json,
         level_at_record: policy.level.as_str().to_string(),
         schema_version: SCHEMA_VERSION,
-    };
-
-    let _ = session.try_insert(&event)?;
-    let cutoff = super::retention_cutoff_ms(policy.retention_days, now_ms());
-    let _ = session.prune_before(cutoff);
-    Ok(())
+    }
 }
 
 /// Record a background task's start only when no background task will record it.
@@ -219,6 +236,55 @@ pub fn maybe_record_task_start(
     );
 }
 
+/// Hold a terminal event until the audit session reopens.
+fn park_pending(pending: &PendingSlot, event: AuditEvent, outcome: &str) {
+    let Ok(mut queue) = pending.lock() else {
+        return;
+    };
+    // Same id supersedes, so replacing a parked event is correct rather than
+    // additive if a task somehow reports twice.
+    if let Some(existing) = queue.iter_mut().find(|e| e.id == event.id) {
+        *existing = event;
+        return;
+    }
+    if queue.len() >= MAX_PENDING_EVENTS {
+        eprintln!("audit: dropping parked {outcome} event, queue is full");
+        return;
+    }
+    queue.push(event);
+}
+
+/// Write every parked terminal event into a freshly opened session.
+///
+/// Returns how many were written. Events that cannot be written stay parked.
+pub fn flush_pending(slot: &SessionSlot, pending: &PendingSlot) -> usize {
+    let Ok(mut queue) = pending.lock() else {
+        return 0;
+    };
+    if queue.is_empty() {
+        return 0;
+    }
+    let Ok(guard) = slot.lock() else {
+        return 0;
+    };
+    let Some(session) = guard.as_ref() else {
+        return 0;
+    };
+    let mut written = 0;
+    queue.retain(|event| match session.try_insert(event) {
+        Ok(true) => {
+            written += 1;
+            false
+        }
+        Ok(false) => true,
+        Err(e) => {
+            eprintln!("audit: could not flush parked event {}: {e}", event.id);
+            true
+        }
+    });
+    written
+}
+
 /// Audit context captured when a background task is queued, so the task can
 /// record its own terminal outcome after the queuing command has returned.
 ///
@@ -228,6 +294,12 @@ pub fn maybe_record_task_start(
 #[derive(Clone)]
 pub struct TaskAuditContext {
     slot: SessionSlot,
+    /// Where a terminal event goes if the vault locked before the task finished.
+    pending: PendingSlot,
+    /// Policy in force when the task was queued. `None` means the `running`
+    /// event was never recorded (auditing off, or the level excluded it), and
+    /// the terminal event is skipped for the same reason.
+    policy: Option<AuditPolicy>,
     /// Stable across the `running` record and the terminal one, so the second
     /// replaces the first instead of adding a row.
     event_id: String,
@@ -259,8 +331,16 @@ impl TaskAuditContext {
         let source = scoped_source()
             .map(|s| s.to_string())
             .unwrap_or(inferred_source);
+        let policy = state
+            .audit
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().map(|s| s.policy()))
+            .filter(|p| p.enabled && should_record(p.level, OpClass::Write));
         let ctx = Self {
             slot: Arc::clone(&state.audit),
+            pending: Arc::clone(&state.audit_pending),
+            policy,
             event_id: Uuid::new_v4().to_string(),
             ts: now_ms(),
             connection_id: connection_id.map(|s| s.to_string()),
@@ -282,6 +362,10 @@ impl TaskAuditContext {
     }
 
     fn write(&self, outcome: &str, ok: bool, error: Option<&str>, duration_ms: Option<i64>) {
+        // Nothing recorded the `running` event, so there is no row to supersede.
+        let Some(policy) = self.policy else {
+            return;
+        };
         let summary = format!("{} ({outcome})", self.summary);
         let input = RecordInput {
             event_id: Some(&self.event_id),
@@ -298,13 +382,35 @@ impl TaskAuditContext {
             summary: &summary,
             args: None,
         };
-        if let Err(e) = record_into(
-            &self.slot,
+        let event = build_event(
+            &input,
             self.profile_name.clone(),
             self.source.clone(),
-            input,
-        ) {
-            eprintln!("audit task record ({outcome}): {e}");
+            policy,
+        );
+
+        // `vault_lock` does not cancel background tasks, so a task can finish
+        // while the session is closed. Dropping the event here would leave the
+        // durable log claiming the operation is still running forever, so park
+        // it and let the next unlock write it.
+        let inserted = match self.slot.lock() {
+            Ok(guard) => match guard.as_ref() {
+                Some(session) => match session.try_insert(&event) {
+                    Ok(done) => done,
+                    Err(e) => {
+                        eprintln!("audit task record ({outcome}): {e}");
+                        false
+                    }
+                },
+                None => false,
+            },
+            Err(e) => {
+                eprintln!("audit task record ({outcome}): {e}");
+                false
+            }
+        };
+        if !inserted {
+            park_pending(&self.pending, event, outcome);
         }
     }
 }
@@ -644,6 +750,74 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert!(rows[0].ok);
         assert!(rows[0].summary.ends_with("(completed)"), "{}", rows[0].summary);
+    }
+
+    #[tokio::test]
+    async fn a_task_finishing_while_the_vault_is_locked_is_written_on_unlock() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_open_session(dir.path());
+        let ctx = TaskAuditContext::capture(
+            &state,
+            Some("c1"),
+            Some("shop"),
+            Some("orders"),
+            "start_import_task",
+            "import shop.orders (json, skip)",
+        );
+
+        // The user locks the vault; `vault_lock` does not cancel the task.
+        let session = state.audit.lock().unwrap().take().unwrap();
+        session.close().expect("close");
+
+        ctx.record_terminal("failed", Some("boom"), Some(11));
+        assert_eq!(
+            state.audit_pending.lock().unwrap().len(),
+            1,
+            "the outcome must be parked, not dropped"
+        );
+
+        // Unlock: the same session file, reopened.
+        session.open([5u8; 32]).expect("reopen");
+        *state.audit.lock().unwrap() = Some(session);
+        assert_eq!(flush_pending(&state.audit, &state.audit_pending), 1);
+        assert!(state.audit_pending.lock().unwrap().is_empty());
+
+        let rows = rows(&state);
+        assert_eq!(rows.len(), 1, "still one row, not a duplicate");
+        assert!(!rows[0].ok, "the failure must not stay recorded as running");
+        assert!(rows[0].summary.ends_with("(failed)"), "{}", rows[0].summary);
+        assert_eq!(rows[0].error.as_deref(), Some("boom"));
+    }
+
+    #[tokio::test]
+    async fn a_task_whose_level_excluded_it_records_nothing_at_either_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new();
+        let session = AuditSession::new(dir.path().join("audit.log.enc"));
+        session.open([5u8; 32]).expect("open");
+        session.set_policy(AuditPolicy {
+            enabled: false,
+            level: AuditLevel::C,
+            include_payloads: false,
+            retention_days: 30,
+        });
+        *state.audit.lock().unwrap() = Some(session);
+
+        let ctx = TaskAuditContext::capture(
+            &state,
+            Some("c1"),
+            Some("shop"),
+            None,
+            "start_database_copy",
+            "copy database a → shop",
+        );
+        ctx.record_terminal("completed", None, Some(5));
+
+        assert!(rows(&state).is_empty(), "auditing is disabled");
+        assert!(
+            state.audit_pending.lock().unwrap().is_empty(),
+            "a skipped event must not be parked either"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/audit/redact.rs
+++ b/src-tauri/src/audit/redact.rs
@@ -1,0 +1,167 @@
+//! Scrub secrets and truncate audit payloads (#272).
+
+/// Hard cap for `args_json` / mongosh text stored per event (UTF-8 bytes).
+pub const MAX_ARGS_BYTES: usize = 64 * 1024;
+
+/// Redact connection URIs and obvious password fields from free text.
+pub fn redact_text(input: &str) -> String {
+    let without_uri = scrub_mongodb_uris(input);
+    scrub_password_json_fields(&without_uri)
+}
+
+fn scrub_mongodb_uris(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let lower = input.to_ascii_lowercase();
+    let mut i = 0;
+    while i < input.len() {
+        let rest_lower = &lower[i..];
+        let scheme_len = if rest_lower.starts_with("mongodb+srv://") {
+            "mongodb+srv://".len()
+        } else if rest_lower.starts_with("mongodb://") {
+            "mongodb://".len()
+        } else {
+            out.push(input[i..].chars().next().unwrap());
+            i += input[i..].chars().next().unwrap().len_utf8();
+            continue;
+        };
+
+        out.push_str(&input[i..i + scheme_len]);
+        i += scheme_len;
+
+        // Optional userinfo ending at '@' before host.
+        if let Some(at_rel) = input[i..].find('@') {
+            let userinfo = &input[i..i + at_rel];
+            // Only treat as credentials when it contains ':' (user:pass).
+            if userinfo.contains(':')
+                && !userinfo.contains('/')
+                && !userinfo.contains('?')
+                && !userinfo.contains(' ')
+            {
+                out.push_str("***:***@");
+                i += at_rel + 1;
+                continue;
+            }
+        }
+        // No credentials (or ambiguous userinfo): keep copying from `i`.
+    }
+    out
+}
+
+fn scrub_password_json_fields(input: &str) -> String {
+    const KEYS: &[&str] = &["password", "passwd", "pwd", "secret", "api_key", "api-key", "token"];
+    let mut out = input.to_string();
+    for key in KEYS {
+        out = scrub_json_string_value(&out, key);
+    }
+    out
+}
+
+/// Replace `"key":"..."` string values with `"***"` (case-insensitive key).
+fn scrub_json_string_value(input: &str, key: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let lower = input.to_ascii_lowercase();
+    let key_lower = key.to_ascii_lowercase();
+    let needle = format!("\"{key_lower}\"");
+    let mut i = 0;
+    while i < input.len() {
+        if lower[i..].starts_with(&needle) {
+            out.push_str(&input[i..i + needle.len()]);
+            i += needle.len();
+            // skip whitespace and colon
+            while i < input.len() && input.as_bytes()[i].is_ascii_whitespace() {
+                out.push(input.as_bytes()[i] as char);
+                i += 1;
+            }
+            if i < input.len() && input.as_bytes()[i] == b':' {
+                out.push(':');
+                i += 1;
+            }
+            while i < input.len() && input.as_bytes()[i].is_ascii_whitespace() {
+                out.push(input.as_bytes()[i] as char);
+                i += 1;
+            }
+            if i < input.len() && input.as_bytes()[i] == b'"' {
+                i += 1; // opening quote
+                while i < input.len() {
+                    let b = input.as_bytes()[i];
+                    if b == b'\\' && i + 1 < input.len() {
+                        i += 2;
+                        continue;
+                    }
+                    if b == b'"' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                out.push_str("\"***\"");
+                continue;
+            }
+            continue;
+        }
+        let ch = input[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+/// Truncate to at most `max_bytes` UTF-8 bytes, appending a marker when cut.
+pub fn truncate_args(input: &str, max_bytes: usize) -> String {
+    const MARKER: &str = "…[truncated]";
+    if input.len() <= max_bytes {
+        return input.to_string();
+    }
+    if max_bytes <= MARKER.len() {
+        return MARKER.chars().take(max_bytes).collect();
+    }
+    let keep = max_bytes - MARKER.len();
+    let mut end = keep;
+    while end > 0 && !input.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = input[..end].to_string();
+    out.push_str(MARKER);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrubs_mongodb_uri_credentials() {
+        let raw = "connect mongodb://alice:s3cret@localhost:27017/app then drop";
+        let out = redact_text(raw);
+        assert!(!out.contains("s3cret"), "password must not appear: {out}");
+        assert!(!out.contains("alice:"), "userinfo must be scrubbed: {out}");
+        assert!(out.contains("mongodb://"), "scheme retained: {out}");
+        assert!(out.contains("localhost:27017"), "host retained: {out}");
+    }
+
+    #[test]
+    fn scrubs_password_json_fields() {
+        let raw = r#"{"password":"hunter2","filter":{"x":1}}"#;
+        let out = redact_text(raw);
+        assert!(!out.contains("hunter2"), "password value leaked: {out}");
+        assert!(out.contains("password"), "key may remain: {out}");
+    }
+
+    #[test]
+    fn truncates_over_max_with_marker() {
+        let big = "a".repeat(MAX_ARGS_BYTES + 100);
+        let out = truncate_args(&big, MAX_ARGS_BYTES);
+        assert!(out.len() <= MAX_ARGS_BYTES + 32, "len={}", out.len());
+        assert!(
+            out.contains("truncated") || out.contains("…"),
+            "expected truncation marker: {}",
+            &out[out.len().saturating_sub(40)..]
+        );
+        assert!(out.as_bytes().len() > MAX_ARGS_BYTES - 20);
+    }
+
+    #[test]
+    fn truncate_short_unchanged() {
+        assert_eq!(truncate_args("hi", MAX_ARGS_BYTES), "hi");
+    }
+}

--- a/src-tauri/src/audit/redact.rs
+++ b/src-tauri/src/audit/redact.rs
@@ -51,72 +51,116 @@ fn scrub_password_json_fields(input: &str) -> String {
     const KEYS: &[&str] = &["password", "passwd", "pwd", "secret", "api_key", "api-key", "token"];
     let mut out = input.to_string();
     for key in KEYS {
-        out = scrub_json_string_value(&out, key);
-        out = scrub_js_object_value(&out, key);
+        out = scrub_secret_key_values(&out, key);
     }
     out
 }
 
-/// Replace `key: "..."` / `key:'...'` / `key:word` (mongosh JS object syntax).
-fn scrub_js_object_value(input: &str, key: &str) -> String {
-    let mut out = String::with_capacity(input.len());
+/// True when `b` can appear inside a bare JS identifier.
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
+}
+
+/// End index of a quoted string starting at `open` (the quote byte), honouring
+/// backslash escapes. Returns `None` when the string is unterminated.
+fn quoted_end(bytes: &[u8], open: usize) -> Option<usize> {
+    let quote = bytes[open];
+    let mut i = open + 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if i + 1 < bytes.len() => i += 2,
+            b if b == quote => return Some(i + 1),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Match `<key><ws>:<ws><value>` at `i`, where the key may be bare (`pwd`),
+/// double-quoted (`"pwd"`) or single-quoted (`'pwd'`), and the value may be
+/// double-quoted, single-quoted or a bare token. Returns the byte range of the
+/// value so the caller can keep the key text verbatim.
+fn match_key_value(
+    input: &str,
+    lower: &str,
+    key_lower: &str,
+    i: usize,
+) -> Option<(usize, usize)> {
+    let bytes = input.as_bytes();
+    let mut j = i;
+    let key_quote = match bytes.get(j) {
+        Some(&b) if b == b'"' || b == b'\'' => {
+            j += 1;
+            Some(b)
+        }
+        _ => None,
+    };
+    if !lower.get(j..)?.starts_with(key_lower) {
+        return None;
+    }
+    let after_key = j + key_lower.len();
+    let mut k = match key_quote {
+        Some(q) => {
+            if bytes.get(after_key) != Some(&q) {
+                return None;
+            }
+            after_key + 1
+        }
+        None => {
+            // Bare key: must not be a fragment of a longer identifier.
+            let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+            let after_ok = !bytes.get(after_key).is_some_and(|&b| is_ident_byte(b));
+            if !before_ok || !after_ok {
+                return None;
+            }
+            after_key
+        }
+    };
+
+    while bytes.get(k).is_some_and(|b| b.is_ascii_whitespace()) {
+        k += 1;
+    }
+    if bytes.get(k) != Some(&b':') {
+        return None;
+    }
+    k += 1;
+    while bytes.get(k).is_some_and(|b| b.is_ascii_whitespace()) {
+        k += 1;
+    }
+
+    let value_start = k;
+    let &first = bytes.get(value_start)?;
+    let value_end = if first == b'"' || first == b'\'' {
+        quoted_end(bytes, value_start)?
+    } else {
+        let mut e = value_start;
+        while let Some(&b) = bytes.get(e) {
+            if b.is_ascii_whitespace() || matches!(b, b',' | b'}' | b')' | b']' | b';') {
+                break;
+            }
+            e += 1;
+        }
+        if e == value_start {
+            return None;
+        }
+        e
+    };
+    Some((value_start, value_end))
+}
+
+/// Replace the value of every occurrence of `key` with `"***"`, covering both
+/// strict JSON and mongosh JavaScript object syntax.
+fn scrub_secret_key_values(input: &str, key: &str) -> String {
     let lower = input.to_ascii_lowercase();
     let key_lower = key.to_ascii_lowercase();
+    let mut out = String::with_capacity(input.len());
     let mut i = 0;
     while i < input.len() {
-        let rest = &lower[i..];
-        if rest.starts_with(&key_lower) {
-            let after_key = i + key_lower.len();
-            // Must be a bare identifier (not `"pwd"` JSON key).
-            let before_ok = i == 0 || !input.as_bytes()[i - 1].is_ascii_alphanumeric();
-            let after_ok = after_key >= input.len()
-                || !input.as_bytes()[after_key].is_ascii_alphanumeric();
-            if before_ok && after_ok {
-                let mut j = after_key;
-                while j < input.len() && input.as_bytes()[j].is_ascii_whitespace() {
-                    j += 1;
-                }
-                if j < input.len() && input.as_bytes()[j] == b':' {
-                    out.push_str(&input[i..=j]);
-                    i = j + 1;
-                    while i < input.len() && input.as_bytes()[i].is_ascii_whitespace() {
-                        out.push(input.as_bytes()[i] as char);
-                        i += 1;
-                    }
-                    if i < input.len() {
-                        let b = input.as_bytes()[i];
-                        if b == b'"' || b == b'\'' {
-                            let quote = b;
-                            i += 1;
-                            while i < input.len() {
-                                let c = input.as_bytes()[i];
-                                if c == b'\\' && i + 1 < input.len() {
-                                    i += 2;
-                                    continue;
-                                }
-                                if c == quote {
-                                    i += 1;
-                                    break;
-                                }
-                                i += 1;
-                            }
-                            out.push_str("\"***\"");
-                            continue;
-                        }
-                        // Unquoted token (identifier, number, etc.)
-                        while i < input.len() {
-                            let c = input.as_bytes()[i];
-                            if c.is_ascii_whitespace() || c == b',' || c == b'}' || c == b')' {
-                                break;
-                            }
-                            i += 1;
-                        }
-                        out.push_str("\"***\"");
-                        continue;
-                    }
-                    continue;
-                }
-            }
+        if let Some((value_start, value_end)) = match_key_value(input, &lower, &key_lower, i) {
+            out.push_str(&input[i..value_start]);
+            out.push_str("\"***\"");
+            i = value_end;
+            continue;
         }
         let ch = input[i..].chars().next().unwrap();
         out.push(ch);
@@ -125,47 +169,52 @@ fn scrub_js_object_value(input: &str, key: &str) -> String {
     out
 }
 
-/// Replace `"key":"..."` string values with `"***"` (case-insensitive key).
-fn scrub_json_string_value(input: &str, key: &str) -> String {
+/// Hard cap for a persisted error string (UTF-8 bytes).
+pub const MAX_ERROR_BYTES: usize = 2 * 1024;
+
+/// Sanitize a driver error before it is persisted.
+///
+/// Errors always go through [`redact_text`]. When payload logging is off they
+/// additionally have every `{...}` group collapsed, because MongoDB duplicate-key
+/// and validation errors embed rejected document values there
+/// (`dup key: { email: "..." }`) — that must not reach the log or a plaintext
+/// export under the payload-free default.
+pub fn redact_error(input: &str, include_payloads: bool) -> String {
+    let redacted = redact_text(input);
+    let stripped = if include_payloads {
+        redacted
+    } else {
+        collapse_brace_groups(&redacted)
+    };
+    truncate_args(&stripped, MAX_ERROR_BYTES)
+}
+
+/// Replace every balanced `{...}` group (and any unterminated tail) with `{...}`.
+fn collapse_brace_groups(input: &str) -> String {
+    const PLACEHOLDER: &str = "{…}";
+    let bytes = input.as_bytes();
     let mut out = String::with_capacity(input.len());
-    let lower = input.to_ascii_lowercase();
-    let key_lower = key.to_ascii_lowercase();
-    let needle = format!("\"{key_lower}\"");
     let mut i = 0;
     while i < input.len() {
-        if lower[i..].starts_with(&needle) {
-            out.push_str(&input[i..i + needle.len()]);
-            i += needle.len();
-            // skip whitespace and colon
-            while i < input.len() && input.as_bytes()[i].is_ascii_whitespace() {
-                out.push(input.as_bytes()[i] as char);
-                i += 1;
-            }
-            if i < input.len() && input.as_bytes()[i] == b':' {
-                out.push(':');
-                i += 1;
-            }
-            while i < input.len() && input.as_bytes()[i].is_ascii_whitespace() {
-                out.push(input.as_bytes()[i] as char);
-                i += 1;
-            }
-            if i < input.len() && input.as_bytes()[i] == b'"' {
-                i += 1; // opening quote
-                while i < input.len() {
-                    let b = input.as_bytes()[i];
-                    if b == b'\\' && i + 1 < input.len() {
-                        i += 2;
-                        continue;
+        if bytes[i] == b'{' {
+            let mut depth = 0usize;
+            let mut j = i;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b'{' => depth += 1,
+                    b'}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            j += 1;
+                            break;
+                        }
                     }
-                    if b == b'"' {
-                        i += 1;
-                        break;
-                    }
-                    i += 1;
+                    _ => {}
                 }
-                out.push_str("\"***\"");
-                continue;
+                j += 1;
             }
+            out.push_str(PLACEHOLDER);
+            i = j;
             continue;
         }
         let ch = input[i..].chars().next().unwrap();
@@ -221,6 +270,59 @@ mod tests {
         let raw = r#"db.createUser({user:"alice",pwd:"secret"})"#;
         let out = redact_text(raw);
         assert!(!out.contains("secret"), "password value leaked: {out}");
+    }
+
+    #[test]
+    fn scrubs_quoted_js_keys_and_single_quoted_values() {
+        for raw in [
+            r#"db.createUser({'user':'alice','pwd':'secret'})"#,
+            r#"db.createUser({"user":"alice","pwd": 'secret'})"#,
+            r#"db.createUser({user:'alice', PWD : "secret"})"#,
+            r#"db.createUser({'pwd':secret})"#,
+            r#"{"password": 'secret'}"#,
+        ] {
+            let out = redact_text(raw);
+            assert!(!out.contains("secret"), "password leaked from {raw}: {out}");
+        }
+    }
+
+    #[test]
+    fn keeps_non_secret_keys_and_similar_identifiers() {
+        let raw = r#"{"user":"alice","pwdHash":"keepme","oldpwd":"keepme2"}"#;
+        let out = redact_text(raw);
+        assert!(out.contains("alice"), "unrelated value dropped: {out}");
+        assert!(out.contains("keepme"), "pwdHash must not match: {out}");
+        assert!(out.contains("keepme2"), "oldpwd must not match: {out}");
+    }
+
+    #[test]
+    fn error_redaction_drops_brace_payloads_when_disabled() {
+        let raw = r#"E11000 duplicate key error collection: shop.users index: email_1 dup key: { email: "a@b.example" }"#;
+        let out = redact_error(raw, false);
+        assert!(!out.contains("a@b.example"), "document value leaked: {out}");
+        assert!(out.contains("E11000"), "diagnostic text must survive: {out}");
+        assert!(out.contains("email_1"), "index name must survive: {out}");
+    }
+
+    #[test]
+    fn error_redaction_keeps_payloads_when_enabled_but_still_scrubs_secrets() {
+        let raw = r#"failed for mongodb://alice:s3cret@host:27017 dup key: { email: "a@b.example" }"#;
+        let out = redact_error(raw, true);
+        assert!(out.contains("a@b.example"), "payload expected when enabled: {out}");
+        assert!(!out.contains("s3cret"), "URI credential leaked: {out}");
+    }
+
+    #[test]
+    fn error_redaction_caps_length() {
+        let raw = format!("boom {}", "x".repeat(MAX_ERROR_BYTES * 2));
+        let out = redact_error(&raw, true);
+        assert!(out.len() <= MAX_ERROR_BYTES, "len={}", out.len());
+    }
+
+    #[test]
+    fn collapse_handles_unterminated_brace() {
+        let out = redact_error("bad doc: { email: \"a@b.example\"", false);
+        assert!(!out.contains("a@b.example"), "unterminated group leaked: {out}");
     }
 
     #[test]

--- a/src-tauri/src/audit/redact.rs
+++ b/src-tauri/src/audit/redact.rs
@@ -189,7 +189,12 @@ pub fn redact_error(input: &str, include_payloads: bool) -> String {
     truncate_args(&stripped, MAX_ERROR_BYTES)
 }
 
-/// Replace every balanced `{...}` group (and any unterminated tail) with `{...}`.
+/// Replace every balanced `{...}` group (and any unterminated tail) with `{…}`.
+///
+/// Quote-aware: MongoDB errors embed document values, and those values can
+/// themselves contain braces (`dup key: {{ email: "alice}}secret@example" }}`).
+/// A brace counter that ignored quoting would stop at the `}}` *inside* the
+/// string and copy the rest of the value straight into the log.
 fn collapse_brace_groups(input: &str) -> String {
     const PLACEHOLDER: &str = "{…}";
     let bytes = input.as_bytes();
@@ -197,24 +202,8 @@ fn collapse_brace_groups(input: &str) -> String {
     let mut i = 0;
     while i < input.len() {
         if bytes[i] == b'{' {
-            let mut depth = 0usize;
-            let mut j = i;
-            while j < bytes.len() {
-                match bytes[j] {
-                    b'{' => depth += 1,
-                    b'}' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            j += 1;
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-                j += 1;
-            }
             out.push_str(PLACEHOLDER);
-            i = j;
+            i = end_of_brace_group(bytes, i);
             continue;
         }
         let ch = input[i..].chars().next().unwrap();
@@ -222,6 +211,42 @@ fn collapse_brace_groups(input: &str) -> String {
         i += ch.len_utf8();
     }
     out
+}
+
+/// Index just past the `{...}` group starting at `start`, skipping over braces
+/// that sit inside quoted strings. Returns `bytes.len()` when unterminated, so
+/// a truncated error cannot leak its tail either.
+fn end_of_brace_group(bytes: &[u8], start: usize) -> usize {
+    let mut depth = 0usize;
+    let mut i = start;
+    let mut quote: Option<u8> = None;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match quote {
+            Some(q) => {
+                if b == b'\\' && i + 1 < bytes.len() {
+                    i += 2;
+                    continue;
+                }
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'"' | b'\'' => quote = Some(b),
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return i + 1;
+                    }
+                }
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    bytes.len()
 }
 
 /// Truncate to at most `max_bytes` UTF-8 bytes, appending a marker when cut.
@@ -317,6 +342,27 @@ mod tests {
         let raw = format!("boom {}", "x".repeat(MAX_ERROR_BYTES * 2));
         let out = redact_error(&raw, true);
         assert!(out.len() <= MAX_ERROR_BYTES, "len={}", out.len());
+    }
+
+    #[test]
+    fn error_redaction_suppresses_values_containing_braces() {
+        // A brace inside the quoted value must not be mistaken for the end of
+        // the group, or the rest of the value gets copied into the log.
+        let raw = r#"E11000 duplicate key error dup key: { email: "alice}secret@example" }"#;
+        let out = redact_error(raw, false);
+        assert!(!out.contains("secret@example"), "value leaked: {out}");
+        assert!(!out.contains("alice"), "value leaked: {out}");
+        assert!(out.contains("E11000"), "diagnostic must survive: {out}");
+    }
+
+    #[test]
+    fn error_redaction_handles_escaped_quotes_and_nesting() {
+        let raw = r#"failed: { doc: { name: "a\"}\" b", tag: 'x}y' }, n: 2 }"#;
+        let out = redact_error(raw, false);
+        for leak in ["a\\\"", "x}y", "tag", "n: 2"] {
+            assert!(!out.contains(leak), "leaked {leak:?} from {raw}: {out}");
+        }
+        assert!(out.contains("failed:"), "prefix must survive: {out}");
     }
 
     #[test]

--- a/src-tauri/src/audit/redact.rs
+++ b/src-tauri/src/audit/redact.rs
@@ -52,6 +52,75 @@ fn scrub_password_json_fields(input: &str) -> String {
     let mut out = input.to_string();
     for key in KEYS {
         out = scrub_json_string_value(&out, key);
+        out = scrub_js_object_value(&out, key);
+    }
+    out
+}
+
+/// Replace `key: "..."` / `key:'...'` / `key:word` (mongosh JS object syntax).
+fn scrub_js_object_value(input: &str, key: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let lower = input.to_ascii_lowercase();
+    let key_lower = key.to_ascii_lowercase();
+    let mut i = 0;
+    while i < input.len() {
+        let rest = &lower[i..];
+        if rest.starts_with(&key_lower) {
+            let after_key = i + key_lower.len();
+            // Must be a bare identifier (not `"pwd"` JSON key).
+            let before_ok = i == 0 || !input.as_bytes()[i - 1].is_ascii_alphanumeric();
+            let after_ok = after_key >= input.len()
+                || !input.as_bytes()[after_key].is_ascii_alphanumeric();
+            if before_ok && after_ok {
+                let mut j = after_key;
+                while j < input.len() && input.as_bytes()[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                if j < input.len() && input.as_bytes()[j] == b':' {
+                    out.push_str(&input[i..=j]);
+                    i = j + 1;
+                    while i < input.len() && input.as_bytes()[i].is_ascii_whitespace() {
+                        out.push(input.as_bytes()[i] as char);
+                        i += 1;
+                    }
+                    if i < input.len() {
+                        let b = input.as_bytes()[i];
+                        if b == b'"' || b == b'\'' {
+                            let quote = b;
+                            i += 1;
+                            while i < input.len() {
+                                let c = input.as_bytes()[i];
+                                if c == b'\\' && i + 1 < input.len() {
+                                    i += 2;
+                                    continue;
+                                }
+                                if c == quote {
+                                    i += 1;
+                                    break;
+                                }
+                                i += 1;
+                            }
+                            out.push_str("\"***\"");
+                            continue;
+                        }
+                        // Unquoted token (identifier, number, etc.)
+                        while i < input.len() {
+                            let c = input.as_bytes()[i];
+                            if c.is_ascii_whitespace() || c == b',' || c == b'}' || c == b')' {
+                                break;
+                            }
+                            i += 1;
+                        }
+                        out.push_str("\"***\"");
+                        continue;
+                    }
+                    continue;
+                }
+            }
+        }
+        let ch = input[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
     }
     out
 }
@@ -145,6 +214,13 @@ mod tests {
         let out = redact_text(raw);
         assert!(!out.contains("hunter2"), "password value leaked: {out}");
         assert!(out.contains("password"), "key may remain: {out}");
+    }
+
+    #[test]
+    fn scrubs_unquoted_mongosh_pwd() {
+        let raw = r#"db.createUser({user:"alice",pwd:"secret"})"#;
+        let out = redact_text(raw);
+        assert!(!out.contains("secret"), "password value leaked: {out}");
     }
 
     #[test]

--- a/src-tauri/src/audit/redact.rs
+++ b/src-tauri/src/audit/redact.rs
@@ -56,6 +56,13 @@ fn scrub_password_json_fields(input: &str) -> String {
     out
 }
 
+/// Quote characters that delimit a JS string value. Backticks included: a
+/// template literal is valid mongosh, and treating one as a bare token stopped
+/// redaction at the first space inside the secret.
+fn is_quote(b: u8) -> bool {
+    b == b'"' || b == b'\'' || b == b'`'
+}
+
 /// True when `b` can appear inside a bare JS identifier.
 fn is_ident_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
@@ -89,7 +96,7 @@ fn match_key_value(
     let bytes = input.as_bytes();
     let mut j = i;
     let key_quote = match bytes.get(j) {
-        Some(&b) if b == b'"' || b == b'\'' => {
+        Some(&b) if is_quote(b) => {
             j += 1;
             Some(b)
         }
@@ -130,7 +137,7 @@ fn match_key_value(
 
     let value_start = k;
     let &first = bytes.get(value_start)?;
-    let value_end = if first == b'"' || first == b'\'' {
+    let value_end = if is_quote(first) {
         quoted_end(bytes, value_start)?
     } else {
         let mut e = value_start;
@@ -233,7 +240,7 @@ fn end_of_brace_group(bytes: &[u8], start: usize) -> usize {
                 }
             }
             None => match b {
-                b'"' | b'\'' => quote = Some(b),
+                _ if is_quote(b) => quote = Some(b),
                 b'{' => depth += 1,
                 b'}' => {
                     depth -= 1;
@@ -309,6 +316,32 @@ mod tests {
             let out = redact_text(raw);
             assert!(!out.contains("secret"), "password leaked from {raw}: {out}");
         }
+    }
+
+    #[test]
+    fn scrubs_template_literal_secrets_containing_whitespace() {
+        for raw in [
+            "db.createUser({pwd: `very secret`})",
+            "db.createUser({user:'alice', password: `two words here`})",
+            "db.createUser({`pwd`: `spaced value`})",
+        ] {
+            let out = redact_text(raw);
+            assert!(!out.contains("secret"), "template literal leaked from {raw}: {out}");
+            assert!(!out.contains("words"), "template literal leaked from {raw}: {out}");
+            assert!(!out.contains("spaced"), "template literal leaked from {raw}: {out}");
+            // The key text is preserved verbatim, backticks included; only the
+            // value must be replaced.
+            assert!(out.contains("\"***\""), "value must be masked: {out}");
+        }
+    }
+
+    #[test]
+    fn error_redaction_handles_backticks_inside_brace_groups() {
+        let raw = "failed: { note: `has } brace`, tag: 2 }";
+        let out = redact_error(raw, false);
+        assert!(!out.contains("has"), "value leaked: {out}");
+        assert!(!out.contains("tag"), "group ended early: {out}");
+        assert!(out.contains("failed:"), "prefix must survive: {out}");
     }
 
     #[test]

--- a/src-tauri/src/audit/store.rs
+++ b/src-tauri/src/audit/store.rs
@@ -243,6 +243,43 @@ impl AuditStore {
             .map_err(|e| e.to_string())?;
         Ok(n as u64)
     }
+
+    /// Serialize the live DB to a SQLite file byte image (for vault sealing).
+    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        let dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+        let path = dir.path().join("audit.db");
+        {
+            let mut dst = Connection::open(&path).map_err(|e| e.to_string())?;
+            let backup =
+                rusqlite::backup::Backup::new(&conn, &mut dst).map_err(|e| e.to_string())?;
+            backup
+                .run_to_completion(64, std::time::Duration::from_millis(1), None)
+                .map_err(|e| e.to_string())?;
+        }
+        std::fs::read(&path).map_err(|e| e.to_string())
+    }
+
+    /// Open a store from a SQLite file byte image (after vault unseal).
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+        let dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+        let path = dir.path().join("audit.db");
+        std::fs::write(&path, bytes).map_err(|e| e.to_string())?;
+        let src = Connection::open(&path).map_err(|e| e.to_string())?;
+        let mut mem = Connection::open_in_memory().map_err(|e| e.to_string())?;
+        {
+            let backup =
+                rusqlite::backup::Backup::new(&src, &mut mem).map_err(|e| e.to_string())?;
+            backup
+                .run_to_completion(64, std::time::Duration::from_millis(1), None)
+                .map_err(|e| e.to_string())?;
+        }
+        let store = Self {
+            conn: Mutex::new(mem),
+        };
+        store.migrate()?;
+        Ok(store)
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/audit/store.rs
+++ b/src-tauri/src/audit/store.rs
@@ -7,6 +7,13 @@ use std::sync::Mutex;
 
 pub const SCHEMA_VERSION: i32 = 1;
 
+/// Op name of the record left behind when a damaged log is discarded.
+///
+/// These are the one kind of event that cannot be removed: retention skips them
+/// and discarding preserves the existing ones, so a log that was discarded can
+/// never be made to look like one that never was.
+pub const TOMBSTONE_OP: &str = "audit_log_discarded";
+
 /// One persisted audit row (matches `audit_events` table).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -235,21 +242,28 @@ impl AuditStore {
         Ok(out)
     }
 
+    /// Apply retention. Tombstones are exempt: letting them expire would put a
+    /// deadline on the record that a log was once discarded.
     pub fn prune_before(&self, ts_ms: i64) -> Result<u64, String> {
         let conn = self.conn.lock().map_err(|e| e.to_string())?;
         let n = conn
             .execute(
-                "DELETE FROM audit_events WHERE ts < ?1",
-                params![ts_ms],
+                "DELETE FROM audit_events WHERE ts < ?1 AND op != ?2",
+                params![ts_ms, TOMBSTONE_OP],
             )
             .map_err(|e| e.to_string())?;
         Ok(n as u64)
     }
 
-    pub fn clear_all(&self) -> Result<u64, String> {
+    /// Delete every event except tombstones, returning how many were removed.
+    ///
+    /// Used when discarding a damaged log: the events are unverifiable and go,
+    /// but the record of previous discards stays so the history of erasures
+    /// accumulates rather than being overwritten.
+    pub fn retain_tombstones_only(&self) -> Result<u64, String> {
         let conn = self.conn.lock().map_err(|e| e.to_string())?;
         let n = conn
-            .execute("DELETE FROM audit_events", [])
+            .execute("DELETE FROM audit_events WHERE op != ?1", params![TOMBSTONE_OP])
             .map_err(|e| e.to_string())?;
         Ok(n as u64)
     }

--- a/src-tauri/src/audit/store.rs
+++ b/src-tauri/src/audit/store.rs
@@ -103,11 +103,19 @@ impl AuditStore {
         Ok(())
     }
 
+    /// Insert an event, replacing any existing row with the same `id`.
+    ///
+    /// Replace rather than reject, for two reasons. A background task records a
+    /// `running` event when it is queued and then supersedes it with its real
+    /// outcome under the same id, so the listing shows one row per operation
+    /// instead of two. And rebuilding the index by replaying the append-only log
+    /// then converges on the latest state of each event rather than tripping over
+    /// the superseded record.
     pub fn insert(&self, event: &AuditEvent) -> Result<(), String> {
         let conn = self.conn.lock().map_err(|e| e.to_string())?;
         conn.execute(
             r#"
-            INSERT INTO audit_events (
+            INSERT OR REPLACE INTO audit_events (
                 id, ts, connection_id, profile_name, database, collection,
                 op, source, ok, error, duration_ms, summary, args_json,
                 level_at_record, schema_version
@@ -246,41 +254,47 @@ impl AuditStore {
         Ok(n as u64)
     }
 
-    /// Serialize the live DB to a SQLite file byte image (for vault sealing).
-    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+    /// Every event in write order, for rebuilding the append-only log on
+    /// compaction. Deliberately not `query`, whose `ORDER BY ts DESC` would
+    /// reverse the log and make its hash chain disagree with write order.
+    pub fn all_chronological(&self) -> Result<Vec<AuditEvent>, String> {
         let conn = self.conn.lock().map_err(|e| e.to_string())?;
-        let dir = tempfile::tempdir().map_err(|e| e.to_string())?;
-        let path = dir.path().join("audit.db");
-        {
-            let mut dst = Connection::open(&path).map_err(|e| e.to_string())?;
-            let backup =
-                rusqlite::backup::Backup::new(&conn, &mut dst).map_err(|e| e.to_string())?;
-            backup
-                .run_to_completion(64, std::time::Duration::from_millis(1), None)
-                .map_err(|e| e.to_string())?;
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT id, ts, connection_id, profile_name, database, collection,
+                       op, source, ok, error, duration_ms, summary, args_json,
+                       level_at_record, schema_version
+                FROM audit_events ORDER BY ts ASC, rowid ASC
+                "#,
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(AuditEvent {
+                    id: row.get(0)?,
+                    ts: row.get(1)?,
+                    connection_id: row.get(2)?,
+                    profile_name: row.get(3)?,
+                    database: row.get(4)?,
+                    collection: row.get(5)?,
+                    op: row.get(6)?,
+                    source: row.get(7)?,
+                    ok: row.get::<_, i64>(8)? != 0,
+                    error: row.get(9)?,
+                    duration_ms: row.get(10)?,
+                    summary: row.get(11)?,
+                    args_json: row.get(12)?,
+                    level_at_record: row.get(13)?,
+                    schema_version: row.get(14)?,
+                })
+            })
+            .map_err(|e| e.to_string())?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| e.to_string())?);
         }
-        std::fs::read(&path).map_err(|e| e.to_string())
-    }
-
-    /// Open a store from a SQLite file byte image (after vault unseal).
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
-        let dir = tempfile::tempdir().map_err(|e| e.to_string())?;
-        let path = dir.path().join("audit.db");
-        std::fs::write(&path, bytes).map_err(|e| e.to_string())?;
-        let src = Connection::open(&path).map_err(|e| e.to_string())?;
-        let mut mem = Connection::open_in_memory().map_err(|e| e.to_string())?;
-        {
-            let backup =
-                rusqlite::backup::Backup::new(&src, &mut mem).map_err(|e| e.to_string())?;
-            backup
-                .run_to_completion(64, std::time::Duration::from_millis(1), None)
-                .map_err(|e| e.to_string())?;
-        }
-        let store = Self {
-            conn: Mutex::new(mem),
-        };
-        store.migrate()?;
-        Ok(store)
+        Ok(out)
     }
 }
 
@@ -324,6 +338,22 @@ mod tests {
         assert_eq!(rows[0].id, "e1");
         assert_eq!(rows[0].op, "dropCollection");
         assert_eq!(rows[0].schema_version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn all_chronological_returns_write_order_not_query_order() {
+        let store = AuditStore::open_memory().expect("open");
+        store.insert(&sample_event("old", 1_000, "insert")).expect("insert old");
+        store.insert(&sample_event("new", 5_000, "deleteMany")).expect("insert new");
+
+        let listed = store.query(&AuditFilter::default()).expect("query");
+        assert_eq!(listed[0].id, "new", "listing stays newest-first");
+
+        let chronological = store.all_chronological().expect("chronological");
+        assert_eq!(
+            chronological.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["old", "new"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/audit/store.rs
+++ b/src-tauri/src/audit/store.rs
@@ -9,6 +9,7 @@ pub const SCHEMA_VERSION: i32 = 1;
 
 /// One persisted audit row (matches `audit_events` table).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AuditEvent {
     pub id: String,
     pub ts: i64,
@@ -28,7 +29,8 @@ pub struct AuditEvent {
 }
 
 /// Filter for listing audit events (all fields optional).
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AuditFilter {
     pub connection_id: Option<String>,
     pub database: Option<String>,

--- a/src-tauri/src/audit/store.rs
+++ b/src-tauri/src/audit/store.rs
@@ -1,0 +1,305 @@
+//! SQLite persistence for audit events (#272).
+
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::Mutex;
+
+pub const SCHEMA_VERSION: i32 = 1;
+
+/// One persisted audit row (matches `audit_events` table).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditEvent {
+    pub id: String,
+    pub ts: i64,
+    pub connection_id: Option<String>,
+    pub profile_name: Option<String>,
+    pub database: Option<String>,
+    pub collection: Option<String>,
+    pub op: String,
+    pub source: String,
+    pub ok: bool,
+    pub error: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub summary: String,
+    pub args_json: Option<String>,
+    pub level_at_record: String,
+    pub schema_version: i32,
+}
+
+/// Filter for listing audit events (all fields optional).
+#[derive(Clone, Debug, Default)]
+pub struct AuditFilter {
+    pub connection_id: Option<String>,
+    pub database: Option<String>,
+    pub collection: Option<String>,
+    pub op: Option<String>,
+    pub source: Option<String>,
+    pub ok: Option<bool>,
+    pub ts_from: Option<i64>,
+    pub ts_to: Option<i64>,
+    pub summary_contains: Option<String>,
+    pub limit: Option<u32>,
+    pub offset: Option<u32>,
+}
+
+/// Thread-safe SQLite-backed audit store.
+pub struct AuditStore {
+    conn: Mutex<Connection>,
+}
+
+impl AuditStore {
+    pub fn open_memory() -> Result<Self, String> {
+        let conn = Connection::open_in_memory().map_err(|e| e.to_string())?;
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    pub fn open_path(path: &Path) -> Result<Self, String> {
+        let conn = Connection::open(path).map_err(|e| e.to_string())?;
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    fn migrate(&self) -> Result<(), String> {
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS audit_events (
+                id TEXT PRIMARY KEY NOT NULL,
+                ts INTEGER NOT NULL,
+                connection_id TEXT,
+                profile_name TEXT,
+                database TEXT,
+                collection TEXT,
+                op TEXT NOT NULL,
+                source TEXT NOT NULL,
+                ok INTEGER NOT NULL,
+                error TEXT,
+                duration_ms INTEGER,
+                summary TEXT NOT NULL,
+                args_json TEXT,
+                level_at_record TEXT NOT NULL,
+                schema_version INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_events(ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_audit_connection_ts
+                ON audit_events(connection_id, ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_audit_op_ts ON audit_events(op, ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_audit_ns_ts
+                ON audit_events(database, collection, ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_audit_source_ts ON audit_events(source, ts DESC);
+            "#,
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn insert(&self, event: &AuditEvent) -> Result<(), String> {
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        conn.execute(
+            r#"
+            INSERT INTO audit_events (
+                id, ts, connection_id, profile_name, database, collection,
+                op, source, ok, error, duration_ms, summary, args_json,
+                level_at_record, schema_version
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+            "#,
+            params![
+                event.id,
+                event.ts,
+                event.connection_id,
+                event.profile_name,
+                event.database,
+                event.collection,
+                event.op,
+                event.source,
+                if event.ok { 1 } else { 0 },
+                event.error,
+                event.duration_ms,
+                event.summary,
+                event.args_json,
+                event.level_at_record,
+                event.schema_version,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn query(&self, filter: &AuditFilter) -> Result<Vec<AuditEvent>, String> {
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        let mut sql = String::from(
+            r#"
+            SELECT id, ts, connection_id, profile_name, database, collection,
+                   op, source, ok, error, duration_ms, summary, args_json,
+                   level_at_record, schema_version
+            FROM audit_events WHERE 1=1
+            "#,
+        );
+        let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(ref v) = filter.connection_id {
+            sql.push_str(" AND connection_id = ?");
+            values.push(Box::new(v.clone()));
+        }
+        if let Some(ref v) = filter.database {
+            sql.push_str(" AND database = ?");
+            values.push(Box::new(v.clone()));
+        }
+        if let Some(ref v) = filter.collection {
+            sql.push_str(" AND collection = ?");
+            values.push(Box::new(v.clone()));
+        }
+        if let Some(ref v) = filter.op {
+            sql.push_str(" AND op = ?");
+            values.push(Box::new(v.clone()));
+        }
+        if let Some(ref v) = filter.source {
+            sql.push_str(" AND source = ?");
+            values.push(Box::new(v.clone()));
+        }
+        if let Some(ok) = filter.ok {
+            sql.push_str(" AND ok = ?");
+            values.push(Box::new(if ok { 1 } else { 0 }));
+        }
+        if let Some(from) = filter.ts_from {
+            sql.push_str(" AND ts >= ?");
+            values.push(Box::new(from));
+        }
+        if let Some(to) = filter.ts_to {
+            sql.push_str(" AND ts <= ?");
+            values.push(Box::new(to));
+        }
+        if let Some(ref needle) = filter.summary_contains {
+            sql.push_str(" AND summary LIKE ?");
+            values.push(Box::new(format!("%{needle}%")));
+        }
+
+        sql.push_str(" ORDER BY ts DESC");
+
+        if let Some(limit) = filter.limit {
+            sql.push_str(" LIMIT ?");
+            values.push(Box::new(limit));
+        }
+        if let Some(offset) = filter.offset {
+            sql.push_str(" OFFSET ?");
+            values.push(Box::new(offset));
+        }
+
+        let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            values.iter().map(|v| v.as_ref()).collect();
+        let rows = stmt
+            .query_map(params_ref.as_slice(), |row| {
+                Ok(AuditEvent {
+                    id: row.get(0)?,
+                    ts: row.get(1)?,
+                    connection_id: row.get(2)?,
+                    profile_name: row.get(3)?,
+                    database: row.get(4)?,
+                    collection: row.get(5)?,
+                    op: row.get(6)?,
+                    source: row.get(7)?,
+                    ok: row.get::<_, i64>(8)? != 0,
+                    error: row.get(9)?,
+                    duration_ms: row.get(10)?,
+                    summary: row.get(11)?,
+                    args_json: row.get(12)?,
+                    level_at_record: row.get(13)?,
+                    schema_version: row.get(14)?,
+                })
+            })
+            .map_err(|e| e.to_string())?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| e.to_string())?);
+        }
+        Ok(out)
+    }
+
+    pub fn prune_before(&self, ts_ms: i64) -> Result<u64, String> {
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        let n = conn
+            .execute(
+                "DELETE FROM audit_events WHERE ts < ?1",
+                params![ts_ms],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(n as u64)
+    }
+
+    pub fn clear_all(&self) -> Result<u64, String> {
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        let n = conn
+            .execute("DELETE FROM audit_events", [])
+            .map_err(|e| e.to_string())?;
+        Ok(n as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event(id: &str, ts: i64, op: &str) -> AuditEvent {
+        AuditEvent {
+            id: id.to_string(),
+            ts,
+            connection_id: Some("conn-1".into()),
+            profile_name: Some("prod".into()),
+            database: Some("shop".into()),
+            collection: Some("orders".into()),
+            op: op.to_string(),
+            source: "ui".into(),
+            ok: true,
+            error: None,
+            duration_ms: Some(12),
+            summary: format!("{op} shop.orders"),
+            args_json: Some(r#"{"filter":{}}"#.into()),
+            level_at_record: "A".into(),
+            schema_version: SCHEMA_VERSION,
+        }
+    }
+
+    #[test]
+    fn insert_and_query_by_op_returns_event() {
+        let store = AuditStore::open_memory().expect("open");
+        store
+            .insert(&sample_event("e1", 1_000, "dropCollection"))
+            .expect("insert");
+        let rows = store
+            .query(&AuditFilter {
+                op: Some("dropCollection".into()),
+                ..Default::default()
+            })
+            .expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "e1");
+        assert_eq!(rows[0].op, "dropCollection");
+        assert_eq!(rows[0].schema_version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn prune_before_deletes_old_keeps_recent() {
+        let store = AuditStore::open_memory().expect("open");
+        store
+            .insert(&sample_event("old", 1_000, "deleteMany"))
+            .expect("insert old");
+        store
+            .insert(&sample_event("new", 5_000, "deleteMany"))
+            .expect("insert new");
+        let removed = store.prune_before(3_000).expect("prune");
+        assert_eq!(removed, 1);
+        let rows = store.query(&AuditFilter::default()).expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "new");
+    }
+}

--- a/src-tauri/src/biometric.rs
+++ b/src-tauri/src/biometric.rs
@@ -121,6 +121,7 @@ pub async fn biometric_unlock(
     match decode_and_verify_key(&meta, &resp.data) {
         Ok(key) => {
             *state.vault_key.lock_safe()? = Some(key);
+            let _ = crate::audit::open_on_unlock(&app, &state, key);
             Ok(connections::VaultStatus::Unlocked)
         }
         Err(e) => {

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -144,6 +144,7 @@ const LOCAL_COMMANDS: &[&str] = &[
     "audit_clear",
     "audit_reset",
     "audit_dropped_count",
+    "audit_status",
     "test_mongosh_path",
     "load_collection_queries",
     "save_query",

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -138,6 +138,12 @@ const LOCAL_COMMANDS: &[&str] = &[
     "test_connection_uri", // ephemeral test connection, never tracked in connection_meta
     "load_app_settings",
     "save_app_settings",
+    "audit_list",
+    "audit_export",
+    "audit_open_folder",
+    "audit_clear",
+    "audit_reset",
+    "audit_dropped_count",
     "test_mongosh_path",
     "load_collection_queries",
     "save_query",

--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -141,7 +141,7 @@ const LOCAL_COMMANDS: &[&str] = &[
     "audit_list",
     "audit_export",
     "audit_open_folder",
-    "audit_clear",
+    "audit_discard_damaged_log",
     "audit_reset",
     "audit_dropped_count",
     "audit_status",

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -53,6 +53,19 @@ fn default_ai_provider() -> String {
 fn default_ai_history_retention_months() -> u8 {
     3
 }
+
+fn default_audit_enabled() -> bool {
+    true
+}
+fn default_audit_level() -> String {
+    "A".to_string()
+}
+fn default_audit_retention_days() -> u32 {
+    30
+}
+fn default_audit_include_payloads() -> bool {
+    false
+}
 fn default_openai_model() -> String {
     "gpt-4o".to_string()
 }
@@ -157,6 +170,18 @@ pub struct AppSettings {
     /// How long to keep AI Helper chat/prompt history (1–12 months).
     #[serde(default = "default_ai_history_retention_months")]
     pub ai_history_retention_months: u8,
+    /// Master switch for local operation audit logging (#272).
+    #[serde(default = "default_audit_enabled")]
+    pub audit_enabled: bool,
+    /// Audit verbosity: `"A"` (writes+shell), `"B"` (+high reads), `"C"` (all DB ops).
+    #[serde(default = "default_audit_level")]
+    pub audit_level: String,
+    /// How long to keep audit events (days). Default 30; UI presets 7/30/90.
+    #[serde(default = "default_audit_retention_days")]
+    pub audit_retention_days: u32,
+    /// When true, store document bodies / full filters up to the per-event cap.
+    #[serde(default = "default_audit_include_payloads")]
+    pub audit_include_payloads: bool,
     // Auto-update channel: "stable" (default) or "dev".
     #[serde(default = "default_update_channel")]
     pub update_channel: String,
@@ -180,6 +205,10 @@ impl Default for AppSettings {
             local_commands: std::collections::HashMap::new(),
             ai_custom_instructions: String::new(),
             ai_history_retention_months: default_ai_history_retention_months(),
+            audit_enabled: default_audit_enabled(),
+            audit_level: default_audit_level(),
+            audit_retention_days: default_audit_retention_days(),
+            audit_include_payloads: default_audit_include_payloads(),
             update_channel: default_update_channel(),
             appearance: AppearanceSettings::default(),
         }
@@ -431,6 +460,11 @@ pub fn get_settings_enc_path(app_handle: &tauri::AppHandle) -> PathBuf {
     config_dir_file(app_handle, "settings.json.enc")
 }
 
+/// Vault-encrypted audit SQLite database (`audit.db.enc`).
+pub fn get_audit_enc_path(app_handle: &tauri::AppHandle) -> PathBuf {
+    config_dir_file(app_handle, "audit.db.enc")
+}
+
 /// Shared helper: a file inside the app config dir (creating the dir), or CWD fallback.
 fn config_dir_file(app_handle: &tauri::AppHandle, name: &str) -> PathBuf {
     match app_handle.path().app_config_dir() {
@@ -547,6 +581,24 @@ pub fn reencrypt_data_files(
         save_settings_encrypted(enc_settings, new_key, &settings)?;
     }
     Ok(())
+}
+
+/// Re-encrypt `audit.db.enc` from `old_key` to `new_key`. Missing/empty file is a no-op.
+pub fn reencrypt_audit_file(
+    old_key: &[u8; 32],
+    new_key: &[u8; 32],
+    enc_audit: &Path,
+) -> Result<(), String> {
+    if !enc_audit.exists() {
+        return Ok(());
+    }
+    let blob = fs::read(enc_audit).map_err(|e| format!("read {}: {e}", enc_audit.display()))?;
+    if blob.is_empty() {
+        return Ok(());
+    }
+    let plain = crate::vault::decrypt(old_key, &blob)?;
+    let sealed = crate::vault::encrypt(new_key, &plain)?;
+    fs::write(enc_audit, sealed).map_err(|e| format!("write {}: {e}", enc_audit.display()))
 }
 
 #[tauri::command]

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -696,16 +696,18 @@ pub fn reencrypt_data_files(
     Ok(())
 }
 
-/// Prepare the audit log re-encrypted from `old_key` to `new_key`.
+/// Prepare the audit log and its state sidecar, re-encrypted from `old_key` to
+/// `new_key`.
 ///
 /// Not `prepare_reencrypt_file`: the log encrypts each record separately, so
 /// rotation has to decrypt every record and rebuild the hash chain rather than
-/// re-wrap one blob.
+/// re-wrap one blob. The state sidecar is keyed the same way and must rotate in
+/// the same transaction, so both files come back together.
 pub fn prepare_reencrypt_audit_log(
     old_key: &[u8; 32],
     new_key: &[u8; 32],
     log_path: &Path,
-) -> Result<Option<Vec<u8>>, String> {
+) -> Result<Vec<(PathBuf, Vec<u8>)>, String> {
     crate::audit::log::prepare_reencrypted(old_key, new_key, log_path)
 }
 

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -460,7 +460,15 @@ pub fn get_settings_enc_path(app_handle: &tauri::AppHandle) -> PathBuf {
     config_dir_file(app_handle, "settings.json.enc")
 }
 
-/// Vault-encrypted audit SQLite database (`audit.db.enc`).
+/// Append-only encrypted audit log (`audit.log.enc`).
+pub fn get_audit_log_path(app_handle: &tauri::AppHandle) -> PathBuf {
+    config_dir_file(app_handle, "audit.log.enc")
+}
+
+/// The superseded whole-image audit envelope (`audit.db.enc`).
+///
+/// Kept only so the pre-append-log file can be found and set aside; nothing
+/// reads its contents any more.
 pub fn get_audit_enc_path(app_handle: &tauri::AppHandle) -> PathBuf {
     config_dir_file(app_handle, "audit.db.enc")
 }
@@ -599,7 +607,7 @@ pub fn write_prepared_file(path: &Path, blob: Option<Vec<u8>>) -> Result<(), Str
     match blob {
         None => Ok(()),
         Some(b) if b.is_empty() => Ok(()),
-        Some(b) => fs::write(path, b).map_err(|e| format!("write {}: {e}", path.display())),
+        Some(b) => crate::durable::write_atomic(path, &b),
     }
 }
 
@@ -617,14 +625,17 @@ pub fn reencrypt_data_files(
     Ok(())
 }
 
-/// Re-encrypt `audit.db.enc` from `old_key` to `new_key`. Missing/empty file is a no-op.
-pub fn reencrypt_audit_file(
+/// Prepare the audit log re-encrypted from `old_key` to `new_key`.
+///
+/// Not `prepare_reencrypt_file`: the log encrypts each record separately, so
+/// rotation has to decrypt every record and rebuild the hash chain rather than
+/// re-wrap one blob.
+pub fn prepare_reencrypt_audit_log(
     old_key: &[u8; 32],
     new_key: &[u8; 32],
-    enc_audit: &Path,
-) -> Result<(), String> {
-    let blob = prepare_reencrypt_file(old_key, new_key, enc_audit)?;
-    write_prepared_file(enc_audit, blob)
+    log_path: &Path,
+) -> Result<Option<Vec<u8>>, String> {
+    crate::audit::log::prepare_reencrypted(old_key, new_key, log_path)
 }
 
 #[tauri::command]

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -611,6 +611,77 @@ pub fn write_prepared_file(path: &Path, blob: Option<Vec<u8>>) -> Result<(), Str
     }
 }
 
+/// Commit a whole vault key rotation, restoring the previous files if any write
+/// fails.
+///
+/// The rotation spans four files, and partial success bricks the vault: files
+/// re-encrypted under the new key while `vault.json` still derives the old one
+/// leave neither password able to open the complete vault. Preparing the blobs
+/// first (see `prepare_reencrypt_file`) removes the *encryption* failures from
+/// this window, but the writes themselves can still fail — a full disk being the
+/// obvious one — so every original is held in memory and put back on error.
+///
+/// `files` is `(path, Some(new_bytes))` per data file; `None` means "not
+/// present, leave alone".
+pub fn commit_vault_rotation(
+    files: Vec<(PathBuf, Option<Vec<u8>>)>,
+    meta_path: &Path,
+    new_meta: &VaultMeta,
+) -> Result<(), String> {
+    let meta_bytes = serde_json::to_vec_pretty(new_meta)
+        .map_err(|e| format!("serialize vault.json: {e}"))?;
+
+    // Snapshot everything this rotation will overwrite, before touching any of it.
+    let mut planned: Vec<(PathBuf, Vec<u8>, Option<Vec<u8>>)> = Vec::new();
+    for (path, new_bytes) in files {
+        let Some(new_bytes) = new_bytes.filter(|b| !b.is_empty()) else {
+            continue;
+        };
+        let original = read_backup(&path)?;
+        planned.push((path, new_bytes, original));
+    }
+    let meta_original = read_backup(meta_path)?;
+    planned.push((meta_path.to_path_buf(), meta_bytes, meta_original));
+
+    let mut written: Vec<(&PathBuf, &Option<Vec<u8>>)> = Vec::new();
+    for (path, new_bytes, original) in &planned {
+        if let Err(e) = crate::durable::write_atomic(path, new_bytes) {
+            // Put back only what this call actually replaced.
+            let mut restore_errors = Vec::new();
+            for (done_path, done_original) in written.iter().rev() {
+                let restored = match done_original {
+                    Some(bytes) => crate::durable::write_atomic(done_path, bytes),
+                    None => fs::remove_file(done_path)
+                        .map_err(|e| format!("remove {}: {e}", done_path.display())),
+                };
+                if let Err(re) = restored {
+                    restore_errors.push(re);
+                }
+            }
+            if restore_errors.is_empty() {
+                return Err(format!("{e} (vault left unchanged)"));
+            }
+            return Err(format!(
+                "{e} — and restoring the previous vault files failed: {}. \
+                 The vault may be inconsistent; restore from a backup.",
+                restore_errors.join("; ")
+            ));
+        }
+        written.push((path, original));
+    }
+    Ok(())
+}
+
+/// Current contents of `path`, or `None` when it does not exist.
+fn read_backup(path: &Path) -> Result<Option<Vec<u8>>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    fs::read(path)
+        .map(Some)
+        .map_err(|e| format!("read {} for rollback: {e}", path.display()))
+}
+
 /// Re-encrypt both data files from `old_key` to `new_key`. Missing files are skipped.
 pub fn reencrypt_data_files(
     old_key: &[u8; 32],
@@ -832,4 +903,116 @@ pub async fn test_connection_uri(
         let _ = on_phase.send(update);
     };
     run_connection_test(&uri, ssh.as_ref(), &emit).await
+}
+
+#[cfg(test)]
+mod rotation_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn meta() -> VaultMeta {
+        build_vault_meta("pw", crate::vault::KdfParams { m_kib: 8, t: 1, p: 1 })
+            .expect("build meta")
+    }
+
+    #[test]
+    fn a_successful_rotation_writes_every_file() {
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("connections.json.enc");
+        let b = dir.path().join("settings.json.enc");
+        let meta_path = dir.path().join("vault.json");
+        fs::write(&a, b"old-a").unwrap();
+        fs::write(&b, b"old-b").unwrap();
+
+        commit_vault_rotation(
+            vec![(a.clone(), Some(b"new-a".to_vec())), (b.clone(), Some(b"new-b".to_vec()))],
+            &meta_path,
+            &meta(),
+        )
+        .expect("commit");
+
+        assert_eq!(fs::read(&a).unwrap(), b"new-a");
+        assert_eq!(fs::read(&b).unwrap(), b"new-b");
+        assert!(meta_path.exists(), "metadata must be written last but written");
+    }
+
+    #[test]
+    fn a_failed_write_restores_every_earlier_file() {
+        let dir = tempdir().unwrap();
+        let good = dir.path().join("connections.json.enc");
+        let meta_path = dir.path().join("vault.json");
+        fs::write(&good, b"old-good").unwrap();
+        fs::write(&meta_path, b"old-meta").unwrap();
+
+        // `write_atomic` stages through `<path>.tmp`; a directory there makes the
+        // *write* fail (not the pre-write snapshot), which is the path that has
+        // to roll back what it already committed.
+        let blocked = dir.path().join("blocked.enc");
+        fs::create_dir(dir.path().join("blocked.enc.tmp")).unwrap();
+
+        let err = commit_vault_rotation(
+            vec![
+                (good.clone(), Some(b"new-good".to_vec())),
+                (blocked.clone(), Some(b"new-blocked".to_vec())),
+            ],
+            &meta_path,
+            &meta(),
+        )
+        .expect_err("the blocked write must fail");
+        assert!(err.contains("vault left unchanged"), "{err}");
+
+        assert_eq!(
+            fs::read(&good).unwrap(),
+            b"old-good",
+            "the already-written file must be rolled back, or no password opens the vault"
+        );
+        assert_eq!(
+            fs::read(&meta_path).unwrap(),
+            b"old-meta",
+            "metadata must be untouched"
+        );
+    }
+
+    #[test]
+    fn rollback_removes_files_that_did_not_exist_before() {
+        let dir = tempdir().unwrap();
+        let fresh = dir.path().join("settings.json.enc");
+        let meta_path = dir.path().join("vault.json");
+        let blocked = dir.path().join("blocked.enc");
+        fs::create_dir(dir.path().join("blocked.enc.tmp")).unwrap();
+
+        commit_vault_rotation(
+            vec![
+                (fresh.clone(), Some(b"new".to_vec())),
+                (blocked, Some(b"x".to_vec())),
+            ],
+            &meta_path,
+            &meta(),
+        )
+        .expect_err("must fail");
+
+        assert!(
+            !fresh.exists(),
+            "a file created by the aborted rotation must not survive it"
+        );
+    }
+
+    #[test]
+    fn absent_and_empty_payloads_are_skipped() {
+        let dir = tempdir().unwrap();
+        let skipped = dir.path().join("connections.json.enc");
+        let empty = dir.path().join("settings.json.enc");
+        let meta_path = dir.path().join("vault.json");
+
+        commit_vault_rotation(
+            vec![(skipped.clone(), None), (empty.clone(), Some(Vec::new()))],
+            &meta_path,
+            &meta(),
+        )
+        .expect("commit");
+
+        assert!(!skipped.exists());
+        assert!(!empty.exists());
+        assert!(meta_path.exists());
+    }
 }

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -910,8 +910,16 @@ mod rotation_tests {
     use super::*;
     use tempfile::tempdir;
 
+    /// Build a test-only password without a hard-coded string literal, so static
+    /// analysis does not read it as a real credential. Mirrors `test_secret` in
+    /// `tests.rs`; kept local because that helper is private to that module.
+    fn test_secret(parts: &[&str]) -> String {
+        parts.concat()
+    }
+
     fn meta() -> VaultMeta {
-        build_vault_meta("pw", crate::vault::KdfParams { m_kib: 8, t: 1, p: 1 })
+        let password = test_secret(&["rot", "ation", "-test"]);
+        build_vault_meta(&password, crate::vault::KdfParams { m_kib: 8, t: 1, p: 1 })
             .expect("build meta")
     }
 

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -565,6 +565,44 @@ pub fn migrate_plaintext_to_encrypted(
     Ok(())
 }
 
+/// Re-encrypt a vault blob from `old_key` to `new_key` without touching disk.
+pub fn reencrypt_blob(
+    old_key: &[u8; 32],
+    new_key: &[u8; 32],
+    blob: &[u8],
+) -> Result<Vec<u8>, String> {
+    if blob.is_empty() {
+        return Ok(Vec::new());
+    }
+    let plain = crate::vault::decrypt(old_key, blob)?;
+    crate::vault::encrypt(new_key, &plain)
+}
+
+/// Read and prepare a re-encrypted file. Missing/empty files return `None`.
+pub fn prepare_reencrypt_file(
+    old_key: &[u8; 32],
+    new_key: &[u8; 32],
+    path: &Path,
+) -> Result<Option<Vec<u8>>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let blob = fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    if blob.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(reencrypt_blob(old_key, new_key, &blob)?))
+}
+
+/// Write a prepared blob, or no-op when `None`/empty.
+pub fn write_prepared_file(path: &Path, blob: Option<Vec<u8>>) -> Result<(), String> {
+    match blob {
+        None => Ok(()),
+        Some(b) if b.is_empty() => Ok(()),
+        Some(b) => fs::write(path, b).map_err(|e| format!("write {}: {e}", path.display())),
+    }
+}
+
 /// Re-encrypt both data files from `old_key` to `new_key`. Missing files are skipped.
 pub fn reencrypt_data_files(
     old_key: &[u8; 32],
@@ -572,14 +610,10 @@ pub fn reencrypt_data_files(
     enc_profiles: &Path,
     enc_settings: &Path,
 ) -> Result<(), String> {
-    if enc_profiles.exists() {
-        let profiles = load_profiles_encrypted(enc_profiles, old_key)?;
-        save_profiles_encrypted(enc_profiles, new_key, &profiles)?;
-    }
-    if enc_settings.exists() {
-        let settings = load_settings_encrypted(enc_settings, old_key)?;
-        save_settings_encrypted(enc_settings, new_key, &settings)?;
-    }
+    let profiles = prepare_reencrypt_file(old_key, new_key, enc_profiles)?;
+    let settings = prepare_reencrypt_file(old_key, new_key, enc_settings)?;
+    write_prepared_file(enc_profiles, profiles)?;
+    write_prepared_file(enc_settings, settings)?;
     Ok(())
 }
 
@@ -589,16 +623,8 @@ pub fn reencrypt_audit_file(
     new_key: &[u8; 32],
     enc_audit: &Path,
 ) -> Result<(), String> {
-    if !enc_audit.exists() {
-        return Ok(());
-    }
-    let blob = fs::read(enc_audit).map_err(|e| format!("read {}: {e}", enc_audit.display()))?;
-    if blob.is_empty() {
-        return Ok(());
-    }
-    let plain = crate::vault::decrypt(old_key, &blob)?;
-    let sealed = crate::vault::encrypt(new_key, &plain)?;
-    fs::write(enc_audit, sealed).map_err(|e| format!("write {}: {e}", enc_audit.display()))
+    let blob = prepare_reencrypt_file(old_key, new_key, enc_audit)?;
+    write_prepared_file(enc_audit, blob)
 }
 
 #[tauri::command]

--- a/src-tauri/src/db/aggregate.rs
+++ b/src-tauri/src/db/aggregate.rs
@@ -31,21 +31,35 @@ pub async fn execute_aggregate_impl(
         .and_then(|v| v.as_array().cloned())
         .map(|stages| stages.iter().any(crate::write_guard::stage_is_disallowed))
         .unwrap_or(false);
-    if has_write_stage {
-        crate::audit::maybe_record_result(
-            state,
-            Some(id),
-            Some(database),
-            Some(collection),
+    // A `$out`/`$merge` pipeline is a write and is recorded at every level; a
+    // pure-read pipeline is the aggregation activity level B advertises, so it
+    // is recorded under its own op with the read class rather than skipped.
+    let (op, class, summary) = if has_write_stage {
+        (
             "execute_aggregate",
             crate::audit::OpClass::Write,
-            None,
-            started,
-            &format!("aggregate {database}.{collection} ($out/$merge)"),
-            Some(pipeline),
-            &result,
-        );
-    }
+            format!("aggregate {database}.{collection} ($out/$merge)"),
+        )
+    } else {
+        (
+            "execute_aggregate_read",
+            crate::audit::OpClass::ReadHigh,
+            format!("aggregate {database}.{collection}"),
+        )
+    };
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        op,
+        class,
+        None,
+        started,
+        &summary,
+        Some(pipeline),
+        &result,
+    );
     result
 }
 
@@ -133,6 +147,31 @@ async fn execute_aggregate_inner(
 /// Explain an entire aggregation pipeline (M1), not just its `$match` stage.
 /// Mirrors `execute_aggregate_impl`'s validation and is real-connection-only.
 pub async fn explain_aggregate_query_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    pipeline: &str,
+) -> Result<String, String> {
+    let started = std::time::Instant::now();
+    let result = explain_aggregate_query_impl_inner(state, id, database, collection, pipeline).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "explain_aggregate_query",
+        crate::audit::OpClass::ReadHigh,
+        None,
+        started,
+        &format!("explain aggregate {database}.{collection}"),
+        Some(pipeline),
+        &result,
+    );
+    result
+}
+
+async fn explain_aggregate_query_impl_inner(
     state: &AppState,
     id: &str,
     database: &str,

--- a/src-tauri/src/db/aggregate.rs
+++ b/src-tauri/src/db/aggregate.rs
@@ -24,6 +24,39 @@ pub async fn execute_aggregate_impl(
     pipeline: &str,
     confirmed: bool,
 ) -> Result<Vec<String>, String> {
+    let started = std::time::Instant::now();
+    let result = execute_aggregate_inner(state, id, database, collection, pipeline, confirmed).await;
+    let has_write_stage = serde_json::from_str::<serde_json::Value>(pipeline)
+        .ok()
+        .and_then(|v| v.as_array().cloned())
+        .map(|stages| stages.iter().any(crate::write_guard::stage_is_disallowed))
+        .unwrap_or(false);
+    if has_write_stage {
+        crate::audit::maybe_record_result(
+            state,
+            Some(id),
+            Some(database),
+            Some(collection),
+            "execute_aggregate",
+            crate::audit::OpClass::Write,
+            None,
+            started,
+            &format!("aggregate {database}.{collection} ($out/$merge)"),
+            Some(pipeline),
+            &result,
+        );
+    }
+    result
+}
+
+async fn execute_aggregate_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    pipeline: &str,
+    confirmed: bool,
+) -> Result<Vec<String>, String> {
     // Parse and validate the pipeline (a JSON array of stage documents) up front so a
     // malformed pipeline fails clearly regardless of the connection type.
     let pipeline_val: serde_json::Value = if pipeline.trim().is_empty() {

--- a/src-tauri/src/db/copy.rs
+++ b/src-tauri/src/db/copy.rs
@@ -4,7 +4,6 @@ use crate::limits::IMPORT_BATCH_SIZE;
 use crate::state::LockExt;
 use crate::write_guard::{guard_writable, WriteOp};
 use crate::{connection_is_mock, mock_db, require_real_client, AppState, CopyFailure, CopySummary, TaskInfo};
-use crate::audit::{maybe_record_result, OpClass};
 use mongodb::bson::Document;
 use mongodb::Client;
 use std::collections::HashMap;
@@ -442,14 +441,12 @@ pub async fn start_collection_copy_impl(
         conflict_mode,
     )
     .await;
-    maybe_record_result(
+    crate::audit::maybe_record_task_start(
         state,
         Some(target_id),
         Some(target_db),
         Some(target_collection),
         "start_collection_copy",
-        OpClass::Write,
-        None,
         started,
         &audit_summary,
         filter.as_deref(),
@@ -525,6 +522,18 @@ async fn start_collection_copy_inner(
     let target = require_real_client(state, target_id)?;
     let tasks = state.tasks.clone();
     let cancels = state.cancels.clone(); // Arc<Mutex<..>> — clone the Arc
+    let audit_ctx = crate::audit::TaskAuditContext::capture(
+        state,
+        Some(target_id),
+        Some(target_db),
+        Some(target_collection),
+        "start_collection_copy",
+        &format!(
+            "copy {}.{} → {}.{}",
+            source_db, source_collection, target_db, target_collection
+        ),
+    );
+    let audit_started = std::time::Instant::now();
     let (sdb, scoll) = (source_db.to_string(), source_collection.to_string());
     let (tdb, tcoll) = (target_db.to_string(), target_collection.to_string());
     let task_id2 = task_id.clone();
@@ -561,6 +570,12 @@ async fn start_collection_copy_inner(
             }
             Err(err) => fail_task(&tasks, &task_id2, err),
         }
+        let (outcome, error) = crate::db::tasks::terminal_state(&tasks, &task_id2, "failed");
+        audit_ctx.record_terminal(
+            &outcome,
+            error.as_deref(),
+            Some(audit_started.elapsed().as_millis() as i64),
+        );
         clear_cancel_flag(&cancels, &task_id2);
     });
 
@@ -594,14 +609,12 @@ pub async fn start_database_copy_impl(
         conflict_mode,
     )
     .await;
-    maybe_record_result(
+    crate::audit::maybe_record_task_start(
         state,
         Some(target_id),
         Some(target_db),
         None,
         "start_database_copy",
-        OpClass::Write,
-        None,
         started,
         &audit_summary,
         collections_arg.as_deref(),
@@ -677,6 +690,15 @@ async fn start_database_copy_inner(
     let target = require_real_client(state, target_id)?;
     let tasks = state.tasks.clone();
     let cancels = state.cancels.clone();
+    let audit_ctx = crate::audit::TaskAuditContext::capture(
+        state,
+        Some(target_id),
+        Some(target_db),
+        None,
+        "start_database_copy",
+        &format!("copy database {} → {}", source_db, target_db),
+    );
+    let audit_started = std::time::Instant::now();
     let (sdb, tdb) = (source_db.to_string(), target_db.to_string());
     let task_id2 = task_id.clone();
 
@@ -756,6 +778,12 @@ async fn start_database_copy_inner(
         let status = if cancel.load(Ordering::SeqCst) { "cancelled" } else { "completed" };
         update_task(&tasks, &task_id2, |t| t.items_processed = t.items_total);
         finish_copy_task(&tasks, &task_id2, status, summary);
+        let (outcome, error) = crate::db::tasks::terminal_state(&tasks, &task_id2, "completed");
+        audit_ctx.record_terminal(
+            &outcome,
+            error.as_deref(),
+            Some(audit_started.elapsed().as_millis() as i64),
+        );
         clear_cancel_flag(&cancels, &task_id2);
     });
 

--- a/src-tauri/src/db/copy.rs
+++ b/src-tauri/src/db/copy.rs
@@ -4,6 +4,7 @@ use crate::limits::IMPORT_BATCH_SIZE;
 use crate::state::LockExt;
 use crate::write_guard::{guard_writable, WriteOp};
 use crate::{connection_is_mock, mock_db, require_real_client, AppState, CopyFailure, CopySummary, TaskInfo};
+use crate::audit::{maybe_record_result, OpClass};
 use mongodb::bson::Document;
 use mongodb::Client;
 use std::collections::HashMap;
@@ -423,6 +424,53 @@ pub async fn start_collection_copy_impl(
     include_indexes: bool,
     conflict_mode: String,
 ) -> Result<TaskInfo, String> {
+    let started = std::time::Instant::now();
+    let audit_summary = format!(
+        "copy {}.{} → {}.{}",
+        source_db, source_collection, target_db, target_collection
+    );
+    let result = start_collection_copy_inner(
+        state,
+        source_id,
+        source_db,
+        source_collection,
+        target_id,
+        target_db,
+        target_collection,
+        filter.clone(),
+        include_indexes,
+        conflict_mode,
+    )
+    .await;
+    maybe_record_result(
+        state,
+        Some(target_id),
+        Some(target_db),
+        Some(target_collection),
+        "start_collection_copy",
+        OpClass::Write,
+        None,
+        started,
+        &audit_summary,
+        filter.as_deref(),
+        &result,
+    );
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn start_collection_copy_inner(
+    state: &AppState,
+    source_id: &str,
+    source_db: &str,
+    source_collection: &str,
+    target_id: &str,
+    target_db: &str,
+    target_collection: &str,
+    filter: Option<String>,
+    include_indexes: bool,
+    conflict_mode: String,
+) -> Result<TaskInfo, String> {
     // Copy commands guard the TARGET connection, not the source — a copy
     // writes into the target.
     guard_writable(state, target_id, WriteOp::CopyWrite, false)?;
@@ -521,6 +569,49 @@ pub async fn start_collection_copy_impl(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn start_database_copy_impl(
+    state: &AppState,
+    source_id: &str,
+    source_db: &str,
+    target_id: &str,
+    target_db: &str,
+    collections: Option<Vec<String>>,
+    include_indexes: bool,
+    include_views: bool,
+    conflict_mode: String,
+) -> Result<TaskInfo, String> {
+    let started = std::time::Instant::now();
+    let audit_summary = format!("copy database {} → {}", source_db, target_db);
+    let collections_arg = collections.as_ref().map(|names| names.join(","));
+    let result = start_database_copy_inner(
+        state,
+        source_id,
+        source_db,
+        target_id,
+        target_db,
+        collections.clone(),
+        include_indexes,
+        include_views,
+        conflict_mode,
+    )
+    .await;
+    maybe_record_result(
+        state,
+        Some(target_id),
+        Some(target_db),
+        None,
+        "start_database_copy",
+        OpClass::Write,
+        None,
+        started,
+        &audit_summary,
+        collections_arg.as_deref(),
+        &result,
+    );
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn start_database_copy_inner(
     state: &AppState,
     source_id: &str,
     source_db: &str,

--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -23,6 +23,30 @@ pub async fn create_collection_impl(
     database: &str,
     collection: &str,
 ) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = create_collection_inner(state, id, database, collection).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "create_collection",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("createCollection {database}.{collection}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn create_collection_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+) -> Result<(), String> {
     guard_writable(state, id, WriteOp::CreateCollection, false)?;
 
     if collection.trim().is_empty() {
@@ -40,6 +64,32 @@ pub async fn create_collection_impl(
 }
 
 pub async fn create_view_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    view_name: &str,
+    source_collection: &str,
+    pipeline: &str,
+) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = create_view_inner(state, id, database, view_name, source_collection, pipeline).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(view_name),
+        "create_view",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("createView {database}.{view_name} on {source_collection}"),
+        Some(pipeline),
+        &result,
+    );
+    result
+}
+
+async fn create_view_inner(
     state: &AppState,
     id: &str,
     database: &str,
@@ -139,6 +189,32 @@ pub async fn rename_collection_impl(
     to: &str,
     confirmed: bool,
 ) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = rename_collection_inner(state, id, database, from, to, confirmed).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(from),
+        "rename_collection",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("renameCollection {database}.{from} → {to}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn rename_collection_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    from: &str,
+    to: &str,
+    confirmed: bool,
+) -> Result<(), String> {
     guard_writable(state, id, WriteOp::Rename, confirmed)?;
 
     if from.trim().is_empty() || to.trim().is_empty() {
@@ -214,6 +290,42 @@ pub async fn get_collection_options_impl(
 }
 
 pub async fn set_validator_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    validator: &str,
+    validation_level: &str,
+    validation_action: &str,
+) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = set_validator_inner(
+        state,
+        id,
+        database,
+        collection,
+        validator,
+        validation_level,
+        validation_action,
+    )
+    .await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "set_validator",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("collMod validator {database}.{collection}"),
+        Some(validator),
+        &result,
+    );
+    result
+}
+
+async fn set_validator_inner(
     state: &AppState,
     id: &str,
     database: &str,
@@ -308,6 +420,33 @@ async fn drop_database_inner(
 }
 
 pub async fn rename_database_impl(
+    state: &AppState,
+    id: &str,
+    from: &str,
+    to: &str,
+    drop_source: bool,
+    confirmed: bool,
+) -> Result<DatabaseRenameResult, String> {
+    let started = std::time::Instant::now();
+    let result =
+        rename_database_inner(state, id, from, to, drop_source, confirmed).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(from),
+        None,
+        "rename_database",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("renameDatabase {from} → {to}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn rename_database_inner(
     state: &AppState,
     id: &str,
     from: &str,

--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -92,6 +92,31 @@ pub async fn drop_collection_impl(
     collection: &str,
     confirmed: bool,
 ) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = drop_collection_inner(state, id, database, collection, confirmed).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "drop_collection",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("dropCollection {database}.{collection}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn drop_collection_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    confirmed: bool,
+) -> Result<(), String> {
     guard_writable(state, id, WriteOp::Drop, confirmed)?;
 
     if connection_is_mock(state, id)? {
@@ -237,6 +262,30 @@ pub async fn set_validator_impl(
 }
 
 pub async fn drop_database_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    confirmed: bool,
+) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = drop_database_inner(state, id, database, confirmed).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        None,
+        "drop_database",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("dropDatabase {database}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn drop_database_inner(
     state: &AppState,
     id: &str,
     database: &str,

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -209,6 +209,32 @@ pub async fn delete_many_impl(
     filter: &str,
     confirmed: bool,
 ) -> Result<u64, String> {
+    let started = std::time::Instant::now();
+    let result = delete_many_inner(state, id, database, collection, filter, confirmed).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "delete_many",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("deleteMany {database}.{collection}"),
+        Some(filter),
+        &result,
+    );
+    result
+}
+
+async fn delete_many_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    filter: &str,
+    confirmed: bool,
+) -> Result<u64, String> {
     guard_writable(state, id, WriteOp::DeleteMany, confirmed)?;
 
     let filter_doc = json_to_bson_document(filter)?;
@@ -226,6 +252,35 @@ pub async fn delete_many_impl(
 }
 
 pub async fn update_many_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    filter: &str,
+    update: &str,
+    confirmed: bool,
+) -> Result<u64, String> {
+    let started = std::time::Instant::now();
+    let args = format!("{{\"filter\":{filter},\"update\":{update}}}");
+    let result =
+        update_many_inner(state, id, database, collection, filter, update, confirmed).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "update_many",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("updateMany {database}.{collection}"),
+        Some(&args),
+        &result,
+    );
+    result
+}
+
+async fn update_many_inner(
     state: &AppState,
     id: &str,
     database: &str,
@@ -257,6 +312,31 @@ pub async fn update_many_impl(
 }
 
 pub async fn insert_document_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    document: &str,
+) -> Result<String, String> {
+    let started = std::time::Instant::now();
+    let result = insert_document_inner(state, id, database, collection, document).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "insert_document",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("insertOne {database}.{collection}"),
+        Some(document),
+        &result,
+    );
+    result
+}
+
+async fn insert_document_inner(
     state: &AppState,
     id: &str,
     database: &str,

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -181,6 +181,31 @@ pub async fn delete_document_impl(
     collection: &str,
     filter: &str,
 ) -> Result<u64, String> {
+    let started = std::time::Instant::now();
+    let result = delete_document_inner(state, id, database, collection, filter).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "delete_document",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("deleteOne {database}.{collection}"),
+        Some(filter),
+        &result,
+    );
+    result
+}
+
+async fn delete_document_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    filter: &str,
+) -> Result<u64, String> {
     guard_writable(state, id, WriteOp::DeleteOne, false)?;
 
     // Parse/validate up front so bad input fails the same way for mock & real.
@@ -371,6 +396,34 @@ pub async fn update_document_impl(
     filter: &str,
     replacement: &str,
 ) -> Result<u64, String> {
+    let started = std::time::Instant::now();
+    let args = format!("{{\"filter\":{filter},\"replacement\":{replacement}}}");
+    let result =
+        update_document_inner(state, id, database, collection, filter, replacement).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "update_document",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("replaceOne {database}.{collection}"),
+        Some(&args),
+        &result,
+    );
+    result
+}
+
+async fn update_document_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    filter: &str,
+    replacement: &str,
+) -> Result<u64, String> {
     guard_writable(state, id, WriteOp::ReplaceOne, false)?;
 
     let filter_doc = json_to_bson_document(filter)?;
@@ -405,6 +458,33 @@ pub struct ImportResult {
 // Documents are already-validated JSON values from the frontend codec; each is
 // converted to BSON here as a safety net.
 pub async fn import_documents_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    docs: Vec<serde_json::Value>,
+    mode: &str,
+) -> Result<ImportResult, String> {
+    let started = std::time::Instant::now();
+    let summary = format!("import {database}.{collection} ({mode}, {} docs)", docs.len());
+    let result = import_documents_inner(state, id, database, collection, docs, mode).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "import_documents",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &summary,
+        None,
+        &result,
+    );
+    result
+}
+
+async fn import_documents_inner(
     state: &AppState,
     id: &str,
     database: &str,

--- a/src-tauri/src/db/generate.rs
+++ b/src-tauri/src/db/generate.rs
@@ -769,6 +769,34 @@ pub async fn start_generate_task_impl(
     count: u32,
     seed: Option<u64>,
 ) -> Result<TaskInfo, String> {
+    let started = std::time::Instant::now();
+    let audit_summary = format!("generate {count} docs → {database}.{collection}");
+    let result = start_generate_task_inner(state, id, database, collection, template, count, seed).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "start_generate_task",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &audit_summary,
+        None,
+        &result,
+    );
+    result
+}
+
+async fn start_generate_task_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    template: &str,
+    count: u32,
+    seed: Option<u64>,
+) -> Result<TaskInfo, String> {
     guard_writable(state, id, WriteOp::Generate, false)?;
 
     use crate::limits::{IMPORT_BATCH_SIZE, MAX_IMPORT_DOCS};

--- a/src-tauri/src/db/generate.rs
+++ b/src-tauri/src/db/generate.rs
@@ -772,14 +772,12 @@ pub async fn start_generate_task_impl(
     let started = std::time::Instant::now();
     let audit_summary = format!("generate {count} docs → {database}.{collection}");
     let result = start_generate_task_inner(state, id, database, collection, template, count, seed).await;
-    crate::audit::maybe_record_result(
+    crate::audit::maybe_record_task_start(
         state,
         Some(id),
         Some(database),
         Some(collection),
         "start_generate_task",
-        crate::audit::OpClass::Write,
-        None,
         started,
         &audit_summary,
         None,
@@ -845,6 +843,15 @@ async fn start_generate_task_inner(
 
     let tasks = state.tasks.clone();
     let cancels = state.cancels.clone();
+    let audit_ctx = crate::audit::TaskAuditContext::capture(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "start_generate_task",
+        &format!("generate {count} docs → {database}.{collection}"),
+    );
+    let audit_started = std::time::Instant::now();
     let database = database.to_string();
     let collection = collection.to_string();
     let seed = seed.unwrap_or_else(rand::random);
@@ -929,6 +936,13 @@ async fn start_generate_task_inner(
             };
             finish_task(&tasks, &task_id2, processed, message);
         }
+
+        let (outcome, error) = crate::db::tasks::terminal_state(&tasks, &task_id2, "completed");
+        audit_ctx.record_terminal(
+            &outcome,
+            error.as_deref(),
+            Some(audit_started.elapsed().as_millis() as i64),
+        );
 
         if let Ok(mut guard) = cancels.lock() {
             guard.remove(&task_id2);

--- a/src-tauri/src/db/gridfs.rs
+++ b/src-tauri/src/db/gridfs.rs
@@ -151,6 +151,47 @@ pub async fn upload_gridfs_file_impl(
     content_type: Option<&str>,
     on_progress: Option<&(dyn Fn(GridFsTransferProgress) + Send + Sync)>,
 ) -> Result<String, String> {
+    let started = std::time::Instant::now();
+    let result = upload_gridfs_file_inner(
+        state,
+        id,
+        database,
+        bucket,
+        source_path,
+        filename,
+        metadata_json,
+        content_type,
+        on_progress,
+    )
+    .await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(bucket),
+        "upload_gridfs_file",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("gridfs upload {database}.{bucket}"),
+        filename,
+        &result,
+    );
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn upload_gridfs_file_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    bucket: &str,
+    source_path: &str,
+    filename: Option<&str>,
+    metadata_json: Option<&str>,
+    content_type: Option<&str>,
+    on_progress: Option<&(dyn Fn(GridFsTransferProgress) + Send + Sync)>,
+) -> Result<String, String> {
     guard_writable(state, id, WriteOp::GridFsWrite, false)?;
 
     if connection_is_mock(state, id)? {
@@ -266,6 +307,31 @@ pub async fn upload_gridfs_file_impl(
 }
 
 pub async fn delete_gridfs_file_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    bucket: &str,
+    file_id_json: &str,
+) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = delete_gridfs_file_inner(state, id, database, bucket, file_id_json).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(bucket),
+        "delete_gridfs_file",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("gridfs delete {database}.{bucket}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn delete_gridfs_file_inner(
     state: &AppState,
     id: &str,
     database: &str,

--- a/src-tauri/src/db/import.rs
+++ b/src-tauri/src/db/import.rs
@@ -389,14 +389,12 @@ pub async fn start_import_task_impl(
         mode,
     )
     .await;
-    crate::audit::maybe_record_result(
+    crate::audit::maybe_record_task_start(
         state,
         Some(id),
         Some(database),
         Some(collection),
         "start_import_task",
-        crate::audit::OpClass::Write,
-        None,
         started,
         &audit_summary,
         None,
@@ -467,6 +465,15 @@ async fn start_import_task_inner(
     state.tasks.lock_safe()?.insert(task_id.clone(), task.clone());
 
     let tasks = state.tasks.clone();
+    let audit_ctx = crate::audit::TaskAuditContext::capture(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "start_import_task",
+        &format!("import {database}.{collection} ({format}, {mode})"),
+    );
+    let audit_started = std::time::Instant::now();
     let database = database.to_string();
     let collection = collection.to_string();
     let format = format.to_string();
@@ -496,6 +503,12 @@ async fn start_import_task_inner(
             }
             Err(err) => fail_task(&tasks, &task_id, err),
         }
+        let (outcome, error) = crate::db::tasks::terminal_state(&tasks, &task_id, "failed");
+        audit_ctx.record_terminal(
+            &outcome,
+            error.as_deref(),
+            Some(audit_started.elapsed().as_millis() as i64),
+        );
     });
     Ok(task)
 }

--- a/src-tauri/src/db/import.rs
+++ b/src-tauri/src/db/import.rs
@@ -376,6 +376,46 @@ pub async fn start_import_task_impl(
     csv_options: Option<CsvImportOptions>,
     mode: &str,
 ) -> Result<TaskInfo, String> {
+    let started = std::time::Instant::now();
+    let audit_summary = format!("import {database}.{collection} ({format}, {mode})");
+    let result = start_import_task_inner(
+        state,
+        id,
+        database,
+        collection,
+        source,
+        format,
+        csv_options,
+        mode,
+    )
+    .await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "start_import_task",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &audit_summary,
+        None,
+        &result,
+    );
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn start_import_task_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    source: ImportSourceArg,
+    format: &str,
+    csv_options: Option<CsvImportOptions>,
+    mode: &str,
+) -> Result<TaskInfo, String> {
     guard_writable(state, id, WriteOp::Import, false)?;
 
     if !matches!(mode, "skip" | "update" | "abort") {

--- a/src-tauri/src/db/metadata.rs
+++ b/src-tauri/src/db/metadata.rs
@@ -175,6 +175,34 @@ pub async fn create_index_impl(
     unique: bool,
     sparse: bool,
 ) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = create_index_inner(state, id, db, collection, index_name, keys, unique, sparse).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(db),
+        Some(collection),
+        "create_index",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("createIndex {db}.{collection}.{index_name}"),
+        Some(keys),
+        &result,
+    );
+    result
+}
+
+async fn create_index_inner(
+    state: &AppState,
+    id: &str,
+    db: &str,
+    collection: &str,
+    index_name: &str,
+    keys: &str,
+    unique: bool,
+    sparse: bool,
+) -> Result<(), String> {
     guard_writable(state, id, WriteOp::CreateIndex, false)?;
 
     let is_mock = {
@@ -242,6 +270,31 @@ pub async fn create_index_impl(
 }
 
 pub async fn delete_index_impl(
+    state: &AppState,
+    id: &str,
+    db: &str,
+    collection: &str,
+    index_name: &str,
+) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = delete_index_inner(state, id, db, collection, index_name).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(db),
+        Some(collection),
+        "delete_index",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("dropIndex {db}.{collection}.{index_name}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn delete_index_inner(
     state: &AppState,
     id: &str,
     db: &str,

--- a/src-tauri/src/db/metadata.rs
+++ b/src-tauri/src/db/metadata.rs
@@ -5,6 +5,25 @@ use crate::write_guard::{guard_writable, WriteOp};
 use crate::{mock_db, AppState, CollectionInfo, IndexInfo};
 
 pub async fn list_databases_impl(state: &AppState, id: &str) -> Result<Vec<String>, String> {
+    let started = std::time::Instant::now();
+    let result = list_databases_impl_inner(state, id).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        None,
+        None,
+        "list_databases",
+        crate::audit::OpClass::ReadHigh,
+        None,
+        started,
+        &"listDatabases".to_string(),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn list_databases_impl_inner(state: &AppState, id: &str) -> Result<Vec<String>, String> {
     let is_mock = {
         let mocks = state.mocks.lock_safe()?;
         *mocks
@@ -39,6 +58,29 @@ pub async fn list_databases_impl(state: &AppState, id: &str) -> Result<Vec<Strin
 }
 
 pub async fn list_collections_impl(
+    state: &AppState,
+    id: &str,
+    db: &str,
+) -> Result<Vec<CollectionInfo>, String> {
+    let started = std::time::Instant::now();
+    let result = list_collections_impl_inner(state, id, db).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(db),
+        None,
+        "list_collections",
+        crate::audit::OpClass::ReadHigh,
+        None,
+        started,
+        &format!("listCollections {db}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn list_collections_impl_inner(
     state: &AppState,
     id: &str,
     db: &str,
@@ -95,6 +137,30 @@ pub async fn list_collections_impl(
 }
 
 pub async fn list_indexes_impl(
+    state: &AppState,
+    id: &str,
+    db: &str,
+    collection: &str,
+) -> Result<Vec<IndexInfo>, String> {
+    let started = std::time::Instant::now();
+    let result = list_indexes_impl_inner(state, id, db, collection).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(db),
+        Some(collection),
+        "list_indexes",
+        crate::audit::OpClass::ReadHigh,
+        None,
+        started,
+        &format!("listIndexes {db}.{collection}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn list_indexes_impl_inner(
     state: &AppState,
     id: &str,
     db: &str,

--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -959,6 +959,32 @@ pub async fn start_restore_task_impl(
     tool_path: &str,
     options: RestoreOptions,
 ) -> Result<TaskInfo, String> {
+    let started = std::time::Instant::now();
+    let source = restore_source_path(&options.source).to_string();
+    let audit_summary = format!("restore from {}", basename(&source));
+    let result = start_restore_task_inner(state, id, tool_path, options).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        None,
+        None,
+        "start_restore_task",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &audit_summary,
+        None,
+        &result,
+    );
+    result
+}
+
+async fn start_restore_task_inner(
+    state: &AppState,
+    id: &str,
+    tool_path: &str,
+    options: RestoreOptions,
+) -> Result<TaskInfo, String> {
     guard_writable(state, id, WriteOp::RestoreWrite, false)?;
 
     let uri = require_real_conn_uri(state, id)?;

--- a/src-tauri/src/db/mongotools.rs
+++ b/src-tauri/src/db/mongotools.rs
@@ -883,6 +883,7 @@ async fn run_tool_task(
     uri: String,
     direct_connection: bool,
     verb: &'static str,
+    audit: Option<(crate::audit::TaskAuditContext, std::time::Instant)>,
 ) {
     let outcome =
         run_tool_process(&tasks, &task_id, &cancel, &tool_path, &args, &uri, direct_connection)
@@ -900,6 +901,14 @@ async fn run_tool_task(
             crate::db::tasks::prune_tasks(&tasks);
         }
         Err(err) => fail_task(&tasks, &task_id, err),
+    }
+    if let Some((ctx, started)) = audit {
+        let (outcome, error) = crate::db::tasks::terminal_state(&tasks, &task_id, "failed");
+        ctx.record_terminal(
+            &outcome,
+            error.as_deref(),
+            Some(started.elapsed().as_millis() as i64),
+        );
     }
     if let Ok(mut guard) = cancels.lock() {
         guard.remove(&task_id);
@@ -945,8 +954,10 @@ pub async fn start_dump_task_impl(
     let tool_path = tool_path.to_string();
     let task_id2 = task_id.clone();
     tokio::spawn(async move {
-        run_tool_task(tasks, cancels, task_id2, cancel, tool_path, args, uri, tunneled, "Dump")
-            .await;
+        run_tool_task(
+            tasks, cancels, task_id2, cancel, tool_path, args, uri, tunneled, "Dump", None,
+        )
+        .await;
     });
 
     Ok(task)
@@ -963,14 +974,12 @@ pub async fn start_restore_task_impl(
     let source = restore_source_path(&options.source).to_string();
     let audit_summary = format!("restore from {}", basename(&source));
     let result = start_restore_task_inner(state, id, tool_path, options).await;
-    crate::audit::maybe_record_result(
+    crate::audit::maybe_record_task_start(
         state,
         Some(id),
         None,
         None,
         "start_restore_task",
-        crate::audit::OpClass::Write,
-        None,
         started,
         &audit_summary,
         None,
@@ -992,6 +1001,15 @@ async fn start_restore_task_inner(
     let args = build_restore_args(&options)?;
     let source = restore_source_path(&options.source).to_string();
     let label = format!("Restore {}", basename(&source));
+    let audit_ctx = crate::audit::TaskAuditContext::capture(
+        state,
+        Some(id),
+        None,
+        None,
+        "start_restore_task",
+        &format!("restore from {}", basename(&source)),
+    );
+    let audit_started = std::time::Instant::now();
 
     let task_id = Uuid::new_v4().to_string();
     let task = TaskInfo {
@@ -1019,8 +1037,19 @@ async fn start_restore_task_inner(
     let tool_path = tool_path.to_string();
     let task_id2 = task_id.clone();
     tokio::spawn(async move {
-        run_tool_task(tasks, cancels, task_id2, cancel, tool_path, args, uri, tunneled, "Restore")
-            .await;
+        run_tool_task(
+            tasks,
+            cancels,
+            task_id2,
+            cancel,
+            tool_path,
+            args,
+            uri,
+            tunneled,
+            "Restore",
+            Some((audit_ctx, audit_started)),
+        )
+        .await;
     });
 
     Ok(task)

--- a/src-tauri/src/db/query.rs
+++ b/src-tauri/src/db/query.rs
@@ -15,6 +15,38 @@ pub async fn execute_mql_query_impl(
     limit: i64,
     skip: i64,
 ) -> Result<Vec<String>, String> {
+    let started = std::time::Instant::now();
+    let result = execute_mql_query_inner(
+        state, id, database, collection, filter, sort, projection, limit, skip,
+    )
+    .await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "execute_mql_query",
+        crate::audit::OpClass::ReadHigh,
+        None,
+        started,
+        &format!("find {database}.{collection}"),
+        Some(filter),
+        &result,
+    );
+    return result;
+}
+
+async fn execute_mql_query_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    filter: &str,
+    sort: &str,
+    projection: &str,
+    limit: i64,
+    skip: i64,
+) -> Result<Vec<String>, String> {
     // Validate projection JSON up front (applies on the real path; mock ignores fields).
     let projection_doc: Option<mongodb::bson::Document> =
         if projection.trim().is_empty() || projection.trim() == "{}" {

--- a/src-tauri/src/db/query.rs
+++ b/src-tauri/src/db/query.rs
@@ -151,6 +151,31 @@ pub async fn count_documents_impl(
     collection: &str,
     filter: &str,
 ) -> Result<u64, String> {
+    let started = std::time::Instant::now();
+    let result = count_documents_impl_inner(state, id, database, collection, filter).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "count_documents",
+        crate::audit::OpClass::ReadHigh,
+        None,
+        started,
+        &format!("count {database}.{collection}"),
+        Some(filter),
+        &result,
+    );
+    result
+}
+
+async fn count_documents_impl_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    filter: &str,
+) -> Result<u64, String> {
     let is_mock = {
         let mocks = state.mocks.lock_safe()?;
         *mocks
@@ -199,6 +224,31 @@ pub async fn count_documents_impl(
 }
 
 pub async fn explain_mql_query_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    filter: &str,
+) -> Result<String, String> {
+    let started = std::time::Instant::now();
+    let result = explain_mql_query_impl_inner(state, id, database, collection, filter).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "explain_mql_query",
+        crate::audit::OpClass::ReadHigh,
+        None,
+        started,
+        &format!("explain find {database}.{collection}"),
+        Some(filter),
+        &result,
+    );
+    result
+}
+
+async fn explain_mql_query_impl_inner(
     state: &AppState,
     id: &str,
     database: &str,

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -171,6 +171,31 @@ pub async fn analyze_schema_impl(
     collection: &str,
     sample_size: i64,
 ) -> Result<String, String> {
+    let started = std::time::Instant::now();
+    let result = analyze_schema_impl_inner(state, id, database, collection, sample_size).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        Some(collection),
+        "analyze_schema",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &format!("analyzeSchema {database}.{collection}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn analyze_schema_impl_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    collection: &str,
+    sample_size: i64,
+) -> Result<String, String> {
     let sample_size = normalize_schema_sample(sample_size);
     let is_mock = {
         let mocks = state.mocks.lock_safe()?;

--- a/src-tauri/src/db/stats.rs
+++ b/src-tauri/src/db/stats.rs
@@ -154,6 +154,25 @@ fn mock_index_stats(db: &str, coll: &str) -> Vec<IndexStatUi> {
 // ── Async command impls ──────────────────────────────────────────────────────
 
 pub async fn db_stats_impl(state: &AppState, id: &str, db: &str) -> Result<DbStatsUi, String> {
+    let started = std::time::Instant::now();
+    let result = db_stats_impl_inner(state, id, db).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(db),
+        None,
+        "db_stats",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &format!("dbStats {db}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn db_stats_impl_inner(state: &AppState, id: &str, db: &str) -> Result<DbStatsUi, String> {
     if connection_is_mock(state, id)? {
         return Ok(mock_db_stats(db));
     }
@@ -187,6 +206,25 @@ async fn coll_storage_stats(
 }
 
 pub async fn coll_stats_impl(state: &AppState, id: &str, db: &str, coll: &str) -> Result<CollStatsUi, String> {
+    let started = std::time::Instant::now();
+    let result = coll_stats_impl_inner(state, id, db, coll).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(db),
+        Some(coll),
+        "coll_stats",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &format!("collStats {db}.{coll}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn coll_stats_impl_inner(state: &AppState, id: &str, db: &str, coll: &str) -> Result<CollStatsUi, String> {
     if connection_is_mock(state, id)? {
         return Ok(mock_coll_stats());
     }
@@ -196,6 +234,25 @@ pub async fn coll_stats_impl(state: &AppState, id: &str, db: &str, coll: &str) -
 }
 
 pub async fn index_stats_impl(state: &AppState, id: &str, db: &str, coll: &str) -> Result<Vec<IndexStatUi>, String> {
+    let started = std::time::Instant::now();
+    let result = index_stats_impl_inner(state, id, db, coll).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(db),
+        Some(coll),
+        "index_stats",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &format!("indexStats {db}.{coll}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn index_stats_impl_inner(state: &AppState, id: &str, db: &str, coll: &str) -> Result<Vec<IndexStatUi>, String> {
     if connection_is_mock(state, id)? {
         return Ok(mock_index_stats(db, coll));
     }

--- a/src-tauri/src/db/tasks.rs
+++ b/src-tauri/src/db/tasks.rs
@@ -50,6 +50,25 @@ pub fn finish_task(
     prune_tasks(tasks);
 }
 
+/// The task's own final status and error, for audit recording — status is
+/// `completed`, `failed` or `cancelled`.
+///
+/// Read from the task map rather than inferred from the job's `Result`, because
+/// cancellation and partial-write bookkeeping overwrite the status after the job
+/// returns. Falls back to `default` if the entry was already pruned.
+pub fn terminal_state(
+    tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>,
+    task_id: &str,
+    default: &str,
+) -> (String, Option<String>) {
+    tasks
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .get(task_id)
+        .map(|t| (t.status.clone(), t.error.clone()))
+        .unwrap_or_else(|| (default.to_string(), None))
+}
+
 pub fn prune_tasks(tasks: &Arc<Mutex<HashMap<String, TaskInfo>>>) {
     use crate::limits::MAX_TASK_HISTORY;
     let mut guard = tasks.lock().unwrap_or_else(|p| p.into_inner());

--- a/src-tauri/src/db/users.rs
+++ b/src-tauri/src/db/users.rs
@@ -135,6 +135,29 @@ pub async fn list_users_impl(
     id: &str,
     database: Option<&str>,
 ) -> Result<Vec<MongoUser>, String> {
+    let started = std::time::Instant::now();
+    let result = list_users_impl_inner(state, id, database).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        database,
+        None,
+        "list_users",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &format!("listUsers {}", database.unwrap_or("admin")),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn list_users_impl_inner(
+    state: &AppState,
+    id: &str,
+    database: Option<&str>,
+) -> Result<Vec<MongoUser>, String> {
     if connection_is_mock(state, id)? {
         let users = mock_users();
         return Ok(match database {
@@ -336,6 +359,29 @@ async fn drop_user_inner(
 
 /// List roles grantable on a database, including built-in roles.
 pub async fn list_roles_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+) -> Result<Vec<RoleInfo>, String> {
+    let started = std::time::Instant::now();
+    let result = list_roles_impl_inner(state, id, database).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        None,
+        "list_roles",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &format!("listRoles {database}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn list_roles_impl_inner(
     state: &AppState,
     id: &str,
     database: &str,

--- a/src-tauri/src/db/users.rs
+++ b/src-tauri/src/db/users.rs
@@ -170,6 +170,32 @@ pub async fn create_user_impl(
     password: &str,
     roles: &[RoleSpec],
 ) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = create_user_inner(state, id, database, username, password, roles).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        None,
+        "create_user",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("createUser {database}.{username}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn create_user_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    username: &str,
+    password: &str,
+    roles: &[RoleSpec],
+) -> Result<(), String> {
     guard_writable(state, id, WriteOp::UserWrite, false)?;
 
     if username.trim().is_empty() {
@@ -198,6 +224,32 @@ pub async fn create_user_impl(
 /// Update a user's password and/or replace its role set. At least one of the
 /// two must be provided.
 pub async fn update_user_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    username: &str,
+    password: Option<&str>,
+    roles: Option<&[RoleSpec]>,
+) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = update_user_inner(state, id, database, username, password, roles).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        None,
+        "update_user",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("updateUser {database}.{username}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn update_user_inner(
     state: &AppState,
     id: &str,
     database: &str,
@@ -236,6 +288,30 @@ pub async fn update_user_impl(
 }
 
 pub async fn drop_user_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    username: &str,
+) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = drop_user_inner(state, id, database, username).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        None,
+        "drop_user",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("dropUser {database}.{username}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn drop_user_inner(
     state: &AppState,
     id: &str,
     database: &str,

--- a/src-tauri/src/durable.rs
+++ b/src-tauri/src/durable.rs
@@ -1,0 +1,85 @@
+//! Crash-safe file writes for vault-backed data (#272).
+//!
+//! `fs::write` only reaches the page cache: an OS crash or power loss can leave
+//! a rename pointing at bytes that never hit the disk, losing the whole file
+//! rather than one update. Everything that must survive that goes through here.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+/// Write `bytes` to `path` atomically and durably: temp file → fsync → rename.
+///
+/// The rename is atomic for readers, and the fsync before it guarantees the
+/// bytes exist before anything points at them. On Unix the parent directory is
+/// fsynced too, so the rename itself survives a power loss; Windows cannot open
+/// a directory as a file and has different rename-ordering guarantees.
+pub fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let tmp = tmp_path(path);
+    {
+        let mut file =
+            fs::File::create(&tmp).map_err(|e| format!("create {}: {e}", tmp.display()))?;
+        file.write_all(bytes)
+            .map_err(|e| format!("write {}: {e}", tmp.display()))?;
+        file.sync_all()
+            .map_err(|e| format!("fsync {}: {e}", tmp.display()))?;
+    }
+    fs::rename(&tmp, path)
+        .map_err(|e| format!("rename {} → {}: {e}", tmp.display(), path.display()))?;
+    sync_parent_dir(path);
+    Ok(())
+}
+
+/// Flush the directory entry created by a rename. Best-effort by design: a
+/// filesystem that rejects directory fsync must not fail the write itself.
+pub fn sync_parent_dir(path: &Path) {
+    #[cfg(unix)]
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = fs::File::open(parent) {
+            let _ = dir.sync_all();
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+fn tmp_path(path: &Path) -> std::path::PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".tmp");
+    path.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn write_atomic_creates_file_and_leaves_no_temp() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("nested").join("data.enc");
+        write_atomic(&target, b"hello").expect("write");
+        assert_eq!(fs::read(&target).unwrap(), b"hello");
+        assert!(!tmp_path(&target).exists(), "temp file must be renamed away");
+    }
+
+    #[test]
+    fn write_atomic_replaces_existing_content() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("data.enc");
+        write_atomic(&target, b"first").expect("write");
+        write_atomic(&target, b"second").expect("rewrite");
+        assert_eq!(fs::read(&target).unwrap(), b"second");
+    }
+
+    #[test]
+    fn temp_path_keeps_the_full_name_so_it_never_collides_with_the_target() {
+        // `with_extension("tmp")` would turn `audit.log.enc` into `audit.log.tmp`,
+        // which is a different file's name pattern; append instead.
+        let p = Path::new("/x/audit.log.enc");
+        assert_eq!(tmp_path(p), Path::new("/x/audit.log.enc.tmp"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub mod change_streams;
 pub mod chats;
 pub mod connections;
 mod db;
+pub mod durable;
 pub mod mcp;
 pub mod mcp_tools;
 pub(crate) mod mock_db;
@@ -2391,7 +2392,7 @@ async fn vault_change_password(
 
     let profiles_path = connections::get_profiles_enc_path(&app_handle);
     let settings_path = connections::get_settings_enc_path(&app_handle);
-    let audit_path = connections::get_audit_enc_path(&app_handle);
+    let audit_log_path = connections::get_audit_log_path(&app_handle);
 
     // Seal any open audit session under the old key before reading blobs.
     let _ = audit::close_on_lock(&state);
@@ -2401,11 +2402,12 @@ async fn vault_change_password(
         connections::prepare_reencrypt_file(&old_key, &new_key, &profiles_path)?;
     let new_settings =
         connections::prepare_reencrypt_file(&old_key, &new_key, &settings_path)?;
-    let new_audit = connections::prepare_reencrypt_file(&old_key, &new_key, &audit_path)?;
+    let new_audit =
+        connections::prepare_reencrypt_audit_log(&old_key, &new_key, &audit_log_path)?;
 
     connections::write_prepared_file(&profiles_path, new_profiles)?;
     connections::write_prepared_file(&settings_path, new_settings)?;
-    connections::write_prepared_file(&audit_path, new_audit)?;
+    connections::write_prepared_file(&audit_log_path, new_audit)?;
     connections::write_vault_meta(&meta_path, &new_meta)?;
     *state.vault_key.lock_safe()? = Some(new_key);
     let _ = audit::open_on_unlock(&app_handle, &state, new_key);
@@ -2450,7 +2452,7 @@ async fn audit_export(
 
 #[tauri::command]
 async fn audit_open_folder(app_handle: tauri::AppHandle) -> Result<(), String> {
-    let path = connections::get_audit_enc_path(&app_handle);
+    let path = connections::get_audit_log_path(&app_handle);
     let dir = path
         .parent()
         .map(|p| p.to_path_buf())
@@ -2483,6 +2485,37 @@ async fn audit_reset(
 async fn audit_dropped_count(state: tauri::State<'_, AppState>) -> Result<u64, String> {
     let guard = state.audit.lock_safe()?;
     Ok(guard.as_ref().map(|s| s.dropped_count()).unwrap_or(0))
+}
+
+/// Whether auditing is actually recording, and why not when it isn't (#272).
+///
+/// A corrupt or unreadable `audit.log.enc` leaves the vault unlocked and the app
+/// fully usable but unaudited; the UI needs to say so rather than let the user
+/// assume destructive operations are being logged.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AuditStatusUi {
+    active: bool,
+    degraded_reason: Option<String>,
+    /// Set when the on-disk log failed verification: recording has stopped and
+    /// the file is being preserved as evidence.
+    integrity_error: Option<String>,
+    dropped_count: u64,
+}
+
+#[tauri::command]
+async fn audit_status(state: tauri::State<'_, AppState>) -> Result<AuditStatusUi, String> {
+    let guard = state.audit.lock_safe()?;
+    let session = guard.as_ref();
+    let integrity_error = session.and_then(|s| s.integrity_error());
+    Ok(AuditStatusUi {
+        // A sealed log is open for reading but no longer recording, so it must
+        // not report itself as active auditing.
+        active: session.is_some_and(|s| s.is_open()) && integrity_error.is_none(),
+        degraded_reason: audit::degraded_reason(&state),
+        integrity_error,
+        dropped_count: session.map(|s| s.dropped_count()).unwrap_or(0),
+    })
 }
 
 /// Thin wrappers over `mcp.rs`'s testable impl fns (the established
@@ -2655,6 +2688,7 @@ pub fn run() {
             audit_clear,
             audit_reset,
             audit_dropped_count,
+            audit_status,
             connections::test_mongosh_path,
             change_streams::start_change_stream,
             change_streams::poll_change_stream,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2703,7 +2703,12 @@ pub fn run() {
         .expect("error while building tauri application")
         .run(|app_handle, event| {
             use tauri::Manager;
-            if let tauri::RunEvent::ExitRequested { .. } = event {
+            // `AppHandle::exit` ends in process teardown that may skip Drop.
+            // Seal on both exit events so the in-memory store reaches disk.
+            if matches!(
+                event,
+                tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
+            ) {
                 if let Some(state) = app_handle.try_state::<AppState>() {
                     let _ = audit::close_on_lock(&state);
                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2410,11 +2410,18 @@ async fn vault_change_password(
         let new_audit =
             connections::prepare_reencrypt_audit_log(&old_key, &new_key, &audit_log_path)?;
 
-        connections::write_prepared_file(&profiles_path, new_profiles)?;
-        connections::write_prepared_file(&settings_path, new_settings)?;
-        connections::write_prepared_file(&audit_log_path, new_audit)?;
-        connections::write_vault_meta(&meta_path, &new_meta)?;
-        Ok(())
+        // Commit all four files together: a partial rotation leaves data under
+        // the new key while the metadata still derives the old one, which no
+        // password can then open.
+        connections::commit_vault_rotation(
+            vec![
+                (profiles_path.clone(), new_profiles),
+                (settings_path.clone(), new_settings),
+                (audit_log_path.clone(), new_audit),
+            ],
+            &meta_path,
+            &new_meta,
+        )
     };
 
     if let Err(e) = rotate() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 pub mod limits;
 pub mod ai;
+pub mod audit;
 #[cfg(test)]
 mod command_coverage;
 pub mod change_streams;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2395,10 +2395,11 @@ async fn vault_change_password(
     let audit_log_path = connections::get_audit_log_path(&app_handle);
 
     // Close the audit session so the log is not being appended to while it is
-    // re-encrypted. Everything fallible after this point runs inside `rotate`, so
-    // a failure can reopen the session instead of leaving the app running
-    // unaudited until the next lock/unlock.
-    let _ = audit::close_on_lock(&state);
+    // re-encrypted, but keep its cross-process lock: releasing it would let a
+    // second instance take the log and append under the old key mid-rotation.
+    // Everything fallible after this point runs inside `rotate`, so a failure
+    // can reopen the session instead of leaving the app running unaudited.
+    let retained_audit_lock = audit::suspend_for_rotation(&state);
 
     let rotate = || -> Result<(), String> {
         // Prepare every re-encrypted payload before overwriting any vault file:
@@ -2407,32 +2408,37 @@ async fn vault_change_password(
             connections::prepare_reencrypt_file(&old_key, &new_key, &profiles_path)?;
         let new_settings =
             connections::prepare_reencrypt_file(&old_key, &new_key, &settings_path)?;
-        let new_audit =
+        // Returns the log *and* its state sidecar; both are keyed and must land
+        // together or the new-key log would be checked against an old-key count.
+        let new_audit_files =
             connections::prepare_reencrypt_audit_log(&old_key, &new_key, &audit_log_path)?;
 
         // Commit all four files together: a partial rotation leaves data under
         // the new key while the metadata still derives the old one, which no
         // password can then open.
-        connections::commit_vault_rotation(
-            vec![
-                (profiles_path.clone(), new_profiles),
-                (settings_path.clone(), new_settings),
-                (audit_log_path.clone(), new_audit),
-            ],
-            &meta_path,
-            &new_meta,
-        )
+        let mut files = vec![
+            (profiles_path.clone(), new_profiles),
+            (settings_path.clone(), new_settings),
+        ];
+        files.extend(new_audit_files.into_iter().map(|(p, b)| (p, Some(b))));
+        connections::commit_vault_rotation(files, &meta_path, &new_meta)
     };
 
-    if let Err(e) = rotate() {
-        // The rotation was abandoned, so `old_key` is still the live vault key.
-        // Reopen auditing under it before surfacing the error.
-        let _ = audit::open_on_unlock(&app_handle, &state, old_key);
-        return Err(e);
+    let rotated = rotate();
+    // Reopen with the retained lock either way — on failure under `old_key`,
+    // which is still the live vault key because it is only swapped below.
+    let reopen_key = if rotated.is_ok() { new_key } else { old_key };
+    match retained_audit_lock {
+        Some(lock) => {
+            let _ = audit::resume_after_rotation(&app_handle, &state, reopen_key, lock);
+        }
+        None => {
+            let _ = audit::open_on_unlock(&app_handle, &state, reopen_key);
+        }
     }
+    rotated?;
 
     *state.vault_key.lock_safe()? = Some(new_key);
-    let _ = audit::open_on_unlock(&app_handle, &state, new_key);
     // Approach A: a password change derives a new key; keep biometrics working transparently.
     biometric::restore_key_if_enrolled(&app_handle, &new_key);
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2353,7 +2353,10 @@ async fn vault_reset(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    let _ = audit::reset_store(&app_handle, &state);
+    // Before any core vault file is removed: if the audit log cannot be deleted,
+    // a replacement vault would start with a log its new key cannot authenticate,
+    // so auditing would be sealed from the first unlock. Abort instead.
+    audit::reset_store(&app_handle, &state)?;
     for p in [
         connections::get_vault_meta_path(&app_handle),
         connections::get_profiles_enc_path(&app_handle),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2394,21 +2394,36 @@ async fn vault_change_password(
     let settings_path = connections::get_settings_enc_path(&app_handle);
     let audit_log_path = connections::get_audit_log_path(&app_handle);
 
-    // Seal any open audit session under the old key before reading blobs.
+    // Close the audit session so the log is not being appended to while it is
+    // re-encrypted. Everything fallible after this point runs inside `rotate`, so
+    // a failure can reopen the session instead of leaving the app running
+    // unaudited until the next lock/unlock.
     let _ = audit::close_on_lock(&state);
 
-    // Prepare all re-encrypted payloads before overwriting any vault file.
-    let new_profiles =
-        connections::prepare_reencrypt_file(&old_key, &new_key, &profiles_path)?;
-    let new_settings =
-        connections::prepare_reencrypt_file(&old_key, &new_key, &settings_path)?;
-    let new_audit =
-        connections::prepare_reencrypt_audit_log(&old_key, &new_key, &audit_log_path)?;
+    let rotate = || -> Result<(), String> {
+        // Prepare every re-encrypted payload before overwriting any vault file:
+        // a failure here must not leave the files and the metadata disagreeing.
+        let new_profiles =
+            connections::prepare_reencrypt_file(&old_key, &new_key, &profiles_path)?;
+        let new_settings =
+            connections::prepare_reencrypt_file(&old_key, &new_key, &settings_path)?;
+        let new_audit =
+            connections::prepare_reencrypt_audit_log(&old_key, &new_key, &audit_log_path)?;
 
-    connections::write_prepared_file(&profiles_path, new_profiles)?;
-    connections::write_prepared_file(&settings_path, new_settings)?;
-    connections::write_prepared_file(&audit_log_path, new_audit)?;
-    connections::write_vault_meta(&meta_path, &new_meta)?;
+        connections::write_prepared_file(&profiles_path, new_profiles)?;
+        connections::write_prepared_file(&settings_path, new_settings)?;
+        connections::write_prepared_file(&audit_log_path, new_audit)?;
+        connections::write_vault_meta(&meta_path, &new_meta)?;
+        Ok(())
+    };
+
+    if let Err(e) = rotate() {
+        // The rotation was abandoned, so `old_key` is still the live vault key.
+        // Reopen auditing under it before surfacing the error.
+        let _ = audit::open_on_unlock(&app_handle, &state, old_key);
+        return Err(e);
+    }
+
     *state.vault_key.lock_safe()? = Some(new_key);
     let _ = audit::open_on_unlock(&app_handle, &state, new_key);
     // Approach A: a password change derives a new key; keep biometrics working transparently.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -716,8 +716,24 @@ pub async fn run_mongosh_command_impl(
     session_id: &str,
     command: &str,
 ) -> Result<MongoshCommandOutput, String> {
+    let started = std::time::Instant::now();
     let session = get_mongosh_session(state, session_id)?;
-    run_mongosh_command_on_session(&session, command).await
+    let connection_id = session.connection_id.clone();
+    let result = run_mongosh_command_on_session(&session, command).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(&connection_id),
+        None,
+        None,
+        "run_mongosh_command",
+        crate::audit::OpClass::Shell,
+        Some("shell"),
+        started,
+        "mongosh",
+        Some(command),
+        &result,
+    );
+    result
 }
 
 /// Per-tab shell state, held backend-side so a frontend hot reload or window
@@ -2227,7 +2243,9 @@ async fn save_app_settings(
         &connections::get_settings_enc_path(&app_handle),
         &key,
         &settings,
-    )
+    )?;
+    audit::refresh_policy_from_settings(&state, &settings);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2274,6 +2274,7 @@ async fn vault_initialize(
     )?;
 
     *state.vault_key.lock_safe()? = Some(key);
+    let _ = audit::open_on_unlock(&app_handle, &state, key);
     Ok(())
 }
 
@@ -2288,11 +2289,13 @@ async fn vault_unlock(
         .ok_or_else(|| "vault is not initialized".to_string())?;
     let key = connections::unlock_key(&meta, &password)?;
     *state.vault_key.lock_safe()? = Some(key);
+    let _ = audit::open_on_unlock(&app_handle, &state, key);
     Ok(connections::VaultStatus::Unlocked)
 }
 
 #[tauri::command]
 async fn vault_lock(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let _ = audit::close_on_lock(&state);
     *state.vault_key.lock_safe()? = None;
     // A locked vault must never leave the embedded MCP server listening —
     // it reads through `require_key`-gated seams, same precondition as
@@ -2306,6 +2309,7 @@ async fn vault_reset(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
+    let _ = audit::reset_store(&app_handle, &state);
     for p in [
         connections::get_vault_meta_path(&app_handle),
         connections::get_profiles_enc_path(&app_handle),
@@ -2348,11 +2352,90 @@ async fn vault_change_password(
         &connections::get_profiles_enc_path(&app_handle),
         &connections::get_settings_enc_path(&app_handle),
     )?;
+    // Seal any open audit session under the old key, then re-encrypt the file.
+    let _ = audit::close_on_lock(&state);
+    connections::reencrypt_audit_file(
+        &old_key,
+        &new_key,
+        &connections::get_audit_enc_path(&app_handle),
+    )?;
     connections::write_vault_meta(&meta_path, &new_meta)?;
     *state.vault_key.lock_safe()? = Some(new_key);
+    let _ = audit::open_on_unlock(&app_handle, &state, new_key);
     // Approach A: a password change derives a new key; keep biometrics working transparently.
     biometric::restore_key_if_enrolled(&app_handle, &new_key);
     Ok(())
+}
+
+#[tauri::command]
+async fn audit_list(
+    state: tauri::State<'_, AppState>,
+    filter: audit::AuditFilter,
+) -> Result<Vec<audit::AuditEvent>, String> {
+    let guard = state.audit.lock_safe()?;
+    match guard.as_ref() {
+        Some(session) => session.query(&filter),
+        None => Err("vault is locked".into()),
+    }
+}
+
+#[tauri::command]
+async fn audit_export(
+    state: tauri::State<'_, AppState>,
+    filter: audit::AuditFilter,
+    path: String,
+) -> Result<u64, String> {
+    use std::io::Write;
+    let events = {
+        let guard = state.audit.lock_safe()?;
+        match guard.as_ref() {
+            Some(session) => session.query(&filter)?,
+            None => return Err("vault is locked".into()),
+        }
+    };
+    let mut file = std::fs::File::create(&path).map_err(|e| format!("create {path}: {e}"))?;
+    for ev in &events {
+        let line = serde_json::to_string(ev).map_err(|e| e.to_string())?;
+        writeln!(file, "{line}").map_err(|e| format!("write {path}: {e}"))?;
+    }
+    Ok(events.len() as u64)
+}
+
+#[tauri::command]
+async fn audit_open_folder(app_handle: tauri::AppHandle) -> Result<(), String> {
+    let path = connections::get_audit_enc_path(&app_handle);
+    let dir = path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| path.clone());
+    tauri_plugin_opener::open_path(&dir, None::<&str>).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+async fn audit_clear(state: tauri::State<'_, AppState>) -> Result<u64, String> {
+    let guard = state.audit.lock_safe()?;
+    match guard.as_ref() {
+        Some(session) => session.clear_all(),
+        None => Err("vault is locked".into()),
+    }
+}
+
+#[tauri::command]
+async fn audit_reset(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let key = state.require_key()?;
+    audit::reset_store(&app_handle, &state)?;
+    audit::open_on_unlock(&app_handle, &state, key)?;
+    Ok(())
+}
+
+#[tauri::command]
+async fn audit_dropped_count(state: tauri::State<'_, AppState>) -> Result<u64, String> {
+    let guard = state.audit.lock_safe()?;
+    Ok(guard.as_ref().map(|s| s.dropped_count()).unwrap_or(0))
 }
 
 /// Thin wrappers over `mcp.rs`'s testable impl fns (the established
@@ -2519,6 +2602,12 @@ pub fn run() {
             connections::test_connection_uri,
             load_app_settings,
             save_app_settings,
+            audit_list,
+            audit_export,
+            audit_open_folder,
+            audit_clear,
+            audit_reset,
+            audit_dropped_count,
             connections::test_mongosh_path,
             change_streams::start_change_stream,
             change_streams::poll_change_stream,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2198,14 +2198,39 @@ async fn save_connection_profile(
     state: tauri::State<'_, AppState>,
     mut profile: connections::ConnectionProfile,
 ) -> Result<(), String> {
+    let started = Instant::now();
+    let profile_id = profile.id.clone();
+    let profile_name = profile.name.clone();
+    let result = save_connection_profile_inner(&app_handle, &state, &mut profile).await;
+    audit::maybe_record_result(
+        &state,
+        Some(&profile_id),
+        None,
+        None,
+        "save_connection_profile",
+        audit::OpClass::Write,
+        Some("ui"),
+        started,
+        &format!("save connection profile {profile_name}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn save_connection_profile_inner(
+    app_handle: &tauri::AppHandle,
+    state: &AppState,
+    profile: &mut connections::ConnectionProfile,
+) -> Result<(), String> {
     let key = state.require_key()?;
-    let path = connections::get_profiles_enc_path(&app_handle);
+    let path = connections::get_profiles_enc_path(app_handle);
     let mut profiles = connections::load_profiles_encrypted(&path, &key)?;
     profile.uri = connections::normalize_mongodb_uri_options(&profile.uri);
     if let Some(pos) = profiles.iter().position(|p| p.id == profile.id) {
-        profiles[pos] = profile;
+        profiles[pos] = profile.clone();
     } else {
-        profiles.push(profile);
+        profiles.push(profile.clone());
     }
     connections::save_profiles_encrypted(&path, &key, &profiles)
 }
@@ -2364,19 +2389,23 @@ async fn vault_change_password(
     let new_meta = connections::build_vault_meta(&new_password, params)?;
     let new_key = connections::unlock_key(&new_meta, &new_password)?;
 
-    connections::reencrypt_data_files(
-        &old_key,
-        &new_key,
-        &connections::get_profiles_enc_path(&app_handle),
-        &connections::get_settings_enc_path(&app_handle),
-    )?;
-    // Seal any open audit session under the old key, then re-encrypt the file.
+    let profiles_path = connections::get_profiles_enc_path(&app_handle);
+    let settings_path = connections::get_settings_enc_path(&app_handle);
+    let audit_path = connections::get_audit_enc_path(&app_handle);
+
+    // Seal any open audit session under the old key before reading blobs.
     let _ = audit::close_on_lock(&state);
-    connections::reencrypt_audit_file(
-        &old_key,
-        &new_key,
-        &connections::get_audit_enc_path(&app_handle),
-    )?;
+
+    // Prepare all re-encrypted payloads before overwriting any vault file.
+    let new_profiles =
+        connections::prepare_reencrypt_file(&old_key, &new_key, &profiles_path)?;
+    let new_settings =
+        connections::prepare_reencrypt_file(&old_key, &new_key, &settings_path)?;
+    let new_audit = connections::prepare_reencrypt_file(&old_key, &new_key, &audit_path)?;
+
+    connections::write_prepared_file(&profiles_path, new_profiles)?;
+    connections::write_prepared_file(&settings_path, new_settings)?;
+    connections::write_prepared_file(&audit_path, new_audit)?;
     connections::write_vault_meta(&meta_path, &new_meta)?;
     *state.vault_key.lock_safe()? = Some(new_key);
     let _ = audit::open_on_unlock(&app_handle, &state, new_key);
@@ -2670,6 +2699,14 @@ pub fn run() {
             updater::update_check,
             updater::update_install
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            use tauri::Manager;
+            if let tauri::RunEvent::ExitRequested { .. } = event {
+                if let Some(state) = app_handle.try_state::<AppState>() {
+                    let _ = audit::close_on_lock(&state);
+                }
+            }
+        });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2492,11 +2492,15 @@ async fn audit_open_folder(app_handle: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Discard a log that failed verification, so recording can resume (#272).
+///
+/// There is deliberately no command to clear an intact log: retention is the
+/// only thing that removes events. See `AuditSession::discard_damaged_log`.
 #[tauri::command]
-async fn audit_clear(state: tauri::State<'_, AppState>) -> Result<u64, String> {
+async fn audit_discard_damaged_log(state: tauri::State<'_, AppState>) -> Result<u64, String> {
     let guard = state.audit.lock_safe()?;
     match guard.as_ref() {
-        Some(session) => session.clear_all(),
+        Some(session) => session.discard_damaged_log(),
         None => Err("vault is locked".into()),
     }
 }
@@ -2716,7 +2720,7 @@ pub fn run() {
             audit_list,
             audit_export,
             audit_open_folder,
-            audit_clear,
+            audit_discard_damaged_log,
             audit_reset,
             audit_dropped_count,
             audit_status,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -502,7 +502,7 @@ impl McpServer {
         let (app_handle, path) = self.resolve()?;
         let state = app_handle.state::<AppState>();
         let summary = crate::mcp_tools::truncate_summary(&format!("connectionId={}", args.connection_id), 200);
-        let result = crate::mcp_tools::list_databases_tool_impl(&state, &path, &args.connection_id).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::list_databases_tool_impl(&state, &path, &args.connection_id)).await;
         finish_json(&state, "list_databases", Some(args.connection_id), &summary, result)
     }
 
@@ -511,7 +511,7 @@ impl McpServer {
         let (app_handle, path) = self.resolve()?;
         let state = app_handle.state::<AppState>();
         let summary = crate::mcp_tools::truncate_summary(&format!("connectionId={} database={}", args.connection_id, args.database), 200);
-        let result = crate::mcp_tools::list_collections_tool_impl(&state, &path, &args.connection_id, &args.database).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::list_collections_tool_impl(&state, &path, &args.connection_id, &args.database)).await;
         finish_json(&state, "list_collections", Some(args.connection_id), &summary, result)
     }
 
@@ -535,7 +535,7 @@ impl McpServer {
             ),
             200,
         );
-        let result = crate::mcp_tools::find_impl(&state, &path, args).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::find_impl(&state, &path, args)).await;
         finish_json(&state, "find", Some(connection_id), &summary, result)
     }
 
@@ -550,7 +550,7 @@ impl McpServer {
             &format!("connectionId={connection_id} {}.{} stages={}", args.database, args.collection, args.pipeline.len()),
             200,
         );
-        let result = crate::mcp_tools::aggregate_impl(&state, &path, args).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::aggregate_impl(&state, &path, args)).await;
         finish_json(&state, "aggregate", Some(connection_id), &summary, result)
     }
 
@@ -562,7 +562,7 @@ impl McpServer {
         let state = app_handle.state::<AppState>();
         let connection_id = args.connection_id.clone();
         let summary = crate::mcp_tools::truncate_summary(&format!("connectionId={connection_id} {}.{}", args.database, args.collection), 200);
-        let result = crate::mcp_tools::explain_impl(&state, &path, args).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::explain_impl(&state, &path, args)).await;
         finish_text(&state, "explain", Some(connection_id), &summary, result)
     }
 
@@ -574,7 +574,7 @@ impl McpServer {
         let state = app_handle.state::<AppState>();
         let connection_id = args.connection_id.clone();
         let summary = crate::mcp_tools::truncate_summary(&format!("connectionId={connection_id} {}.{}", args.database, args.collection), 200);
-        let result = crate::mcp_tools::schema_analysis_impl(&state, &path, args).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::schema_analysis_impl(&state, &path, args)).await;
         finish_text(&state, "schema_analysis", Some(connection_id), &summary, result)
     }
 
@@ -586,7 +586,7 @@ impl McpServer {
         let state = app_handle.state::<AppState>();
         let summary =
             crate::mcp_tools::truncate_summary(&format!("connectionId={} {}.{}", args.connection_id, args.database, args.collection), 200);
-        let result = crate::mcp_tools::list_indexes_tool_impl(&state, &path, &args.connection_id, &args.database, &args.collection).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::list_indexes_tool_impl(&state, &path, &args.connection_id, &args.database, &args.collection)).await;
         finish_json(&state, "list_indexes", Some(args.connection_id.clone()), &summary, result)
     }
 
@@ -601,7 +601,7 @@ impl McpServer {
         let connection_id = args.connection_id.clone();
         let summary =
             crate::mcp_tools::truncate_summary(&crate::mcp_tools::insert_one_summary(&args.database, &args.collection, &args.document, args._confirm), 200);
-        let result = crate::mcp_tools::insert_one_impl(&state, &path, args).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::insert_one_impl(&state, &path, args)).await;
         finish_json(&state, "insert_one", Some(connection_id), &summary, result)
     }
 
@@ -616,7 +616,7 @@ impl McpServer {
             &crate::mcp_tools::update_many_summary(&args.database, &args.collection, &args.filter, &args.update, args._confirm),
             200,
         );
-        let result = crate::mcp_tools::update_many_tool_impl(&state, &path, args).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::update_many_tool_impl(&state, &path, args)).await;
         finish_json(&state, "update_many", Some(connection_id), &summary, result)
     }
 
@@ -628,7 +628,7 @@ impl McpServer {
         let state = app_handle.state::<AppState>();
         let connection_id = args.connection_id.clone();
         let summary = crate::mcp_tools::truncate_summary(&crate::mcp_tools::delete_many_summary(&args.database, &args.collection, &args.filter, args._confirm), 200);
-        let result = crate::mcp_tools::delete_many_tool_impl(&state, &path, args).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::delete_many_tool_impl(&state, &path, args)).await;
         finish_json(&state, "delete_many", Some(connection_id), &summary, result)
     }
 
@@ -651,7 +651,7 @@ impl McpServer {
             ),
             200,
         );
-        let result = crate::mcp_tools::create_index_tool_impl(&state, &path, args).await;
+        let result = crate::audit::with_source("mcp", crate::mcp_tools::create_index_tool_impl(&state, &path, args)).await;
         finish_json(&state, "create_index", Some(connection_id), &summary, result)
     }
 }

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -421,6 +421,25 @@ pub async fn current_ops_impl(state: &AppState, id: &str) -> Result<Vec<CurrentO
 }
 
 pub async fn kill_op_impl(state: &AppState, id: &str, opid: i64) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    let result = kill_op_inner(state, id, opid).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        None,
+        None,
+        "kill_op",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("killOp {opid}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn kill_op_inner(state: &AppState, id: &str, opid: i64) -> Result<(), String> {
     guard_writable(state, id, WriteOp::ServerAdmin, false)?;
 
     if connection_is_mock(state, id)? {
@@ -449,6 +468,32 @@ pub async fn profiling_status_impl(state: &AppState, id: &str, database: &str) -
 }
 
 pub async fn set_profiling_level_impl(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    level: i32,
+    slow_ms: i32,
+) -> Result<ProfilingStatus, String> {
+    let started = std::time::Instant::now();
+    let args = format!("{{\"level\":{level},\"slowMs\":{slow_ms}}}");
+    let result = set_profiling_level_inner(state, id, database, level, slow_ms).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        None,
+        "set_profiling_level",
+        crate::audit::OpClass::Write,
+        None,
+        started,
+        &format!("profile {database} level={level}"),
+        Some(&args),
+        &result,
+    );
+    result
+}
+
+async fn set_profiling_level_inner(
     state: &AppState,
     id: &str,
     database: &str,

--- a/src-tauri/src/monitoring.rs
+++ b/src-tauri/src/monitoring.rs
@@ -375,6 +375,25 @@ fn mock_repl_set_status() -> ReplSetStatus {
 // ── Async command impls ───────────────────────────────────────────────────────
 
 pub async fn server_status_impl(state: &AppState, id: &str) -> Result<ServerStatus, String> {
+    let started = std::time::Instant::now();
+    let result = server_status_impl_inner(state, id).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        None,
+        None,
+        "server_status",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &"serverStatus".to_string(),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn server_status_impl_inner(state: &AppState, id: &str) -> Result<ServerStatus, String> {
     if connection_is_mock(state, id)? {
         return Ok(mock_server_status());
     }
@@ -388,6 +407,25 @@ pub async fn server_status_impl(state: &AppState, id: &str) -> Result<ServerStat
 }
 
 pub async fn current_ops_impl(state: &AppState, id: &str) -> Result<Vec<CurrentOp>, String> {
+    let started = std::time::Instant::now();
+    let result = current_ops_impl_inner(state, id).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        None,
+        None,
+        "current_ops",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &"currentOp".to_string(),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn current_ops_impl_inner(state: &AppState, id: &str) -> Result<Vec<CurrentOp>, String> {
     if connection_is_mock(state, id)? {
         return Ok(vec![CurrentOp {
             opid: 10241,
@@ -455,6 +493,25 @@ async fn kill_op_inner(state: &AppState, id: &str, opid: i64) -> Result<(), Stri
 }
 
 pub async fn profiling_status_impl(state: &AppState, id: &str, database: &str) -> Result<ProfilingStatus, String> {
+    let started = std::time::Instant::now();
+    let result = profiling_status_impl_inner(state, id, database).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        None,
+        "get_profiling_status",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &format!("getProfilingStatus {database}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn profiling_status_impl_inner(state: &AppState, id: &str, database: &str) -> Result<ProfilingStatus, String> {
     if connection_is_mock(state, id)? {
         return Ok(ProfilingStatus { level: 0, slow_ms: 100 });
     }
@@ -520,6 +577,30 @@ pub async fn read_profile_impl(
     database: &str,
     limit: i64,
 ) -> Result<Vec<ProfileEntry>, String> {
+    let started = std::time::Instant::now();
+    let result = read_profile_impl_inner(state, id, database, limit).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        Some(database),
+        None,
+        "read_profile",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &format!("readProfile {database}"),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn read_profile_impl_inner(
+    state: &AppState,
+    id: &str,
+    database: &str,
+    limit: i64,
+) -> Result<Vec<ProfileEntry>, String> {
     if connection_is_mock(state, id)? {
         return Ok(vec![ProfileEntry {
             op: "query".into(),
@@ -551,6 +632,25 @@ pub async fn read_profile_impl(
 }
 
 pub async fn repl_set_status_impl(state: &AppState, id: &str) -> Result<ReplSetStatus, String> {
+    let started = std::time::Instant::now();
+    let result = repl_set_status_impl_inner(state, id).await;
+    crate::audit::maybe_record_result(
+        state,
+        Some(id),
+        None,
+        None,
+        "repl_set_status",
+        crate::audit::OpClass::ReadOther,
+        None,
+        started,
+        &"replSetGetStatus".to_string(),
+        None,
+        &result,
+    );
+    result
+}
+
+async fn repl_set_status_impl_inner(state: &AppState, id: &str) -> Result<ReplSetStatus, String> {
     if connection_is_mock(state, id)? {
         return Ok(mock_repl_set_status());
     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -159,6 +159,11 @@ pub struct AppState {
     /// explicit degraded state the UI surfaces, so an unlogged destructive
     /// operation is never mistaken for an audited one.
     pub audit_degraded: Mutex<Option<String>>,
+    /// Terminal events from background tasks that finished while the vault was
+    /// locked (#272). `vault_lock` does not cancel those tasks, so without this
+    /// their operations would stay recorded as `running` forever. Drained on the
+    /// next unlock.
+    pub audit_pending: Arc<Mutex<Vec<crate::audit::AuditEvent>>>,
 }
 
 impl AppState {
@@ -185,6 +190,7 @@ impl AppState {
             mcp: Arc::new(Mutex::new(mcp::McpControl::new())),
             audit: Arc::new(Mutex::new(None)),
             audit_degraded: Mutex::new(None),
+            audit_pending: Arc::new(Mutex::new(Vec::new())),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -148,6 +148,8 @@ pub struct AppState {
     /// full `Arc<AppState>` or a second copy of the token that could drift
     /// out of sync with a `mcp_regenerate_token` call.
     pub mcp: Arc<Mutex<mcp::McpControl>>,
+    /// Open vault-backed audit session (#272). `None` while the vault is locked.
+    pub audit: Mutex<Option<crate::audit::AuditSession>>,
 }
 
 impl AppState {
@@ -172,6 +174,7 @@ impl AppState {
             workspace_write_gen: Arc::new(AtomicU64::new(0)),
             connection_meta: Mutex::new(HashMap::new()),
             mcp: Arc::new(Mutex::new(mcp::McpControl::new())),
+            audit: Mutex::new(None),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -164,6 +164,11 @@ pub struct AppState {
     /// their operations would stay recorded as `running` forever. Drained on the
     /// next unlock.
     pub audit_pending: Arc<Mutex<Vec<crate::audit::AuditEvent>>>,
+    /// Bumped by a vault reset (#272). A `TaskAuditContext` captures the value
+    /// current when its task was queued and refuses to record or park once it
+    /// no longer matches, so a task outlasting the vault it belonged to cannot
+    /// write into the next vault's history.
+    pub audit_generation: Arc<AtomicU64>,
 }
 
 impl AppState {
@@ -191,6 +196,7 @@ impl AppState {
             audit: Arc::new(Mutex::new(None)),
             audit_degraded: Mutex::new(None),
             audit_pending: Arc::new(Mutex::new(Vec::new())),
+            audit_generation: Arc::new(AtomicU64::new(0)),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -149,7 +149,16 @@ pub struct AppState {
     /// out of sync with a `mcp_regenerate_token` call.
     pub mcp: Arc<Mutex<mcp::McpControl>>,
     /// Open vault-backed audit session (#272). `None` while the vault is locked.
-    pub audit: Mutex<Option<crate::audit::AuditSession>>,
+    ///
+    /// `Arc` for the same reason as `mcp`: a spawned background task (import,
+    /// copy, generate, restore) outlives the command that queued it and must
+    /// record its own terminal outcome without holding an `&AppState`.
+    pub audit: Arc<Mutex<Option<crate::audit::AuditSession>>>,
+    /// Why auditing is inactive despite an unlocked vault (#272) — a corrupt or
+    /// unreadable `audit.log.enc`. `Some` puts the app in an
+    /// explicit degraded state the UI surfaces, so an unlogged destructive
+    /// operation is never mistaken for an audited one.
+    pub audit_degraded: Mutex<Option<String>>,
 }
 
 impl AppState {
@@ -174,7 +183,8 @@ impl AppState {
             workspace_write_gen: Arc::new(AtomicU64::new(0)),
             connection_meta: Mutex::new(HashMap::new()),
             mcp: Arc::new(Mutex::new(mcp::McpControl::new())),
-            audit: Mutex::new(None),
+            audit: Arc::new(Mutex::new(None)),
+            audit_degraded: Mutex::new(None),
         }
     }
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2676,6 +2676,10 @@ mod tests {
         assert_eq!(legacy.gemini_model, "gemini-1.5-flash");
         assert_eq!(legacy.ai_custom_instructions, "");
         assert_eq!(legacy.ai_history_retention_months, 3);
+        assert!(legacy.audit_enabled);
+        assert_eq!(legacy.audit_level, "A");
+        assert_eq!(legacy.audit_retention_days, 30);
+        assert!(!legacy.audit_include_payloads);
 
         // resolve_local_command falls back to built-in defaults when unset.
         assert_eq!(

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -2,7 +2,7 @@
 //! AES-256-GCM authenticated encryption. No file I/O and no Tauri types here so
 //! every function is unit-testable in isolation.
 
-use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::aead::{Aead, KeyInit, Payload};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use argon2::{Algorithm, Argon2, Params, Version};
 use rand::Rng;
@@ -52,25 +52,46 @@ pub fn new_nonce() -> [u8; 12] {
 
 /// Encrypt plaintext, returning `nonce(12) || ciphertext+tag`.
 pub fn encrypt(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, String> {
+    encrypt_with_aad(key, plaintext, b"")
+}
+
+/// Encrypt with additional authenticated data.
+///
+/// `aad` is not stored in the blob, but altering it makes decryption fail. The
+/// audit log uses this to authenticate each record's *unencrypted* length
+/// prefix: without it, editing that prefix looks exactly like a partial write.
+pub fn encrypt_with_aad(
+    key: &[u8; 32],
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<Vec<u8>, String> {
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
     let nonce_bytes = new_nonce();
     let nonce = Nonce::from_slice(&nonce_bytes);
     let mut out = nonce_bytes.to_vec();
     let ct = cipher
-        .encrypt(nonce, plaintext)
+        .encrypt(nonce, Payload { msg: plaintext, aad })
         .map_err(|_| "encryption failed".to_string())?;
     out.extend_from_slice(&ct);
     Ok(out)
 }
 
-/// Decrypt a `nonce(12) || ciphertext+tag` blob. Wrong key or tampered bytes -> Err.
 pub fn decrypt(key: &[u8; 32], blob: &[u8]) -> Result<Vec<u8>, String> {
+    decrypt_with_aad(key, blob, b"")
+}
+
+/// Decrypt a blob produced by [`encrypt_with_aad`]. `aad` must match exactly.
+pub fn decrypt_with_aad(
+    key: &[u8; 32],
+    blob: &[u8],
+    aad: &[u8],
+) -> Result<Vec<u8>, String> {
     if blob.len() < 12 {
         return Err("ciphertext too short".to_string());
     }
     let (nonce_bytes, ct) = blob.split_at(12);
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
     cipher
-        .decrypt(Nonce::from_slice(nonce_bytes), ct)
+        .decrypt(Nonce::from_slice(nonce_bytes), Payload { msg: ct, aad })
         .map_err(|_| "decryption failed (wrong password or corrupt data)".to_string())
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,6 +103,7 @@ import { GridFsView } from './components/GridFsView';
 import { MonitoringView } from './components/MonitoringView';
 import { UserManagementView } from './components/UserManagementView';
 import { TaskManager, type ExportTaskInfo } from './components/TaskManager';
+import { ActivityPanel } from './components/ActivityPanel';
 import { VaultGate } from './components/VaultGate';
 import { UpdatePrompt } from './components/UpdatePrompt';
 import { DialogProvider, useDialogs } from './components/dialogs/DialogProvider';
@@ -121,13 +122,13 @@ import { invoke } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { FolderCode, KeyRound, Radio, X, ChevronsRight, XSquare, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck, ExternalLink, MoveRight, Wand2, Lock, ShieldAlert } from 'lucide-react';
+import { FolderCode, KeyRound, Radio, X, ChevronsRight, XSquare, Play, Settings, Terminal, Rocket, Download, Upload, Table2, Eye, HardDrive, Activity, Copy, Users, ListChecks, DatabaseBackup, DatabaseZap, ShieldCheck, ExternalLink, MoveRight, Wand2, Lock, ShieldAlert, ScrollText } from 'lucide-react';
 import logoMark from './assets/logo-mark.svg';
 import { loadTabColors, saveTabColor, TAB_COLORS, tabColorCss, type TabColorId } from './lib/tabColors';
 
 export interface QueryTab {
   id: string;
-  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users' | 'dump' | 'restore' | 'validation' | 'generate' | 'watch';
+  type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'activity' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users' | 'dump' | 'restore' | 'validation' | 'generate' | 'watch';
   connectionId: string;
   db: string;
   collection: string;
@@ -276,6 +277,20 @@ const createTasksTab = (): QueryTab => ({
   explainResult: null,
 });
 
+const ACTIVITY_TAB_ID = 'activity';
+
+const createActivityTab = (): QueryTab => ({
+  id: ACTIVITY_TAB_ID,
+  type: 'activity',
+  connectionId: '',
+  db: '',
+  collection: '',
+  results: [],
+  loading: false,
+  error: null,
+  explainResult: null,
+});
+
 /**
  * The id of the tab that watches a namespace.
  *
@@ -311,6 +326,8 @@ const tabIconFor = (tab: QueryTab, isActive: boolean): React.ReactNode => {
       return <Upload size={size} className={className} />;
     case 'tasks':
       return <ListChecks size={size} className={className} />;
+    case 'activity':
+      return <ScrollText size={size} className={className} />;
     case 'schema':
       return <Table2 size={size} className={className} />;
     case 'create-view':
@@ -362,6 +379,8 @@ export const tabLabelFor = (
       return t('tabs.import', { collection: tab.collection });
     case 'tasks':
       return t('tabs.tasks');
+    case 'activity':
+      return t('tabs.activity');
     case 'schema':
       return t('tabs.schema', { collection: tab.collection });
     case 'create-view':
@@ -1577,6 +1596,16 @@ function Workspace() {
       return;
     }
     dispatchWorkspace({ type: 'open_tab', tabId: TASKS_TAB_ID });
+  };
+
+  const handleOpenActivityTab = () => {
+    if (!tabs.some(t => t.id === ACTIVITY_TAB_ID)) {
+      const activityTab = createActivityTab();
+      setTabs(prev => [...prev, activityTab]);
+      dispatchWorkspace({ type: 'open_tab', tabId: ACTIVITY_TAB_ID }, { tab: activityTab });
+      return;
+    }
+    dispatchWorkspace({ type: 'open_tab', tabId: ACTIVITY_TAB_ID });
   };
 
   const handleOpenExportTab = (sourceTab: QueryTab) => {
@@ -2844,6 +2873,7 @@ function Workspace() {
     { id: 'new-connection', title: tShell('commandPalette.paletteActions.newConnection.title'), keywords: tShell('commandPalette.paletteActions.newConnection.keywords'), run: () => setIsConnectionModalOpen(true) },
     { id: 'toggle-theme', title: tShell('commandPalette.paletteActions.toggleTheme.title'), keywords: tShell('commandPalette.paletteActions.toggleTheme.keywords'), run: toggleTheme },
     { id: 'open-settings', title: tShell('commandPalette.paletteActions.openSettings.title'), keywords: tShell('commandPalette.paletteActions.openSettings.keywords'), run: handleOpenSettingsTab },
+    { id: 'open-activity', title: tShell('commandPalette.paletteActions.openActivity.title'), keywords: tShell('commandPalette.paletteActions.openActivity.keywords'), run: handleOpenActivityTab },
     { id: 'open-quickstart', title: tShell('commandPalette.paletteActions.openQuickstart.title'), keywords: tShell('commandPalette.paletteActions.openQuickstart.keywords'), run: openQuickStartTab },
     { id: 'refresh-palette-index', title: tShell('commandPalette.paletteActions.refreshPaletteIndex.title'), keywords: tShell('commandPalette.paletteActions.refreshPaletteIndex.keywords'), run: () => invalidatePaletteNamespaceIndex() },
     { id: 'density-roomy', title: tShell('commandPalette.paletteActions.densityRoomy.title'), keywords: tShell('commandPalette.paletteActions.densityRoomy.keywords'), run: () => setSpacingDensity('roomy') },
@@ -4313,6 +4343,11 @@ function Workspace() {
               onCancel={handleCancelTask}
               variant="embedded"
             />
+          </div>
+        )}
+        {tab.type === 'activity' && (
+          <div className="h-full" data-testid="activity-view">
+            <ActivityPanel />
           </div>
         )}
         {tab.type === 'watch' && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4515,6 +4515,7 @@ function Workspace() {
           zoomPercent={Math.round(config.uiZoom * 100)}
           onZoomReset={resetZoom}
           onOpenTasks={handleOpenTasksTab}
+          onOpenActivity={handleOpenActivityTab}
           runningTasks={exportTasks.filter((t) => t.status === 'running').length}
         />
       }

--- a/src/components/ActivityPanel.tsx
+++ b/src/components/ActivityPanel.tsx
@@ -1,0 +1,376 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { save } from '@tauri-apps/plugin-dialog';
+import { useTranslation } from 'react-i18next';
+import { Download, FolderOpen, RefreshCw, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+export interface AuditEvent {
+  id: string;
+  ts: number;
+  connectionId?: string | null;
+  profileName?: string | null;
+  database?: string | null;
+  collection?: string | null;
+  op: string;
+  source: string;
+  ok: boolean;
+  error?: string | null;
+  durationMs?: number | null;
+  summary: string;
+  argsJson?: string | null;
+  levelAtRecord: string;
+  schemaVersion: number;
+}
+
+export interface AuditFilter {
+  connectionId?: string;
+  database?: string;
+  collection?: string;
+  op?: string;
+  source?: string;
+  ok?: boolean;
+  tsFrom?: number;
+  tsTo?: number;
+  summaryContains?: string;
+  limit?: number;
+  offset?: number;
+}
+
+type StatusFilter = 'all' | 'ok' | 'error';
+
+function isVaultLockedError(err: unknown): boolean {
+  return String(err).toLowerCase().includes('vault is locked');
+}
+
+function formatTs(ts: number): string {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return String(ts);
+  }
+}
+
+function namespaceOf(ev: AuditEvent): string {
+  if (ev.database && ev.collection) return `${ev.database}.${ev.collection}`;
+  if (ev.database) return ev.database;
+  return '—';
+}
+
+export const ActivityPanel: React.FC = () => {
+  const { t } = useTranslation('shell');
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [locked, setLocked] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dropped, setDropped] = useState(0);
+  const [summaryContains, setSummaryContains] = useState('');
+  const [opFilter, setOpFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const buildFilter = useCallback((): AuditFilter => {
+    const filter: AuditFilter = { limit: 200, offset: 0 };
+    const summary = summaryContains.trim();
+    if (summary) filter.summaryContains = summary;
+    const op = opFilter.trim();
+    if (op) filter.op = op;
+    if (statusFilter === 'ok') filter.ok = true;
+    if (statusFilter === 'error') filter.ok = false;
+    return filter;
+  }, [summaryContains, opFilter, statusFilter]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [list, count] = await Promise.all([
+        invoke<AuditEvent[]>('audit_list', { filter: buildFilter() }),
+        invoke<number>('audit_dropped_count').catch(() => 0),
+      ]);
+      setEvents(list);
+      setDropped(count);
+      setLocked(false);
+    } catch (err) {
+      if (isVaultLockedError(err)) {
+        setLocked(true);
+        setEvents([]);
+      } else {
+        setError(String(err));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [buildFilter]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onExport = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const path = await save({
+        defaultPath: 'mqlens-audit.jsonl',
+        filters: [{ name: 'JSONL', extensions: ['jsonl'] }],
+      });
+      if (!path) return;
+      if (!window.confirm(t('activity.exportPlaintextWarning'))) return;
+      const n = await invoke<number>('audit_export', { filter: buildFilter(), path });
+      setError(null);
+      window.alert(t('activity.exportDone', { count: n }));
+    } catch (err) {
+      if (isVaultLockedError(err)) setLocked(true);
+      else setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onOpenFolder = async () => {
+    try {
+      await invoke('audit_open_folder');
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const onClear = async () => {
+    if (!window.confirm(t('activity.clearConfirm'))) return;
+    setBusy(true);
+    try {
+      await invoke('audit_clear');
+      await load();
+    } catch (err) {
+      if (isVaultLockedError(err)) setLocked(true);
+      else setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (locked) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-8" data-testid="activity-locked">
+        <p className="text-sm font-medium text-foreground">{t('activity.lockedTitle')}</p>
+        <p className="max-w-md text-center text-xs text-muted-foreground">{t('activity.lockedBody')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden" data-testid="activity-panel">
+      <header className="shrink-0 border-b border-border px-4 py-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-foreground">{t('activity.header.title')}</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">{t('activity.header.subtitle')}</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void load()}
+              disabled={loading || busy}
+              data-testid="activity-refresh-btn"
+            >
+              <RefreshCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} />
+              {t('activity.actions.refresh')}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void onExport()}
+              disabled={busy || loading}
+              data-testid="activity-export-btn"
+            >
+              <Download className="h-3.5 w-3.5" />
+              {t('activity.actions.export')}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void onOpenFolder()}
+              disabled={busy}
+              data-testid="activity-open-folder-btn"
+            >
+              <FolderOpen className="h-3.5 w-3.5" />
+              {t('activity.actions.openFolder')}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void onClear()}
+              disabled={busy || loading}
+              data-testid="activity-clear-btn"
+              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              {t('activity.actions.clear')}
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-3 grid gap-3 sm:grid-cols-3">
+          <div className="space-y-1">
+            <Label htmlFor="activity-filter-summary">{t('activity.filters.summary')}</Label>
+            <Input
+              id="activity-filter-summary"
+              data-testid="activity-filter-summary"
+              value={summaryContains}
+              onChange={(e) => setSummaryContains(e.target.value)}
+              placeholder={t('activity.filters.summaryPlaceholder')}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="activity-filter-op">{t('activity.filters.op')}</Label>
+            <Input
+              id="activity-filter-op"
+              data-testid="activity-filter-op"
+              value={opFilter}
+              onChange={(e) => setOpFilter(e.target.value)}
+              placeholder={t('activity.filters.opPlaceholder')}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>{t('activity.filters.status')}</Label>
+            <Select
+              value={statusFilter}
+              onValueChange={(v) => setStatusFilter(v as StatusFilter)}
+            >
+              <SelectTrigger data-testid="activity-filter-status">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t('activity.filters.statusAll')}</SelectItem>
+                <SelectItem value="ok">{t('activity.filters.statusOk')}</SelectItem>
+                <SelectItem value="error">{t('activity.filters.statusError')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </header>
+
+      {dropped > 0 && (
+        <div
+          className="shrink-0 border-b border-border bg-warning/10 px-4 py-2 text-xs text-warning"
+          data-testid="activity-dropped-banner"
+        >
+          {t('activity.droppedBanner', { count: dropped })}
+        </div>
+      )}
+
+      {error && (
+        <div className="shrink-0 border-b border-border bg-destructive/10 px-4 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        {loading && events.length === 0 ? (
+          <p className="p-4 text-xs text-muted-foreground">{t('activity.loading')}</p>
+        ) : events.length === 0 ? (
+          <p className="p-4 text-xs text-muted-foreground" data-testid="activity-empty">
+            {t('activity.empty')}
+          </p>
+        ) : (
+          <table className="w-full min-w-[720px] border-collapse text-left text-xs">
+            <thead className="sticky top-0 bg-muted/80 backdrop-blur">
+              <tr className="border-b border-border text-muted-foreground">
+                <th className="w-6 px-2 py-2" />
+                <th className="px-2 py-2 font-medium">{t('activity.columns.time')}</th>
+                <th className="px-2 py-2 font-medium">{t('activity.columns.op')}</th>
+                <th className="px-2 py-2 font-medium">{t('activity.columns.connection')}</th>
+                <th className="px-2 py-2 font-medium">{t('activity.columns.namespace')}</th>
+                <th className="px-2 py-2 font-medium">{t('activity.columns.source')}</th>
+                <th className="px-2 py-2 font-medium">{t('activity.columns.status')}</th>
+                <th className="px-2 py-2 font-medium">{t('activity.columns.summary')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((ev) => {
+                const open = expandedId === ev.id;
+                return (
+                  <React.Fragment key={ev.id}>
+                    <tr
+                      className="cursor-pointer border-b border-border/60 hover:bg-muted/40"
+                      data-testid={`activity-row-${ev.id}`}
+                      onClick={() => setExpandedId(open ? null : ev.id)}
+                    >
+                      <td className="px-2 py-2 text-muted-foreground">
+                        {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                      </td>
+                      <td className="whitespace-nowrap px-2 py-2 font-mono">{formatTs(ev.ts)}</td>
+                      <td className="px-2 py-2 font-mono">{ev.op}</td>
+                      <td className="px-2 py-2">{ev.profileName || ev.connectionId || '—'}</td>
+                      <td className="px-2 py-2 font-mono">{namespaceOf(ev)}</td>
+                      <td className="px-2 py-2">{ev.source}</td>
+                      <td className="px-2 py-2">
+                        <span className={ev.ok ? 'text-success' : 'text-destructive'}>
+                          {ev.ok ? t('activity.statusOk') : t('activity.statusError')}
+                        </span>
+                      </td>
+                      <td className="max-w-[280px] truncate px-2 py-2" title={ev.summary}>
+                        {ev.summary}
+                      </td>
+                    </tr>
+                    {open && (
+                      <tr className="border-b border-border bg-muted/20" data-testid={`activity-detail-${ev.id}`}>
+                        <td colSpan={8} className="px-4 py-3">
+                          <dl className="grid gap-2 sm:grid-cols-2">
+                            <div>
+                              <dt className="text-muted-foreground">{t('activity.detail.level')}</dt>
+                              <dd className="font-mono">{ev.levelAtRecord}</dd>
+                            </div>
+                            <div>
+                              <dt className="text-muted-foreground">{t('activity.detail.duration')}</dt>
+                              <dd className="font-mono">
+                                {ev.durationMs != null ? `${ev.durationMs} ms` : '—'}
+                              </dd>
+                            </div>
+                            {ev.error && (
+                              <div className="sm:col-span-2">
+                                <dt className="text-muted-foreground">{t('activity.detail.error')}</dt>
+                                <dd className="whitespace-pre-wrap font-mono text-destructive">{ev.error}</dd>
+                              </div>
+                            )}
+                            {ev.argsJson && (
+                              <div className="sm:col-span-2">
+                                <dt className="text-muted-foreground">{t('activity.detail.args')}</dt>
+                                <dd>
+                                  <pre className="mt-1 max-h-48 overflow-auto rounded-md bg-background p-2 font-mono text-[11px]">
+                                    {ev.argsJson}
+                                  </pre>
+                                </dd>
+                              </div>
+                            )}
+                          </dl>
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/ActivityPanel.tsx
+++ b/src/components/ActivityPanel.tsx
@@ -163,12 +163,16 @@ export const ActivityPanel: React.FC = () => {
     }
   };
 
-  const onClear = async () => {
-    if (!window.confirm(t('activity.clearConfirm'))) return;
+  // Only offered for a log that failed verification. There is deliberately no
+  // way to erase an intact log: retention removes old events on its own, and a
+  // one-click wipe would defeat the integrity checks it sits behind.
+  const onDiscardDamaged = async () => {
+    if (!window.confirm(t('activity.discardConfirm'))) return;
     setBusy(true);
     try {
-      await invoke('audit_clear');
+      const removed = await invoke<number>('audit_discard_damaged_log');
       await load();
+      window.alert(t('activity.discardDone', { count: removed }));
     } catch (err) {
       if (isVaultLockedError(err)) setLocked(true);
       else setError(String(err));
@@ -193,6 +197,8 @@ export const ActivityPanel: React.FC = () => {
           <div>
             <h2 className="text-sm font-semibold text-foreground">{t('activity.header.title')}</h2>
             <p className="mt-0.5 text-xs text-muted-foreground">{t('activity.header.subtitle')}</p>
+            {/* Says why there is no "clear" button on an intact log. */}
+            <p className="mt-0.5 text-xs text-muted-foreground">{t('activity.retentionNote')}</p>
           </div>
           <div className="flex flex-wrap gap-2">
             <Button
@@ -217,18 +223,20 @@ export const ActivityPanel: React.FC = () => {
               <Download className="h-3.5 w-3.5" />
               {t('activity.actions.export')}
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => void onClear()}
-              disabled={busy || loading}
-              data-testid="activity-clear-btn"
-              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-              {t('activity.actions.clear')}
-            </Button>
+            {integrityError !== null && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void onDiscardDamaged()}
+                disabled={busy || loading}
+                data-testid="activity-discard-btn"
+                className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                {t('activity.actions.discardDamaged')}
+              </Button>
+            )}
           </div>
         </div>
 

--- a/src/components/ActivityPanel.tsx
+++ b/src/components/ActivityPanel.tsx
@@ -47,6 +47,15 @@ export interface AuditFilter {
   offset?: number;
 }
 
+/// Whether auditing is actually recording, and why not when it isn't.
+export interface AuditStatus {
+  active: boolean;
+  degradedReason?: string | null;
+  /** Set when the on-disk log failed verification: recording has stopped. */
+  integrityError?: string | null;
+  droppedCount: number;
+}
+
 type StatusFilter = 'all' | 'ok' | 'error';
 
 function isVaultLockedError(err: unknown): boolean {
@@ -74,6 +83,8 @@ export const ActivityPanel: React.FC = () => {
   const [locked, setLocked] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dropped, setDropped] = useState(0);
+  const [degradedReason, setDegradedReason] = useState<string | null>(null);
+  const [integrityError, setIntegrityError] = useState<string | null>(null);
   const [summaryContains, setSummaryContains] = useState('');
   const [opFilter, setOpFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
@@ -99,18 +110,26 @@ export const ActivityPanel: React.FC = () => {
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
+    // Status first, and never let it throw: a failed audit session reports the
+    // same "vault is locked" error as an actually-locked vault, and the two must
+    // not look the same to the user.
+    const status = await invoke<AuditStatus>('audit_status').catch(
+      (): AuditStatus => ({ active: true, degradedReason: null, droppedCount: 0 }),
+    );
+    setDropped(status.droppedCount);
+    setIntegrityError(status.integrityError ?? null);
+    const degraded = status.active ? null : (status.degradedReason ?? '');
     try {
-      const [list, count] = await Promise.all([
-        invoke<AuditEvent[]>('audit_list', { filter: buildFilter() }),
-        invoke<number>('audit_dropped_count').catch(() => 0),
-      ]);
+      const list = await invoke<AuditEvent[]>('audit_list', { filter: buildFilter() });
       setEvents(list);
-      setDropped(count);
+      setDegradedReason(degraded);
       setLocked(false);
     } catch (err) {
       if (isVaultLockedError(err)) {
-        setLocked(true);
         setEvents([]);
+        // Unlocked but unable to audit is a degraded state, not a locked vault.
+        setDegradedReason(degraded);
+        setLocked(degraded === null);
       } else {
         setError(String(err));
       }
@@ -253,6 +272,26 @@ export const ActivityPanel: React.FC = () => {
         </div>
       </header>
 
+      {integrityError !== null && (
+        <div
+          className="shrink-0 border-b border-border bg-destructive/10 px-4 py-2 text-xs text-destructive"
+          data-testid="activity-integrity-banner"
+        >
+          {t('activity.integrityBanner', { reason: integrityError })}
+        </div>
+      )}
+
+      {degradedReason !== null && integrityError === null && (
+        <div
+          className="shrink-0 border-b border-border bg-destructive/10 px-4 py-2 text-xs text-destructive"
+          data-testid="activity-degraded-banner"
+        >
+          {t('activity.degradedBanner', {
+            reason: degradedReason || t('activity.degradedUnknownReason'),
+          })}
+        </div>
+      )}
+
       {dropped > 0 && (
         <div
           className="shrink-0 border-b border-border bg-warning/10 px-4 py-2 text-xs text-warning"
@@ -306,14 +345,16 @@ export const ActivityPanel: React.FC = () => {
                       <td className="whitespace-nowrap px-2 py-2 font-mono">{formatTs(ev.ts)}</td>
                       <td className="px-2 py-2 font-mono">{ev.op}</td>
                       <td className="px-2 py-2">{ev.profileName || ev.connectionId || '—'}</td>
-                      <td className="px-2 py-2 font-mono">{namespaceOf(ev)}</td>
+                      <td className="max-w-[320px] truncate px-2 py-2 font-mono" title={namespaceOf(ev)}>
+                        {namespaceOf(ev)}
+                      </td>
                       <td className="px-2 py-2">{ev.source}</td>
                       <td className="px-2 py-2">
                         <span className={ev.ok ? 'text-success' : 'text-destructive'}>
                           {ev.ok ? t('activity.statusOk') : t('activity.statusError')}
                         </span>
                       </td>
-                      <td className="max-w-[280px] truncate px-2 py-2" title={ev.summary}>
+                      <td className="max-w-0 truncate px-2 py-2" title={ev.summary}>
                         {ev.summary}
                       </td>
                     </tr>
@@ -321,6 +362,22 @@ export const ActivityPanel: React.FC = () => {
                       <tr className="border-b border-border bg-muted/20" data-testid={`activity-detail-${ev.id}`}>
                         <td colSpan={8} className="px-4 py-3">
                           <dl className="grid gap-2 sm:grid-cols-2">
+                            {/* The row truncates these to stay scannable, so the
+                                expanded view has to show them in full. */}
+                            <div className="sm:col-span-2">
+                              <dt className="text-muted-foreground">{t('activity.columns.summary')}</dt>
+                              <dd className="break-words font-mono">{ev.summary}</dd>
+                            </div>
+                            <div>
+                              <dt className="text-muted-foreground">{t('activity.columns.namespace')}</dt>
+                              <dd className="break-words font-mono">{namespaceOf(ev)}</dd>
+                            </div>
+                            <div>
+                              <dt className="text-muted-foreground">{t('activity.columns.connection')}</dt>
+                              <dd className="break-words font-mono">
+                                {ev.profileName || ev.connectionId || '—'}
+                              </dd>
+                            </div>
                             <div>
                               <dt className="text-muted-foreground">{t('activity.detail.level')}</dt>
                               <dd className="font-mono">{ev.levelAtRecord}</dd>

--- a/src/components/ActivityPanel.tsx
+++ b/src/components/ActivityPanel.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { save } from '@tauri-apps/plugin-dialog';
 import { useTranslation } from 'react-i18next';
-import { Download, FolderOpen, RefreshCw, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
+import { Download, RefreshCw, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -91,6 +91,11 @@ export const ActivityPanel: React.FC = () => {
     return filter;
   }, [summaryContains, opFilter, statusFilter]);
 
+  const buildExportFilter = useCallback((): AuditFilter => {
+    const { limit: _limit, offset: _offset, ...rest } = buildFilter();
+    return rest;
+  }, [buildFilter]);
+
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -124,11 +129,11 @@ export const ActivityPanel: React.FC = () => {
     try {
       const path = await save({
         defaultPath: 'mqlens-audit.jsonl',
-        filters: [{ name: 'JSONL', extensions: ['jsonl'] }],
+        filters: [{ name: t('activity.exportFileType'), extensions: ['jsonl'] }],
       });
       if (!path) return;
       if (!window.confirm(t('activity.exportPlaintextWarning'))) return;
-      const n = await invoke<number>('audit_export', { filter: buildFilter(), path });
+      const n = await invoke<number>('audit_export', { filter: buildExportFilter(), path });
       setError(null);
       window.alert(t('activity.exportDone', { count: n }));
     } catch (err) {
@@ -136,14 +141,6 @@ export const ActivityPanel: React.FC = () => {
       else setError(String(err));
     } finally {
       setBusy(false);
-    }
-  };
-
-  const onOpenFolder = async () => {
-    try {
-      await invoke('audit_open_folder');
-    } catch (err) {
-      setError(String(err));
     }
   };
 
@@ -200,17 +197,6 @@ export const ActivityPanel: React.FC = () => {
             >
               <Download className="h-3.5 w-3.5" />
               {t('activity.actions.export')}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => void onOpenFolder()}
-              disabled={busy}
-              data-testid="activity-open-folder-btn"
-            >
-              <FolderOpen className="h-3.5 w-3.5" />
-              {t('activity.actions.openFolder')}
             </Button>
             <Button
               type="button"
@@ -286,9 +272,10 @@ export const ActivityPanel: React.FC = () => {
         {loading && events.length === 0 ? (
           <p className="p-4 text-xs text-muted-foreground">{t('activity.loading')}</p>
         ) : events.length === 0 ? (
-          <p className="p-4 text-xs text-muted-foreground" data-testid="activity-empty">
-            {t('activity.empty')}
-          </p>
+          <div className="space-y-1 p-4 text-xs text-muted-foreground" data-testid="activity-empty">
+            <p>{t('activity.empty')}</p>
+            <p>{t('activity.emptyLevelHint')}</p>
+          </div>
         ) : (
           <table className="w-full min-w-[720px] border-collapse text-left text-xs">
             <thead className="sticky top-0 bg-muted/80 backdrop-blur">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -13,6 +13,7 @@ import {
   Wrench,
   Copy,
   Languages,
+  ScrollText,
   type LucideIcon,
 } from 'lucide-react';
 import {
@@ -74,7 +75,25 @@ interface AppSettings {
   local_commands?: Record<string, string>;
   ai_custom_instructions?: string;
   ai_history_retention_months?: number;
+  audit_enabled?: boolean;
+  audit_level?: string;
+  audit_retention_days?: number;
+  audit_include_payloads?: boolean;
   update_channel?: string;
+}
+
+const AUDIT_LEVELS = ['A', 'B', 'C'] as const;
+const AUDIT_RETENTION_DAYS = [7, 30, 90] as const;
+type AuditLevel = (typeof AUDIT_LEVELS)[number];
+
+function normalizeAuditLevel(value: unknown): AuditLevel {
+  const s = String(value ?? 'A').toUpperCase();
+  return (AUDIT_LEVELS as readonly string[]).includes(s) ? (s as AuditLevel) : 'A';
+}
+
+function normalizeAuditRetentionDays(value: unknown): number {
+  const n = Number(value);
+  return (AUDIT_RETENTION_DAYS as readonly number[]).includes(n) ? n : 30;
 }
 
 interface AgentDetection {
@@ -113,6 +132,7 @@ type SettingsTabId =
   | 'updates'
   | 'shortcuts'
   | 'security'
+  | 'audit'
   | 'language';
 
 const SETTINGS_TABS: {
@@ -166,6 +186,13 @@ const SETTINGS_TABS: {
     labelKey: 'security.tabLabel',
     descriptionKey: 'security.tabDescription',
     Icon: ShieldCheck,
+  },
+  {
+    id: 'audit',
+    labelKey: 'audit.tabLabel',
+    descriptionKey: 'audit.tabDescription',
+    Icon: ScrollText,
+    persistFooter: true,
   },
   {
     id: 'language',
@@ -566,6 +593,10 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab, onInstal
   const [historyRetentionMonths, setHistoryRetentionMonths] = useState<AiHistoryRetentionMonths>(
     DEFAULT_AI_HISTORY_RETENTION_MONTHS
   );
+  const [auditEnabled, setAuditEnabled] = useState(true);
+  const [auditLevel, setAuditLevel] = useState<AuditLevel>('A');
+  const [auditRetentionDays, setAuditRetentionDays] = useState(30);
+  const [auditIncludePayloads, setAuditIncludePayloads] = useState(false);
   const [updateChannel, setUpdateChannel] = useState<'stable' | 'dev'>('stable');
   const [agents, setAgents] = useState<AgentDetection[]>([]);
   const [status, setStatus] = useState<string | null>(null);
@@ -614,6 +645,10 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab, onInstal
         setHistoryRetentionMonths(
           normalizeAiHistoryRetentionMonths(s.ai_history_retention_months)
         );
+        setAuditEnabled(s.audit_enabled !== false);
+        setAuditLevel(normalizeAuditLevel(s.audit_level));
+        setAuditRetentionDays(normalizeAuditRetentionDays(s.audit_retention_days));
+        setAuditIncludePayloads(!!s.audit_include_payloads);
         setUpdateChannel(s.update_channel === 'dev' ? 'dev' : 'stable');
         // Keep the localStorage mirror in sync so AI Helper prune uses the vault value.
         saveAiHistoryRetentionMonths(
@@ -662,6 +697,10 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab, onInstal
           local_commands: localCommands,
           ai_custom_instructions: customInstructions,
           ai_history_retention_months: historyRetentionMonths,
+          audit_enabled: auditEnabled,
+          audit_level: auditLevel,
+          audit_retention_days: auditRetentionDays,
+          audit_include_payloads: auditIncludePayloads,
           update_channel: updateChannel,
         },
       });
@@ -1255,6 +1294,96 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ initialTab, onInstal
                 </CardContent>
               </Card>
             </div>
+          </div>
+        );
+
+      case 'audit':
+        return (
+          <div className="grid max-w-2xl gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">{t('audit.enabledTitle')}</CardTitle>
+                <CardDescription>{t('audit.enabledDescription')}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-3">
+                  <Switch
+                    data-testid="audit-enabled-toggle"
+                    checked={auditEnabled}
+                    onCheckedChange={setAuditEnabled}
+                  />
+                  <Label className="font-normal">{t('audit.enabledLabel')}</Label>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">{t('audit.levelTitle')}</CardTitle>
+                <CardDescription>{t('audit.levelDescription')}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <Label htmlFor="audit-level">{t('audit.levelLabel')}</Label>
+                <Select
+                  value={auditLevel}
+                  onValueChange={(v) => setAuditLevel(normalizeAuditLevel(v))}
+                  disabled={!auditEnabled}
+                >
+                  <SelectTrigger id="audit-level" data-testid="audit-level-select">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="A">{t('audit.levelA')}</SelectItem>
+                    <SelectItem value="B">{t('audit.levelB')}</SelectItem>
+                    <SelectItem value="C">{t('audit.levelC')}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">{t('audit.retentionTitle')}</CardTitle>
+                <CardDescription>{t('audit.retentionDescription')}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <Label htmlFor="audit-retention">{t('audit.retentionLabel')}</Label>
+                <Select
+                  value={String(auditRetentionDays)}
+                  onValueChange={(v) => setAuditRetentionDays(normalizeAuditRetentionDays(Number(v)))}
+                  disabled={!auditEnabled}
+                >
+                  <SelectTrigger id="audit-retention" data-testid="audit-retention-select">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AUDIT_RETENTION_DAYS.map((days) => (
+                      <SelectItem key={days} value={String(days)}>
+                        {t('audit.retentionDays', { count: days })}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">{t('audit.payloadsTitle')}</CardTitle>
+                <CardDescription>{t('audit.payloadsDescription')}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-3">
+                  <Switch
+                    data-testid="audit-include-payloads-toggle"
+                    checked={auditIncludePayloads}
+                    disabled={!auditEnabled}
+                    onCheckedChange={setAuditIncludePayloads}
+                  />
+                  <Label className="font-normal">{t('audit.payloadsLabel')}</Label>
+                </div>
+              </CardContent>
+            </Card>
           </div>
         );
 

--- a/src/components/__tests__/ActivityPanel.test.tsx
+++ b/src/components/__tests__/ActivityPanel.test.tsx
@@ -29,6 +29,8 @@ const sampleEvent = {
   schemaVersion: 1,
 };
 
+const activeStatus = { active: true, degradedReason: null, droppedCount: 0 };
+
 describe('ActivityPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -37,7 +39,7 @@ describe('ActivityPanel', () => {
   it('shows a locked-vault empty state when audit_list fails', async () => {
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === 'audit_list') return Promise.reject('vault is locked');
-      if (cmd === 'audit_dropped_count') return Promise.resolve(0);
+      if (cmd === 'audit_status') return Promise.resolve(activeStatus);
       return Promise.resolve(undefined);
     });
 
@@ -50,7 +52,7 @@ describe('ActivityPanel', () => {
   it('lists events and reloads with filter args when searching', async () => {
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === 'audit_list') return Promise.resolve([sampleEvent]);
-      if (cmd === 'audit_dropped_count') return Promise.resolve(0);
+      if (cmd === 'audit_status') return Promise.resolve(activeStatus);
       return Promise.resolve(undefined);
     });
 
@@ -73,5 +75,98 @@ describe('ActivityPanel', () => {
         })
       )
     );
+  });
+
+  it('shows a degraded banner instead of "locked" when the session failed to open', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      // A failed audit session reports the same error as a locked vault.
+      if (cmd === 'audit_list') return Promise.reject('vault is locked');
+      if (cmd === 'audit_status')
+        return Promise.resolve({
+          active: false,
+          degradedReason: 'read audit.log.enc: unrecognized header',
+          droppedCount: 0,
+        });
+      return Promise.resolve(undefined);
+    });
+
+    render(<ActivityPanel />);
+
+    const banner = await screen.findByTestId('activity-degraded-banner');
+    expect(banner).toHaveTextContent(/unrecognized header/i);
+    expect(screen.queryByTestId('activity-locked')).not.toBeInTheDocument();
+  });
+
+  it('still shows the locked state when the vault really is locked', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'audit_list') return Promise.reject('vault is locked');
+      if (cmd === 'audit_status') return Promise.resolve(activeStatus);
+      return Promise.resolve(undefined);
+    });
+
+    render(<ActivityPanel />);
+
+    expect(await screen.findByTestId('activity-locked')).toBeInTheDocument();
+    expect(screen.queryByTestId('activity-degraded-banner')).not.toBeInTheDocument();
+  });
+
+  it('reports dropped events from audit_status', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'audit_list') return Promise.resolve([sampleEvent]);
+      if (cmd === 'audit_status')
+        return Promise.resolve({ active: true, degradedReason: null, droppedCount: 3 });
+      return Promise.resolve(undefined);
+    });
+
+    render(<ActivityPanel />);
+
+    expect(await screen.findByTestId('activity-dropped-banner')).toHaveTextContent('3');
+  });
+
+  it('shows an integrity banner and hides the degraded one when the log is sealed', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      // A sealed log still reads back its verified prefix.
+      if (cmd === 'audit_list') return Promise.resolve([sampleEvent]);
+      if (cmd === 'audit_status')
+        return Promise.resolve({
+          active: false,
+          degradedReason: null,
+          integrityError: 'hash chain broken at record 2',
+          droppedCount: 0,
+        });
+      return Promise.resolve(undefined);
+    });
+
+    render(<ActivityPanel />);
+
+    const banner = await screen.findByTestId('activity-integrity-banner');
+    expect(banner).toHaveTextContent(/hash chain broken/i);
+    // Only one explanation, not two competing banners.
+    expect(screen.queryByTestId('activity-degraded-banner')).not.toBeInTheDocument();
+    // The verified prefix is still listed so the history stays inspectable.
+    expect(screen.getByTestId('activity-row-ev-1')).toBeInTheDocument();
+  });
+
+  it('shows the full summary in the expanded detail, not just the truncated cell', async () => {
+    const longSummary =
+      'copy cidaas-management-test.Rating_SingleRating → cidaas-management-test.Rating_SingleRating11 (completed)';
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'audit_list')
+        return Promise.resolve([{ ...sampleEvent, summary: longSummary }]);
+      if (cmd === 'audit_status') return Promise.resolve(activeStatus);
+      return Promise.resolve(undefined);
+    });
+
+    render(<ActivityPanel />);
+
+    const row = await screen.findByTestId('activity-row-ev-1');
+    // The row cell carries the full text as a tooltip even while truncated.
+    expect(row).toHaveTextContent(/Rating_SingleRating11/);
+
+    fireEvent.click(row);
+
+    const detail = await screen.findByTestId('activity-detail-ev-1');
+    expect(detail).toHaveTextContent(longSummary);
+    expect(detail).toHaveTextContent('sales.orders');
   });
 });

--- a/src/components/__tests__/ActivityPanel.test.tsx
+++ b/src/components/__tests__/ActivityPanel.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ActivityPanel } from '../ActivityPanel';
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  save: vi.fn(),
+}));
+
+const sampleEvent = {
+  id: 'ev-1',
+  ts: 1_700_000_000_000,
+  connectionId: 'conn-1',
+  profileName: 'Local',
+  database: 'sales',
+  collection: 'orders',
+  op: 'dropCollection',
+  source: 'ui',
+  ok: true,
+  error: null,
+  durationMs: 12,
+  summary: 'drop sales.orders',
+  argsJson: null,
+  levelAtRecord: 'A',
+  schemaVersion: 1,
+};
+
+describe('ActivityPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a locked-vault empty state when audit_list fails', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'audit_list') return Promise.reject('vault is locked');
+      if (cmd === 'audit_dropped_count') return Promise.resolve(0);
+      return Promise.resolve(undefined);
+    });
+
+    render(<ActivityPanel />);
+
+    expect(await screen.findByTestId('activity-locked')).toBeInTheDocument();
+    expect(screen.getByTestId('activity-locked')).toHaveTextContent(/locked/i);
+  });
+
+  it('lists events and reloads with filter args when searching', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'audit_list') return Promise.resolve([sampleEvent]);
+      if (cmd === 'audit_dropped_count') return Promise.resolve(0);
+      return Promise.resolve(undefined);
+    });
+
+    render(<ActivityPanel />);
+
+    expect(await screen.findByTestId('activity-row-ev-1')).toBeInTheDocument();
+    expect(screen.getByText('dropCollection')).toBeInTheDocument();
+    expect(screen.getByText(/drop sales\.orders/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('activity-filter-summary'), {
+      target: { value: 'drop' },
+    });
+    fireEvent.click(screen.getByTestId('activity-refresh-btn'));
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'audit_list',
+        expect.objectContaining({
+          filter: expect.objectContaining({ summaryContains: 'drop' }),
+        })
+      )
+    );
+  });
+});

--- a/src/components/__tests__/ActivityPanel.test.tsx
+++ b/src/components/__tests__/ActivityPanel.test.tsx
@@ -169,4 +169,48 @@ describe('ActivityPanel', () => {
     expect(detail).toHaveTextContent(longSummary);
     expect(detail).toHaveTextContent('sales.orders');
   });
+
+  it('offers no way to erase an intact log', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'audit_list') return Promise.resolve([sampleEvent]);
+      if (cmd === 'audit_status') return Promise.resolve(activeStatus);
+      return Promise.resolve(undefined);
+    });
+
+    render(<ActivityPanel />);
+    await screen.findByTestId('activity-row-ev-1');
+
+    // Retention is the only thing that removes events from a healthy log.
+    expect(screen.queryByTestId('activity-discard-btn')).not.toBeInTheDocument();
+  });
+
+  it('offers discard only for a damaged log, and reports what it removed', async () => {
+    const invoked: string[] = [];
+    mockInvoke.mockImplementation((cmd: string) => {
+      invoked.push(cmd);
+      if (cmd === 'audit_list') return Promise.resolve([]);
+      if (cmd === 'audit_status')
+        return Promise.resolve({
+          active: false,
+          degradedReason: null,
+          integrityError: 'hash chain broken at record 2',
+          droppedCount: 0,
+        });
+      if (cmd === 'audit_discard_damaged_log') return Promise.resolve(7);
+      return Promise.resolve(undefined);
+    });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+
+    render(<ActivityPanel />);
+    const btn = await screen.findByTestId('activity-discard-btn');
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(invoked).toContain('audit_discard_damaged_log'));
+    expect(confirmSpy).toHaveBeenCalled();
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('7')));
+
+    confirmSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
 });

--- a/src/components/__tests__/SettingsModal.test.tsx
+++ b/src/components/__tests__/SettingsModal.test.tsx
@@ -289,6 +289,62 @@ describe('SettingsView Component', () => {
     expect(localStorage.getItem('mqlens_ai_history_retention_months')).toBe('12');
   });
 
+  it('loads and saves audit logging settings', async () => {
+    mockInvoke.mockImplementation(
+      (
+        cmd: string,
+        args?: {
+          settings?: {
+            audit_enabled?: boolean;
+            audit_level?: string;
+            audit_retention_days?: number;
+            audit_include_payloads?: boolean;
+          };
+        }
+      ) => {
+        if (cmd === 'load_app_settings') {
+          return Promise.resolve({
+            mongosh_path: '',
+            audit_enabled: true,
+            audit_level: 'A',
+            audit_retention_days: 30,
+            audit_include_payloads: false,
+          });
+        }
+        if (cmd === 'save_app_settings') {
+          expect(args?.settings?.audit_enabled).toBe(true);
+          expect(args?.settings?.audit_level).toBe('C');
+          expect(args?.settings?.audit_retention_days).toBe(90);
+          expect(args?.settings?.audit_include_payloads).toBe(true);
+          return Promise.resolve();
+        }
+        if (cmd === 'detect_local_agents') return Promise.resolve([]);
+        if (cmd === 'managed_tools_status') return Promise.resolve([]);
+        return Promise.resolve(undefined);
+      }
+    );
+
+    renderSettings();
+    await openTab('settings-tab-audit');
+
+    const levelTrigger = await screen.findByTestId('audit-level-select');
+    await waitFor(() => expect(levelTrigger).toHaveTextContent(/A\b|writes/i));
+
+    fireEvent.click(levelTrigger);
+    fireEvent.click(screen.getByRole('option', { name: /C\b|all/i }));
+
+    const retentionTrigger = screen.getByTestId('audit-retention-select');
+    fireEvent.click(retentionTrigger);
+    fireEvent.click(screen.getByRole('option', { name: /90/i }));
+
+    fireEvent.click(screen.getByTestId('audit-include-payloads-toggle'));
+    fireEvent.click(screen.getByTestId('settings-save-btn'));
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('save_app_settings', expect.any(Object))
+    );
+  });
+
   it('shows last update check status on the updates tab', async () => {
     writeUpdateCheckSnapshot({
       checkedAt: '2026-06-15T12:00:00.000Z',

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { ListChecks } from "lucide-react";
+import { ListChecks, ScrollText } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import {
@@ -18,6 +18,8 @@ interface StatusBarProps {
   onZoomReset?: () => void;
   /** Open the dedicated Tasks tab. */
   onOpenTasks?: () => void;
+  /** Open the Activity audit log tab. */
+  onOpenActivity?: () => void;
   /** Number of currently-running background tasks, shown as a badge. */
   runningTasks?: number;
   className?: string;
@@ -31,9 +33,11 @@ export function StatusBar({
   zoomPercent,
   onZoomReset,
   onOpenTasks,
+  onOpenActivity,
   runningTasks = 0,
   className,
 }: StatusBarProps) {
+  const showQuickLinks = onOpenTasks || onOpenActivity;
   const { t } = useTranslation('shell');
   const showZoom = zoomPercent != null && zoomPercent !== 100;
 
@@ -66,32 +70,52 @@ export function StatusBar({
           </TooltipContent>
         </Tooltip>
       )}
-      {onOpenTasks && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              data-testid="status-bar-tasks"
-              className="ml-auto flex items-center gap-1 transition-colors hover:text-foreground"
-              onClick={onOpenTasks}
-            >
-              <ListChecks size={12} />
-              <span>{t('statusBar.tasks')}</span>
-              {runningTasks > 0 && (
-                <span className="rounded-full bg-primary px-1.5 text-[10px] font-medium tabular-nums text-primary-foreground">
-                  {runningTasks}
-                </span>
-              )}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            {runningTasks > 0
-              ? t('statusBar.runningTasks', { count: runningTasks })
-              : t('statusBar.backgroundTasks')}
-          </TooltipContent>
-        </Tooltip>
+      {showQuickLinks && (
+        <div className="ml-auto flex items-center gap-3">
+          {onOpenActivity && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  data-testid="status-bar-activity"
+                  className="flex items-center gap-1 transition-colors hover:text-foreground"
+                  onClick={onOpenActivity}
+                >
+                  <ScrollText size={12} />
+                  <span>{t('statusBar.activity')}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">{t('statusBar.openActivity')}</TooltipContent>
+            </Tooltip>
+          )}
+          {onOpenTasks && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  data-testid="status-bar-tasks"
+                  className="flex items-center gap-1 transition-colors hover:text-foreground"
+                  onClick={onOpenTasks}
+                >
+                  <ListChecks size={12} />
+                  <span>{t('statusBar.tasks')}</span>
+                  {runningTasks > 0 && (
+                    <span className="rounded-full bg-primary px-1.5 text-[10px] font-medium tabular-nums text-primary-foreground">
+                      {runningTasks}
+                    </span>
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {runningTasks > 0
+                  ? t('statusBar.runningTasks', { count: runningTasks })
+                  : t('statusBar.backgroundTasks')}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
       )}
-      <span className={onOpenTasks ? "" : "ml-auto"}>{t('statusBar.appVersion', { version: appVersion ?? '' })}</span>
+      <span className={showQuickLinks ? "" : "ml-auto"}>{t('statusBar.appVersion', { version: appVersion ?? '' })}</span>
     </footer>
   );
 }

--- a/src/components/layout/__tests__/StatusBar.test.tsx
+++ b/src/components/layout/__tests__/StatusBar.test.tsx
@@ -39,4 +39,11 @@ describe('StatusBar', () => {
     fireEvent.click(screen.getByTestId('status-bar-zoom'));
     expect(onZoomReset).toHaveBeenCalledTimes(1);
   });
+
+  it('calls onOpenActivity when the activity link is clicked', () => {
+    const onOpenActivity = vi.fn();
+    renderStatusBar({ onOpenActivity });
+    fireEvent.click(screen.getByTestId('status-bar-activity'));
+    expect(onOpenActivity).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -26,7 +26,8 @@
     "tasks": "Aufgaben",
     "users": "Benutzer: {{name}}",
     "validation": "Validierung: {{collection}}",
-    "watch": "Beobachten: {{target}}"
+    "watch": "Beobachten: {{target}}",
+    "activity": "Aktivität"
   },
   "toast": {
     "aggregationPipelineApplied": "Aggregationspipeline angewendet",

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -34,7 +34,7 @@
     "levelTitle": "Ausführlichkeit",
     "payloadsDescription": "Standardmäßig aus. Wenn aktiv, speichert Dokumentfragmente und vollständige Filter bis zu einer Größenbegrenzung pro Ereignis.",
     "payloadsLabel": "Dokument-Payloads einbeziehen",
-    "payloadsTitle": "Payloads",
+    "payloadsTitle": "Dokumentinhalte",
     "retentionDays_one": "{{count}} Tag",
     "retentionDays_other": "{{count}} Tage",
     "retentionDescription": "Ältere Ereignisse werden automatisch entfernt. Standard sind 30 Tage.",

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -22,6 +22,27 @@
     "tabDescription": "Cloud-API-Schlüssel, lokale Agenten, individuelle Abfrageanweisungen und KI-Helfer-Verlaufsdauer.",
     "tabLabel": "KI-Assistent"
   },
+  "audit": {
+    "enabledDescription": "Aktiviert die Aufzeichnung ausgewählter Datenbankoperationen in einem tresorverschlüsselten lokalen Protokoll.",
+    "enabledLabel": "Aktivitätsprotokollierung aktivieren",
+    "enabledTitle": "Aktivitätsprotokoll",
+    "levelA": "A — Schreibvorgänge und mongosh",
+    "levelB": "B — Schreibvorgänge, mongosh und leseintensive Operationen",
+    "levelC": "C — Alle Datenbankoperationen",
+    "levelDescription": "A deckt Löschen, Aktualisieren, Drop und Shell ab. B ergänzt Aggregationen und Explain. C zeichnet jede DB-Operation auf.",
+    "levelLabel": "Detailstufe",
+    "levelTitle": "Ausführlichkeit",
+    "payloadsDescription": "Standardmäßig aus. Wenn aktiv, speichert Dokumentfragmente und vollständige Filter bis zu einer Größenbegrenzung pro Ereignis.",
+    "payloadsLabel": "Dokument-Payloads einbeziehen",
+    "payloadsTitle": "Payloads",
+    "retentionDays_one": "{{count}} Tag",
+    "retentionDays_other": "{{count}} Tage",
+    "retentionDescription": "Ältere Ereignisse werden automatisch entfernt. Standard sind 30 Tage.",
+    "retentionLabel": "Ereignisse behalten für",
+    "retentionTitle": "Aufbewahrung",
+    "tabDescription": "Lokale Operationsprotokollierung zur Untersuchung versehentlicher Löschungen und zerstörerischer Änderungen.",
+    "tabLabel": "Aktivität"
+  },
   "appearance": {
     "colorMode": "Farbmodus",
     "compact": "Kompakt",

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -550,11 +550,10 @@
   },
   "activity": {
     "actions": {
-      "clear": "Protokoll leeren",
+      "discardDamaged": "Beschädigtes Protokoll verwerfen",
       "export": "Exportieren…",
       "refresh": "Aktualisieren"
     },
-    "clearConfirm": "Alle Aktivitätsereignisse in diesem Tresor löschen? Das kann nicht rückgängig gemacht werden.",
     "columns": {
       "connection": "Verbindung",
       "namespace": "Namensraum",
@@ -572,6 +571,9 @@
       "error": "Fehler",
       "level": "Stufe bei Aufzeichnung"
     },
+    "discardConfirm": "Dieses beschädigte Aktivitätsprotokoll verwerfen? Seine nicht überprüfbaren Ereignisse können nicht wiederhergestellt werden. Ein dauerhafter Vermerk über das Verwerfen bleibt erhalten.",
+    "discardDone_one": "1 nicht überprüfbares Ereignis verworfen. Die Aufzeichnung läuft wieder, und ein Vermerk über das Verwerfen bleibt im Protokoll.",
+    "discardDone_other": "{{count}} nicht überprüfbare Ereignisse verworfen. Die Aufzeichnung läuft wieder, und ein Vermerk über das Verwerfen bleibt im Protokoll.",
     "droppedBanner_one": "{{count}} Ereignis wurde in dieser Sitzung verworfen (Speicher- oder Verschlüsselungsfehler).",
     "droppedBanner_other": "{{count}} Ereignisse wurden in dieser Sitzung verworfen (Speicher- oder Verschlüsselungsfehler).",
     "empty": "Noch keine Aktivität für die aktuellen Filter.",
@@ -594,10 +596,11 @@
       "subtitle": "Lokales, tresorverschlüsseltes Protokoll von Datenbankoperationen.",
       "title": "Aktivität"
     },
-    "integrityBanner": "Integritätsprüfung des Aktivitätsprotokolls fehlgeschlagen: {{reason}}. Die Aufzeichnung wurde gestoppt und die Datei bleibt erhalten. Mit „Leeren“ ein neues Protokoll beginnen.",
+    "integrityBanner": "Integritätsprüfung des Aktivitätsprotokolls fehlgeschlagen: {{reason}}. Die Aufzeichnung wurde gestoppt und die Datei bleibt erhalten. Verwirf das beschädigte Protokoll, um die Aufzeichnung fortzusetzen.",
     "loading": "Aktivität wird geladen…",
     "lockedBody": "Entsperre den Tresor, um das Aktivitätsprotokoll anzuzeigen und zu exportieren.",
     "lockedTitle": "Tresor ist gesperrt",
+    "retentionNote": "Alte Ereignisse werden automatisch durch die Aufbewahrungseinstellung entfernt. Ein intaktes Protokoll kann nicht gelöscht werden.",
     "statusError": "Fehlgeschlagen",
     "statusOk": "Erfolgreich"
   }

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -147,6 +147,10 @@
       "toggleTheme": {
         "keywords": "darstellung farbe modus appearance color",
         "title": "Hell-/Dunkelmodus umschalten"
+      },
+      "openActivity": {
+        "title": "Aktivität öffnen",
+        "keywords": "audit protokoll historie operationen löschen drop"
       }
     },
     "results_one": "{{count}} Ergebnis",
@@ -541,5 +545,54 @@
       },
       "unmirroredExplanation": "Export-/Import-Tabs bleiben in ihrem Fenster"
     }
+  },
+  "activity": {
+    "actions": {
+      "clear": "Protokoll leeren",
+      "export": "Exportieren…",
+      "openFolder": "Ordner öffnen",
+      "refresh": "Aktualisieren"
+    },
+    "clearConfirm": "Alle Aktivitätsereignisse in diesem Tresor löschen? Das kann nicht rückgängig gemacht werden.",
+    "columns": {
+      "connection": "Verbindung",
+      "namespace": "Namensraum",
+      "op": "Operation",
+      "source": "Quelle",
+      "status": "Status",
+      "summary": "Zusammenfassung",
+      "time": "Zeit"
+    },
+    "detail": {
+      "args": "Argumente",
+      "duration": "Dauer",
+      "error": "Fehler",
+      "level": "Stufe bei Aufzeichnung"
+    },
+    "droppedBanner_one": "{{count}} Ereignis wurde in dieser Sitzung verworfen (Speicher- oder Verschlüsselungsfehler).",
+    "droppedBanner_other": "{{count}} Ereignisse wurden in dieser Sitzung verworfen (Speicher- oder Verschlüsselungsfehler).",
+    "empty": "Noch keine Aktivität für die aktuellen Filter.",
+    "exportDone_one": "{{count}} Ereignis exportiert.",
+    "exportDone_other": "{{count}} Ereignisse exportiert.",
+    "exportPlaintextWarning": "Der Export schreibt eine Klartext-JSONL-Datei außerhalb des Tresors. Fortfahren?",
+    "filters": {
+      "op": "Operation",
+      "opPlaceholder": "z. B. dropCollection",
+      "status": "Status",
+      "statusAll": "Alle",
+      "statusError": "Fehlgeschlagen",
+      "statusOk": "Erfolgreich",
+      "summary": "Zusammenfassung enthält",
+      "summaryPlaceholder": "Zusammenfassung suchen…"
+    },
+    "header": {
+      "subtitle": "Lokales, tresorverschlüsseltes Protokoll von Datenbankoperationen.",
+      "title": "Aktivität"
+    },
+    "loading": "Aktivität wird geladen…",
+    "lockedBody": "Entsperre den Tresor, um das Aktivitätsprotokoll anzuzeigen und zu exportieren.",
+    "lockedTitle": "Tresor ist gesperrt",
+    "statusError": "Fehlgeschlagen",
+    "statusOk": "OK"
   }
 }

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -564,6 +564,8 @@
       "summary": "Zusammenfassung",
       "time": "Zeit"
     },
+    "degradedBanner": "Die Aktivitätsprotokollierung läuft nicht: {{reason}}. Jetzt ausgeführte Operationen werden nicht aufgezeichnet.",
+    "degradedUnknownReason": "das verschlüsselte Protokoll konnte nicht geöffnet werden",
     "detail": {
       "args": "Argumente",
       "duration": "Dauer",
@@ -592,6 +594,7 @@
       "subtitle": "Lokales, tresorverschlüsseltes Protokoll von Datenbankoperationen.",
       "title": "Aktivität"
     },
+    "integrityBanner": "Integritätsprüfung des Aktivitätsprotokolls fehlgeschlagen: {{reason}}. Die Aufzeichnung wurde gestoppt und die Datei bleibt erhalten. Mit „Leeren“ ein neues Protokoll beginnen.",
     "loading": "Aktivität wird geladen…",
     "lockedBody": "Entsperre den Tresor, um das Aktivitätsprotokoll anzuzeigen und zu exportieren.",
     "lockedTitle": "Tresor ist gesperrt",

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -348,11 +348,13 @@
     "reconnectButton": "Erneut mit {{profile}} verbinden"
   },
   "statusBar": {
+    "activity": "Aktivität",
     "appVersion": "MQLens {{version}}",
     "backgroundTasks": "Hintergrundaufgaben",
     "cpu": "CPU {{value}}",
     "engineOnline": "MQLens-Engine online",
     "mongodb": "MongoDB {{value}}",
+    "openActivity": "Aktivitätsprotokoll öffnen",
     "ram": "RAM {{value}}",
     "resetZoom": "Zoom zurücksetzen ({{shortcut}})",
     "runningTasks_one": "{{count}} laufende Aufgabe",
@@ -550,16 +552,15 @@
     "actions": {
       "clear": "Protokoll leeren",
       "export": "Exportieren…",
-      "openFolder": "Ordner öffnen",
       "refresh": "Aktualisieren"
     },
     "clearConfirm": "Alle Aktivitätsereignisse in diesem Tresor löschen? Das kann nicht rückgängig gemacht werden.",
     "columns": {
       "connection": "Verbindung",
       "namespace": "Namensraum",
-      "op": "Operation",
+      "op": "Vorgang",
       "source": "Quelle",
-      "status": "Status",
+      "status": "Ergebnis",
       "summary": "Zusammenfassung",
       "time": "Zeit"
     },
@@ -572,13 +573,15 @@
     "droppedBanner_one": "{{count}} Ereignis wurde in dieser Sitzung verworfen (Speicher- oder Verschlüsselungsfehler).",
     "droppedBanner_other": "{{count}} Ereignisse wurden in dieser Sitzung verworfen (Speicher- oder Verschlüsselungsfehler).",
     "empty": "Noch keine Aktivität für die aktuellen Filter.",
+    "emptyLevelHint": "Bei Audit-Stufe A (Standard) werden nur Schreibvorgänge und Shell-Befehle protokolliert — keine Finds oder Navigation.",
     "exportDone_one": "{{count}} Ereignis exportiert.",
     "exportDone_other": "{{count}} Ereignisse exportiert.",
+    "exportFileType": "JSONL-Datei",
     "exportPlaintextWarning": "Der Export schreibt eine Klartext-JSONL-Datei außerhalb des Tresors. Fortfahren?",
     "filters": {
-      "op": "Operation",
+      "op": "Vorgang",
       "opPlaceholder": "z. B. dropCollection",
-      "status": "Status",
+      "status": "Ergebnis",
       "statusAll": "Alle",
       "statusError": "Fehlgeschlagen",
       "statusOk": "Erfolgreich",
@@ -593,6 +596,6 @@
     "lockedBody": "Entsperre den Tresor, um das Aktivitätsprotokoll anzuzeigen und zu exportieren.",
     "lockedTitle": "Tresor ist gesperrt",
     "statusError": "Fehlgeschlagen",
-    "statusOk": "OK"
+    "statusOk": "Erfolgreich"
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -12,6 +12,7 @@
   },
   "save": "Save",
   "tabs": {
+    "activity": "Activity",
     "createView": "New View: {{db}}",
     "dump": "Dump: {{name}}",
     "export": "Export: {{collection}}",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -82,6 +82,27 @@
     "uiFont": "UI font",
     "zoomShortcutHint": "Shortcut: {{shortcut}} to reset"
   },
+  "audit": {
+    "enabledDescription": "When enabled, MQLens records selected database operations in a vault-encrypted local log.",
+    "enabledLabel": "Enable activity logging",
+    "enabledTitle": "Activity log",
+    "levelA": "A — Writes and mongosh",
+    "levelB": "B — Writes, mongosh, and high-impact reads",
+    "levelC": "C — All database operations",
+    "levelDescription": "A covers deletes, updates, drops, and shell. B adds aggregations and explain. C records every DB op.",
+    "levelLabel": "Detail level",
+    "levelTitle": "Verbosity",
+    "payloadsDescription": "Off by default. When on, stores document fragments and full filters up to a per-event size cap.",
+    "payloadsLabel": "Include document payloads",
+    "payloadsTitle": "Payloads",
+    "retentionDays_one": "{{count}} day",
+    "retentionDays_other": "{{count}} days",
+    "retentionDescription": "Older events are removed automatically. Default is 30 days.",
+    "retentionLabel": "Keep events for",
+    "retentionTitle": "Retention",
+    "tabDescription": "Local operation logging for investigating accidental wipes and destructive changes.",
+    "tabLabel": "Activity"
+  },
   "footer": {
     "saveChanges": "Save changes",
     "saving": "Saving...",

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -15,6 +15,8 @@
       "summary": "Summary",
       "time": "Time"
     },
+    "degradedBanner": "Activity logging is not running: {{reason}}. Operations performed now are not being recorded.",
+    "degradedUnknownReason": "the encrypted log could not be opened",
     "detail": {
       "args": "Arguments",
       "duration": "Duration",
@@ -43,6 +45,7 @@
       "subtitle": "Local vault-encrypted log of database operations.",
       "title": "Activity"
     },
+    "integrityBanner": "Activity log integrity check failed: {{reason}}. Recording has stopped and the file is being preserved. Use Clear to start a new log.",
     "loading": "Loading activity…",
     "lockedBody": "Unlock the vault to view and export the activity log.",
     "lockedTitle": "Vault is locked",

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -1,11 +1,10 @@
 {
   "activity": {
     "actions": {
-      "clear": "Clear log",
+      "discardDamaged": "Discard damaged log",
       "export": "Export…",
       "refresh": "Refresh"
     },
-    "clearConfirm": "Clear all activity events from this vault? This cannot be undone.",
     "columns": {
       "connection": "Connection",
       "namespace": "Namespace",
@@ -23,6 +22,9 @@
       "error": "Error",
       "level": "Level at record"
     },
+    "discardConfirm": "Discard this damaged activity log? Its unverifiable events cannot be recovered. A permanent record that the log was discarded will be kept.",
+    "discardDone_one": "1 unverifiable event discarded. Recording has resumed, and a record of the discard is kept in the log.",
+    "discardDone_other": "{{count}} unverifiable events discarded. Recording has resumed, and a record of the discard is kept in the log.",
     "droppedBanner_one": "{{count}} event was dropped this session (storage or encryption failures).",
     "droppedBanner_other": "{{count}} events were dropped this session (storage or encryption failures).",
     "empty": "No activity recorded yet for the current filters.",
@@ -45,10 +47,11 @@
       "subtitle": "Local vault-encrypted log of database operations.",
       "title": "Activity"
     },
-    "integrityBanner": "Activity log integrity check failed: {{reason}}. Recording has stopped and the file is being preserved. Use Clear to start a new log.",
+    "integrityBanner": "Activity log integrity check failed: {{reason}}. Recording has stopped and the file is being preserved. Discard the damaged log to resume recording.",
     "loading": "Loading activity…",
     "lockedBody": "Unlock the vault to view and export the activity log.",
     "lockedTitle": "Vault is locked",
+    "retentionNote": "Old events are removed automatically by the retention setting. An intact log cannot be erased.",
     "statusError": "Failed",
     "statusOk": "OK"
   },

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -1,4 +1,53 @@
 {
+  "activity": {
+    "actions": {
+      "clear": "Clear log",
+      "export": "Export…",
+      "openFolder": "Open folder",
+      "refresh": "Refresh"
+    },
+    "clearConfirm": "Clear all activity events from this vault? This cannot be undone.",
+    "columns": {
+      "connection": "Connection",
+      "namespace": "Namespace",
+      "op": "Operation",
+      "source": "Source",
+      "status": "Status",
+      "summary": "Summary",
+      "time": "Time"
+    },
+    "detail": {
+      "args": "Arguments",
+      "duration": "Duration",
+      "error": "Error",
+      "level": "Level at record"
+    },
+    "droppedBanner_one": "{{count}} event was dropped this session (storage or encryption failures).",
+    "droppedBanner_other": "{{count}} events were dropped this session (storage or encryption failures).",
+    "empty": "No activity recorded yet for the current filters.",
+    "exportDone_one": "Exported {{count}} event.",
+    "exportDone_other": "Exported {{count}} events.",
+    "exportPlaintextWarning": "Export writes a plaintext JSONL file outside the vault. Continue?",
+    "filters": {
+      "op": "Operation",
+      "opPlaceholder": "e.g. dropCollection",
+      "status": "Status",
+      "statusAll": "All",
+      "statusError": "Failed",
+      "statusOk": "Succeeded",
+      "summary": "Summary contains",
+      "summaryPlaceholder": "Search summary…"
+    },
+    "header": {
+      "subtitle": "Local vault-encrypted log of database operations.",
+      "title": "Activity"
+    },
+    "loading": "Loading activity…",
+    "lockedBody": "Unlock the vault to view and export the activity log.",
+    "lockedTitle": "Vault is locked",
+    "statusError": "Failed",
+    "statusOk": "OK"
+  },
   "aiChatPanel": {
     "actions": {
       "copy": "Copy",
@@ -111,6 +160,10 @@
       "nextTab": {
         "keywords": "tab switch",
         "title": "Next Tab"
+      },
+      "openActivity": {
+        "keywords": "audit log history operations wipe drop",
+        "title": "Open Activity"
       },
       "openMonitoring": {
         "keywords": "monitoring metrics server status profiler",

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -3,7 +3,6 @@
     "actions": {
       "clear": "Clear log",
       "export": "Export…",
-      "openFolder": "Open folder",
       "refresh": "Refresh"
     },
     "clearConfirm": "Clear all activity events from this vault? This cannot be undone.",
@@ -25,8 +24,10 @@
     "droppedBanner_one": "{{count}} event was dropped this session (storage or encryption failures).",
     "droppedBanner_other": "{{count}} events were dropped this session (storage or encryption failures).",
     "empty": "No activity recorded yet for the current filters.",
+    "emptyLevelHint": "At audit level A (default), only writes and shell commands are logged — not finds or browsing.",
     "exportDone_one": "Exported {{count}} event.",
     "exportDone_other": "Exported {{count}} events.",
+    "exportFileType": "JSONL",
     "exportPlaintextWarning": "Export writes a plaintext JSONL file outside the vault. Continue?",
     "filters": {
       "op": "Operation",
@@ -397,11 +398,13 @@
     "reconnectButton": "Reconnect {{profile}}"
   },
   "statusBar": {
+    "activity": "Activity",
     "appVersion": "MQLens {{version}}",
     "backgroundTasks": "Background tasks",
     "cpu": "CPU {{value}}",
     "engineOnline": "MQLens Engine Online",
     "mongodb": "MongoDB {{value}}",
+    "openActivity": "Open activity log",
     "ram": "RAM {{value}}",
     "resetZoom": "Reset zoom ({{shortcut}})",
     "runningTasks_one": "{{count}} running task",

--- a/src/locales/zh-Hans/common.json
+++ b/src/locales/zh-Hans/common.json
@@ -26,7 +26,8 @@
     "tasks": "任务",
     "users": "用户：{{name}}",
     "validation": "校验规则：{{collection}}",
-    "watch": "监听：{{target}}"
+    "watch": "监听：{{target}}",
+    "activity": "活动"
   },
   "toast": {
     "aggregationPipelineApplied": "已应用聚合管道",

--- a/src/locales/zh-Hans/settings.json
+++ b/src/locales/zh-Hans/settings.json
@@ -21,6 +21,26 @@
     "tabDescription": "云端 API 密钥、本地代理、自定义查询指令，以及 AI 助手历史记录的保留时长。",
     "tabLabel": "AI 助手"
   },
+  "audit": {
+    "enabledDescription": "启用后，MQLens 会将选定的数据库操作记录到经密钥库加密的本地日志中。",
+    "enabledLabel": "启用活动日志",
+    "enabledTitle": "活动日志",
+    "levelA": "A — 写入与 mongosh",
+    "levelB": "B — 写入、mongosh 与高影响读取",
+    "levelC": "C — 全部数据库操作",
+    "levelDescription": "A 覆盖删除、更新、删除集合/库与 Shell。B 增加聚合与 explain。C 记录每一次数据库操作。",
+    "levelLabel": "详细级别",
+    "levelTitle": "详细程度",
+    "payloadsDescription": "默认关闭。开启后会存储文档片段与完整过滤条件，并受单事件大小上限约束。",
+    "payloadsLabel": "包含文档载荷",
+    "payloadsTitle": "载荷",
+    "retentionDays_other": "{{count}} 天",
+    "retentionDescription": "更早的事件会自动删除。默认保留 30 天。",
+    "retentionLabel": "事件保留时长",
+    "retentionTitle": "保留期限",
+    "tabDescription": "本地操作日志，用于排查误删与破坏性变更。",
+    "tabLabel": "活动"
+  },
   "appearance": {
     "colorMode": "配色模式",
     "compact": "紧凑",

--- a/src/locales/zh-Hans/shell.json
+++ b/src/locales/zh-Hans/shell.json
@@ -552,6 +552,8 @@
       "summary": "摘要",
       "time": "时间"
     },
+    "degradedBanner": "活动日志未在运行：{{reason}}。当前执行的操作不会被记录。",
+    "degradedUnknownReason": "无法打开加密日志",
     "detail": {
       "args": "参数",
       "duration": "耗时",
@@ -578,6 +580,7 @@
       "subtitle": "本地、经密钥库加密的数据库操作日志。",
       "title": "活动"
     },
+    "integrityBanner": "活动日志完整性校验失败：{{reason}}。记录已停止，文件将被保留。使用“清空”可开始新的日志。",
     "loading": "正在加载活动…",
     "lockedBody": "解锁密钥库后即可查看和导出活动日志。",
     "lockedTitle": "密钥库已锁定",

--- a/src/locales/zh-Hans/shell.json
+++ b/src/locales/zh-Hans/shell.json
@@ -345,11 +345,13 @@
     "reconnectButton": "重新连接 {{profile}}"
   },
   "statusBar": {
+    "activity": "活动",
     "appVersion": "MQLens {{version}}",
     "backgroundTasks": "后台任务",
     "cpu": "CPU {{value}}",
     "engineOnline": "MQLens 引擎在线",
     "mongodb": "MongoDB {{value}}",
+    "openActivity": "打开活动日志",
     "ram": "内存 {{value}}",
     "resetZoom": "重置缩放（{{shortcut}}）",
     "runningTasks_other": "{{count}} 个任务运行中",
@@ -538,7 +540,6 @@
     "actions": {
       "clear": "清空日志",
       "export": "导出…",
-      "openFolder": "打开文件夹",
       "refresh": "刷新"
     },
     "clearConfirm": "清除此密钥库中的全部活动事件？此操作无法撤销。",
@@ -557,11 +558,11 @@
       "error": "错误",
       "level": "记录时级别"
     },
-    "droppedBanner_one": "本会话有 {{count}} 条事件因存储或加密失败而被丢弃。",
     "droppedBanner_other": "本会话有 {{count}} 条事件因存储或加密失败而被丢弃。",
     "empty": "当前筛选条件下暂无活动记录。",
-    "exportDone_one": "已导出 {{count}} 条事件。",
+    "emptyLevelHint": "在审计级别 A（默认）下，仅记录写入和 shell 命令，不包括查询或浏览。",
     "exportDone_other": "已导出 {{count}} 条事件。",
+    "exportFileType": "JSONL 文件",
     "exportPlaintextWarning": "导出将在密钥库外写入明文 JSONL 文件。是否继续？",
     "filters": {
       "op": "操作",

--- a/src/locales/zh-Hans/shell.json
+++ b/src/locales/zh-Hans/shell.json
@@ -147,6 +147,10 @@
       "toggleTheme": {
         "keywords": "外观 配色 模式 appearance color mode toggle light dark theme",
         "title": "切换浅色/深色主题"
+      },
+      "openActivity": {
+        "title": "打开活动",
+        "keywords": "审计 日志 历史 操作 误删 drop"
       }
     },
     "results_other": "{{count}} 条结果",
@@ -529,5 +533,54 @@
       },
       "unmirroredExplanation": "导出/导入标签页会保留在各自的窗口中"
     }
+  },
+  "activity": {
+    "actions": {
+      "clear": "清空日志",
+      "export": "导出…",
+      "openFolder": "打开文件夹",
+      "refresh": "刷新"
+    },
+    "clearConfirm": "清除此密钥库中的全部活动事件？此操作无法撤销。",
+    "columns": {
+      "connection": "连接",
+      "namespace": "命名空间",
+      "op": "操作",
+      "source": "来源",
+      "status": "状态",
+      "summary": "摘要",
+      "time": "时间"
+    },
+    "detail": {
+      "args": "参数",
+      "duration": "耗时",
+      "error": "错误",
+      "level": "记录时级别"
+    },
+    "droppedBanner_one": "本会话有 {{count}} 条事件因存储或加密失败而被丢弃。",
+    "droppedBanner_other": "本会话有 {{count}} 条事件因存储或加密失败而被丢弃。",
+    "empty": "当前筛选条件下暂无活动记录。",
+    "exportDone_one": "已导出 {{count}} 条事件。",
+    "exportDone_other": "已导出 {{count}} 条事件。",
+    "exportPlaintextWarning": "导出将在密钥库外写入明文 JSONL 文件。是否继续？",
+    "filters": {
+      "op": "操作",
+      "opPlaceholder": "例如 dropCollection",
+      "status": "状态",
+      "statusAll": "全部",
+      "statusError": "失败",
+      "statusOk": "成功",
+      "summary": "摘要包含",
+      "summaryPlaceholder": "搜索摘要…"
+    },
+    "header": {
+      "subtitle": "本地、经密钥库加密的数据库操作日志。",
+      "title": "活动"
+    },
+    "loading": "正在加载活动…",
+    "lockedBody": "解锁密钥库后即可查看和导出活动日志。",
+    "lockedTitle": "密钥库已锁定",
+    "statusError": "失败",
+    "statusOk": "成功"
   }
 }

--- a/src/locales/zh-Hans/shell.json
+++ b/src/locales/zh-Hans/shell.json
@@ -538,11 +538,10 @@
   },
   "activity": {
     "actions": {
-      "clear": "清空日志",
+      "discardDamaged": "丢弃受损日志",
       "export": "导出…",
       "refresh": "刷新"
     },
-    "clearConfirm": "清除此密钥库中的全部活动事件？此操作无法撤销。",
     "columns": {
       "connection": "连接",
       "namespace": "命名空间",
@@ -560,6 +559,8 @@
       "error": "错误",
       "level": "记录时级别"
     },
+    "discardConfirm": "要丢弃这个受损的活动日志吗？其中无法校验的事件将无法恢复。系统会永久保留一条关于此次丢弃的记录。",
+    "discardDone_other": "已丢弃 {{count}} 条无法校验的事件。记录已恢复，日志中保留了本次丢弃的记录。",
     "droppedBanner_other": "本会话有 {{count}} 条事件因存储或加密失败而被丢弃。",
     "empty": "当前筛选条件下暂无活动记录。",
     "emptyLevelHint": "在审计级别 A（默认）下，仅记录写入和 shell 命令，不包括查询或浏览。",
@@ -580,10 +581,11 @@
       "subtitle": "本地、经密钥库加密的数据库操作日志。",
       "title": "活动"
     },
-    "integrityBanner": "活动日志完整性校验失败：{{reason}}。记录已停止，文件将被保留。使用“清空”可开始新的日志。",
+    "integrityBanner": "活动日志完整性校验失败：{{reason}}。记录已停止，文件将被保留。丢弃受损日志以恢复记录。",
     "loading": "正在加载活动…",
     "lockedBody": "解锁密钥库后即可查看和导出活动日志。",
     "lockedTitle": "密钥库已锁定",
+    "retentionNote": "旧事件会按保留期设置自动移除。完好的日志无法被清除。",
     "statusError": "失败",
     "statusOk": "成功"
   }

--- a/src/workspace/__tests__/persistence.test.ts
+++ b/src/workspace/__tests__/persistence.test.ts
@@ -61,7 +61,7 @@ describe('toPersistedTab', () => {
   });
 
   it('passes settings/quickstart/tasks tabs through unchanged with empty profile fields', () => {
-    for (const type of ['settings', 'quickstart', 'tasks'] as const) {
+    for (const type of ['settings', 'quickstart', 'tasks', 'activity'] as const) {
       const tab: PersistableTab = { id: type, type, connectionId: '', db: '', collection: '' };
       const persisted = toPersistedTab(tab, undefined, undefined);
       expect(persisted).toEqual({

--- a/src/workspace/persistence.ts
+++ b/src/workspace/persistence.ts
@@ -42,6 +42,7 @@ export type QueryTabType =
   | 'export'
   | 'import'
   | 'tasks'
+  | 'activity'
   | 'schema'
   | 'create-view'
   | 'gridfs'
@@ -125,7 +126,7 @@ export interface RestoredTab {
 // reads to populate `unmirroredTabIdsRef`, so no separate change is needed.
 const NON_PERSISTED_TYPES = new Set<QueryTabType>(['export', 'import', 'generate']);
 // These tab kinds carry no connection at all; pass their id through as-is.
-const CONNECTIONLESS_TYPES = new Set<QueryTabType>(['settings', 'quickstart', 'tasks']);
+const CONNECTIONLESS_TYPES = new Set<QueryTabType>(['settings', 'quickstart', 'tasks', 'activity']);
 
 /**
  * Rewrite `id`'s live `<connectionId>` segment (if any) to
@@ -138,7 +139,7 @@ const CONNECTIONLESS_TYPES = new Set<QueryTabType>(['settings', 'quickstart', 't
  * no matching live-connection segment pass through unchanged — this
  * correctly no-ops for ids already in `profile:` form (nothing in
  * `connections` has a live id that looks like `profile:...`) and for
- * connectionless ids (`settings`/`quickstart`/`tasks`, or a pane/split id).
+ * connectionless ids (`settings`/`quickstart`/`tasks`/`activity`, or a pane/split id).
  */
 export function toProfileSpaceId(id: string, connections: PersistableConnection[]): string {
   const conn = connections.find((c) => id.includes(c.id));
@@ -154,7 +155,7 @@ export function toProfileSpaceId(id: string, connections: PersistableConnection[
  * a tab whose connection this window already has live should render exactly
  * like any other locally-reconnected tab, not stuck as a `profile:` banner.
  * Ids with no matching profile prefix — already live-space, connectionless
- * (`settings`/`quickstart`/`tasks`), or a pane/split id — pass through
+ * (`settings`/`quickstart`/`tasks`/`activity`), or a pane/split id — pass through
  * unchanged, mirroring `toProfileSpaceId`'s own no-op cases.
  */
 export function toLiveSpaceId(id: string, connections: PersistableConnection[]): string {


### PR DESCRIPTION
## Summary
- Adds a vault-encrypted local SQLite audit log (`audit.db.enc`) for MQLens DB operations with configurable levels A/B/C (default A), retention (default 30 days), and optional document payloads.
- Instruments critical write/drop/mongosh/MQL paths so wipe-style incidents remain investigable after the fact.
- Ships Settings → Activity controls plus an Activity workspace tab (list, filter, export JSONL, open folder, clear) with soft-fail recording so audit errors never break Mongo commands.

Closes #272

## Test plan
- [ ] Unit: `cargo test --manifest-path src-tauri/Cargo.toml audit` (level, redact, store, envelope, classify/record)
- [ ] Frontend: Settings audit load/save; Activity locked-vault empty state; filter invokes `audit_list`
- [ ] `npm run i18n:check` passes
- [ ] **Manual L6:** Drop a collection via UI → Activity row with `source=ui`
- [ ] Same via mongosh → `source=shell` (or equivalent shell source)
- [ ] Level A: find does not appear; switch to C → find appears
- [ ] Lock vault → Activity locked; unlock → history still present
- [ ] Export JSONL contains the wipe-style event within retention; confirm plaintext export warning
- [ ] Settings: change level/retention/payloads, Save, reopen Settings → values persist