### PR TITLE
fix(documents): apply field-level updates so a projected edit keeps other fields (#275)

### DIFF
--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -398,40 +398,71 @@ fn path_is_unaddressable(key: &str) -> bool {
     key.contains('.') || key.starts_with('$')
 }
 
-/// Which parts of a document a find projection leaves incomplete.
+/// What a find projection returned, and therefore what may be hidden.
 ///
-/// A bare "was a projection used?" flag is not enough. `{"address": 1}` includes
-/// the whole sub-document, so deleting `address` should remove the field, while
-/// `{"address.city": 1}` loads only one leaf and deleting it must not touch the
-/// hidden siblings. The distinction is whether the projection names a path
-/// *strictly below* the one being written — which reads the same way for
-/// inclusions, exclusions (`{"address.zip": 0}` also yields a partial `address`)
-/// and operators (`{"roles": {"$slice": 2}}` yields a truncated array).
+/// Two different questions have to be answered, and one predicate cannot do
+/// both:
+///
+/// * *Was the value at this path returned whole?* `{"address": 1}` includes the
+///   whole sub-document, so deleting `address` may remove the field; with
+///   `{"address.city": 1}` only one leaf was loaded, so a removal must not touch
+///   the siblings it hid. That is [`Self::is_partial_at`] — is any path named
+///   *strictly below* this one — and it reads the same for inclusions,
+///   exclusions (`{"address.zip": 0}` also yields a partial `address`) and
+///   operators (`{"roles": {"$slice": 2}}` yields a truncated array).
+///
+/// * *Was this path returned at all?* Under `{"name": 1}` a stored `address` is
+///   never shown, so a field the editor "adds" may already exist and be
+///   overwritten. That is [`Self::may_hide`], and it needs the projection's
+///   scope, not just its paths.
 #[derive(Debug, Default, Clone)]
 pub struct ProjectionShape {
     /// Every path the projection names, flattened to dotted form.
     paths: Vec<String>,
-    /// The projection could not be parsed, so nothing may be assumed complete.
-    opaque: bool,
+    scope: Scope,
+}
+
+/// Which fields a projection returned.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum Scope {
+    /// Every field. No projection, or one made only of operators such as
+    /// `$slice`, which truncate a value without restricting the field list.
+    #[default]
+    All,
+    /// Only the named paths (plus `_id` unless excluded).
+    Included,
+    /// Everything except the named paths.
+    Excluded,
+    /// Unknowable: the rows came from an aggregation, the projection could not be
+    /// parsed, or it mixes inclusion and exclusion (which MongoDB rejects).
+    Unknown,
+}
+
+/// What a projection entry says about its path.
+enum Leaf {
+    Include,
+    Exclude,
+    /// `$slice`, `$elemMatch`, `$meta`: truncates a value, does not restrict the
+    /// field list.
+    Operator,
 }
 
 impl ProjectionShape {
     /// Parse a find projection, or `None` when the shape cannot be known — the
     /// rows came from an aggregation, whose `$project`/`$replaceRoot`/`$unset`
-    /// stages cannot be reduced to a field list. Treated as naming everything,
-    /// so nothing is assumed complete and no whole-value write is allowed.
+    /// stages cannot be reduced to a field list.
     pub fn parse_optional(projection: Option<&str>) -> Self {
         match projection {
             Some(p) => Self::parse(p),
             None => Self {
                 paths: Vec::new(),
-                opaque: true,
+                scope: Scope::Unknown,
             },
         }
     }
 
-    /// Parse a find projection. An unparseable one is treated as naming
-    /// everything, so nothing is assumed complete.
+    /// Parse a find projection. An unparseable one is treated as unknowable, so
+    /// nothing is assumed complete or absent.
     pub fn parse(projection: &str) -> Self {
         let trimmed = projection.trim();
         if trimmed.is_empty() || trimmed == "{}" {
@@ -440,36 +471,77 @@ impl ProjectionShape {
         let Ok(serde_json::Value::Object(map)) = serde_json::from_str(trimmed) else {
             return Self {
                 paths: Vec::new(),
-                opaque: true,
+                scope: Scope::Unknown,
             };
         };
-        let mut paths = Vec::new();
-        flatten_projection("", &map, &mut paths);
+        let mut entries = Vec::new();
+        flatten_projection("", &map, &mut entries);
+
+        let mut includes = false;
+        let mut excludes = false;
+        for (path, leaf) in &entries {
+            // `_id` is returned unless excluded and never restricts anything else,
+            // so `{"name": 1, "_id": 0}` is still a plain inclusion.
+            if path == "_id" {
+                continue;
+            }
+            match leaf {
+                Leaf::Include => includes = true,
+                Leaf::Exclude => excludes = true,
+                Leaf::Operator => {}
+            }
+        }
+        let scope = match (includes, excludes) {
+            (true, true) => Scope::Unknown,
+            (true, false) => Scope::Included,
+            (false, true) => Scope::Excluded,
+            (false, false) => Scope::All,
+        };
         Self {
-            paths,
-            opaque: false,
+            paths: entries.into_iter().map(|(path, _)| path).collect(),
+            scope,
         }
     }
 
     /// True when nothing was projected away, so the document is whole.
     pub fn is_whole_document(&self) -> bool {
-        !self.opaque && self.paths.is_empty()
+        self.scope == Scope::All && self.paths.is_empty()
     }
 
     /// True when the value at `path` may hold parts that were not loaded.
     fn is_partial_at(&self, path: &str) -> bool {
-        if self.opaque {
+        if self.scope == Scope::Unknown {
             return true;
         }
         let prefix = format!("{path}.");
         self.paths.iter().any(|p| p.starts_with(&prefix))
+    }
+
+    /// True when the stored document could hold a value at `path` that was never
+    /// returned — so a field the editor appears to *add* might already exist.
+    fn may_hide(&self, path: &str) -> bool {
+        match self.scope {
+            Scope::All => false,
+            Scope::Unknown => true,
+            // Only the named paths came back, so anything outside them is unseen.
+            Scope::Included => !self.names_self_or_ancestor(path),
+            // Everything came back except the named paths.
+            Scope::Excluded => self.names_self_or_ancestor(path),
+        }
+    }
+
+    /// Whether the projection names `path` itself or a path it sits under.
+    fn names_self_or_ancestor(&self, path: &str) -> bool {
+        self.paths
+            .iter()
+            .any(|p| p == path || path.starts_with(&format!("{p}.")))
     }
 }
 
 fn flatten_projection(
     prefix: &str,
     map: &serde_json::Map<String, serde_json::Value>,
-    out: &mut Vec<String>,
+    out: &mut Vec<(String, Leaf)>,
 ) {
     for (key, value) in map {
         let path = if prefix.is_empty() {
@@ -478,13 +550,24 @@ fn flatten_projection(
             format!("{prefix}.{key}")
         };
         match value {
-            // `{"address": {"city": 1}}` is the nested spelling of
-            // `{"address.city": 1}`; `{"roles": {"$slice": 2}}` names a path
-            // below `roles` too, which is exactly what makes it partial.
-            serde_json::Value::Object(inner) if !inner.is_empty() => {
-                flatten_projection(&path, inner, out);
+            serde_json::Value::Object(inner) if inner.is_empty() => {
+                out.push((path, Leaf::Include));
             }
-            _ => out.push(path),
+            // `{"roles": {"$slice": 2}}` truncates a value; it does not restrict
+            // which fields come back.
+            serde_json::Value::Object(inner) if inner.keys().all(|k| k.starts_with('$')) => {
+                for op in inner.keys() {
+                    out.push((format!("{path}.{op}"), Leaf::Operator));
+                }
+            }
+            // `{"address": {"city": 1}}` is the nested spelling of
+            // `{"address.city": 1}`.
+            serde_json::Value::Object(inner) => flatten_projection(&path, inner, out),
+            serde_json::Value::Bool(false) => out.push((path, Leaf::Exclude)),
+            serde_json::Value::Number(n) if n.as_f64() == Some(0.0) => {
+                out.push((path, Leaf::Exclude))
+            }
+            _ => out.push((path, Leaf::Include)),
         }
     }
 }
@@ -566,6 +649,7 @@ pub fn build_field_update(
     let mut blocked: Vec<String> = Vec::new();
     let mut partial_writes: Vec<String> = Vec::new();
     let mut ambiguous_removals: Vec<String> = Vec::new();
+    let mut hidden_additions: Vec<String> = Vec::new();
     diff_documents(
         "",
         original,
@@ -577,6 +661,7 @@ pub fn build_field_update(
             blocked: &mut blocked,
             partial_writes: &mut partial_writes,
             ambiguous_removals: &mut ambiguous_removals,
+            hidden_additions: &mut hidden_additions,
         },
     );
 
@@ -588,6 +673,16 @@ pub fn build_field_update(
              separator and a leading \"$\" as an operator. Re-run the query without a \
              projection so the whole document can be saved.",
             blocked.join(", ")
+        )));
+    }
+    if !hidden_additions.is_empty() {
+        hidden_additions.sort();
+        hidden_additions.dedup();
+        return Err(UpdateBuildError::PartialWrite(format!(
+            "cannot add field(s) {}: the projection did not return them, so a field that is \
+             genuinely new cannot be told apart from one that already exists and would be \
+             overwritten. Re-run the query without the projection to add these.",
+            hidden_additions.join(", ")
         )));
     }
     if !ambiguous_removals.is_empty() {
@@ -634,6 +729,9 @@ struct DiffSink<'a> {
     /// Removals that cannot be expressed at all, because the projection returned
     /// the object empty.
     ambiguous_removals: &'a mut Vec<String>,
+    /// Fields the editor appears to add, but which the projection may simply not
+    /// have returned — so writing them could overwrite an existing value.
+    hidden_additions: &'a mut Vec<String>,
 }
 
 fn diff_documents(
@@ -686,7 +784,14 @@ fn diff_documents(
         }
         match old {
             None => {
-                sink.set.insert(path, new_value.clone());
+                // Absent from the loaded row is not the same as absent from the
+                // document: under `{"name": 1}` a stored `address` is never shown,
+                // so `$set`ting it would replace whatever is really there.
+                if shape.may_hide(&path) {
+                    sink.hidden_additions.push(path);
+                } else {
+                    sink.set.insert(path, new_value.clone());
+                }
             }
             Some(old_value) if old_value == new_value => {}
             Some(mongodb::bson::Bson::Document(old_doc)) => match new_value {
@@ -1370,9 +1475,12 @@ mod csv_import_tests {
 
     #[test]
     fn adding_a_field_sets_it() {
+        // Without a projection, absent from the row really does mean absent from
+        // the document. The projected case is refused; see
+        // `adding_a_field_the_projection_did_not_return_is_refused`.
         let original = doc_of(r#"{"_id":"66a1","age":34}"#);
         let edited = doc_of(r#"{"_id":"66a1","age":34,"city":"Pforzheim"}"#);
-        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
+        let update = build_field_update(&original, &edited, &no_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"city":"Pforzheim"}}"#));
     }
 
@@ -1462,6 +1570,86 @@ mod csv_import_tests {
         let edited = doc_of(r#"{"_id":"66a1"}"#);
         let update = build_field_update(&original, &edited, &no_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$unset":{"address":""}}"#));
+    }
+
+    #[test]
+    fn adding_a_field_the_projection_did_not_return_is_refused() {
+        // Under `{"name": 1}` a stored `address` is never shown, so `$set`ting it
+        // would replace whatever is really there — street and zip included.
+        let shape = ProjectionShape::parse(r#"{"name":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","name":"Grace"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","name":"Grace","address":{"city":"Berlin"}}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("address"), "{err}");
+        assert!(err.contains("did not return"), "{err}");
+    }
+
+    #[test]
+    fn adding_a_field_the_projection_returned_is_allowed() {
+        // `{"address": 1}` did return `address`, so its absence from the row is
+        // real and adding it is safe.
+        let shape = ProjectionShape::parse(r#"{"name":1,"address":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","name":"Grace"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","name":"Grace","address":{"city":"Berlin"}}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"address":{"city":"Berlin"}}}"#));
+    }
+
+    #[test]
+    fn adding_an_excluded_field_is_refused() {
+        // `{"address": 0}` withheld it, so it may already exist.
+        let shape = ProjectionShape::parse(r#"{"address":0}"#);
+        let original = doc_of(r#"{"_id":"66a1","name":"Grace"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","name":"Grace","address":{"city":"Berlin"}}"#);
+        assert!(build_field_update(&original, &edited, &shape).is_err());
+    }
+
+    #[test]
+    fn adding_a_field_under_an_exclusion_that_did_not_hide_it_is_allowed() {
+        // Everything except `secret` came back, so `city` really is new.
+        let shape = ProjectionShape::parse(r#"{"secret":0}"#);
+        let original = doc_of(r#"{"_id":"66a1","name":"Grace"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","name":"Grace","city":"Berlin"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"city":"Berlin"}}"#));
+    }
+
+    #[test]
+    fn adding_a_nested_field_the_projection_did_not_return_is_refused() {
+        // `{"address.city": 1}` never showed `address.street`, so it may exist.
+        let shape = ProjectionShape::parse(r#"{"address.city":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited =
+            doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim","street":"Haupt 1"}}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("address.street"), "{err}");
+    }
+
+    #[test]
+    fn a_slice_only_projection_still_returns_every_field() {
+        // `{"roles": {"$slice": 2}}` truncates an array without restricting the
+        // field list, so adding a field is safe even though `roles` is partial.
+        let shape = ProjectionShape::parse(r#"{"roles":{"$slice":2}}"#);
+        let original = doc_of(r#"{"_id":"66a1","roles":["a","b"]}"#);
+        let edited = doc_of(r#"{"_id":"66a1","roles":["a","b"],"city":"Berlin"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"city":"Berlin"}}"#));
+    }
+
+    #[test]
+    fn an_id_only_exclusion_is_still_a_plain_inclusion() {
+        // `{"name": 1, "_id": 0}` must not read as a mixed projection.
+        let shape = ProjectionShape::parse(r#"{"name":1,"_id":0}"#);
+        let original = doc_of(r#"{"name":"Grace"}"#);
+        let edited = doc_of(r#"{"name":"Grace","city":"Berlin"}"#);
+        assert!(
+            build_field_update(&original, &edited, &shape).is_err(),
+            "city was outside an inclusion projection, so it may already exist"
+        );
     }
 
     #[test]
@@ -1712,7 +1900,7 @@ mod csv_import_tests {
     fn a_new_nested_document_is_set_whole() {
         let original = doc_of(r#"{"_id":"66a1"}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Berlin"}}"#);
-        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
+        let update = build_field_update(&original, &edited, &no_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"address":{"city":"Berlin"}}}"#));
     }
 }

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -521,9 +521,9 @@ pub fn build_field_update(
     let mut set = Document::new();
     let mut unset = Document::new();
     let mut blocked: Vec<String> = Vec::new();
-    let mut truncated: Vec<String> = Vec::new();
+    let mut partial_writes: Vec<String> = Vec::new();
     diff_documents(
-        "", original, edited, shape, &mut set, &mut unset, &mut blocked, &mut truncated,
+        "", original, edited, shape, &mut set, &mut unset, &mut blocked, &mut partial_writes,
     );
 
     if !blocked.is_empty() {
@@ -536,14 +536,14 @@ pub fn build_field_update(
             blocked.join(", ")
         ));
     }
-    if !truncated.is_empty() {
-        truncated.sort();
-        truncated.dedup();
+    if !partial_writes.is_empty() {
+        partial_writes.sort();
+        partial_writes.dedup();
         return Err(format!(
-            "cannot save field(s) {}: the projection returned only part of the array, so \
-             writing it back would discard the rest. Re-run the query without the \
+            "cannot save field(s) {}: the projection returned only part of their contents, \
+             so writing them back would discard the rest. Re-run the query without the \
              projection to edit these.",
-            truncated.join(", ")
+            partial_writes.join(", ")
         ));
     }
 
@@ -566,7 +566,7 @@ fn diff_documents(
     set: &mut Document,
     unset: &mut Document,
     blocked: &mut Vec<String>,
-    truncated: &mut Vec<String>,
+    partial_writes: &mut Vec<String>,
 ) {
     let path_of = |key: &str| {
         if prefix.is_empty() {
@@ -590,13 +590,23 @@ fn diff_documents(
             blocked.push(path);
             continue;
         }
-        // A `$slice`/`$elemMatch` projection returns part of an array. Writing it
-        // back as a whole value would silently discard the rest.
-        if changed
-            && matches!(new_value, mongodb::bson::Bson::Array(_))
-            && shape.is_partial_at(&path)
-        {
-            truncated.push(path);
+        // Anything the projection loaded only partly cannot be written back as a
+        // whole value: a `$slice`/`$elemMatch` array would lose its unseen
+        // elements, and replacing a partially loaded object — including with a
+        // scalar or null — would lose the siblings it hid.
+        let old_may_hide_more = matches!(
+            old,
+            Some(mongodb::bson::Bson::Document(_)) | Some(mongodb::bson::Bson::Array(_))
+        );
+        let writes_whole_value = !matches!(
+            (old, new_value),
+            (
+                Some(mongodb::bson::Bson::Document(_)),
+                mongodb::bson::Bson::Document(_)
+            )
+        );
+        if changed && old_may_hide_more && writes_whole_value && shape.is_partial_at(&path) {
+            partial_writes.push(path);
             continue;
         }
         match old {
@@ -609,7 +619,7 @@ fn diff_documents(
                 // actually differ are written.
                 mongodb::bson::Bson::Document(new_doc) => {
                     diff_documents(
-                        &path, old_doc, new_doc, shape, set, unset, blocked, truncated,
+                        &path, old_doc, new_doc, shape, set, unset, blocked, partial_writes,
                     );
                 }
                 _ => {
@@ -634,6 +644,12 @@ fn diff_documents(
         match old_value {
             mongodb::bson::Bson::Document(old_doc) => {
                 unset_removed_subtree(&path, old_doc, shape, unset, blocked);
+            }
+            // A partially loaded array reaches here rather than the change guard,
+            // because the key is simply absent from the edited document. Unsetting
+            // it would delete the elements the projection never showed.
+            mongodb::bson::Bson::Array(_) if shape.is_partial_at(&path) => {
+                partial_writes.push(path);
             }
             _ => {
                 unset.insert(path, "");
@@ -1248,7 +1264,57 @@ mod csv_import_tests {
         let edited = doc_of(r#"{"_id":"66a1","roles":["admin","editor"]}"#);
         let err = build_field_update(&original, &edited, &shape).expect_err("must refuse");
         assert!(err.contains("roles"), "{err}");
-        assert!(err.contains("part of the array"), "{err}");
+        assert!(err.contains("part of their contents"), "{err}");
+    }
+
+    #[test]
+    fn replacing_a_partially_projected_object_with_a_scalar_is_refused() {
+        // Under `{"address.city": 1}` the loaded `address` hides street and zip;
+        // `$set: {address: "unknown"}` would replace the whole stored object.
+        let shape = ProjectionShape::parse(r#"{"address.city":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1","address":"unknown"}"#);
+        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse");
+        assert!(err.contains("address"), "{err}");
+        assert!(err.contains("part of their contents"), "{err}");
+    }
+
+    #[test]
+    fn nulling_a_partially_projected_object_is_refused() {
+        let shape = ProjectionShape::parse(r#"{"address.city":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1","address":null}"#);
+        assert!(build_field_update(&original, &edited, &shape).is_err());
+    }
+
+    #[test]
+    fn replacing_a_fully_included_object_with_a_scalar_is_allowed() {
+        // Nothing was hidden, so the whole value really is the whole value.
+        let shape = ProjectionShape::parse(r#"{"address":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1","address":"unknown"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"address":"unknown"}}"#));
+    }
+
+    #[test]
+    fn removing_a_partially_projected_array_is_refused() {
+        // The key is absent from the edited document, so this never reaches the
+        // change guard — but unsetting it would delete the unseen elements.
+        let shape = ProjectionShape::parse(r#"{"roles":{"$slice":2}}"#);
+        let original = doc_of(r#"{"_id":"66a1","roles":["admin","devops"]}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse");
+        assert!(err.contains("roles"), "{err}");
+    }
+
+    #[test]
+    fn removing_a_fully_included_array_is_allowed() {
+        let shape = ProjectionShape::parse(r#"{"roles":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","roles":["admin","devops"]}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$unset":{"roles":""}}"#));
     }
 
     #[test]
@@ -1327,9 +1393,15 @@ mod csv_import_tests {
 
     #[test]
     fn replacing_a_document_with_a_scalar_sets_the_whole_path() {
+        // Written before the diff knew about projections, so it asked for the
+        // whole path to be set under a *nested* projection — which is exactly the
+        // unsafe write now refused. The behaviour it meant to pin only holds when
+        // nothing was hidden; see
+        // `replacing_a_partially_projected_object_with_a_scalar_is_refused` for
+        // the projected case.
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":"unknown"}"#);
-        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
+        let update = build_field_update(&original, &edited, &no_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"address":"unknown"}}"#));
     }
 

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -480,9 +480,11 @@ impl ProjectionShape {
         let mut includes = false;
         let mut excludes = false;
         for (path, leaf) in &entries {
-            // `_id` is returned unless excluded and never restricts anything else,
-            // so `{"name": 1, "_id": 0}` is still a plain inclusion.
-            if path == "_id" {
+            // `_id: 0` is the idiom for dropping the id alongside an inclusion, and
+            // must not read as an exclusion projection. But `_id: 1` is a real
+            // inclusion — only `_id` comes back — so it may not be skipped, or an
+            // added field would look new when the document already has one.
+            if path == "_id" && matches!(leaf, Leaf::Exclude) {
                 continue;
             }
             match leaf {
@@ -1636,6 +1638,30 @@ mod csv_import_tests {
         let shape = ProjectionShape::parse(r#"{"roles":{"$slice":2}}"#);
         let original = doc_of(r#"{"_id":"66a1","roles":["a","b"]}"#);
         let edited = doc_of(r#"{"_id":"66a1","roles":["a","b"],"city":"Berlin"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"city":"Berlin"}}"#));
+    }
+
+    #[test]
+    fn an_id_only_inclusion_hides_every_other_field() {
+        // `{"_id": 1}` returns nothing but `_id`, so an added field may already
+        // exist in the stored document.
+        let shape = ProjectionShape::parse(r#"{"_id":1}"#);
+        let original = doc_of(r#"{"_id":"66a1"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Berlin"}}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("address"), "{err}");
+    }
+
+    #[test]
+    fn an_id_only_exclusion_still_returns_every_other_field() {
+        // `{"_id": 0}` withholds only the id, so anything else absent from the row
+        // really is absent.
+        let shape = ProjectionShape::parse(r#"{"_id":0}"#);
+        let original = doc_of(r#"{"name":"Grace"}"#);
+        let edited = doc_of(r#"{"name":"Grace","city":"Berlin"}"#);
         let update = build_field_update(&original, &edited, &shape).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"city":"Berlin"}}"#));
     }

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -422,6 +422,15 @@ pub struct ProjectionShape {
     /// Paths whose value the projection *computed*, so there is nothing in the
     /// stored document to write back to.
     computed: Vec<String>,
+    /// Embedded documents whose other fields may not have come back, because a
+    /// `$slice`/`$elemMatch` targeted something *inside* them.
+    ///
+    /// MongoDB's behaviour here has changed across releases: older servers return
+    /// only the sliced field within the embedded document, dropping its siblings.
+    /// MQLens targets servers that old (#232), and on newer ones the cost of
+    /// assuming siblings may be hidden is a refusal with a clear message rather
+    /// than a silent overwrite — so this is treated conservatively either way.
+    locally_hidden: Vec<String>,
     scope: Scope,
 }
 
@@ -493,6 +502,7 @@ impl ProjectionShape {
             None => Self {
                 paths: Vec::new(),
                 computed: Vec::new(),
+                locally_hidden: Vec::new(),
                 scope: Scope::Unknown,
             },
         }
@@ -509,6 +519,7 @@ impl ProjectionShape {
             return Self {
                 paths: Vec::new(),
                 computed: Vec::new(),
+                locally_hidden: Vec::new(),
                 scope: Scope::Unknown,
             };
         };
@@ -542,9 +553,22 @@ impl ProjectionShape {
             .filter(|(_, leaf)| !leaf.is_writable())
             .map(|(path, _)| path.clone())
             .collect();
+        // A `$slice`/`$elemMatch` inside an embedded document may have dropped
+        // that document's other fields. The entry path is `<field>.<$op>`, so the
+        // container is the field's parent.
+        let locally_hidden = entries
+            .iter()
+            .filter(|(_, leaf)| matches!(leaf, Leaf::Slice | Leaf::ElemMatch))
+            .filter_map(|(path, _)| {
+                let field = path.rsplit_once('.').map(|(head, _)| head)?;
+                field.rsplit_once('.').map(|(container, _)| container.to_string())
+            })
+            .collect();
+
         Self {
             paths: entries.into_iter().map(|(path, _)| path).collect(),
             computed,
+            locally_hidden,
             scope,
         }
     }
@@ -574,6 +598,15 @@ impl ProjectionShape {
     /// True when the stored document could hold a value at `path` that was never
     /// returned — so a field the editor appears to *add* might already exist.
     fn may_hide(&self, path: &str) -> bool {
+        // Inside an embedded document a nested `$slice` may have withheld the
+        // siblings, even when every top-level field came back.
+        if self
+            .locally_hidden
+            .iter()
+            .any(|container| path.starts_with(&format!("{container}.")))
+        {
+            return true;
+        }
         match self.scope {
             Scope::All => false,
             Scope::Unknown => true,
@@ -2064,6 +2097,42 @@ mod csv_import_tests {
             .expect_err("must refuse")
             .to_string();
         assert!(err.contains("address"), "{err}");
+    }
+
+    #[test]
+    fn a_nested_slice_may_have_hidden_its_containers_siblings() {
+        // `{"details.colors": {"$slice": 1}}` — older servers return only `colors`
+        // inside `details`, so `sizes` may exist unseen and must not be `$set`.
+        let shape = ProjectionShape::parse(r#"{"details.colors":{"$slice":1}}"#);
+        let original = doc_of(r#"{"_id":"66a1","details":{"colors":["red"]}}"#);
+        let edited =
+            doc_of(r#"{"_id":"66a1","details":{"colors":["red"],"sizes":["m"]}}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("details.sizes"), "{err}");
+    }
+
+    #[test]
+    fn a_nested_slice_leaves_unrelated_top_level_fields_addable() {
+        // Only the containing embedded document is suspect; the rest of the
+        // document came back in full.
+        let shape = ProjectionShape::parse(r#"{"details.colors":{"$slice":1}}"#);
+        let original = doc_of(r#"{"_id":"66a1","details":{"colors":["red"]}}"#);
+        let edited =
+            doc_of(r#"{"_id":"66a1","details":{"colors":["red"]},"city":"Berlin"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"city":"Berlin"}}"#));
+    }
+
+    #[test]
+    fn a_top_level_slice_hides_nothing() {
+        // No containing embedded document, so every field still came back.
+        let shape = ProjectionShape::parse(r#"{"roles":{"$slice":2}}"#);
+        let original = doc_of(r#"{"_id":"66a1","roles":["a","b"]}"#);
+        let edited = doc_of(r#"{"_id":"66a1","roles":["a","b"],"city":"Berlin"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"city":"Berlin"}}"#));
     }
 
     #[test]

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -398,6 +398,83 @@ fn path_is_unaddressable(key: &str) -> bool {
     key.contains('.') || key.starts_with('$')
 }
 
+/// Which parts of a document a find projection leaves incomplete.
+///
+/// A bare "was a projection used?" flag is not enough. `{"address": 1}` includes
+/// the whole sub-document, so deleting `address` should remove the field, while
+/// `{"address.city": 1}` loads only one leaf and deleting it must not touch the
+/// hidden siblings. The distinction is whether the projection names a path
+/// *strictly below* the one being written — which reads the same way for
+/// inclusions, exclusions (`{"address.zip": 0}` also yields a partial `address`)
+/// and operators (`{"roles": {"$slice": 2}}` yields a truncated array).
+#[derive(Debug, Default, Clone)]
+pub struct ProjectionShape {
+    /// Every path the projection names, flattened to dotted form.
+    paths: Vec<String>,
+    /// The projection could not be parsed, so nothing may be assumed complete.
+    opaque: bool,
+}
+
+impl ProjectionShape {
+    /// Parse a find projection. An unparseable one is treated as naming
+    /// everything, so nothing is assumed complete.
+    pub fn parse(projection: &str) -> Self {
+        let trimmed = projection.trim();
+        if trimmed.is_empty() || trimmed == "{}" {
+            return Self::default();
+        }
+        let Ok(serde_json::Value::Object(map)) = serde_json::from_str(trimmed) else {
+            return Self {
+                paths: Vec::new(),
+                opaque: true,
+            };
+        };
+        let mut paths = Vec::new();
+        flatten_projection("", &map, &mut paths);
+        Self {
+            paths,
+            opaque: false,
+        }
+    }
+
+    /// True when nothing was projected away, so the document is whole.
+    pub fn is_whole_document(&self) -> bool {
+        !self.opaque && self.paths.is_empty()
+    }
+
+    /// True when the value at `path` may hold parts that were not loaded.
+    fn is_partial_at(&self, path: &str) -> bool {
+        if self.opaque {
+            return true;
+        }
+        let prefix = format!("{path}.");
+        self.paths.iter().any(|p| p.starts_with(&prefix))
+    }
+}
+
+fn flatten_projection(
+    prefix: &str,
+    map: &serde_json::Map<String, serde_json::Value>,
+    out: &mut Vec<String>,
+) {
+    for (key, value) in map {
+        let path = if prefix.is_empty() {
+            key.clone()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        match value {
+            // `{"address": {"city": 1}}` is the nested spelling of
+            // `{"address.city": 1}`; `{"roles": {"$slice": 2}}` names a path
+            // below `roles` too, which is exactly what makes it partial.
+            serde_json::Value::Object(inner) if !inner.is_empty() => {
+                flatten_projection(&path, inner, out);
+            }
+            _ => out.push(path),
+        }
+    }
+}
+
 /// Build a field-level update from the document as it was loaded and as it was
 /// edited (#275).
 ///
@@ -410,28 +487,44 @@ fn path_is_unaddressable(key: &str) -> bool {
 /// Sub-documents are compared recursively and emitted as dotted paths, because a
 /// projection can target a nested path (`{"address.city": 1}`) — setting the
 /// whole `address` object would reproduce the same bug one level down. Removals
-/// follow the same rule: deleting a partially loaded `address` unsets the leaves
-/// that were visible, never the parent, which would take the hidden siblings
-/// with it.
-///
-/// `partial` says whether `original` came back under a projection. It only
-/// affects one otherwise-undecidable case: removing an empty sub-document, where
-/// `{}` on screen could be a genuinely empty object or one whose fields the
-/// projection hid.
+/// follow the same rule, but only where the projection actually left that
+/// sub-tree incomplete: see [`ProjectionShape`].
 ///
 /// Returns `Err` when a changed field cannot be addressed (see
-/// [`path_is_unaddressable`]); the caller decides what to do about it.
+/// [`path_is_unaddressable`]) or when it cannot be written without losing data
+/// the projection hid; the caller decides what to do about it.
 ///
 /// An empty `Ok` result means nothing changed.
 pub fn build_field_update(
     original: &Document,
     edited: &Document,
-    partial: bool,
+    shape: &ProjectionShape,
 ) -> Result<Document, String> {
+    // `_id` is immutable. The old replacement surfaced MongoDB's error; skipping
+    // the change silently would report a save that did not happen.
+    if let Some(original_id) = original.get("_id") {
+        match edited.get("_id") {
+            None => {
+                return Err("cannot remove _id: a document's _id is immutable. \
+                            Restore it and save again."
+                    .into())
+            }
+            Some(edited_id) if edited_id != original_id => {
+                return Err("cannot change _id: a document's _id is immutable. \
+                            Insert a new document instead."
+                    .into())
+            }
+            Some(_) => {}
+        }
+    }
+
     let mut set = Document::new();
     let mut unset = Document::new();
     let mut blocked: Vec<String> = Vec::new();
-    diff_documents("", original, edited, partial, &mut set, &mut unset, &mut blocked);
+    let mut truncated: Vec<String> = Vec::new();
+    diff_documents(
+        "", original, edited, shape, &mut set, &mut unset, &mut blocked, &mut truncated,
+    );
 
     if !blocked.is_empty() {
         blocked.sort();
@@ -441,6 +534,16 @@ pub fn build_field_update(
              separator and a leading \"$\" as an operator. Re-run the query without a \
              projection so the whole document can be saved.",
             blocked.join(", ")
+        ));
+    }
+    if !truncated.is_empty() {
+        truncated.sort();
+        truncated.dedup();
+        return Err(format!(
+            "cannot save field(s) {}: the projection returned only part of the array, so \
+             writing it back would discard the rest. Re-run the query without the \
+             projection to edit these.",
+            truncated.join(", ")
         ));
     }
 
@@ -459,10 +562,11 @@ fn diff_documents(
     prefix: &str,
     original: &Document,
     edited: &Document,
-    partial: bool,
+    shape: &ProjectionShape,
     set: &mut Document,
     unset: &mut Document,
     blocked: &mut Vec<String>,
+    truncated: &mut Vec<String>,
 ) {
     let path_of = |key: &str| {
         if prefix.is_empty() {
@@ -471,8 +575,8 @@ fn diff_documents(
             format!("{prefix}.{key}")
         }
     };
-    // `_id` is immutable, and only at the top level — a nested field may well be
-    // called `_id`.
+    // `_id` is immutable and validated by the caller; only at the top level, since
+    // a nested field may well be called `_id`.
     let is_immutable_id = |key: &str| prefix.is_empty() && key == "_id";
 
     for (key, new_value) in edited {
@@ -481,8 +585,18 @@ fn diff_documents(
         }
         let path = path_of(key);
         let old = original.get(key);
-        if old != Some(new_value) && path_is_unaddressable(key) {
+        let changed = old != Some(new_value);
+        if changed && path_is_unaddressable(key) {
             blocked.push(path);
+            continue;
+        }
+        // A `$slice`/`$elemMatch` projection returns part of an array. Writing it
+        // back as a whole value would silently discard the rest.
+        if changed
+            && matches!(new_value, mongodb::bson::Bson::Array(_))
+            && shape.is_partial_at(&path)
+        {
+            truncated.push(path);
             continue;
         }
         match old {
@@ -494,7 +608,9 @@ fn diff_documents(
                 // Both sides are sub-documents: recurse so only the fields that
                 // actually differ are written.
                 mongodb::bson::Bson::Document(new_doc) => {
-                    diff_documents(&path, old_doc, new_doc, partial, set, unset, blocked);
+                    diff_documents(
+                        &path, old_doc, new_doc, shape, set, unset, blocked, truncated,
+                    );
                 }
                 _ => {
                     set.insert(path, new_value.clone());
@@ -514,58 +630,50 @@ fn diff_documents(
             blocked.push(path_of(key));
             continue;
         }
-        // Removing a sub-document must unset the leaves that were on screen, not
-        // the parent: under a nested projection the parent also holds fields the
-        // user never saw, and unsetting it would delete them.
+        let path = path_of(key);
         match old_value {
             mongodb::bson::Bson::Document(old_doc) => {
-                if !partial {
-                    // The whole document was loaded, so nothing is hidden under
-                    // this key: remove the field itself. Unsetting leaf by leaf
-                    // would leave an empty `{}` behind, so the stored document
-                    // would differ from the editor and still satisfy
-                    // `{field: {$exists: true}}`.
-                    unset.insert(path_of(key), "");
-                } else if !old_doc.is_empty() {
-                    // Partial view: only the leaves that were actually visible
-                    // can safely go, or the projection's hidden siblings go too.
-                    unset_visible_leaves(&path_of(key), old_doc, unset, blocked);
-                }
-                // Partial *and* empty: `{}` on screen may be a genuinely empty
-                // object or one whose fields the projection hid, so there is no
-                // leaf it is safe to unset and nothing is emitted.
+                unset_removed_subtree(&path, old_doc, shape, unset, blocked);
             }
             _ => {
-                unset.insert(path_of(key), "");
+                unset.insert(path, "");
             }
         }
     }
 }
 
-/// Unset every leaf path under a removed sub-document.
+/// Unset a removed sub-document, descending only as far as the projection left
+/// it incomplete.
 ///
-/// An empty sub-document has no leaves, so nothing is emitted for it: what is on
-/// screen cannot tell a genuinely empty object apart from one whose fields a
-/// projection hid, and unsetting the parent on that guess is exactly how
-/// unprojected siblings get destroyed.
-fn unset_visible_leaves(
-    prefix: &str,
+/// At a path the projection loaded whole, the field itself is unset — going
+/// deeper would leave an empty `{}` behind. Where it loaded only part, the walk
+/// continues so the siblings it hid are not taken along. An empty sub-document
+/// inside a partial path yields nothing at all: `{}` on screen may be genuinely
+/// empty or hidden, and there is no leaf it is safe to unset.
+fn unset_removed_subtree(
+    path: &str,
     doc: &Document,
+    shape: &ProjectionShape,
     unset: &mut Document,
     blocked: &mut Vec<String>,
 ) {
+    if !shape.is_partial_at(path) {
+        unset.insert(path.to_string(), "");
+        return;
+    }
     for (key, value) in doc {
         if path_is_unaddressable(key) {
-            blocked.push(format!("{prefix}.{key}"));
+            blocked.push(format!("{path}.{key}"));
             continue;
         }
-        let path = format!("{prefix}.{key}");
+        let child = format!("{path}.{key}");
         match value {
             mongodb::bson::Bson::Document(inner) if !inner.is_empty() => {
-                unset_visible_leaves(&path, inner, unset, blocked);
+                unset_removed_subtree(&child, inner, shape, unset, blocked);
             }
+            mongodb::bson::Bson::Document(_) => {}
             _ => {
-                unset.insert(path, "");
+                unset.insert(child, "");
             }
         }
     }
@@ -579,11 +687,11 @@ pub async fn update_document_impl(
     filter: &str,
     original: &str,
     edited: &str,
-    partial: bool,
+    projection: &str,
 ) -> Result<u64, String> {
     let started = std::time::Instant::now();
     let result = update_document_inner(
-        state, id, database, collection, filter, original, edited, partial,
+        state, id, database, collection, filter, original, edited, projection,
     )
     .await;
     // Record the operation that actually ran and the operators it applied. The
@@ -642,7 +750,7 @@ async fn update_document_inner(
     filter: &str,
     original: &str,
     edited: &str,
-    partial: bool,
+    projection: &str,
 ) -> Result<(u64, AppliedWrite), String> {
     // Still `ReplaceOne`: this is the single-document edit from the grid, and
     // that variant is deliberately outside the confirm-required set. Only the
@@ -653,7 +761,8 @@ async fn update_document_inner(
     let original_doc = json_to_bson_document(original)?;
     let edited_doc = json_to_bson_document(edited)?;
 
-    let plan = match build_field_update(&original_doc, &edited_doc, partial) {
+    let shape = ProjectionShape::parse(projection);
+    let plan = match build_field_update(&original_doc, &edited_doc, &shape) {
         // Mongo rejects an empty update document, and there is nothing to do.
         Ok(update) if update.is_empty() => {
             return Ok((
@@ -666,7 +775,7 @@ async fn update_document_inner(
         }
         Ok(update) => WritePlan::Update(update),
         Err(e) => {
-            if partial {
+            if !shape.is_whole_document() {
                 // The document on screen is incomplete, so replacing it would
                 // delete whatever the projection hid. Nothing safe to do here.
                 return Err(e);
@@ -979,13 +1088,22 @@ mod csv_import_tests {
         crate::json_to_bson_document(json).expect("parse")
     }
 
+    fn no_projection() -> ProjectionShape {
+        ProjectionShape::parse("{}")
+    }
+
+    /// A projection that loads only one leaf of `address`.
+    fn nested_projection() -> ProjectionShape {
+        ProjectionShape::parse(r#"{"address.city":1}"#)
+    }
+
     #[test]
     fn editing_a_projected_field_touches_only_that_field() {
         // The bug: a projection returns {_id, age}, and replacing the document
         // with it deleted username, email, roles, address and the rest.
         let original = doc_of(r#"{"_id":"66a1","age":34}"#);
         let edited = doc_of(r#"{"_id":"66a1","age":35}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
 
         assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
         assert!(
@@ -997,14 +1115,14 @@ mod csv_import_tests {
     #[test]
     fn an_unchanged_document_produces_no_update() {
         let d = doc_of(r#"{"_id":"66a1","age":34}"#);
-        assert!(build_field_update(&d, &d, true).expect("addressable").is_empty());
+        assert!(build_field_update(&d, &d, &no_projection()).expect("addressable").is_empty());
     }
 
     #[test]
     fn removing_a_shown_field_unsets_it() {
         let original = doc_of(r#"{"_id":"66a1","age":34,"nickname":"nav"}"#);
         let edited = doc_of(r#"{"_id":"66a1","age":34}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$unset":{"nickname":""}}"#));
     }
 
@@ -1012,7 +1130,7 @@ mod csv_import_tests {
     fn adding_a_field_sets_it() {
         let original = doc_of(r#"{"_id":"66a1","age":34}"#);
         let edited = doc_of(r#"{"_id":"66a1","age":34,"city":"Pforzheim"}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"city":"Pforzheim"}}"#));
     }
 
@@ -1023,7 +1141,7 @@ mod csv_import_tests {
         // would delete street/zip/country — the same bug one level down.
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Berlin"}}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"address.city":"Berlin"}}"#));
     }
 
@@ -1031,7 +1149,7 @@ mod csv_import_tests {
     fn a_nested_removal_unsets_the_dotted_path() {
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim","zip":"75172"}}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$unset":{"address.zip":""}}"#));
     }
 
@@ -1042,16 +1160,19 @@ mod csv_import_tests {
         // with it, which is the very bug this change exists to prevent.
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
         let edited = doc_of(r#"{"_id":"66a1"}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$unset":{"address.city":""}}"#));
     }
 
     #[test]
     fn removing_a_nested_subdocument_unsets_its_leaves_recursively() {
+        // `{"a.b.c": 1}` leaves both `a` and `a.b` incomplete, so the walk has to
+        // reach the leaves.
+        let shape = ProjectionShape::parse(r#"{"a.b.c":1}"#);
         let original =
             doc_of(r#"{"_id":"66a1","a":{"b":{"c":1,"d":2},"e":3}}"#);
         let edited = doc_of(r#"{"_id":"66a1"}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
         assert_eq!(
             update,
             doc_of(r#"{"$unset":{"a.b.c":"","a.b.d":"","a.e":""}}"#)
@@ -1065,7 +1186,7 @@ mod csv_import_tests {
         // showed and still matches `{address: {$exists: true}}`.
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
         let edited = doc_of(r#"{"_id":"66a1"}"#);
-        let update = build_field_update(&original, &edited, false).expect("addressable");
+        let update = build_field_update(&original, &edited, &no_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$unset":{"address":""}}"#));
     }
 
@@ -1075,7 +1196,7 @@ mod csv_import_tests {
         // the projection hid — so there is no leaf it is safe to unset.
         let original = doc_of(r#"{"_id":"66a1","address":{}}"#);
         let edited = doc_of(r#"{"_id":"66a1"}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert!(update.is_empty(), "must not guess at hidden fields: {update:?}");
     }
 
@@ -1084,8 +1205,87 @@ mod csv_import_tests {
         // Nothing was hidden, so `{}` really is empty and the removal applies.
         let original = doc_of(r#"{"_id":"66a1","address":{}}"#);
         let edited = doc_of(r#"{"_id":"66a1"}"#);
-        let update = build_field_update(&original, &edited, false).expect("addressable");
+        let update = build_field_update(&original, &edited, &no_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$unset":{"address":""}}"#));
+    }
+
+    #[test]
+    fn a_fully_included_subdocument_unsets_its_parent() {
+        // `{"address": 1}` loads the whole sub-document, so deleting it must
+        // remove the field — not leave `address: {}` behind.
+        let shape = ProjectionShape::parse(r#"{"address":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$unset":{"address":""}}"#));
+    }
+
+    #[test]
+    fn the_nested_spelling_of_a_projection_is_treated_the_same_as_dotted() {
+        // `{"address": {"city": 1}}` means the same as `{"address.city": 1}`.
+        let shape = ProjectionShape::parse(r#"{"address":{"city":1}}"#);
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$unset":{"address.city":""}}"#));
+    }
+
+    #[test]
+    fn a_nested_exclusion_also_makes_a_subdocument_partial() {
+        // `{"address.zip": 0}` returns address without zip, so a removal must
+        // still go leaf by leaf.
+        let shape = ProjectionShape::parse(r#"{"address.zip":0}"#);
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$unset":{"address.city":""}}"#));
+    }
+
+    #[test]
+    fn a_sliced_array_is_refused_rather_than_truncating_the_stored_one() {
+        let shape = ProjectionShape::parse(r#"{"roles":{"$slice":2}}"#);
+        let original = doc_of(r#"{"_id":"66a1","roles":["admin","devops"]}"#);
+        let edited = doc_of(r#"{"_id":"66a1","roles":["admin","editor"]}"#);
+        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse");
+        assert!(err.contains("roles"), "{err}");
+        assert!(err.contains("part of the array"), "{err}");
+    }
+
+    #[test]
+    fn a_fully_included_array_is_editable() {
+        let shape = ProjectionShape::parse(r#"{"roles":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","roles":["admin","devops"]}"#);
+        let edited = doc_of(r#"{"_id":"66a1","roles":["admin","editor"]}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"roles":["admin","editor"]}}"#));
+    }
+
+    #[test]
+    fn changing_the_id_is_refused_not_silently_dropped() {
+        // The old replacement surfaced MongoDB's immutable-field error; skipping
+        // the change would report a save that never happened.
+        let original = doc_of(r#"{"_id":"66a1","age":34}"#);
+        let edited = doc_of(r#"{"_id":"different","age":34}"#);
+        let err = build_field_update(&original, &edited, &no_projection())
+            .expect_err("must refuse");
+        assert!(err.contains("_id"), "{err}");
+        assert!(err.contains("immutable"), "{err}");
+    }
+
+    #[test]
+    fn removing_the_id_is_refused() {
+        let original = doc_of(r#"{"_id":"66a1","age":34}"#);
+        let edited = doc_of(r#"{"age":34}"#);
+        let err = build_field_update(&original, &edited, &no_projection())
+            .expect_err("must refuse");
+        assert!(err.contains("_id"), "{err}");
+    }
+
+    #[test]
+    fn an_unparseable_projection_assumes_nothing_is_complete() {
+        let shape = ProjectionShape::parse("{not json");
+        assert!(!shape.is_whole_document());
+        assert!(shape.is_partial_at("anything"));
     }
 
     #[test]
@@ -1094,7 +1294,7 @@ mod csv_import_tests {
         // MongoDB traverse into a `price` sub-document instead.
         let original = doc_of(r#"{"_id":"66a1","price.usd":10}"#);
         let edited = doc_of(r#"{"_id":"66a1","price.usd":11}"#);
-        let err = build_field_update(&original, &edited, true).expect_err("must refuse");
+        let err = build_field_update(&original, &edited, &nested_projection()).expect_err("must refuse");
         assert!(err.contains("price.usd"), "{err}");
         assert!(err.contains("projection"), "should say how to proceed: {err}");
     }
@@ -1103,7 +1303,7 @@ mod csv_import_tests {
     fn a_dollar_prefixed_field_name_is_refused() {
         let original = doc_of(r#"{"_id":"66a1","$weird":1}"#);
         let edited = doc_of(r#"{"_id":"66a1","$weird":2}"#);
-        assert!(build_field_update(&original, &edited, true).is_err());
+        assert!(build_field_update(&original, &edited, &nested_projection()).is_err());
     }
 
     #[test]
@@ -1112,24 +1312,16 @@ mod csv_import_tests {
         // such a name is still editable elsewhere.
         let original = doc_of(r#"{"_id":"66a1","price.usd":10,"age":34}"#);
         let edited = doc_of(r#"{"_id":"66a1","price.usd":10,"age":35}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
     }
 
-    #[test]
-    fn the_id_is_never_written() {
-        // `_id` is immutable; an edit that changes it must not reach the update.
-        let original = doc_of(r#"{"_id":"66a1","age":34}"#);
-        let edited = doc_of(r#"{"_id":"different","age":35}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
-        assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
-    }
 
     #[test]
     fn arrays_are_replaced_as_a_whole_value() {
         let original = doc_of(r#"{"_id":"66a1","roles":["admin","devops"]}"#);
         let edited = doc_of(r#"{"_id":"66a1","roles":["admin","editor"]}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"roles":["admin","editor"]}}"#));
     }
 
@@ -1137,7 +1329,7 @@ mod csv_import_tests {
     fn replacing_a_document_with_a_scalar_sets_the_whole_path() {
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":"unknown"}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"address":"unknown"}}"#));
     }
 
@@ -1145,7 +1337,7 @@ mod csv_import_tests {
     fn a_new_nested_document_is_set_whole() {
         let original = doc_of(r#"{"_id":"66a1"}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Berlin"}}"#);
-        let update = build_field_update(&original, &edited, true).expect("addressable");
+        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"address":{"city":"Berlin"}}}"#));
     }
 }

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -388,6 +388,16 @@ async fn insert_document_inner(
     Ok(res.inserted_id.into_relaxed_extjson().to_string())
 }
 
+/// A field path that MongoDB cannot address literally in an update.
+///
+/// A dot makes it traverse into a sub-document and a leading `$` makes it an
+/// operator, so a field genuinely *named* `price.usd` cannot be targeted by
+/// `$set`/`$unset` at all. Such names are legal in MongoDB documents, and the
+/// old whole-document replacement handled them correctly by never naming them.
+fn path_is_unaddressable(key: &str) -> bool {
+    key.contains('.') || key.starts_with('$')
+}
+
 /// Build a field-level update from the document as it was loaded and as it was
 /// edited (#275).
 ///
@@ -399,38 +409,60 @@ async fn insert_document_inner(
 ///
 /// Sub-documents are compared recursively and emitted as dotted paths, because a
 /// projection can target a nested path (`{"address.city": 1}`) — setting the
-/// whole `address` object would reproduce the same bug one level down.
+/// whole `address` object would reproduce the same bug one level down. Removals
+/// follow the same rule: deleting a partially loaded `address` unsets the leaves
+/// that were visible, never the parent, which would take the hidden siblings
+/// with it.
 ///
-/// Arrays are replaced as a single value. A projection using `$slice` or
-/// `$elemMatch` returns a partial array that is indistinguishable from a short
-/// one, so those remain lossy; `update_document_inner` refuses the save when the
-/// document could not have come from a plain projection.
+/// `partial` says whether `original` came back under a projection. It only
+/// affects one otherwise-undecidable case: removing an empty sub-document, where
+/// `{}` on screen could be a genuinely empty object or one whose fields the
+/// projection hid.
 ///
-/// An empty result means nothing changed.
+/// Returns `Err` when a changed field cannot be addressed (see
+/// [`path_is_unaddressable`]); the caller decides what to do about it.
+///
+/// An empty `Ok` result means nothing changed.
 pub fn build_field_update(
-    original: &mongodb::bson::Document,
-    edited: &mongodb::bson::Document,
-) -> mongodb::bson::Document {
-    let mut set = mongodb::bson::Document::new();
-    let mut unset = mongodb::bson::Document::new();
-    diff_documents("", original, edited, &mut set, &mut unset);
+    original: &Document,
+    edited: &Document,
+    partial: bool,
+) -> Result<Document, String> {
+    let mut set = Document::new();
+    let mut unset = Document::new();
+    let mut blocked: Vec<String> = Vec::new();
+    diff_documents("", original, edited, partial, &mut set, &mut unset, &mut blocked);
 
-    let mut update = mongodb::bson::Document::new();
+    if !blocked.is_empty() {
+        blocked.sort();
+        blocked.dedup();
+        return Err(format!(
+            "cannot update field name(s) {} in place: MongoDB reads \".\" as a path \
+             separator and a leading \"$\" as an operator. Re-run the query without a \
+             projection so the whole document can be saved.",
+            blocked.join(", ")
+        ));
+    }
+
+    let mut update = Document::new();
     if !set.is_empty() {
         update.insert("$set", set);
     }
     if !unset.is_empty() {
         update.insert("$unset", unset);
     }
-    update
+    Ok(update)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn diff_documents(
     prefix: &str,
-    original: &mongodb::bson::Document,
-    edited: &mongodb::bson::Document,
-    set: &mut mongodb::bson::Document,
-    unset: &mut mongodb::bson::Document,
+    original: &Document,
+    edited: &Document,
+    partial: bool,
+    set: &mut Document,
+    unset: &mut Document,
+    blocked: &mut Vec<String>,
 ) {
     let path_of = |key: &str| {
         if prefix.is_empty() {
@@ -448,35 +480,85 @@ fn diff_documents(
             continue;
         }
         let path = path_of(key);
-        match original.get(key) {
+        let old = original.get(key);
+        if old != Some(new_value) && path_is_unaddressable(key) {
+            blocked.push(path);
+            continue;
+        }
+        match old {
             None => {
                 set.insert(path, new_value.clone());
             }
             Some(old_value) if old_value == new_value => {}
-            Some(mongodb::bson::Bson::Document(old_doc)) => {
-                match new_value {
-                    // Both sides are sub-documents: recurse so only the fields
-                    // that actually differ are written.
-                    mongodb::bson::Bson::Document(new_doc) => {
-                        diff_documents(&path, old_doc, new_doc, set, unset);
-                    }
-                    _ => {
-                        set.insert(path, new_value.clone());
-                    }
+            Some(mongodb::bson::Bson::Document(old_doc)) => match new_value {
+                // Both sides are sub-documents: recurse so only the fields that
+                // actually differ are written.
+                mongodb::bson::Bson::Document(new_doc) => {
+                    diff_documents(&path, old_doc, new_doc, partial, set, unset, blocked);
                 }
-            }
+                _ => {
+                    set.insert(path, new_value.clone());
+                }
+            },
             Some(_) => {
                 set.insert(path, new_value.clone());
             }
         }
     }
 
-    for (key, _) in original {
+    for (key, old_value) in original {
         if is_immutable_id(key) || edited.contains_key(key) {
             continue;
         }
-        // Shown to the user and removed by them, so this is a deliberate delete.
-        unset.insert(path_of(key), "");
+        if path_is_unaddressable(key) {
+            blocked.push(path_of(key));
+            continue;
+        }
+        // Removing a sub-document must unset the leaves that were on screen, not
+        // the parent: under a nested projection the parent also holds fields the
+        // user never saw, and unsetting it would delete them.
+        match old_value {
+            mongodb::bson::Bson::Document(old_doc) if !old_doc.is_empty() => {
+                unset_visible_leaves(&path_of(key), old_doc, unset, blocked);
+            }
+            // An empty sub-document has no visible leaf to unset. If the document
+            // was loaded under a projection it may still hold hidden fields, so
+            // unsetting the parent would be a guess — skip it. With the whole
+            // document loaded, `{}` really is empty and the removal can apply.
+            mongodb::bson::Bson::Document(_) if partial => {}
+            _ => {
+                unset.insert(path_of(key), "");
+            }
+        }
+    }
+}
+
+/// Unset every leaf path under a removed sub-document.
+///
+/// An empty sub-document has no leaves, so nothing is emitted for it: what is on
+/// screen cannot tell a genuinely empty object apart from one whose fields a
+/// projection hid, and unsetting the parent on that guess is exactly how
+/// unprojected siblings get destroyed.
+fn unset_visible_leaves(
+    prefix: &str,
+    doc: &Document,
+    unset: &mut Document,
+    blocked: &mut Vec<String>,
+) {
+    for (key, value) in doc {
+        if path_is_unaddressable(key) {
+            blocked.push(format!("{prefix}.{key}"));
+            continue;
+        }
+        let path = format!("{prefix}.{key}");
+        match value {
+            mongodb::bson::Bson::Document(inner) if !inner.is_empty() => {
+                unset_visible_leaves(&path, inner, unset, blocked);
+            }
+            _ => {
+                unset.insert(path, "");
+            }
+        }
     }
 }
 
@@ -488,16 +570,30 @@ pub async fn update_document_impl(
     filter: &str,
     original: &str,
     edited: &str,
+    partial: bool,
 ) -> Result<u64, String> {
     let started = std::time::Instant::now();
-    let result = update_document_inner(state, id, database, collection, filter, original, edited).await;
-    // Record the operators actually applied rather than the whole document: it
-    // is both smaller and a truer account of what changed.
-    let summary = match &result {
-        Ok(_) => format!("updateOne {database}.{collection}"),
-        Err(_) => format!("updateOne {database}.{collection} (failed)"),
+    let result = update_document_inner(
+        state, id, database, collection, filter, original, edited, partial,
+    )
+    .await;
+    // Record the operation that actually ran and the operators it applied. The
+    // edited document alone cannot show that removing a field issued `$unset`,
+    // so the mutation would not be reconstructable from the log.
+    let (summary, args) = match &result {
+        Ok((_, applied)) => (
+            format!("{} {database}.{collection}", applied.op),
+            format!(
+                "{{\"filter\":{filter},\"{}\":{}}}",
+                applied.op, applied.payload
+            ),
+        ),
+        Err(_) => (
+            format!("updateOne {database}.{collection} (failed)"),
+            format!("{{\"filter\":{filter},\"edited\":{edited}}}"),
+        ),
     };
-    let args = format!("{{\"filter\":{filter},\"edited\":{edited}}}");
+    let outcome = result.as_ref().map(|(modified, _)| *modified);
     crate::audit::maybe_record_result(
         state,
         Some(id),
@@ -509,11 +605,26 @@ pub async fn update_document_impl(
         started,
         &summary,
         Some(&args),
-        &result,
+        &outcome,
     );
-    result
+    result.map(|(modified, _)| modified)
 }
 
+/// What [`update_document_inner`] actually sent, for the audit record.
+struct AppliedWrite {
+    /// `updateOne` or `replaceOne`.
+    op: &'static str,
+    /// The update document or the replacement, as JSON.
+    payload: String,
+}
+
+/// Which Mongo write to issue for an edited document.
+enum WritePlan {
+    Update(Document),
+    Replace,
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn update_document_inner(
     state: &AppState,
     id: &str,
@@ -522,7 +633,8 @@ async fn update_document_inner(
     filter: &str,
     original: &str,
     edited: &str,
-) -> Result<u64, String> {
+    partial: bool,
+) -> Result<(u64, AppliedWrite), String> {
     // Still `ReplaceOne`: this is the single-document edit from the grid, and
     // that variant is deliberately outside the confirm-required set. Only the
     // Mongo operation underneath changed.
@@ -532,28 +644,63 @@ async fn update_document_inner(
     let original_doc = json_to_bson_document(original)?;
     let edited_doc = json_to_bson_document(edited)?;
 
-    // A field-level update rather than a replacement: the editor may hold only a
-    // projection of the document, and replacing with that deleted every field the
-    // projection left out (#275).
-    let update = build_field_update(&original_doc, &edited_doc);
-    if update.is_empty() {
+    let plan = match build_field_update(&original_doc, &edited_doc, partial) {
         // Mongo rejects an empty update document, and there is nothing to do.
-        return Ok(0);
-    }
+        Ok(update) if update.is_empty() => {
+            return Ok((
+                0,
+                AppliedWrite {
+                    op: "updateOne",
+                    payload: "{}".into(),
+                },
+            ));
+        }
+        Ok(update) => WritePlan::Update(update),
+        Err(e) => {
+            if partial {
+                // The document on screen is incomplete, so replacing it would
+                // delete whatever the projection hid. Nothing safe to do here.
+                return Err(e);
+            }
+            // The whole document is loaded, so replacing it is both safe and the
+            // only way to address a field whose name contains "." or "$".
+            WritePlan::Replace
+        }
+    };
+
+    let applied = match &plan {
+        WritePlan::Update(update) => AppliedWrite {
+            op: "updateOne",
+            payload: serde_json::to_string(&mongodb::bson::Bson::Document(update.clone()))
+                .unwrap_or_else(|_| "{}".into()),
+        },
+        WritePlan::Replace => AppliedWrite {
+            op: "replaceOne",
+            payload: edited.to_string(),
+        },
+    };
 
     if connection_is_mock(state, id)? {
-        return Ok(1);
+        return Ok((1, applied));
     }
 
     let client = require_real_client(state, id)?;
     let coll = client
         .database(database)
-        .collection::<mongodb::bson::Document>(collection);
-    let res = coll
-        .update_one(filter_doc, update)
-        .await
-        .map_err(|e| format!("Failed to update document: {}", e))?;
-    Ok(res.modified_count)
+        .collection::<Document>(collection);
+    let modified = match plan {
+        WritePlan::Update(update) => coll
+            .update_one(filter_doc, update)
+            .await
+            .map_err(|e| format!("Failed to update document: {}", e))?
+            .modified_count,
+        WritePlan::Replace => coll
+            .replace_one(filter_doc, edited_doc)
+            .await
+            .map_err(|e| format!("Failed to update document: {}", e))?
+            .modified_count,
+    };
+    Ok((modified, applied))
 }
 
 #[derive(serde::Serialize)]
@@ -829,7 +976,7 @@ mod csv_import_tests {
         // with it deleted username, email, roles, address and the rest.
         let original = doc_of(r#"{"_id":"66a1","age":34}"#);
         let edited = doc_of(r#"{"_id":"66a1","age":35}"#);
-        let update = build_field_update(&original, &edited);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
 
         assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
         assert!(
@@ -841,14 +988,14 @@ mod csv_import_tests {
     #[test]
     fn an_unchanged_document_produces_no_update() {
         let d = doc_of(r#"{"_id":"66a1","age":34}"#);
-        assert!(build_field_update(&d, &d).is_empty());
+        assert!(build_field_update(&d, &d, true).expect("addressable").is_empty());
     }
 
     #[test]
     fn removing_a_shown_field_unsets_it() {
         let original = doc_of(r#"{"_id":"66a1","age":34,"nickname":"nav"}"#);
         let edited = doc_of(r#"{"_id":"66a1","age":34}"#);
-        let update = build_field_update(&original, &edited);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$unset":{"nickname":""}}"#));
     }
 
@@ -856,7 +1003,7 @@ mod csv_import_tests {
     fn adding_a_field_sets_it() {
         let original = doc_of(r#"{"_id":"66a1","age":34}"#);
         let edited = doc_of(r#"{"_id":"66a1","age":34,"city":"Pforzheim"}"#);
-        let update = build_field_update(&original, &edited);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"city":"Pforzheim"}}"#));
     }
 
@@ -867,7 +1014,7 @@ mod csv_import_tests {
         // would delete street/zip/country — the same bug one level down.
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Berlin"}}"#);
-        let update = build_field_update(&original, &edited);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"address.city":"Berlin"}}"#));
     }
 
@@ -875,8 +1022,78 @@ mod csv_import_tests {
     fn a_nested_removal_unsets_the_dotted_path() {
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim","zip":"75172"}}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
-        let update = build_field_update(&original, &edited);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$unset":{"address.zip":""}}"#));
+    }
+
+    #[test]
+    fn removing_a_projected_subdocument_unsets_only_what_was_visible() {
+        // Under `{"address.city": 1}` the loaded `address` holds only `city`.
+        // Deleting it must not `$unset: address` — that takes street/zip/country
+        // with it, which is the very bug this change exists to prevent.
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$unset":{"address.city":""}}"#));
+    }
+
+    #[test]
+    fn removing_a_nested_subdocument_unsets_its_leaves_recursively() {
+        let original =
+            doc_of(r#"{"_id":"66a1","a":{"b":{"c":1,"d":2},"e":3}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
+        assert_eq!(
+            update,
+            doc_of(r#"{"$unset":{"a.b.c":"","a.b.d":"","a.e":""}}"#)
+        );
+    }
+
+    #[test]
+    fn removing_an_empty_subdocument_under_a_projection_writes_nothing() {
+        // `{}` on screen could be a genuinely empty object, or one whose fields
+        // the projection hid — so there is no leaf it is safe to unset.
+        let original = doc_of(r#"{"_id":"66a1","address":{}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
+        assert!(update.is_empty(), "must not guess at hidden fields: {update:?}");
+    }
+
+    #[test]
+    fn removing_an_empty_subdocument_from_a_whole_document_unsets_it() {
+        // Nothing was hidden, so `{}` really is empty and the removal applies.
+        let original = doc_of(r#"{"_id":"66a1","address":{}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, false).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$unset":{"address":""}}"#));
+    }
+
+    #[test]
+    fn a_literal_dotted_field_name_is_refused_not_mistargeted() {
+        // `price.usd` is a legal field name. Emitting it into `$set` would make
+        // MongoDB traverse into a `price` sub-document instead.
+        let original = doc_of(r#"{"_id":"66a1","price.usd":10}"#);
+        let edited = doc_of(r#"{"_id":"66a1","price.usd":11}"#);
+        let err = build_field_update(&original, &edited, true).expect_err("must refuse");
+        assert!(err.contains("price.usd"), "{err}");
+        assert!(err.contains("projection"), "should say how to proceed: {err}");
+    }
+
+    #[test]
+    fn a_dollar_prefixed_field_name_is_refused() {
+        let original = doc_of(r#"{"_id":"66a1","$weird":1}"#);
+        let edited = doc_of(r#"{"_id":"66a1","$weird":2}"#);
+        assert!(build_field_update(&original, &edited, true).is_err());
+    }
+
+    #[test]
+    fn an_untouched_dotted_field_name_does_not_block_the_update() {
+        // Only *changed* fields need addressing, so a document merely containing
+        // such a name is still editable elsewhere.
+        let original = doc_of(r#"{"_id":"66a1","price.usd":10,"age":34}"#);
+        let edited = doc_of(r#"{"_id":"66a1","price.usd":10,"age":35}"#);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
     }
 
     #[test]
@@ -884,7 +1101,7 @@ mod csv_import_tests {
         // `_id` is immutable; an edit that changes it must not reach the update.
         let original = doc_of(r#"{"_id":"66a1","age":34}"#);
         let edited = doc_of(r#"{"_id":"different","age":35}"#);
-        let update = build_field_update(&original, &edited);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
     }
 
@@ -892,7 +1109,7 @@ mod csv_import_tests {
     fn arrays_are_replaced_as_a_whole_value() {
         let original = doc_of(r#"{"_id":"66a1","roles":["admin","devops"]}"#);
         let edited = doc_of(r#"{"_id":"66a1","roles":["admin","editor"]}"#);
-        let update = build_field_update(&original, &edited);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"roles":["admin","editor"]}}"#));
     }
 
@@ -900,7 +1117,7 @@ mod csv_import_tests {
     fn replacing_a_document_with_a_scalar_sets_the_whole_path() {
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":"unknown"}"#);
-        let update = build_field_update(&original, &edited);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"address":"unknown"}}"#));
     }
 
@@ -908,7 +1125,7 @@ mod csv_import_tests {
     fn a_new_nested_document_is_set_whole() {
         let original = doc_of(r#"{"_id":"66a1"}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Berlin"}}"#);
-        let update = build_field_update(&original, &edited);
+        let update = build_field_update(&original, &edited, true).expect("addressable");
         assert_eq!(update, doc_of(r#"{"$set":{"address":{"city":"Berlin"}}}"#));
     }
 }

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -565,8 +565,19 @@ pub fn build_field_update(
     let mut unset = Document::new();
     let mut blocked: Vec<String> = Vec::new();
     let mut partial_writes: Vec<String> = Vec::new();
+    let mut ambiguous_removals: Vec<String> = Vec::new();
     diff_documents(
-        "", original, edited, shape, &mut set, &mut unset, &mut blocked, &mut partial_writes,
+        "",
+        original,
+        edited,
+        shape,
+        &mut DiffSink {
+            set: &mut set,
+            unset: &mut unset,
+            blocked: &mut blocked,
+            partial_writes: &mut partial_writes,
+            ambiguous_removals: &mut ambiguous_removals,
+        },
     );
 
     if !blocked.is_empty() {
@@ -577,6 +588,16 @@ pub fn build_field_update(
              separator and a leading \"$\" as an operator. Re-run the query without a \
              projection so the whole document can be saved.",
             blocked.join(", ")
+        )));
+    }
+    if !ambiguous_removals.is_empty() {
+        ambiguous_removals.sort();
+        ambiguous_removals.dedup();
+        return Err(UpdateBuildError::PartialWrite(format!(
+            "cannot remove field(s) {}: the projection returned them empty, so an empty \
+             stored object cannot be told apart from one whose fields it hid. Re-run the \
+             query without the projection to remove these.",
+            ambiguous_removals.join(", ")
         )));
     }
     if !partial_writes.is_empty() {
@@ -600,16 +621,27 @@ pub fn build_field_update(
     Ok(update)
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Where a diff deposits what it works out. Grouped because the list kept
+/// growing a parameter at a time as refusal cases were added.
+struct DiffSink<'a> {
+    set: &'a mut Document,
+    unset: &'a mut Document,
+    /// Field names an update operator cannot address.
+    blocked: &'a mut Vec<String>,
+    /// Values the projection loaded only partly, so writing them whole would
+    /// discard the rest.
+    partial_writes: &'a mut Vec<String>,
+    /// Removals that cannot be expressed at all, because the projection returned
+    /// the object empty.
+    ambiguous_removals: &'a mut Vec<String>,
+}
+
 fn diff_documents(
     prefix: &str,
     original: &Document,
     edited: &Document,
     shape: &ProjectionShape,
-    set: &mut Document,
-    unset: &mut Document,
-    blocked: &mut Vec<String>,
-    partial_writes: &mut Vec<String>,
+    sink: &mut DiffSink<'_>,
 ) {
     let path_of = |key: &str| {
         if prefix.is_empty() {
@@ -630,7 +662,7 @@ fn diff_documents(
         let old = original.get(key);
         let changed = old != Some(new_value);
         if changed && path_is_unaddressable(key) {
-            blocked.push(path);
+            sink.blocked.push(path);
             continue;
         }
         // Anything the projection loaded only partly cannot be written back as a
@@ -649,28 +681,26 @@ fn diff_documents(
             )
         );
         if changed && old_may_hide_more && writes_whole_value && shape.is_partial_at(&path) {
-            partial_writes.push(path);
+            sink.partial_writes.push(path);
             continue;
         }
         match old {
             None => {
-                set.insert(path, new_value.clone());
+                sink.set.insert(path, new_value.clone());
             }
             Some(old_value) if old_value == new_value => {}
             Some(mongodb::bson::Bson::Document(old_doc)) => match new_value {
                 // Both sides are sub-documents: recurse so only the fields that
                 // actually differ are written.
                 mongodb::bson::Bson::Document(new_doc) => {
-                    diff_documents(
-                        &path, old_doc, new_doc, shape, set, unset, blocked, partial_writes,
-                    );
+                    diff_documents(&path, old_doc, new_doc, shape, sink);
                 }
                 _ => {
-                    set.insert(path, new_value.clone());
+                    sink.set.insert(path, new_value.clone());
                 }
             },
             Some(_) => {
-                set.insert(path, new_value.clone());
+                sink.set.insert(path, new_value.clone());
             }
         }
     }
@@ -680,17 +710,10 @@ fn diff_documents(
             continue;
         }
         if path_is_unaddressable(key) {
-            blocked.push(path_of(key));
+            sink.blocked.push(path_of(key));
             continue;
         }
-        plan_removal(
-            &path_of(key),
-            old_value,
-            shape,
-            unset,
-            blocked,
-            partial_writes,
-        );
+        plan_removal(&path_of(key), old_value, shape, sink);
     }
 }
 
@@ -704,9 +727,7 @@ fn plan_removal(
     path: &str,
     value: &mongodb::bson::Bson,
     shape: &ProjectionShape,
-    unset: &mut Document,
-    blocked: &mut Vec<String>,
-    partial_writes: &mut Vec<String>,
+    sink: &mut DiffSink<'_>,
 ) {
     match value {
         mongodb::bson::Bson::Document(doc) => {
@@ -714,34 +735,46 @@ fn plan_removal(
                 // Loaded whole — because nothing was projected, or because the
                 // projection included it outright (`{"address": 1}`) — so remove
                 // the field itself. Descending would leave an empty `{}` behind.
-                unset.insert(path.to_string(), "");
+                sink.unset.insert(path.to_string(), "");
                 return;
             }
             // Partial: only what was visible may go, or the projection's hidden
-            // siblings go with it. An empty sub-document yields nothing at all,
-            // since `{}` on screen may be genuinely empty or hidden.
+            // siblings go with it.
+            let before = (
+                sink.unset.len(),
+                sink.blocked.len(),
+                sink.partial_writes.len(),
+                sink.ambiguous_removals.len(),
+            );
             for (key, child) in doc {
                 if path_is_unaddressable(key) {
-                    blocked.push(format!("{path}.{key}"));
+                    sink.blocked.push(format!("{path}.{key}"));
                     continue;
                 }
-                plan_removal(
-                    &format!("{path}.{key}"),
-                    child,
-                    shape,
-                    unset,
-                    blocked,
-                    partial_writes,
-                );
+                plan_removal(&format!("{path}.{key}"), child, shape, sink);
+            }
+            let after = (
+                sink.unset.len(),
+                sink.blocked.len(),
+                sink.partial_writes.len(),
+                sink.ambiguous_removals.len(),
+            );
+            if before == after {
+                // Nothing could be expressed: what was shown is an empty object
+                // (or only empty objects), so an empty stored object cannot be
+                // told apart from one whose fields the projection hid. Emitting
+                // nothing would close the editor with a success message over a
+                // document that did not change.
+                sink.ambiguous_removals.push(path.to_string());
             }
         }
         // `$slice`/`$elemMatch` returned only part of the array, so unsetting it
         // would delete the elements that were never shown.
         mongodb::bson::Bson::Array(_) if shape.is_partial_at(path) => {
-            partial_writes.push(path.to_string());
+            sink.partial_writes.push(path.to_string());
         }
         _ => {
-            unset.insert(path.to_string(), "");
+            sink.unset.insert(path.to_string(), "");
         }
     }
 }
@@ -757,27 +790,32 @@ pub async fn update_document_impl(
     projection: Option<&str>,
 ) -> Result<u64, String> {
     let started = std::time::Instant::now();
-    let result = update_document_inner(
+    let outcome = update_document_inner(
         state, id, database, collection, filter, original, edited, projection,
     )
     .await;
-    // Record the operation that actually ran and the operators it applied. The
-    // edited document alone cannot show that removing a field issued `$unset`,
-    // so the mutation would not be reconstructable from the log.
-    let (summary, args) = match &result {
-        Ok((_, applied)) => (
-            format!("{} {database}.{collection}", applied.op),
-            format!(
-                "{{\"filter\":{filter},\"{}\":{}}}",
-                applied.op, applied.payload
-            ),
-        ),
-        Err(_) => (
-            format!("updateOne {database}.{collection} (failed)"),
+    // Record the operation that was attempted and the operators it carried —
+    // including when the database rejected it. The edited document alone cannot
+    // show that removing a field issued `$unset`, and a failed replacement
+    // fallback must not be logged as an update.
+    let (summary, args) = match &outcome.attempted {
+        Some(applied) => {
+            let suffix = if outcome.result.is_err() { " (failed)" } else { "" };
+            (
+                format!("{} {database}.{collection}{suffix}", applied.op),
+                format!(
+                    "{{\"filter\":{filter},\"{}\":{}}}",
+                    applied.op, applied.payload
+                ),
+            )
+        }
+        // Rejected before a write was planned: a write guard, unparseable JSON,
+        // or a refusal. There is no operation to name, so record the input.
+        None => (
+            format!("updateOne {database}.{collection} (rejected)"),
             format!("{{\"filter\":{filter},\"edited\":{edited}}}"),
         ),
     };
-    let outcome = result.as_ref().map(|(modified, _)| *modified);
     crate::audit::maybe_record_result(
         state,
         Some(id),
@@ -789,12 +827,21 @@ pub async fn update_document_impl(
         started,
         &summary,
         Some(&args),
-        &outcome,
+        &outcome.result,
     );
-    result.map(|(modified, _)| modified)
+    outcome.result
 }
 
-/// What [`update_document_inner`] actually sent, for the audit record.
+/// The write that was attempted, plus how it went.
+///
+/// `attempted` survives a database error on purpose: a failed mutation is
+/// exactly the one an audit trail needs to be reconstructable from.
+struct WriteOutcome {
+    attempted: Option<AppliedWrite>,
+    result: Result<u64, String>,
+}
+
+/// What [`update_document_inner`] sent, for the audit record.
 struct AppliedWrite {
     /// `updateOne` or `replaceOne`.
     op: &'static str,
@@ -818,27 +865,46 @@ async fn update_document_inner(
     original: &str,
     edited: &str,
     projection: Option<&str>,
-) -> Result<(u64, AppliedWrite), String> {
+) -> WriteOutcome {
+    macro_rules! rejected {
+        ($e:expr) => {
+            return WriteOutcome {
+                attempted: None,
+                result: Err($e),
+            }
+        };
+    }
     // Still `ReplaceOne`: this is the single-document edit from the grid, and
     // that variant is deliberately outside the confirm-required set. Only the
     // Mongo operation underneath changed.
-    guard_writable(state, id, WriteOp::ReplaceOne, false)?;
+    if let Err(e) = guard_writable(state, id, WriteOp::ReplaceOne, false) {
+        rejected!(e);
+    }
 
-    let filter_doc = json_to_bson_document(filter)?;
-    let original_doc = json_to_bson_document(original)?;
-    let edited_doc = json_to_bson_document(edited)?;
+    let filter_doc = match json_to_bson_document(filter) {
+        Ok(d) => d,
+        Err(e) => rejected!(e),
+    };
+    let original_doc = match json_to_bson_document(original) {
+        Ok(d) => d,
+        Err(e) => rejected!(e),
+    };
+    let edited_doc = match json_to_bson_document(edited) {
+        Ok(d) => d,
+        Err(e) => rejected!(e),
+    };
 
     let shape = ProjectionShape::parse_optional(projection);
     let plan = match build_field_update(&original_doc, &edited_doc, &shape) {
         // Mongo rejects an empty update document, and there is nothing to do.
         Ok(update) if update.is_empty() => {
-            return Ok((
-                0,
-                AppliedWrite {
+            return WriteOutcome {
+                attempted: Some(AppliedWrite {
                     op: "updateOne",
                     payload: "{}".into(),
-                },
-            ));
+                }),
+                result: Ok(0),
+            };
         }
         Ok(update) => WritePlan::Update(update),
         Err(err) => {
@@ -850,13 +916,13 @@ async fn update_document_inner(
             let recoverable = matches!(err, UpdateBuildError::UnaddressableNames(_))
                 && shape.is_whole_document();
             if !recoverable {
-                return Err(err.to_string());
+                rejected!(err.to_string());
             }
             WritePlan::Replace
         }
     };
 
-    let applied = match &plan {
+    let attempted = Some(match &plan {
         WritePlan::Update(update) => AppliedWrite {
             op: "updateOne",
             payload: serde_json::to_string(&mongodb::bson::Bson::Document(update.clone()))
@@ -866,29 +932,51 @@ async fn update_document_inner(
             op: "replaceOne",
             payload: edited.to_string(),
         },
-    };
+    });
 
-    if connection_is_mock(state, id)? {
-        return Ok((1, applied));
+    match connection_is_mock(state, id) {
+        Ok(true) => {
+            return WriteOutcome {
+                attempted,
+                result: Ok(1),
+            }
+        }
+        Ok(false) => {}
+        Err(e) => {
+            return WriteOutcome {
+                attempted,
+                result: Err(e),
+            }
+        }
     }
 
-    let client = require_real_client(state, id)?;
+    let client = match require_real_client(state, id) {
+        Ok(c) => c,
+        Err(e) => {
+            return WriteOutcome {
+                attempted,
+                result: Err(e),
+            }
+        }
+    };
     let coll = client
         .database(database)
         .collection::<Document>(collection);
-    let modified = match plan {
+    // The plan is already decided, so a database rejection keeps `attempted` —
+    // a failed mutation is exactly the one the audit trail must describe.
+    let result = match plan {
         WritePlan::Update(update) => coll
             .update_one(filter_doc, update)
             .await
-            .map_err(|e| format!("Failed to update document: {}", e))?
-            .modified_count,
+            .map(|r| r.modified_count)
+            .map_err(|e| format!("Failed to update document: {}", e)),
         WritePlan::Replace => coll
             .replace_one(filter_doc, edited_doc)
             .await
-            .map_err(|e| format!("Failed to update document: {}", e))?
-            .modified_count,
+            .map(|r| r.modified_count)
+            .map_err(|e| format!("Failed to update document: {}", e)),
     };
-    Ok((modified, applied))
+    WriteOutcome { attempted, result }
 }
 
 #[derive(serde::Serialize)]
@@ -1260,14 +1348,27 @@ mod csv_import_tests {
         assert_eq!(update, doc_of(r#"{"$unset":{"address":""}}"#));
     }
 
+
     #[test]
-    fn removing_an_empty_subdocument_under_a_projection_writes_nothing() {
-        // `{}` on screen could be a genuinely empty object, or one whose fields
-        // the projection hid — so there is no leaf it is safe to unset.
+    fn removing_an_empty_projected_subdocument_is_refused_not_a_silent_no_op() {
+        // Emitting nothing closed the editor with a success message over a
+        // document that had not changed.
         let original = doc_of(r#"{"_id":"66a1","address":{}}"#);
         let edited = doc_of(r#"{"_id":"66a1"}"#);
-        let update = build_field_update(&original, &edited, &nested_projection()).expect("addressable");
-        assert!(update.is_empty(), "must not guess at hidden fields: {update:?}");
+        let err = build_field_update(&original, &edited, &nested_projection())
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("address"), "{err}");
+        assert!(err.contains("returned them empty"), "{err}");
+    }
+
+    #[test]
+    fn removing_a_subdocument_of_only_empty_objects_is_also_refused() {
+        // Nothing expressible any number of levels down, not just immediately.
+        let shape = ProjectionShape::parse(r#"{"a.b.c":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","a":{"b":{}}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        assert!(build_field_update(&original, &edited, &shape).is_err());
     }
 
     #[test]

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -518,14 +518,23 @@ fn diff_documents(
         // the parent: under a nested projection the parent also holds fields the
         // user never saw, and unsetting it would delete them.
         match old_value {
-            mongodb::bson::Bson::Document(old_doc) if !old_doc.is_empty() => {
-                unset_visible_leaves(&path_of(key), old_doc, unset, blocked);
+            mongodb::bson::Bson::Document(old_doc) => {
+                if !partial {
+                    // The whole document was loaded, so nothing is hidden under
+                    // this key: remove the field itself. Unsetting leaf by leaf
+                    // would leave an empty `{}` behind, so the stored document
+                    // would differ from the editor and still satisfy
+                    // `{field: {$exists: true}}`.
+                    unset.insert(path_of(key), "");
+                } else if !old_doc.is_empty() {
+                    // Partial view: only the leaves that were actually visible
+                    // can safely go, or the projection's hidden siblings go too.
+                    unset_visible_leaves(&path_of(key), old_doc, unset, blocked);
+                }
+                // Partial *and* empty: `{}` on screen may be a genuinely empty
+                // object or one whose fields the projection hid, so there is no
+                // leaf it is safe to unset and nothing is emitted.
             }
-            // An empty sub-document has no visible leaf to unset. If the document
-            // was loaded under a projection it may still hold hidden fields, so
-            // unsetting the parent would be a guess — skip it. With the whole
-            // document loaded, `{}` really is empty and the removal can apply.
-            mongodb::bson::Bson::Document(_) if partial => {}
             _ => {
                 unset.insert(path_of(key), "");
             }
@@ -1047,6 +1056,17 @@ mod csv_import_tests {
             update,
             doc_of(r#"{"$unset":{"a.b.c":"","a.b.d":"","a.e":""}}"#)
         );
+    }
+
+    #[test]
+    fn removing_a_subdocument_from_a_whole_document_unsets_the_parent() {
+        // Nothing is hidden, so the field itself goes. Unsetting `address.city`
+        // alone would leave `address: {}` stored, which is not what the editor
+        // showed and still matches `{address: {$exists: true}}`.
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, false).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$unset":{"address":""}}"#));
     }
 
     #[test]

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -419,6 +419,9 @@ fn path_is_unaddressable(key: &str) -> bool {
 pub struct ProjectionShape {
     /// Every path the projection names, flattened to dotted form.
     paths: Vec<String>,
+    /// Paths whose value the projection *computed*, so there is nothing in the
+    /// stored document to write back to.
+    computed: Vec<String>,
     scope: Scope,
 }
 
@@ -442,10 +445,18 @@ enum Scope {
 enum Leaf {
     Include,
     Exclude,
-    /// `$slice`, `$elemMatch`, `$meta`: truncates a value, does not restrict the
-    /// field list.
+    /// A true projection operator — `$slice`, `$elemMatch`, `$meta`. These
+    /// truncate a value without restricting which fields come back.
     Operator,
+    /// A computed expression such as `{"display": {"$concat": [...]}}`. It both
+    /// restricts the field list, like any inclusion, *and* produces a value that
+    /// does not exist in the stored document.
+    Computed,
 }
+
+/// Operators that truncate a value rather than compute one. Everything else
+/// under a `$` is an aggregation expression, which restricts the field list.
+const PROJECTION_OPERATORS: [&str; 3] = ["$slice", "$elemMatch", "$meta"];
 
 impl ProjectionShape {
     /// Parse a find projection, or `None` when the shape cannot be known — the
@@ -456,6 +467,7 @@ impl ProjectionShape {
             Some(p) => Self::parse(p),
             None => Self {
                 paths: Vec::new(),
+                computed: Vec::new(),
                 scope: Scope::Unknown,
             },
         }
@@ -471,6 +483,7 @@ impl ProjectionShape {
         let Ok(serde_json::Value::Object(map)) = serde_json::from_str(trimmed) else {
             return Self {
                 paths: Vec::new(),
+                computed: Vec::new(),
                 scope: Scope::Unknown,
             };
         };
@@ -488,7 +501,9 @@ impl ProjectionShape {
                 continue;
             }
             match leaf {
-                Leaf::Include => includes = true,
+                // A computed field restricts the field list exactly as an
+                // inclusion does: nothing unlisted comes back.
+                Leaf::Include | Leaf::Computed => includes = true,
                 Leaf::Exclude => excludes = true,
                 Leaf::Operator => {}
             }
@@ -499,10 +514,24 @@ impl ProjectionShape {
             (false, true) => Scope::Excluded,
             (false, false) => Scope::All,
         };
+        let computed = entries
+            .iter()
+            .filter(|(_, leaf)| matches!(leaf, Leaf::Computed))
+            .map(|(path, _)| path.clone())
+            .collect();
         Self {
             paths: entries.into_iter().map(|(path, _)| path).collect(),
+            computed,
             scope,
         }
+    }
+
+    /// True when the value at `path` was computed by the projection, so there is
+    /// no stored field it corresponds to.
+    fn is_computed(&self, path: &str) -> bool {
+        self.computed
+            .iter()
+            .any(|p| p == path || path.starts_with(&format!("{p}.")))
     }
 
     /// True when nothing was projected away, so the document is whole.
@@ -557,10 +586,19 @@ fn flatten_projection(
             }
             // `{"roles": {"$slice": 2}}` truncates a value; it does not restrict
             // which fields come back.
-            serde_json::Value::Object(inner) if inner.keys().all(|k| k.starts_with('$')) => {
+            serde_json::Value::Object(inner)
+                if !inner.is_empty()
+                    && inner.keys().all(|k| PROJECTION_OPERATORS.contains(&k.as_str())) =>
+            {
                 for op in inner.keys() {
                     out.push((format!("{path}.{op}"), Leaf::Operator));
                 }
+            }
+            // Any other `$`-keyed object is an aggregation expression, e.g.
+            // `{"display": {"$concat": [...]}}`. It restricts the field list and
+            // its value is synthesized, so it cannot be written back.
+            serde_json::Value::Object(inner) if inner.keys().any(|k| k.starts_with('$')) => {
+                out.push((path, Leaf::Computed));
             }
             // `{"address": {"city": 1}}` is the nested spelling of
             // `{"address.city": 1}`.
@@ -582,6 +620,8 @@ fn flatten_projection(
 /// falling back would report a save that silently kept the old value.
 #[derive(Debug)]
 pub enum UpdateBuildError {
+    /// The rows have no known source document, so nothing may be written.
+    NoLineage(String),
     /// `_id` was changed or removed.
     ImmutableId(String),
     /// A changed field's name contains `.` or starts with `$`.
@@ -593,7 +633,10 @@ pub enum UpdateBuildError {
 impl std::fmt::Display for UpdateBuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let msg = match self {
-            Self::ImmutableId(m) | Self::UnaddressableNames(m) | Self::PartialWrite(m) => m,
+            Self::NoLineage(m)
+            | Self::ImmutableId(m)
+            | Self::UnaddressableNames(m)
+            | Self::PartialWrite(m) => m,
         };
         f.write_str(msg)
     }
@@ -624,6 +667,18 @@ pub fn build_field_update(
     edited: &Document,
     shape: &ProjectionShape,
 ) -> Result<Document, UpdateBuildError> {
+    // An unknown shape means the rows did not come from a find, so `_id` may be a
+    // group key rather than a document id. Writing anything would target whichever
+    // source document happens to share that value — or none at all. There is no
+    // safe subset here, not even a scalar field.
+    if shape.scope == Scope::Unknown {
+        return Err(UpdateBuildError::NoLineage(
+            "cannot save: these rows did not come from a plain query, so MQLens cannot tell \
+             which stored document each one came from. Re-run as a find query to edit \
+             documents."
+                .into(),
+        ));
+    }
     // `_id` is immutable. The old replacement surfaced MongoDB's error; skipping
     // the change silently would report a save that did not happen.
     if let Some(original_id) = original.get("_id") {
@@ -652,6 +707,7 @@ pub fn build_field_update(
     let mut partial_writes: Vec<String> = Vec::new();
     let mut ambiguous_removals: Vec<String> = Vec::new();
     let mut hidden_additions: Vec<String> = Vec::new();
+    let mut computed_writes: Vec<String> = Vec::new();
     diff_documents(
         "",
         original,
@@ -664,6 +720,7 @@ pub fn build_field_update(
             partial_writes: &mut partial_writes,
             ambiguous_removals: &mut ambiguous_removals,
             hidden_additions: &mut hidden_additions,
+            computed_writes: &mut computed_writes,
         },
     );
 
@@ -675,6 +732,16 @@ pub fn build_field_update(
              separator and a leading \"$\" as an operator. Re-run the query without a \
              projection so the whole document can be saved.",
             blocked.join(", ")
+        )));
+    }
+    if !computed_writes.is_empty() {
+        computed_writes.sort();
+        computed_writes.dedup();
+        return Err(UpdateBuildError::PartialWrite(format!(
+            "cannot save field(s) {}: the projection computed them, so there is no stored \
+             field to write back to. Re-run the query without the projection to edit this \
+             document.",
+            computed_writes.join(", ")
         )));
     }
     if !hidden_additions.is_empty() {
@@ -734,6 +801,8 @@ struct DiffSink<'a> {
     /// Fields the editor appears to add, but which the projection may simply not
     /// have returned — so writing them could overwrite an existing value.
     hidden_additions: &'a mut Vec<String>,
+    /// Fields the projection computed, which have no stored counterpart.
+    computed_writes: &'a mut Vec<String>,
 }
 
 fn diff_documents(
@@ -761,6 +830,10 @@ fn diff_documents(
         let path = path_of(key);
         let old = original.get(key);
         let changed = old != Some(new_value);
+        if changed && shape.is_computed(&path) {
+            sink.computed_writes.push(path);
+            continue;
+        }
         if changed && path_is_unaddressable(key) {
             sink.blocked.push(path);
             continue;
@@ -1815,31 +1888,7 @@ mod csv_import_tests {
         assert!(err.contains("profile.roles"), "{err}");
     }
 
-    #[test]
-    fn an_aggregation_result_assumes_nothing_is_complete() {
-        // A pipeline's shape cannot be reduced to a field list, so no whole-value
-        // write is allowed and removals stay leaf-only.
-        let shape = ProjectionShape::parse_optional(None);
-        assert!(!shape.is_whole_document());
 
-        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
-        let edited = doc_of(r#"{"_id":"66a1"}"#);
-        let update = build_field_update(&original, &edited, &shape).expect("addressable");
-        assert_eq!(
-            update,
-            doc_of(r#"{"$unset":{"address.city":""}}"#),
-            "must not unset the parent on an unknown shape"
-        );
-    }
-
-    #[test]
-    fn a_scalar_edit_still_works_on_an_aggregation_result() {
-        let shape = ProjectionShape::parse_optional(None);
-        let original = doc_of(r#"{"_id":"66a1","age":34}"#);
-        let edited = doc_of(r#"{"_id":"66a1","age":35}"#);
-        let update = build_field_update(&original, &edited, &shape).expect("addressable");
-        assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
-    }
 
     #[test]
     fn an_immutable_id_error_is_reported_as_such_not_as_an_addressing_problem() {
@@ -1862,6 +1911,56 @@ mod csv_import_tests {
         let err = build_field_update(&original, &edited, &no_projection())
             .expect_err("must refuse");
         assert!(matches!(err, UpdateBuildError::UnaddressableNames(_)), "{err:?}");
+    }
+
+    #[test]
+    fn rows_without_known_lineage_cannot_be_saved_at_all() {
+        // Aggregation rows may carry a group key as `_id`, so any write would
+        // target whichever stored document happens to share that value — or none.
+        // There is no safe subset, not even a scalar field.
+        let shape = ProjectionShape::parse_optional(None);
+        let original = doc_of(r#"{"_id":"active","count":3}"#);
+        let edited = doc_of(r#"{"_id":"active","count":4}"#);
+        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse");
+        assert!(matches!(err, UpdateBuildError::NoLineage(_)), "{err:?}");
+        assert!(err.to_string().contains("find query"), "{err}");
+    }
+
+    #[test]
+    fn a_computed_projection_field_cannot_be_written_back() {
+        // `{"display": {"$concat": [...]}}` synthesizes a value; there is no
+        // stored `display` to update.
+        let shape = ProjectionShape::parse(r#"{"display":{"$concat":["$first"," ","$last"]}}"#);
+        let original = doc_of(r#"{"_id":"66a1","display":"Ada L"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","display":"Ada Lovelace"}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("display"), "{err}");
+        assert!(err.contains("computed"), "{err}");
+    }
+
+    #[test]
+    fn a_computed_projection_establishes_inclusion_scope() {
+        // It restricts the field list like any inclusion, so an unlisted field may
+        // already exist and must not be added blindly.
+        let shape = ProjectionShape::parse(r#"{"display":{"$concat":["$first"," ","$last"]}}"#);
+        let original = doc_of(r#"{"_id":"66a1","display":"Ada L"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","display":"Ada L","address":{"city":"Berlin"}}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("address"), "{err}");
+    }
+
+    #[test]
+    fn a_slice_is_still_treated_as_a_projection_operator_not_an_expression() {
+        // Only $slice/$elemMatch/$meta truncate a value; they must keep leaving the
+        // field list unrestricted.
+        let shape = ProjectionShape::parse(r#"{"roles":{"$slice":2}}"#);
+        assert!(shape.is_partial_at("roles"));
+        assert!(!shape.is_computed("roles"));
+        assert!(!shape.may_hide("city"), "a $slice-only projection returns every field");
     }
 
     #[test]

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -416,6 +416,20 @@ pub struct ProjectionShape {
 }
 
 impl ProjectionShape {
+    /// Parse a find projection, or `None` when the shape cannot be known — the
+    /// rows came from an aggregation, whose `$project`/`$replaceRoot`/`$unset`
+    /// stages cannot be reduced to a field list. Treated as naming everything,
+    /// so nothing is assumed complete and no whole-value write is allowed.
+    pub fn parse_optional(projection: Option<&str>) -> Self {
+        match projection {
+            Some(p) => Self::parse(p),
+            None => Self {
+                paths: Vec::new(),
+                opaque: true,
+            },
+        }
+    }
+
     /// Parse a find projection. An unparseable one is treated as naming
     /// everything, so nothing is assumed complete.
     pub fn parse(projection: &str) -> Self {
@@ -475,6 +489,31 @@ fn flatten_projection(
     }
 }
 
+/// Why a field-level update could not be built.
+///
+/// The kind matters: an unaddressable field name is recoverable by replacing the
+/// whole document (when the whole document is what was loaded), while a changed
+/// `_id` is not — MongoDB's replacement semantics preserve an omitted `_id`, so
+/// falling back would report a save that silently kept the old value.
+#[derive(Debug)]
+pub enum UpdateBuildError {
+    /// `_id` was changed or removed.
+    ImmutableId(String),
+    /// A changed field's name contains `.` or starts with `$`.
+    UnaddressableNames(String),
+    /// A value the projection loaded only partly would be overwritten whole.
+    PartialWrite(String),
+}
+
+impl std::fmt::Display for UpdateBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            Self::ImmutableId(m) | Self::UnaddressableNames(m) | Self::PartialWrite(m) => m,
+        };
+        f.write_str(msg)
+    }
+}
+
 /// Build a field-level update from the document as it was loaded and as it was
 /// edited (#275).
 ///
@@ -499,20 +538,24 @@ pub fn build_field_update(
     original: &Document,
     edited: &Document,
     shape: &ProjectionShape,
-) -> Result<Document, String> {
+) -> Result<Document, UpdateBuildError> {
     // `_id` is immutable. The old replacement surfaced MongoDB's error; skipping
     // the change silently would report a save that did not happen.
     if let Some(original_id) = original.get("_id") {
         match edited.get("_id") {
             None => {
-                return Err("cannot remove _id: a document's _id is immutable. \
-                            Restore it and save again."
-                    .into())
+                return Err(UpdateBuildError::ImmutableId(
+                    "cannot remove _id: a document's _id is immutable. Restore it and \
+                     save again."
+                        .into(),
+                ))
             }
             Some(edited_id) if edited_id != original_id => {
-                return Err("cannot change _id: a document's _id is immutable. \
-                            Insert a new document instead."
-                    .into())
+                return Err(UpdateBuildError::ImmutableId(
+                    "cannot change _id: a document's _id is immutable. Insert a new \
+                     document instead."
+                        .into(),
+                ))
             }
             Some(_) => {}
         }
@@ -529,22 +572,22 @@ pub fn build_field_update(
     if !blocked.is_empty() {
         blocked.sort();
         blocked.dedup();
-        return Err(format!(
+        return Err(UpdateBuildError::UnaddressableNames(format!(
             "cannot update field name(s) {} in place: MongoDB reads \".\" as a path \
              separator and a leading \"$\" as an operator. Re-run the query without a \
              projection so the whole document can be saved.",
             blocked.join(", ")
-        ));
+        )));
     }
     if !partial_writes.is_empty() {
         partial_writes.sort();
         partial_writes.dedup();
-        return Err(format!(
+        return Err(UpdateBuildError::PartialWrite(format!(
             "cannot save field(s) {}: the projection returned only part of their contents, \
              so writing them back would discard the rest. Re-run the query without the \
              projection to edit these.",
             partial_writes.join(", ")
-        ));
+        )));
     }
 
     let mut update = Document::new();
@@ -640,57 +683,65 @@ fn diff_documents(
             blocked.push(path_of(key));
             continue;
         }
-        let path = path_of(key);
-        match old_value {
-            mongodb::bson::Bson::Document(old_doc) => {
-                unset_removed_subtree(&path, old_doc, shape, unset, blocked);
-            }
-            // A partially loaded array reaches here rather than the change guard,
-            // because the key is simply absent from the edited document. Unsetting
-            // it would delete the elements the projection never showed.
-            mongodb::bson::Bson::Array(_) if shape.is_partial_at(&path) => {
-                partial_writes.push(path);
-            }
-            _ => {
-                unset.insert(path, "");
-            }
-        }
+        plan_removal(
+            &path_of(key),
+            old_value,
+            shape,
+            unset,
+            blocked,
+            partial_writes,
+        );
     }
 }
 
-/// Unset a removed sub-document, descending only as far as the projection left
-/// it incomplete.
+/// Plan the removal of the value at `path`, at any depth.
 ///
-/// At a path the projection loaded whole, the field itself is unset — going
-/// deeper would leave an empty `{}` behind. Where it loaded only part, the walk
-/// continues so the siblings it hid are not taken along. An empty sub-document
-/// inside a partial path yields nothing at all: `{}` on screen may be genuinely
-/// empty or hidden, and there is no leaf it is safe to unset.
-fn unset_removed_subtree(
+/// Deliberately one function for every removal, top level and nested alike. The
+/// cases were previously split between the caller and a recursive helper, and
+/// each guard added to one of them had to be remembered in the other — which is
+/// how partial nested arrays kept slipping through.
+fn plan_removal(
     path: &str,
-    doc: &Document,
+    value: &mongodb::bson::Bson,
     shape: &ProjectionShape,
     unset: &mut Document,
     blocked: &mut Vec<String>,
+    partial_writes: &mut Vec<String>,
 ) {
-    if !shape.is_partial_at(path) {
-        unset.insert(path.to_string(), "");
-        return;
-    }
-    for (key, value) in doc {
-        if path_is_unaddressable(key) {
-            blocked.push(format!("{path}.{key}"));
-            continue;
+    match value {
+        mongodb::bson::Bson::Document(doc) => {
+            if !shape.is_partial_at(path) {
+                // Loaded whole — because nothing was projected, or because the
+                // projection included it outright (`{"address": 1}`) — so remove
+                // the field itself. Descending would leave an empty `{}` behind.
+                unset.insert(path.to_string(), "");
+                return;
+            }
+            // Partial: only what was visible may go, or the projection's hidden
+            // siblings go with it. An empty sub-document yields nothing at all,
+            // since `{}` on screen may be genuinely empty or hidden.
+            for (key, child) in doc {
+                if path_is_unaddressable(key) {
+                    blocked.push(format!("{path}.{key}"));
+                    continue;
+                }
+                plan_removal(
+                    &format!("{path}.{key}"),
+                    child,
+                    shape,
+                    unset,
+                    blocked,
+                    partial_writes,
+                );
+            }
         }
-        let child = format!("{path}.{key}");
-        match value {
-            mongodb::bson::Bson::Document(inner) if !inner.is_empty() => {
-                unset_removed_subtree(&child, inner, shape, unset, blocked);
-            }
-            mongodb::bson::Bson::Document(_) => {}
-            _ => {
-                unset.insert(child, "");
-            }
+        // `$slice`/`$elemMatch` returned only part of the array, so unsetting it
+        // would delete the elements that were never shown.
+        mongodb::bson::Bson::Array(_) if shape.is_partial_at(path) => {
+            partial_writes.push(path.to_string());
+        }
+        _ => {
+            unset.insert(path.to_string(), "");
         }
     }
 }
@@ -703,7 +754,7 @@ pub async fn update_document_impl(
     filter: &str,
     original: &str,
     edited: &str,
-    projection: &str,
+    projection: Option<&str>,
 ) -> Result<u64, String> {
     let started = std::time::Instant::now();
     let result = update_document_inner(
@@ -766,7 +817,7 @@ async fn update_document_inner(
     filter: &str,
     original: &str,
     edited: &str,
-    projection: &str,
+    projection: Option<&str>,
 ) -> Result<(u64, AppliedWrite), String> {
     // Still `ReplaceOne`: this is the single-document edit from the grid, and
     // that variant is deliberately outside the confirm-required set. Only the
@@ -777,7 +828,7 @@ async fn update_document_inner(
     let original_doc = json_to_bson_document(original)?;
     let edited_doc = json_to_bson_document(edited)?;
 
-    let shape = ProjectionShape::parse(projection);
+    let shape = ProjectionShape::parse_optional(projection);
     let plan = match build_field_update(&original_doc, &edited_doc, &shape) {
         // Mongo rejects an empty update document, and there is nothing to do.
         Ok(update) if update.is_empty() => {
@@ -790,14 +841,17 @@ async fn update_document_inner(
             ));
         }
         Ok(update) => WritePlan::Update(update),
-        Err(e) => {
-            if !shape.is_whole_document() {
-                // The document on screen is incomplete, so replacing it would
-                // delete whatever the projection hid. Nothing safe to do here.
-                return Err(e);
+        Err(err) => {
+            // Only an unaddressable field name is recoverable by replacing, and
+            // only when the whole document was loaded. An immutable-`_id` error
+            // must never reach the fallback: replacement preserves an omitted
+            // `_id`, so the request would succeed and report a save while the
+            // old value quietly stayed.
+            let recoverable = matches!(err, UpdateBuildError::UnaddressableNames(_))
+                && shape.is_whole_document();
+            if !recoverable {
+                return Err(err.to_string());
             }
-            // The whole document is loaded, so replacing it is both safe and the
-            // only way to address a field whose name contains "." or "$".
             WritePlan::Replace
         }
     };
@@ -1262,7 +1316,7 @@ mod csv_import_tests {
         let shape = ProjectionShape::parse(r#"{"roles":{"$slice":2}}"#);
         let original = doc_of(r#"{"_id":"66a1","roles":["admin","devops"]}"#);
         let edited = doc_of(r#"{"_id":"66a1","roles":["admin","editor"]}"#);
-        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse");
+        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse").to_string();
         assert!(err.contains("roles"), "{err}");
         assert!(err.contains("part of their contents"), "{err}");
     }
@@ -1274,7 +1328,7 @@ mod csv_import_tests {
         let shape = ProjectionShape::parse(r#"{"address.city":1}"#);
         let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
         let edited = doc_of(r#"{"_id":"66a1","address":"unknown"}"#);
-        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse");
+        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse").to_string();
         assert!(err.contains("address"), "{err}");
         assert!(err.contains("part of their contents"), "{err}");
     }
@@ -1304,7 +1358,7 @@ mod csv_import_tests {
         let shape = ProjectionShape::parse(r#"{"roles":{"$slice":2}}"#);
         let original = doc_of(r#"{"_id":"66a1","roles":["admin","devops"]}"#);
         let edited = doc_of(r#"{"_id":"66a1"}"#);
-        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse");
+        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse").to_string();
         assert!(err.contains("roles"), "{err}");
     }
 
@@ -1333,7 +1387,7 @@ mod csv_import_tests {
         let original = doc_of(r#"{"_id":"66a1","age":34}"#);
         let edited = doc_of(r#"{"_id":"different","age":34}"#);
         let err = build_field_update(&original, &edited, &no_projection())
-            .expect_err("must refuse");
+            .expect_err("must refuse").to_string();
         assert!(err.contains("_id"), "{err}");
         assert!(err.contains("immutable"), "{err}");
     }
@@ -1343,8 +1397,72 @@ mod csv_import_tests {
         let original = doc_of(r#"{"_id":"66a1","age":34}"#);
         let edited = doc_of(r#"{"age":34}"#);
         let err = build_field_update(&original, &edited, &no_projection())
-            .expect_err("must refuse");
+            .expect_err("must refuse").to_string();
         assert!(err.contains("_id"), "{err}");
+    }
+
+    #[test]
+    fn removing_a_nested_partial_array_reached_by_recursion_is_refused() {
+        // `{"profile.roles": {"$slice": 2}}` truncates a *nested* array. Removing
+        // the visible `profile` descends into it, and the top-level array guard
+        // never sees it.
+        let shape = ProjectionShape::parse(r#"{"profile.roles":{"$slice":2}}"#);
+        let original =
+            doc_of(r#"{"_id":"66a1","profile":{"roles":["admin","devops"]}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("profile.roles"), "{err}");
+    }
+
+    #[test]
+    fn an_aggregation_result_assumes_nothing_is_complete() {
+        // A pipeline's shape cannot be reduced to a field list, so no whole-value
+        // write is allowed and removals stay leaf-only.
+        let shape = ProjectionShape::parse_optional(None);
+        assert!(!shape.is_whole_document());
+
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(
+            update,
+            doc_of(r#"{"$unset":{"address.city":""}}"#),
+            "must not unset the parent on an unknown shape"
+        );
+    }
+
+    #[test]
+    fn a_scalar_edit_still_works_on_an_aggregation_result() {
+        let shape = ProjectionShape::parse_optional(None);
+        let original = doc_of(r#"{"_id":"66a1","age":34}"#);
+        let edited = doc_of(r#"{"_id":"66a1","age":35}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
+    }
+
+    #[test]
+    fn an_immutable_id_error_is_reported_as_such_not_as_an_addressing_problem() {
+        // The caller may only fall back to a replacement for unaddressable names;
+        // replacement would preserve an omitted `_id` and report a false save.
+        let original = doc_of(r#"{"_id":"66a1","age":34}"#);
+        let edited = doc_of(r#"{"age":34}"#);
+        let err = build_field_update(&original, &edited, &no_projection())
+            .expect_err("must refuse");
+        assert!(
+            matches!(err, UpdateBuildError::ImmutableId(_)),
+            "expected ImmutableId, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn an_unaddressable_name_error_is_typed_so_the_caller_can_recover() {
+        let original = doc_of(r#"{"_id":"66a1","price.usd":10}"#);
+        let edited = doc_of(r#"{"_id":"66a1","price.usd":11}"#);
+        let err = build_field_update(&original, &edited, &no_projection())
+            .expect_err("must refuse");
+        assert!(matches!(err, UpdateBuildError::UnaddressableNames(_)), "{err:?}");
     }
 
     #[test]
@@ -1360,7 +1478,7 @@ mod csv_import_tests {
         // MongoDB traverse into a `price` sub-document instead.
         let original = doc_of(r#"{"_id":"66a1","price.usd":10}"#);
         let edited = doc_of(r#"{"_id":"66a1","price.usd":11}"#);
-        let err = build_field_update(&original, &edited, &nested_projection()).expect_err("must refuse");
+        let err = build_field_update(&original, &edited, &nested_projection()).expect_err("must refuse").to_string();
         assert!(err.contains("price.usd"), "{err}");
         assert!(err.contains("projection"), "should say how to proceed: {err}");
     }

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -388,18 +388,116 @@ async fn insert_document_inner(
     Ok(res.inserted_id.into_relaxed_extjson().to_string())
 }
 
+/// Build a field-level update from the document as it was loaded and as it was
+/// edited (#275).
+///
+/// The editor is fed whatever the query returned, and a projection makes that a
+/// *partial* view of the document. Saving it with `replaceOne` therefore deleted
+/// every field the projection had left out. Diffing loaded-against-edited fixes
+/// that by construction: a field that was never shown appears in neither side,
+/// so no operator mentions it and the stored value is untouched.
+///
+/// Sub-documents are compared recursively and emitted as dotted paths, because a
+/// projection can target a nested path (`{"address.city": 1}`) — setting the
+/// whole `address` object would reproduce the same bug one level down.
+///
+/// Arrays are replaced as a single value. A projection using `$slice` or
+/// `$elemMatch` returns a partial array that is indistinguishable from a short
+/// one, so those remain lossy; `update_document_inner` refuses the save when the
+/// document could not have come from a plain projection.
+///
+/// An empty result means nothing changed.
+pub fn build_field_update(
+    original: &mongodb::bson::Document,
+    edited: &mongodb::bson::Document,
+) -> mongodb::bson::Document {
+    let mut set = mongodb::bson::Document::new();
+    let mut unset = mongodb::bson::Document::new();
+    diff_documents("", original, edited, &mut set, &mut unset);
+
+    let mut update = mongodb::bson::Document::new();
+    if !set.is_empty() {
+        update.insert("$set", set);
+    }
+    if !unset.is_empty() {
+        update.insert("$unset", unset);
+    }
+    update
+}
+
+fn diff_documents(
+    prefix: &str,
+    original: &mongodb::bson::Document,
+    edited: &mongodb::bson::Document,
+    set: &mut mongodb::bson::Document,
+    unset: &mut mongodb::bson::Document,
+) {
+    let path_of = |key: &str| {
+        if prefix.is_empty() {
+            key.to_string()
+        } else {
+            format!("{prefix}.{key}")
+        }
+    };
+    // `_id` is immutable, and only at the top level — a nested field may well be
+    // called `_id`.
+    let is_immutable_id = |key: &str| prefix.is_empty() && key == "_id";
+
+    for (key, new_value) in edited {
+        if is_immutable_id(key) {
+            continue;
+        }
+        let path = path_of(key);
+        match original.get(key) {
+            None => {
+                set.insert(path, new_value.clone());
+            }
+            Some(old_value) if old_value == new_value => {}
+            Some(mongodb::bson::Bson::Document(old_doc)) => {
+                match new_value {
+                    // Both sides are sub-documents: recurse so only the fields
+                    // that actually differ are written.
+                    mongodb::bson::Bson::Document(new_doc) => {
+                        diff_documents(&path, old_doc, new_doc, set, unset);
+                    }
+                    _ => {
+                        set.insert(path, new_value.clone());
+                    }
+                }
+            }
+            Some(_) => {
+                set.insert(path, new_value.clone());
+            }
+        }
+    }
+
+    for (key, _) in original {
+        if is_immutable_id(key) || edited.contains_key(key) {
+            continue;
+        }
+        // Shown to the user and removed by them, so this is a deliberate delete.
+        unset.insert(path_of(key), "");
+    }
+}
+
 pub async fn update_document_impl(
     state: &AppState,
     id: &str,
     database: &str,
     collection: &str,
     filter: &str,
-    replacement: &str,
+    original: &str,
+    edited: &str,
 ) -> Result<u64, String> {
     let started = std::time::Instant::now();
-    let args = format!("{{\"filter\":{filter},\"replacement\":{replacement}}}");
-    let result =
-        update_document_inner(state, id, database, collection, filter, replacement).await;
+    let result = update_document_inner(state, id, database, collection, filter, original, edited).await;
+    // Record the operators actually applied rather than the whole document: it
+    // is both smaller and a truer account of what changed.
+    let summary = match &result {
+        Ok(_) => format!("updateOne {database}.{collection}"),
+        Err(_) => format!("updateOne {database}.{collection} (failed)"),
+    };
+    let args = format!("{{\"filter\":{filter},\"edited\":{edited}}}");
     crate::audit::maybe_record_result(
         state,
         Some(id),
@@ -409,7 +507,7 @@ pub async fn update_document_impl(
         crate::audit::OpClass::Write,
         None,
         started,
-        &format!("replaceOne {database}.{collection}"),
+        &summary,
         Some(&args),
         &result,
     );
@@ -422,12 +520,26 @@ async fn update_document_inner(
     database: &str,
     collection: &str,
     filter: &str,
-    replacement: &str,
+    original: &str,
+    edited: &str,
 ) -> Result<u64, String> {
+    // Still `ReplaceOne`: this is the single-document edit from the grid, and
+    // that variant is deliberately outside the confirm-required set. Only the
+    // Mongo operation underneath changed.
     guard_writable(state, id, WriteOp::ReplaceOne, false)?;
 
     let filter_doc = json_to_bson_document(filter)?;
-    let replacement_doc = json_to_bson_document(replacement)?;
+    let original_doc = json_to_bson_document(original)?;
+    let edited_doc = json_to_bson_document(edited)?;
+
+    // A field-level update rather than a replacement: the editor may hold only a
+    // projection of the document, and replacing with that deleted every field the
+    // projection left out (#275).
+    let update = build_field_update(&original_doc, &edited_doc);
+    if update.is_empty() {
+        // Mongo rejects an empty update document, and there is nothing to do.
+        return Ok(0);
+    }
 
     if connection_is_mock(state, id)? {
         return Ok(1);
@@ -438,7 +550,7 @@ async fn update_document_inner(
         .database(database)
         .collection::<mongodb::bson::Document>(collection);
     let res = coll
-        .replace_one(filter_doc, replacement_doc)
+        .update_one(filter_doc, update)
         .await
         .map_err(|e| format!("Failed to update document: {}", e))?;
     Ok(res.modified_count)
@@ -703,5 +815,100 @@ mod csv_import_tests {
         o.quote = "€".into();
         assert!(validate_csv_import_options(&o).is_err());
         assert!(validate_csv_import_options(&CsvImportOptions::default()).is_ok());
+    }
+
+    // ── #275: editing a projected document must not wipe unprojected fields ──
+
+    fn doc_of(json: &str) -> mongodb::bson::Document {
+        crate::json_to_bson_document(json).expect("parse")
+    }
+
+    #[test]
+    fn editing_a_projected_field_touches_only_that_field() {
+        // The bug: a projection returns {_id, age}, and replacing the document
+        // with it deleted username, email, roles, address and the rest.
+        let original = doc_of(r#"{"_id":"66a1","age":34}"#);
+        let edited = doc_of(r#"{"_id":"66a1","age":35}"#);
+        let update = build_field_update(&original, &edited);
+
+        assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
+        assert!(
+            !update.contains_key("$unset"),
+            "nothing was shown as removed, so nothing may be unset: {update:?}"
+        );
+    }
+
+    #[test]
+    fn an_unchanged_document_produces_no_update() {
+        let d = doc_of(r#"{"_id":"66a1","age":34}"#);
+        assert!(build_field_update(&d, &d).is_empty());
+    }
+
+    #[test]
+    fn removing_a_shown_field_unsets_it() {
+        let original = doc_of(r#"{"_id":"66a1","age":34,"nickname":"nav"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","age":34}"#);
+        let update = build_field_update(&original, &edited);
+        assert_eq!(update, doc_of(r#"{"$unset":{"nickname":""}}"#));
+    }
+
+    #[test]
+    fn adding_a_field_sets_it() {
+        let original = doc_of(r#"{"_id":"66a1","age":34}"#);
+        let edited = doc_of(r#"{"_id":"66a1","age":34,"city":"Pforzheim"}"#);
+        let update = build_field_update(&original, &edited);
+        assert_eq!(update, doc_of(r#"{"$set":{"city":"Pforzheim"}}"#));
+    }
+
+    #[test]
+    fn a_nested_edit_uses_a_dotted_path_so_siblings_survive() {
+        // A projection can target a nested path (`{"address.city": 1}`), so the
+        // loaded sub-document is partial too. Setting the whole `address` object
+        // would delete street/zip/country — the same bug one level down.
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Berlin"}}"#);
+        let update = build_field_update(&original, &edited);
+        assert_eq!(update, doc_of(r#"{"$set":{"address.city":"Berlin"}}"#));
+    }
+
+    #[test]
+    fn a_nested_removal_unsets_the_dotted_path() {
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim","zip":"75172"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let update = build_field_update(&original, &edited);
+        assert_eq!(update, doc_of(r#"{"$unset":{"address.zip":""}}"#));
+    }
+
+    #[test]
+    fn the_id_is_never_written() {
+        // `_id` is immutable; an edit that changes it must not reach the update.
+        let original = doc_of(r#"{"_id":"66a1","age":34}"#);
+        let edited = doc_of(r#"{"_id":"different","age":35}"#);
+        let update = build_field_update(&original, &edited);
+        assert_eq!(update, doc_of(r#"{"$set":{"age":35}}"#));
+    }
+
+    #[test]
+    fn arrays_are_replaced_as_a_whole_value() {
+        let original = doc_of(r#"{"_id":"66a1","roles":["admin","devops"]}"#);
+        let edited = doc_of(r#"{"_id":"66a1","roles":["admin","editor"]}"#);
+        let update = build_field_update(&original, &edited);
+        assert_eq!(update, doc_of(r#"{"$set":{"roles":["admin","editor"]}}"#));
+    }
+
+    #[test]
+    fn replacing_a_document_with_a_scalar_sets_the_whole_path() {
+        let original = doc_of(r#"{"_id":"66a1","address":{"city":"Pforzheim"}}"#);
+        let edited = doc_of(r#"{"_id":"66a1","address":"unknown"}"#);
+        let update = build_field_update(&original, &edited);
+        assert_eq!(update, doc_of(r#"{"$set":{"address":"unknown"}}"#));
+    }
+
+    #[test]
+    fn a_new_nested_document_is_set_whole() {
+        let original = doc_of(r#"{"_id":"66a1"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","address":{"city":"Berlin"}}"#);
+        let update = build_field_update(&original, &edited);
+        assert_eq!(update, doc_of(r#"{"$set":{"address":{"city":"Berlin"}}}"#));
     }
 }

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -452,9 +452,12 @@ enum Leaf {
     Include,
     /// `0` / `false`. Excludes; other values are the stored ones.
     Exclude,
-    /// `$slice` / `$elemMatch`. Does not restrict the field list; the value is a
-    /// truncated view of the stored one.
+    /// `$slice`. Does not restrict the field list; the value is a truncated view
+    /// of the stored array.
     Slice,
+    /// `$elemMatch`. Unlike `$slice` this *is* an inclusion projection — only the
+    /// named field comes back — and the array holds just the matching element.
+    ElemMatch,
     /// An aggregation expression. Restricts the field list *and* synthesizes its
     /// value, so there is nothing to write back to.
     Computed,
@@ -468,12 +471,17 @@ impl Leaf {
     fn is_writable(&self) -> bool {
         !matches!(self, Leaf::Computed | Leaf::Meta)
     }
+
+    /// Whether the entry limits the result to the named fields.
+    fn restricts_field_list(&self) -> bool {
+        matches!(self, Leaf::Include | Leaf::Computed | Leaf::ElemMatch)
+    }
 }
 
 /// Operators that return a view of the stored value rather than computing one.
 /// `$meta` is deliberately absent: it does not restrict the field list either,
 /// but its value is synthesized.
-const SLICE_OPERATORS: [&str; 2] = ["$slice", "$elemMatch"];
+const SLICE_OPERATORS: [&str; 1] = ["$slice"];
 
 impl ProjectionShape {
     /// Parse a find projection, or `None` when the shape cannot be known — the
@@ -517,13 +525,10 @@ impl ProjectionShape {
             if path == "_id" && matches!(leaf, Leaf::Exclude) {
                 continue;
             }
-            match leaf {
-                // A computed field restricts the field list exactly as an
-                // inclusion does: nothing unlisted comes back.
-                Leaf::Include | Leaf::Computed => includes = true,
-                Leaf::Exclude => excludes = true,
-                // Neither restricts the field list.
-                Leaf::Slice | Leaf::Meta => {}
+            if leaf.restricts_field_list() {
+                includes = true;
+            } else if matches!(leaf, Leaf::Exclude) {
+                excludes = true;
             }
         }
         let scope = match (includes, excludes) {
@@ -622,6 +627,11 @@ fn flatten_projection(
                     out.push((format!("{path}.{op}"), Leaf::Slice));
                 }
             }
+            // `{"roles": {"$elemMatch": {...}}}` returns only the matching element,
+            // and unlike `$slice` it hides every unlisted field.
+            serde_json::Value::Object(inner) if inner.keys().all(|k| k == "$elemMatch") => {
+                out.push((format!("{path}.$elemMatch"), Leaf::ElemMatch));
+            }
             // `{"score": {"$meta": "textScore"}}` adds a field from result
             // metadata: nothing is hidden, but nothing is stored there either.
             serde_json::Value::Object(inner) if inner.keys().all(|k| k == "$meta") => {
@@ -702,6 +712,17 @@ pub fn build_field_update(
     // group key rather than a document id. Writing anything would target whichever
     // source document happens to share that value — or none at all. There is no
     // safe subset here, not even a scalar field.
+    // A find projection can replace `_id` with an expression
+    // (`{"_id": "$email"}`), in which case the row's id is not the document's and
+    // any filter built from it targets whatever happens to match.
+    if shape.is_computed("_id") {
+        return Err(UpdateBuildError::NoLineage(
+            "cannot save: the query replaced _id with a computed value, so MQLens cannot \
+             tell which stored document this row came from. Re-run the query without \
+             projecting _id to edit documents."
+                .into(),
+        ));
+    }
     if shape.scope == Scope::Unknown {
         return Err(UpdateBuildError::NoLineage(
             "cannot save: these rows did not come from a plain query, so MQLens cannot tell \
@@ -2043,6 +2064,53 @@ mod csv_import_tests {
             .expect_err("must refuse")
             .to_string();
         assert!(err.contains("address"), "{err}");
+    }
+
+    #[test]
+    fn an_elem_match_projection_hides_unlisted_fields() {
+        // Unlike `$slice`, `$elemMatch` returns only the named field, so an
+        // apparently absent `address` may already exist.
+        let shape = ProjectionShape::parse(r#"{"roles":{"$elemMatch":{"$eq":"admin"}}}"#);
+        let original = doc_of(r#"{"_id":"66a1","roles":["admin"]}"#);
+        let edited = doc_of(r#"{"_id":"66a1","roles":["admin"],"address":{"city":"Berlin"}}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("address"), "{err}");
+    }
+
+    #[test]
+    fn an_elem_match_array_is_still_partial() {
+        // Only the matching element came back, so writing the array whole would
+        // discard the others.
+        let shape = ProjectionShape::parse(r#"{"roles":{"$elemMatch":{"$eq":"admin"}}}"#);
+        let original = doc_of(r#"{"_id":"66a1","roles":["admin"]}"#);
+        let edited = doc_of(r#"{"_id":"66a1","roles":["admin","editor"]}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("roles"), "{err}");
+    }
+
+    #[test]
+    fn a_computed_id_means_the_row_has_no_known_document() {
+        // `{"_id": "$email"}` is a plain find, but the row's id is not the
+        // document's — a filter built from it would hit whatever matches.
+        let shape = ProjectionShape::parse(r#"{"_id":"$email","name":1}"#);
+        let original = doc_of(r#"{"_id":"ada@example.com","name":"Ada"}"#);
+        let edited = doc_of(r#"{"_id":"ada@example.com","name":"Grace"}"#);
+        let err = build_field_update(&original, &edited, &shape).expect_err("must refuse");
+        assert!(matches!(err, UpdateBuildError::NoLineage(_)), "{err:?}");
+        assert!(err.to_string().contains("_id"), "{err}");
+    }
+
+    #[test]
+    fn an_included_id_keeps_lineage() {
+        let shape = ProjectionShape::parse(r#"{"_id":1,"name":1}"#);
+        let original = doc_of(r#"{"_id":"66a1","name":"Ada"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","name":"Grace"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"name":"Grace"}}"#));
     }
 
     #[test]

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -442,21 +442,38 @@ enum Scope {
 }
 
 /// What a projection entry says about its path.
+///
+/// Two independent axes, which an earlier version conflated: whether the entry
+/// *restricts the field list*, and whether the returned value *exists in the
+/// stored document*. `$meta` is the case that separates them — it adds a
+/// synthesized field without hiding anything else.
 enum Leaf {
+    /// `1` / `true`. Restricts the field list; the value is the stored one.
     Include,
+    /// `0` / `false`. Excludes; other values are the stored ones.
     Exclude,
-    /// A true projection operator — `$slice`, `$elemMatch`, `$meta`. These
-    /// truncate a value without restricting which fields come back.
-    Operator,
-    /// A computed expression such as `{"display": {"$concat": [...]}}`. It both
-    /// restricts the field list, like any inclusion, *and* produces a value that
-    /// does not exist in the stored document.
+    /// `$slice` / `$elemMatch`. Does not restrict the field list; the value is a
+    /// truncated view of the stored one.
+    Slice,
+    /// An aggregation expression. Restricts the field list *and* synthesizes its
+    /// value, so there is nothing to write back to.
     Computed,
+    /// `$meta`. Does not restrict the field list, but synthesizes its value from
+    /// result metadata.
+    Meta,
 }
 
-/// Operators that truncate a value rather than compute one. Everything else
-/// under a `$` is an aggregation expression, which restricts the field list.
-const PROJECTION_OPERATORS: [&str; 3] = ["$slice", "$elemMatch", "$meta"];
+impl Leaf {
+    /// Whether the value came from the stored field, so a write can go back to it.
+    fn is_writable(&self) -> bool {
+        !matches!(self, Leaf::Computed | Leaf::Meta)
+    }
+}
+
+/// Operators that return a view of the stored value rather than computing one.
+/// `$meta` is deliberately absent: it does not restrict the field list either,
+/// but its value is synthesized.
+const SLICE_OPERATORS: [&str; 2] = ["$slice", "$elemMatch"];
 
 impl ProjectionShape {
     /// Parse a find projection, or `None` when the shape cannot be known — the
@@ -505,7 +522,8 @@ impl ProjectionShape {
                 // inclusion does: nothing unlisted comes back.
                 Leaf::Include | Leaf::Computed => includes = true,
                 Leaf::Exclude => excludes = true,
-                Leaf::Operator => {}
+                // Neither restricts the field list.
+                Leaf::Slice | Leaf::Meta => {}
             }
         }
         let scope = match (includes, excludes) {
@@ -516,7 +534,7 @@ impl ProjectionShape {
         };
         let computed = entries
             .iter()
-            .filter(|(_, leaf)| matches!(leaf, Leaf::Computed))
+            .filter(|(_, leaf)| !leaf.is_writable())
             .map(|(path, _)| path.clone())
             .collect();
         Self {
@@ -581,33 +599,46 @@ fn flatten_projection(
             format!("{prefix}.{key}")
         };
         match value {
+            serde_json::Value::Bool(true) => out.push((path, Leaf::Include)),
+            serde_json::Value::Bool(false) => out.push((path, Leaf::Exclude)),
+            serde_json::Value::Number(n) => {
+                let leaf = if n.as_f64() == Some(0.0) {
+                    Leaf::Exclude
+                } else {
+                    Leaf::Include
+                };
+                out.push((path, leaf));
+            }
             serde_json::Value::Object(inner) if inner.is_empty() => {
                 out.push((path, Leaf::Include));
             }
-            // `{"roles": {"$slice": 2}}` truncates a value; it does not restrict
-            // which fields come back.
+            // `{"roles": {"$slice": 2}}` returns a truncated view of the stored
+            // array; the field list is untouched and the value is still the
+            // document's own.
             serde_json::Value::Object(inner)
-                if !inner.is_empty()
-                    && inner.keys().all(|k| PROJECTION_OPERATORS.contains(&k.as_str())) =>
+                if inner.keys().all(|k| SLICE_OPERATORS.contains(&k.as_str())) =>
             {
                 for op in inner.keys() {
-                    out.push((format!("{path}.{op}"), Leaf::Operator));
+                    out.push((format!("{path}.{op}"), Leaf::Slice));
                 }
             }
+            // `{"score": {"$meta": "textScore"}}` adds a field from result
+            // metadata: nothing is hidden, but nothing is stored there either.
+            serde_json::Value::Object(inner) if inner.keys().all(|k| k == "$meta") => {
+                out.push((path, Leaf::Meta));
+            }
             // Any other `$`-keyed object is an aggregation expression, e.g.
-            // `{"display": {"$concat": [...]}}`. It restricts the field list and
-            // its value is synthesized, so it cannot be written back.
+            // `{"display": {"$concat": [...]}}`.
             serde_json::Value::Object(inner) if inner.keys().any(|k| k.starts_with('$')) => {
                 out.push((path, Leaf::Computed));
             }
             // `{"address": {"city": 1}}` is the nested spelling of
             // `{"address.city": 1}`.
             serde_json::Value::Object(inner) => flatten_projection(&path, inner, out),
-            serde_json::Value::Bool(false) => out.push((path, Leaf::Exclude)),
-            serde_json::Value::Number(n) if n.as_f64() == Some(0.0) => {
-                out.push((path, Leaf::Exclude))
-            }
-            _ => out.push((path, Leaf::Include)),
+            // Anything else is an aggregation expression too: `{"display": "$name"}`
+            // aliases a field, `{"tag": "fixed"}` is a literal, and an array is a
+            // computed list. None of them read the stored field of that name.
+            _ => out.push((path, Leaf::Computed)),
         }
     }
 }
@@ -805,6 +836,16 @@ struct DiffSink<'a> {
     computed_writes: &'a mut Vec<String>,
 }
 
+/// Compare loaded against edited, depositing operators and refusals in `sink`.
+///
+/// Three directions, each needing its own guards — a rule added to one does not
+/// apply itself to the others, which is how several were missed:
+///
+/// | direction | guards |
+/// |---|---|
+/// | change  | computed value, unaddressable name, whole-value write to a partial |
+/// | add     | computed value, unaddressable name, path the projection may hide   |
+/// | remove  | computed value, unaddressable name, partial array, inexpressible   |
 fn diff_documents(
     prefix: &str,
     original: &Document,
@@ -909,6 +950,12 @@ fn plan_removal(
     shape: &ProjectionShape,
     sink: &mut DiffSink<'_>,
 ) {
+    // The value on screen was synthesized, so `$unset` here would delete a stored
+    // field of that name which the editor never showed.
+    if shape.is_computed(path) {
+        sink.computed_writes.push(path.to_string());
+        return;
+    }
     match value {
         mongodb::bson::Bson::Document(doc) => {
             if !shape.is_partial_at(path) {
@@ -1951,6 +1998,74 @@ mod csv_import_tests {
             .expect_err("must refuse")
             .to_string();
         assert!(err.contains("address"), "{err}");
+    }
+
+    #[test]
+    fn removing_a_computed_field_is_refused() {
+        // `$unset: {display: ""}` would delete a stored `display` the editor never
+        // showed — the synthesized value is not evidence one exists.
+        let shape = ProjectionShape::parse(r#"{"display":{"$concat":["$first"," ","$last"]}}"#);
+        let original = doc_of(r#"{"_id":"66a1","display":"Ada L"}"#);
+        let edited = doc_of(r#"{"_id":"66a1"}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("display"), "{err}");
+        assert!(err.contains("computed"), "{err}");
+    }
+
+    #[test]
+    fn a_field_alias_projection_is_computed_not_an_inclusion() {
+        // `{"display": "$name"}` reads `name`; there is no stored `display`.
+        let shape = ProjectionShape::parse(r#"{"display":"$name"}"#);
+        let original = doc_of(r#"{"_id":"66a1","display":"Ada"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","display":"Grace"}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("display"), "{err}");
+    }
+
+    #[test]
+    fn a_literal_projection_value_is_computed_too() {
+        let shape = ProjectionShape::parse(r#"{"tag":"fixed"}"#);
+        let original = doc_of(r#"{"_id":"66a1","tag":"fixed"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","tag":"other"}"#);
+        assert!(build_field_update(&original, &edited, &shape).is_err());
+    }
+
+    #[test]
+    fn a_field_alias_projection_still_restricts_the_field_list() {
+        let shape = ProjectionShape::parse(r#"{"display":"$name"}"#);
+        let original = doc_of(r#"{"_id":"66a1","display":"Ada"}"#);
+        let edited = doc_of(r#"{"_id":"66a1","display":"Ada","address":{"city":"Berlin"}}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("address"), "{err}");
+    }
+
+    #[test]
+    fn a_meta_projection_adds_a_field_without_hiding_any() {
+        // `{"score": {"$meta": "textScore"}}` returns every field plus a
+        // synthesized score, so it must not read as an inclusion...
+        let shape = ProjectionShape::parse(r#"{"score":{"$meta":"textScore"}}"#);
+        let original = doc_of(r#"{"_id":"66a1","name":"Ada","score":1.5}"#);
+        let edited = doc_of(r#"{"_id":"66a1","name":"Ada","score":1.5,"city":"Berlin"}"#);
+        let update = build_field_update(&original, &edited, &shape).expect("addressable");
+        assert_eq!(update, doc_of(r#"{"$set":{"city":"Berlin"}}"#));
+    }
+
+    #[test]
+    fn a_meta_projection_value_cannot_be_written_back() {
+        // ...but the score itself came from result metadata, not the document.
+        let shape = ProjectionShape::parse(r#"{"score":{"$meta":"textScore"}}"#);
+        let original = doc_of(r#"{"_id":"66a1","score":1.5}"#);
+        let edited = doc_of(r#"{"_id":"66a1","score":9.9}"#);
+        let err = build_field_update(&original, &edited, &shape)
+            .expect_err("must refuse")
+            .to_string();
+        assert!(err.contains("score"), "{err}");
     }
 
     #[test]

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -794,28 +794,8 @@ pub async fn update_document_impl(
         state, id, database, collection, filter, original, edited, projection,
     )
     .await;
-    // Record the operation that was attempted and the operators it carried —
-    // including when the database rejected it. The edited document alone cannot
-    // show that removing a field issued `$unset`, and a failed replacement
-    // fallback must not be logged as an update.
-    let (summary, args) = match &outcome.attempted {
-        Some(applied) => {
-            let suffix = if outcome.result.is_err() { " (failed)" } else { "" };
-            (
-                format!("{} {database}.{collection}{suffix}", applied.op),
-                format!(
-                    "{{\"filter\":{filter},\"{}\":{}}}",
-                    applied.op, applied.payload
-                ),
-            )
-        }
-        // Rejected before a write was planned: a write guard, unparseable JSON,
-        // or a refusal. There is no operation to name, so record the input.
-        None => (
-            format!("updateOne {database}.{collection} (rejected)"),
-            format!("{{\"filter\":{filter},\"edited\":{edited}}}"),
-        ),
-    };
+    let (summary, args) = audit_labels(&outcome, database, collection, filter, edited);
+
     crate::audit::maybe_record_result(
         state,
         Some(id),
@@ -830,6 +810,45 @@ pub async fn update_document_impl(
         &outcome.result,
     );
     outcome.result
+}
+
+/// Summary and payload for the audit record.
+///
+/// Three states, all derivable from [`WriteOutcome`]: a write was attempted and
+/// went through, a write was attempted and the database rejected it, or no write
+/// was ever planned — either because nothing changed or because it was refused
+/// before reaching MongoDB. Naming an operation that never ran, or attaching an
+/// update document MongoDB would itself reject, makes the trail describe
+/// something that did not happen.
+fn audit_labels(
+    outcome: &WriteOutcome,
+    database: &str,
+    collection: &str,
+    filter: &str,
+    edited: &str,
+) -> (String, String) {
+    let submitted = format!("{{\"filter\":{filter},\"edited\":{edited}}}");
+    match (&outcome.attempted, &outcome.result) {
+        (Some(applied), result) => {
+            let suffix = if result.is_err() { " (failed)" } else { "" };
+            (
+                format!("{} {database}.{collection}{suffix}", applied.op),
+                format!(
+                    "{{\"filter\":{filter},\"{}\":{}}}",
+                    applied.op, applied.payload
+                ),
+            )
+        }
+        // Saved without editing anything: a real user action worth recording, but
+        // no database operation to name.
+        (None, Ok(_)) => (format!("no change {database}.{collection}"), submitted),
+        // Rejected before a write was planned: a write guard, unparseable JSON,
+        // or one of the refusals.
+        (None, Err(_)) => (
+            format!("update_document {database}.{collection} (rejected)"),
+            submitted,
+        ),
+    }
 }
 
 /// The write that was attempted, plus how it went.
@@ -898,11 +917,10 @@ async fn update_document_inner(
     let plan = match build_field_update(&original_doc, &edited_doc, &shape) {
         // Mongo rejects an empty update document, and there is nothing to do.
         Ok(update) if update.is_empty() => {
+            // Nothing changed, so nothing is sent. `attempted: None` with an `Ok`
+            // result is what distinguishes this from a rejection.
             return WriteOutcome {
-                attempted: Some(AppliedWrite {
-                    op: "updateOne",
-                    payload: "{}".into(),
-                }),
+                attempted: None,
                 result: Ok(0),
             };
         }
@@ -1238,6 +1256,72 @@ mod csv_import_tests {
         o.quote = "€".into();
         assert!(validate_csv_import_options(&o).is_err());
         assert!(validate_csv_import_options(&CsvImportOptions::default()).is_ok());
+    }
+
+    // ── #275: the audit record must describe what actually happened ──
+
+    fn outcome(attempted: Option<&'static str>, result: Result<u64, String>) -> WriteOutcome {
+        WriteOutcome {
+            attempted: attempted.map(|op| AppliedWrite {
+                op,
+                payload: r#"{"$set":{"age":35}}"#.into(),
+            }),
+            result,
+        }
+    }
+
+    #[test]
+    fn an_unchanged_save_is_not_recorded_as_a_database_write() {
+        // It used to log `updateOne` carrying `{}` — an update MongoDB would
+        // itself reject, describing a write that never happened.
+        let (summary, args) = audit_labels(
+            &outcome(None, Ok(0)),
+            "shop",
+            "orders",
+            r#"{"_id":1}"#,
+            r#"{"_id":1}"#,
+        );
+        assert_eq!(summary, "no change shop.orders");
+        assert!(!args.contains("$set"), "must not invent an update: {args}");
+        assert!(args.contains("edited"), "should record what was submitted: {args}");
+    }
+
+    #[test]
+    fn a_successful_write_records_its_operation_and_operators() {
+        let (summary, args) = audit_labels(
+            &outcome(Some("updateOne"), Ok(1)),
+            "shop",
+            "orders",
+            r#"{"_id":1}"#,
+            r#"{"_id":1,"age":35}"#,
+        );
+        assert_eq!(summary, "updateOne shop.orders");
+        assert!(args.contains(r#""$set""#), "{args}");
+    }
+
+    #[test]
+    fn a_failed_write_keeps_the_operation_it_attempted() {
+        let (summary, args) = audit_labels(
+            &outcome(Some("replaceOne"), Err("boom".into())),
+            "shop",
+            "orders",
+            r#"{"_id":1}"#,
+            r#"{"_id":1,"age":35}"#,
+        );
+        assert_eq!(summary, "replaceOne shop.orders (failed)");
+        assert!(args.contains("replaceOne"), "must not be relabelled: {args}");
+    }
+
+    #[test]
+    fn a_refusal_names_no_operation() {
+        let (summary, _) = audit_labels(
+            &outcome(None, Err("refused".into())),
+            "shop",
+            "orders",
+            r#"{"_id":1}"#,
+            r#"{"_id":1}"#,
+        );
+        assert_eq!(summary, "update_document shop.orders (rejected)");
     }
 
     // ── #275: editing a projected document must not wipe unprojected fields ──

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -337,7 +337,7 @@ mod integration {
             r#"{"_id":"u1"}"#,
             r#"{"_id":"u1","name":"Ada","tier":"gold"}"#,
             r#"{"_id":"u1","name":"Ada Lovelace","tier":"platinum"}"#,
-            "{}",
+            Some("{}"),
         )
         .await
         .expect("update");
@@ -374,7 +374,7 @@ mod integration {
             r#"{"_id":"p275"}"#,
             r#"{"_id":"p275","age":34}"#,
             r#"{"_id":"p275","age":35}"#,
-            r#"{"age":1}"#,
+            Some(r#"{"age":1}"#),
         )
         .await
         .expect("update projected");
@@ -418,7 +418,7 @@ mod integration {
             r#"{"_id":"p275n","address":{"city":"Pforzheim"}}"#,
             // The user deleted the whole visible `address` object.
             r#"{"_id":"p275n"}"#,
-            r#"{"address.city":1}"#,
+            Some(r#"{"address.city":1}"#),
         )
         .await
         .expect("update nested projection");
@@ -450,7 +450,7 @@ mod integration {
             r#"{"_id":"p275n"}"#,
             r#"{"_id":"p275n","address":{"street":"Maximilianstrasse 12","zip":"75172"}}"#,
             r#"{"_id":"p275n"}"#,
-            "{}",
+            Some("{}"),
         )
         .await
         .expect("update whole document");

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -337,6 +337,7 @@ mod integration {
             r#"{"_id":"u1"}"#,
             r#"{"_id":"u1","name":"Ada","tier":"gold"}"#,
             r#"{"_id":"u1","name":"Ada Lovelace","tier":"platinum"}"#,
+            false,
         )
         .await
         .expect("update");
@@ -373,6 +374,7 @@ mod integration {
             r#"{"_id":"p275"}"#,
             r#"{"_id":"p275","age":34}"#,
             r#"{"_id":"p275","age":35}"#,
+            true,
         )
         .await
         .expect("update projected");
@@ -391,6 +393,51 @@ mod integration {
             serde_json::json!(["admin", "devops"]),
             "an unprojected array must survive"
         );
+
+        // #275 follow-up: removing a sub-document that was loaded under a *nested*
+        // projection must unset only the leaf that was visible. Unsetting the
+        // parent would delete the siblings the projection hid — the same bug one
+        // level down.
+        insert_document_impl(
+            &state,
+            &id,
+            &db,
+            "people",
+            r#"{"_id":"p275n","address":{"city":"Pforzheim","street":"Maximilianstrasse 12","zip":"75172"}}"#,
+        )
+        .await
+        .expect("insert p275n");
+
+        update_document_impl(
+            &state,
+            &id,
+            &db,
+            "people",
+            r#"{"_id":"p275n"}"#,
+            // What `{"address.city": 1}` returns.
+            r#"{"_id":"p275n","address":{"city":"Pforzheim"}}"#,
+            // The user deleted the whole visible `address` object.
+            r#"{"_id":"p275n"}"#,
+            true,
+        )
+        .await
+        .expect("update nested projection");
+
+        let nested = execute_mql_query_impl(
+            &state, &id, &db, "people", r#"{"_id":"p275n"}"#, "{}", "{}", 1, 0,
+        )
+        .await
+        .expect("read back nested");
+        let nested: serde_json::Value = serde_json::from_str(&nested[0]).unwrap();
+        assert!(
+            nested["address"].get("city").is_none(),
+            "the visible leaf must be removed: {nested:?}"
+        );
+        assert_eq!(
+            nested["address"]["street"], "Maximilianstrasse 12",
+            "a hidden sibling must survive"
+        );
+        assert_eq!(nested["address"]["zip"], "75172", "a hidden sibling must survive");
 
         // update_many with an operator.
         seed(

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -337,7 +337,7 @@ mod integration {
             r#"{"_id":"u1"}"#,
             r#"{"_id":"u1","name":"Ada","tier":"gold"}"#,
             r#"{"_id":"u1","name":"Ada Lovelace","tier":"platinum"}"#,
-            false,
+            "{}",
         )
         .await
         .expect("update");
@@ -374,7 +374,7 @@ mod integration {
             r#"{"_id":"p275"}"#,
             r#"{"_id":"p275","age":34}"#,
             r#"{"_id":"p275","age":35}"#,
-            true,
+            r#"{"age":1}"#,
         )
         .await
         .expect("update projected");
@@ -418,7 +418,7 @@ mod integration {
             r#"{"_id":"p275n","address":{"city":"Pforzheim"}}"#,
             // The user deleted the whole visible `address` object.
             r#"{"_id":"p275n"}"#,
-            true,
+            r#"{"address.city":1}"#,
         )
         .await
         .expect("update nested projection");
@@ -450,7 +450,7 @@ mod integration {
             r#"{"_id":"p275n"}"#,
             r#"{"_id":"p275n","address":{"street":"Maximilianstrasse 12","zip":"75172"}}"#,
             r#"{"_id":"p275n"}"#,
-            false,
+            "{}",
         )
         .await
         .expect("update whole document");

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -439,6 +439,33 @@ mod integration {
         );
         assert_eq!(nested["address"]["zip"], "75172", "a hidden sibling must survive");
 
+        // The whole-document counterpart: with nothing hidden, deleting a
+        // sub-document must remove the field itself rather than leave `{}` behind,
+        // which would still satisfy `{address: {$exists: true}}`.
+        update_document_impl(
+            &state,
+            &id,
+            &db,
+            "people",
+            r#"{"_id":"p275n"}"#,
+            r#"{"_id":"p275n","address":{"street":"Maximilianstrasse 12","zip":"75172"}}"#,
+            r#"{"_id":"p275n"}"#,
+            false,
+        )
+        .await
+        .expect("update whole document");
+
+        let gone = execute_mql_query_impl(
+            &state, &id, &db, "people", r#"{"_id":"p275n"}"#, "{}", "{}", 1, 0,
+        )
+        .await
+        .expect("read back after full removal");
+        let gone: serde_json::Value = serde_json::from_str(&gone[0]).unwrap();
+        assert!(
+            gone.get("address").is_none(),
+            "the field itself must be removed, not left as an empty object: {gone:?}"
+        );
+
         // update_many with an operator.
         seed(
             &state,

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -327,18 +327,70 @@ mod integration {
         .expect("insert");
         assert!(inserted.contains("u1"));
 
-        // replace_one via update_document_impl.
+        // A field-level update: the whole document is loaded and edited, so every
+        // field is sent and the result is the same as the old replace.
         let modified = update_document_impl(
             &state,
             &id,
             &db,
             "people",
             r#"{"_id":"u1"}"#,
+            r#"{"_id":"u1","name":"Ada","tier":"gold"}"#,
             r#"{"_id":"u1","name":"Ada Lovelace","tier":"platinum"}"#,
         )
         .await
-        .expect("replace");
+        .expect("update");
         assert_eq!(modified, 1);
+
+        // #275: editing a *projected* document must leave the fields the
+        // projection hid completely alone. This used to `replaceOne` with the
+        // partial view and delete them.
+        insert_document_impl(
+            &state,
+            &id,
+            &db,
+            "people",
+            r#"{"_id":"p275","name":"Grace","tier":"gold","age":34,"roles":["admin","devops"]}"#,
+        )
+        .await
+        .expect("insert p275");
+
+        // What the grid holds after a `{ "age": 1 }` projection.
+        let projected = execute_mql_query_impl(
+            &state, &id, &db, "people", r#"{"_id":"p275"}"#, "{}", r#"{"age":1}"#, 1, 0,
+        )
+        .await
+        .expect("projected find");
+        let loaded: serde_json::Value = serde_json::from_str(&projected[0]).unwrap();
+        assert_eq!(loaded["age"], 34);
+        assert!(loaded.get("name").is_none(), "projection must hide name");
+
+        update_document_impl(
+            &state,
+            &id,
+            &db,
+            "people",
+            r#"{"_id":"p275"}"#,
+            r#"{"_id":"p275","age":34}"#,
+            r#"{"_id":"p275","age":35}"#,
+        )
+        .await
+        .expect("update projected");
+
+        let after = execute_mql_query_impl(
+            &state, &id, &db, "people", r#"{"_id":"p275"}"#, "{}", "{}", 1, 0,
+        )
+        .await
+        .expect("read back");
+        let full: serde_json::Value = serde_json::from_str(&after[0]).unwrap();
+        assert_eq!(full["age"], 35, "the edited field must be written");
+        assert_eq!(full["name"], "Grace", "an unprojected field must survive");
+        assert_eq!(full["tier"], "gold", "an unprojected field must survive");
+        assert_eq!(
+            full["roles"],
+            serde_json::json!(["admin", "devops"]),
+            "an unprojected array must survive"
+        );
 
         // update_many with an operator.
         seed(

--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -466,6 +466,44 @@ mod integration {
             "the field itself must be removed, not left as an empty object: {gone:?}"
         );
 
+        // A document whose `_id` is a real ObjectId, saved through the same
+        // serialization the UI uses. Sending the original as shell text made this
+        // fail with "Invalid JSON" before any update was attempted, which the
+        // string-`_id` fixtures above could not catch.
+        let oid = mongodb::bson::oid::ObjectId::new();
+        seed(
+            &state,
+            &id,
+            &db,
+            "people",
+            vec![doc! { "_id": oid, "name": "Hopper", "tier": "gold" }],
+        )
+        .await;
+
+        let filter = format!(r#"{{"_id":{{"$oid":"{}"}}}}"#, oid.to_hex());
+        let loaded = format!(
+            r#"{{"_id":{{"$oid":"{}"}},"name":"Hopper","tier":"gold"}}"#,
+            oid.to_hex()
+        );
+        let saved = format!(
+            r#"{{"_id":{{"$oid":"{}"}},"name":"Grace Hopper","tier":"gold"}}"#,
+            oid.to_hex()
+        );
+        let modified = update_document_impl(
+            &state, &id, &db, "people", &filter, &loaded, &saved, Some("{}"),
+        )
+        .await
+        .expect("an ObjectId _id must round-trip");
+        assert_eq!(modified, 1);
+
+        let back = execute_mql_query_impl(
+            &state, &id, &db, "people", &filter, "{}", "{}", 1, 0,
+        )
+        .await
+        .expect("read back objectid doc");
+        let back: serde_json::Value = serde_json::from_str(&back[0]).unwrap();
+        assert_eq!(back["name"], "Grace Hopper");
+
         // update_many with an operator.
         seed(
             &state,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2188,13 +2188,21 @@ async fn update_document(
     original: String,
     edited: String,
     // The find projection the row came back under, so the backend knows which
-    // parts of `original` are complete. `{"address": 1}` includes the whole
+    // parts of `original` are complete: `{"address": 1}` includes the whole
     // sub-document while `{"address.city": 1}` does not, and a removal has to
-    // tell those apart.
-    projection: String,
+    // tell those apart. `None` means the shape cannot be known — the rows came
+    // from an aggregation — and nothing is then assumed complete.
+    projection: Option<String>,
 ) -> Result<u64, String> {
     update_document_impl(
-        &state, &id, &database, &collection, &filter, &original, &edited, &projection,
+        &state,
+        &id,
+        &database,
+        &collection,
+        &filter,
+        &original,
+        &edited,
+        projection.as_deref(),
     )
     .await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2178,6 +2178,7 @@ async fn start_generate_task(
 /// Takes the document as it was loaded *and* as it was edited, rather than one
 /// replacement: the grid may be showing a projection, and replacing the stored
 /// document with a partial view deleted every field the projection left out.
+#[allow(clippy::too_many_arguments)]
 async fn update_document(
     state: tauri::State<'_, AppState>,
     id: String,
@@ -2186,8 +2187,15 @@ async fn update_document(
     filter: String,
     original: String,
     edited: String,
+    // `partial` is true when the document was loaded under a projection, so
+    // `original` is only a partial view — which decides whether falling back to
+    // a whole-document replacement is safe.
+    partial: bool,
 ) -> Result<u64, String> {
-    update_document_impl(&state, &id, &database, &collection, &filter, &original, &edited).await
+    update_document_impl(
+        &state, &id, &database, &collection, &filter, &original, &edited, partial,
+    )
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2187,13 +2187,14 @@ async fn update_document(
     filter: String,
     original: String,
     edited: String,
-    // `partial` is true when the document was loaded under a projection, so
-    // `original` is only a partial view — which decides whether falling back to
-    // a whole-document replacement is safe.
-    partial: bool,
+    // The find projection the row came back under, so the backend knows which
+    // parts of `original` are complete. `{"address": 1}` includes the whole
+    // sub-document while `{"address.city": 1}` does not, and a removal has to
+    // tell those apart.
+    projection: String,
 ) -> Result<u64, String> {
     update_document_impl(
-        &state, &id, &database, &collection, &filter, &original, &edited, partial,
+        &state, &id, &database, &collection, &filter, &original, &edited, &projection,
     )
     .await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2173,15 +2173,21 @@ async fn start_generate_task(
 }
 
 #[tauri::command]
+/// Save an edited document as a field-level update (#275).
+///
+/// Takes the document as it was loaded *and* as it was edited, rather than one
+/// replacement: the grid may be showing a projection, and replacing the stored
+/// document with a partial view deleted every field the projection left out.
 async fn update_document(
     state: tauri::State<'_, AppState>,
     id: String,
     database: String,
     collection: String,
     filter: String,
-    replacement: String,
+    original: String,
+    edited: String,
 ) -> Result<u64, String> {
-    update_document_impl(&state, &id, &database, &collection, &filter, &replacement).await
+    update_document_impl(&state, &id, &database, &collection, &filter, &original, &edited).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1060,7 +1060,7 @@ mod tests {
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"}}"#,
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"},"name":"Original"}"#,
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"},"name":"Edited"}"#,
-            false,
+            "{}",
         )
         .await
         .expect("update should succeed in mock mode");

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1051,13 +1051,14 @@ mod tests {
         .expect("insert should succeed in mock mode");
         assert!(!inserted_id.is_empty());
 
-        // replace_one
+        // field-level update
         let modified = update_document_impl(
             &state,
             &conn_id,
             "sales_db",
             "customers",
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"}}"#,
+            r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"},"name":"Original"}"#,
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"},"name":"Edited"}"#,
         )
         .await

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1060,7 +1060,7 @@ mod tests {
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"}}"#,
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"},"name":"Original"}"#,
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"},"name":"Edited"}"#,
-            "{}",
+            Some("{}"),
         )
         .await
         .expect("update should succeed in mock mode");

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1060,6 +1060,7 @@ mod tests {
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"}}"#,
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"},"name":"Original"}"#,
             r#"{"_id":{"$oid":"507f1f77bcf86cd799439011"},"name":"Edited"}"#,
+            false,
         )
         .await
         .expect("update should succeed in mock mode");

--- a/src-tauri/src/write_guard.rs
+++ b/src-tauri/src/write_guard.rs
@@ -231,7 +231,7 @@ mod tests {
             (
                 "update_document_impl",
                 Box::pin(async move {
-                    documents::update_document_impl(state, "ro", "db", "coll", "{}", "{}", "{}")
+                    documents::update_document_impl(state, "ro", "db", "coll", "{}", "{}", "{}", false)
                         .await
                         .map(|_| ())
                 }),

--- a/src-tauri/src/write_guard.rs
+++ b/src-tauri/src/write_guard.rs
@@ -231,7 +231,7 @@ mod tests {
             (
                 "update_document_impl",
                 Box::pin(async move {
-                    documents::update_document_impl(state, "ro", "db", "coll", "{}", "{}")
+                    documents::update_document_impl(state, "ro", "db", "coll", "{}", "{}", "{}")
                         .await
                         .map(|_| ())
                 }),

--- a/src-tauri/src/write_guard.rs
+++ b/src-tauri/src/write_guard.rs
@@ -231,7 +231,7 @@ mod tests {
             (
                 "update_document_impl",
                 Box::pin(async move {
-                    documents::update_document_impl(state, "ro", "db", "coll", "{}", "{}", "{}", "{}")
+                    documents::update_document_impl(state, "ro", "db", "coll", "{}", "{}", "{}", Some("{}"))
                         .await
                         .map(|_| ())
                 }),

--- a/src-tauri/src/write_guard.rs
+++ b/src-tauri/src/write_guard.rs
@@ -231,7 +231,7 @@ mod tests {
             (
                 "update_document_impl",
                 Box::pin(async move {
-                    documents::update_document_impl(state, "ro", "db", "coll", "{}", "{}", "{}", false)
+                    documents::update_document_impl(state, "ro", "db", "coll", "{}", "{}", "{}", "{}")
                         .await
                         .map(|_| ())
                 }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3936,12 +3936,17 @@ function Workspace() {
       // its error banner, so the text is user-facing copy, not a dev invariant.
       throw new Error(t('documents:editModal.errors.noId'));
     }
+    // Send the document as loaded *and* as edited so the backend can apply only
+    // the fields that changed. The grid may be showing a projection, and saving
+    // that partial view as a replacement deleted everything else (#275).
+    // `docToShell` on both sides means they go through the identical parse path.
     await invoke('update_document', {
       id: tab.connectionId,
       database: tab.db,
       collection,
       filter: JSON.stringify({ _id: target._id }),
-      replacement: json,
+      original: docToShell(target),
+      edited: json,
     });
     setDocumentModal(null);
     await refreshTabResults(tab);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3950,7 +3950,12 @@ function Workspace() {
       // The projection the row came back under, so the backend knows which parts
       // of `original` are complete: `{"address": 1}` includes the whole
       // sub-document, `{"address.city": 1}` does not (see ProjectionShape).
-      projection: tab.lastQuery?.projection ?? '{}',
+      //
+      // `null` when the rows came from an aggregation: `lastQuery` is left intact
+      // by handleExecuteAggregate and would be stale, and a pipeline's shape
+      // cannot be reduced to a field list. The backend then assumes nothing is
+      // complete rather than trusting a projection that did not produce these rows.
+      projection: tab.lastAggregate ? null : (tab.lastQuery?.projection ?? '{}'),
     });
     setDocumentModal(null);
     await refreshTabResults(tab);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,7 +110,7 @@ import { DialogProvider, useDialogs } from './components/dialogs/DialogProvider'
 import { formatBytes } from './lib/format';
 import type { QueryCodeSpec } from './lib/queryCodeGen';
 import type { IndexSuggestion } from './lib/indexSuggestions';
-import { docToShell } from './lib/shellDoc';
+import { docToShell, shellToEjson } from './lib/shellDoc';
 import { recordHistory, loadCollectionQueries, type SavedQueryBody } from './lib/queryStore';
 import { clearNamespaceIndex, loadNamespaceIndex, matchesNamespaceScope } from './lib/paletteIndex';
 import { CHECK_UPDATE_EVENT } from './components/UpdatePrompt';
@@ -174,15 +174,38 @@ export function pipelineYieldsWholeDocuments(pipeline?: Record<string, unknown>[
   });
 }
 
+/// True when a find projection replaces `_id` with a computed value, e.g.
+/// `{"_id": "$email"}`. The row's `_id` is then not the document's, so a filter
+/// built from it targets whatever happens to match. Only `1`/`0`/`true`/`false`
+/// keep `_id` as the stored id; any other value is an aggregation expression.
+export function projectionComputesId(projection?: string): boolean {
+  const trimmed = (projection ?? '').trim();
+  if (trimmed === '' || trimmed === '{}') return false;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== 'object' || parsed === null || !('_id' in parsed)) return false;
+    const value = (parsed as Record<string, unknown>)._id;
+    return !(typeof value === 'number' || typeof value === 'boolean');
+  } catch {
+    // Unparseable: the backend refuses anyway, so withhold the action.
+    return true;
+  }
+}
+
 /// Whether a tab's rows are stored documents that row actions may target by
-/// `_id`. False for reshaping pipelines, where `_id` may be a group key and
-/// editing or deleting would hit an unrelated document.
+/// `_id`. False for reshaping pipelines, where `_id` may be a group key, and for
+/// a find projection that computes `_id` — both make the row's id something other
+/// than the stored document's, so editing or deleting would hit an unrelated one.
 ///
 /// `DataGrid` offers the edit and delete actions only when the callbacks are
 /// provided, so passing `undefined` withholds them rather than showing something
 /// that would be refused.
-function rowsAreStoredDocuments(tab: { lastAggregate?: Record<string, unknown>[] }): boolean {
-  return !tab.lastAggregate || pipelineYieldsWholeDocuments(tab.lastAggregate);
+function rowsAreStoredDocuments(tab: {
+  lastAggregate?: Record<string, unknown>[];
+  lastQuery?: { projection: string };
+}): boolean {
+  if (tab.lastAggregate) return pipelineYieldsWholeDocuments(tab.lastAggregate);
+  return !projectionComputesId(tab.lastQuery?.projection);
 }
 
 const DEFAULT_QUERY = { filter: '{}', sort: '{}', projection: '{}', limit: 50, skip: 0 };
@@ -3974,7 +3997,14 @@ function Workspace() {
       database: tab.db,
       collection,
       filter: JSON.stringify({ _id: target._id }),
-      original: docToShell(target),
+      // Must be EJSON, not shell text: the backend parses both sides with strict
+      // `serde_json`, and DocumentEditModal already converts the editor contents
+      // with `shellToEjson` before calling onSave — so sending shell here failed
+      // on any document with an ObjectId `_id`. Running the original through the
+      // same docToShell → shellToEjson pipeline also makes an unedited save
+      // produce byte-identical sides, so the diff cannot report a change that came
+      // from serialization rather than from the user.
+      original: shellToEjson(docToShell(target)),
       edited: json,
       // The projection the row came back under, so the backend knows which parts
       // of `original` are complete: `{"address": 1}` includes the whole

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,6 +156,19 @@ export interface QueryTab {
   estimated?: boolean;
 }
 
+/** True when a find projection actually restricts the fields returned. */
+function hasProjection(projection?: string): boolean {
+  const trimmed = (projection ?? '').trim();
+  if (trimmed === '' || trimmed === '{}') return false;
+  try {
+    return Object.keys(JSON.parse(trimmed)).length > 0;
+  } catch {
+    // Unparseable projection: the query would not have run with it, but treat it
+    // as restricting rather than risk a replacement that deletes hidden fields.
+    return true;
+  }
+}
+
 const DEFAULT_QUERY = { filter: '{}', sort: '{}', projection: '{}', limit: 50, skip: 0 };
 
 // A cached/restored builder state may carry "{}" in the query/sort/projection
@@ -3947,6 +3960,10 @@ function Workspace() {
       filter: JSON.stringify({ _id: target._id }),
       original: docToShell(target),
       edited: json,
+      // Whether the row came back under a projection, i.e. whether `original` is
+      // a partial view. The backend needs it to know if falling back to a whole
+      // document replacement is safe (see update_document_inner).
+      partial: hasProjection(tab.lastQuery?.projection),
     });
     setDocumentModal(null);
     await refreshTabResults(tab);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,19 +156,6 @@ export interface QueryTab {
   estimated?: boolean;
 }
 
-/** True when a find projection actually restricts the fields returned. */
-function hasProjection(projection?: string): boolean {
-  const trimmed = (projection ?? '').trim();
-  if (trimmed === '' || trimmed === '{}') return false;
-  try {
-    return Object.keys(JSON.parse(trimmed)).length > 0;
-  } catch {
-    // Unparseable projection: the query would not have run with it, but treat it
-    // as restricting rather than risk a replacement that deletes hidden fields.
-    return true;
-  }
-}
-
 const DEFAULT_QUERY = { filter: '{}', sort: '{}', projection: '{}', limit: 50, skip: 0 };
 
 // A cached/restored builder state may carry "{}" in the query/sort/projection
@@ -3960,10 +3947,10 @@ function Workspace() {
       filter: JSON.stringify({ _id: target._id }),
       original: docToShell(target),
       edited: json,
-      // Whether the row came back under a projection, i.e. whether `original` is
-      // a partial view. The backend needs it to know if falling back to a whole
-      // document replacement is safe (see update_document_inner).
-      partial: hasProjection(tab.lastQuery?.projection),
+      // The projection the row came back under, so the backend knows which parts
+      // of `original` are complete: `{"address": 1}` includes the whole
+      // sub-document, `{"address.city": 1}` does not (see ProjectionShape).
+      projection: tab.lastQuery?.projection ?? '{}',
     });
     setDocumentModal(null);
     await refreshTabResults(tab);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,6 +156,35 @@ export interface QueryTab {
   estimated?: boolean;
 }
 
+/// Stages that pass documents through unchanged, so the rows are still whole
+/// stored documents with their real `_id`s and can be edited.
+///
+/// Anything else — `$group`, `$project`, `$replaceRoot`, `$unwind`, `$lookup`,
+/// `$addFields` — reshapes the row or replaces its identity, so its `_id` may be
+/// a group key rather than a document id and saving could hit an unrelated
+/// document.
+const DOCUMENT_PRESERVING_STAGES = new Set(['$match', '$sort', '$limit', '$skip']);
+
+/** True when every stage of `pipeline` leaves documents intact. */
+export function pipelineYieldsWholeDocuments(pipeline?: Record<string, unknown>[]): boolean {
+  if (!pipeline || pipeline.length === 0) return true;
+  return pipeline.every((stage) => {
+    const keys = Object.keys(stage ?? {});
+    return keys.length === 1 && DOCUMENT_PRESERVING_STAGES.has(keys[0]);
+  });
+}
+
+/// Whether a tab's rows are stored documents that row actions may target by
+/// `_id`. False for reshaping pipelines, where `_id` may be a group key and
+/// editing or deleting would hit an unrelated document.
+///
+/// `DataGrid` offers the edit and delete actions only when the callbacks are
+/// provided, so passing `undefined` withholds them rather than showing something
+/// that would be refused.
+function rowsAreStoredDocuments(tab: { lastAggregate?: Record<string, unknown>[] }): boolean {
+  return !tab.lastAggregate || pipelineYieldsWholeDocuments(tab.lastAggregate);
+}
+
 const DEFAULT_QUERY = { filter: '{}', sort: '{}', projection: '{}', limit: 50, skip: 0 };
 
 // A cached/restored builder state may carry "{}" in the query/sort/projection
@@ -3951,11 +3980,14 @@ function Workspace() {
       // of `original` are complete: `{"address": 1}` includes the whole
       // sub-document, `{"address.city": 1}` does not (see ProjectionShape).
       //
-      // `null` when the rows came from an aggregation: `lastQuery` is left intact
-      // by handleExecuteAggregate and would be stale, and a pipeline's shape
-      // cannot be reduced to a field list. The backend then assumes nothing is
-      // complete rather than trusting a projection that did not produce these rows.
-      projection: tab.lastAggregate ? null : (tab.lastQuery?.projection ?? '{}'),
+      // `null` when the rows came from a pipeline that reshapes them: `lastQuery`
+      // is left intact by handleExecuteAggregate and would be stale, and a row's
+      // `_id` may be a group key rather than a document id. The backend refuses
+      // to write in that case. A pipeline of only $match/$sort/$limit/$skip
+      // passes documents through untouched, so those rows are whole documents.
+      projection: tab.lastAggregate
+        ? (pipelineYieldsWholeDocuments(tab.lastAggregate) ? '{}' : null)
+        : (tab.lastQuery?.projection ?? '{}'),
     });
     setDocumentModal(null);
     await refreshTabResults(tab);
@@ -4114,9 +4146,9 @@ function Workspace() {
                     explainResult={tab.explainResult}
                     querySpec={buildTabQuerySpec(tab)}
                     onInsertDocument={() => handleInsertDocument(tab)}
-                    onEditDocument={doc => handleEditDocument(tab, doc)}
+                    onEditDocument={rowsAreStoredDocuments(tab) ? (doc => handleEditDocument(tab, doc)) : undefined}
                     onDuplicateDocument={doc => handleDuplicateDocument(tab, doc)}
-                    onDeleteDocument={doc => handleDeleteDocument(tab, doc)}
+                    onDeleteDocument={rowsAreStoredDocuments(tab) ? (doc => handleDeleteDocument(tab, doc)) : undefined}
                     onAnalyzeSchema={() => handleOpenSchemaTab(tab.connectionId, tab.db, tab.collection)}
                     onUpdateMany={() => handleUpdateMany(tab)}
                     onDeleteMany={() => handleDeleteMany(tab)}

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -4463,4 +4463,51 @@ describe('App Component', () => {
       expect(upd.args.edited).toBe('{"_id":"66a1","age":35}');
     });
   });
+
+  it('withholds row edit and delete for a reshaping pipeline (#275)', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'execute_mql_query') {
+        return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+    fireEvent.click(screen.getByTestId('select-collection-btn'));
+    // A find result: the row is a stored document, so editing is offered.
+    expect(await screen.findByTestId('edit-doc-btn')).toBeInTheDocument();
+  });
+});
+
+describe('pipelineYieldsWholeDocuments (#275)', () => {
+  it('accepts stages that pass documents through untouched', async () => {
+    const { pipelineYieldsWholeDocuments } = await import('../../App');
+    expect(pipelineYieldsWholeDocuments(undefined)).toBe(true);
+    expect(pipelineYieldsWholeDocuments([])).toBe(true);
+    expect(pipelineYieldsWholeDocuments([{ $match: { active: true } }])).toBe(true);
+    expect(
+      pipelineYieldsWholeDocuments([{ $match: {} }, { $sort: { a: 1 } }, { $limit: 10 }, { $skip: 5 }])
+    ).toBe(true);
+  });
+
+  it('rejects stages that reshape a row or replace its identity', async () => {
+    const { pipelineYieldsWholeDocuments } = await import('../../App');
+    // `_id` becomes the group key, so row actions would target the wrong document.
+    expect(pipelineYieldsWholeDocuments([{ $group: { _id: '$status' } }])).toBe(false);
+    expect(pipelineYieldsWholeDocuments([{ $project: { name: 1 } }])).toBe(false);
+    expect(pipelineYieldsWholeDocuments([{ $replaceRoot: { newRoot: '$x' } }])).toBe(false);
+    expect(pipelineYieldsWholeDocuments([{ $unwind: '$roles' }])).toBe(false);
+    expect(pipelineYieldsWholeDocuments([{ $lookup: {} }])).toBe(false);
+    expect(pipelineYieldsWholeDocuments([{ $addFields: { n: 1 } }])).toBe(false);
+    // One safe stage does not redeem an unsafe one.
+    expect(pipelineYieldsWholeDocuments([{ $match: {} }, { $group: { _id: '$s' } }])).toBe(false);
+  });
+
+  it('rejects a malformed stage rather than assuming it is safe', async () => {
+    const { pipelineYieldsWholeDocuments } = await import('../../App');
+    expect(pipelineYieldsWholeDocuments([{} as Record<string, unknown>])).toBe(false);
+    expect(pipelineYieldsWholeDocuments([{ $match: {}, $sort: {} }])).toBe(false);
+  });
 });

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -782,7 +782,11 @@ describe('App Component', () => {
       // Both sides are sent so the backend can write only what changed; a bare
       // `replacement` would wipe fields a projection had left out (#275).
       expect(upd.args.edited).toBe('{"_id":"1","name":"Ada"}');
-      expect(upd.args.original).toContain('"name" : "John Doe"');
+      // Must be parseable JSON, not shell text: the backend parses it with strict
+      // serde_json, so `ObjectId(...)` in here fails the save outright. A
+      // substring assertion passed while that was broken.
+      expect(() => JSON.parse(upd.args.original)).not.toThrow();
+      expect(JSON.parse(upd.args.original)).toEqual({ _id: '1', name: 'John Doe' });
       expect(upd.args.replacement).toBeUndefined();
       expect(screen.getByText(/Document saved in customers/)).toBeInTheDocument();
     });
@@ -4459,7 +4463,7 @@ describe('App Component', () => {
       expect(upd).toBeTruthy();
       // The projected document goes as `original`, so the backend diff can tell
       // "not shown" from "deleted" and leaves username/email/roles alone.
-      expect(upd.args.original).toContain('"age" : 34');
+      expect(JSON.parse(upd.args.original)).toEqual({ _id: '66a1', age: 34 });
       expect(upd.args.edited).toBe('{"_id":"66a1","age":35}');
     });
   });
@@ -4478,6 +4482,26 @@ describe('App Component', () => {
     fireEvent.click(screen.getByTestId('select-collection-btn'));
     // A find result: the row is a stored document, so editing is offered.
     expect(await screen.findByTestId('edit-doc-btn')).toBeInTheDocument();
+  });
+});
+
+describe('projectionComputesId (#275)', () => {
+  it('accepts projections that keep _id as the stored id', async () => {
+    const { projectionComputesId } = await import('../../App');
+    expect(projectionComputesId(undefined)).toBe(false);
+    expect(projectionComputesId('{}')).toBe(false);
+    expect(projectionComputesId('{"name":1}')).toBe(false);
+    expect(projectionComputesId('{"_id":1,"name":1}')).toBe(false);
+    expect(projectionComputesId('{"_id":0,"name":1}')).toBe(false);
+    expect(projectionComputesId('{"_id":true}')).toBe(false);
+  });
+
+  it('rejects a computed _id, whose value is not the document id', async () => {
+    const { projectionComputesId } = await import('../../App');
+    expect(projectionComputesId('{"_id":"$email","name":1}')).toBe(true);
+    expect(projectionComputesId('{"_id":{"$concat":["$a","$b"]}}')).toBe(true);
+    // Unparseable: the backend refuses, so the action is withheld too.
+    expect(projectionComputesId('{not json')).toBe(true);
   });
 });
 

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -752,7 +752,7 @@ describe('App Component', () => {
     });
   });
 
-  it('edits a document via replace by _id (C1)', async () => {
+  it('edits a document as a field-level update by _id (C1)', async () => {
     const calls: any[] = [];
     mockInvoke.mockImplementation((cmd, args) => {
       calls.push({ cmd, args });
@@ -779,7 +779,11 @@ describe('App Component', () => {
       const upd = calls.find((c) => c.cmd === 'update_document');
       expect(upd).toBeTruthy();
       expect(upd.args.filter).toBe('{"_id":"1"}');
-      expect(upd.args.replacement).toBe('{"_id":"1","name":"Ada"}');
+      // Both sides are sent so the backend can write only what changed; a bare
+      // `replacement` would wipe fields a projection had left out (#275).
+      expect(upd.args.edited).toBe('{"_id":"1","name":"Ada"}');
+      expect(upd.args.original).toContain('"name" : "John Doe"');
+      expect(upd.args.replacement).toBeUndefined();
       expect(screen.getByText(/Document saved in customers/)).toBeInTheDocument();
     });
   });
@@ -4424,6 +4428,39 @@ describe('App Component', () => {
       } finally {
         await i18next.changeLanguage('en');
       }
+    });
+  });
+
+  it('sends the projected document as the original so unprojected fields survive (#275)', async () => {
+    const calls: any[] = [];
+    mockInvoke.mockImplementation((cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'execute_mql_query') {
+        // What a `{ "age": 1 }` projection returns: a partial view.
+        return Promise.resolve([JSON.stringify({ _id: '66a1', age: 34 })]);
+      }
+      if (cmd === 'update_document') return Promise.resolve(1);
+      return Promise.resolve([]);
+    });
+
+    const { fireEvent, waitFor } = await import('@testing-library/react');
+    renderWithProviders(<App />);
+    await screen.findByTestId('mock-sidebar');
+    fireEvent.click(screen.getByTestId('select-collection-btn'));
+    await screen.findByText(/34/);
+
+    fireEvent.click(screen.getAllByTestId('edit-doc-btn')[0]);
+    const input = await screen.findByTestId('document-json-input');
+    fireEvent.change(input, { target: { value: '{"_id":"66a1","age":35}' } });
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+
+    await waitFor(() => {
+      const upd = calls.find((c) => c.cmd === 'update_document');
+      expect(upd).toBeTruthy();
+      // The projected document goes as `original`, so the backend diff can tell
+      // "not shown" from "deleted" and leaves username/email/roles alone.
+      expect(upd.args.original).toContain('"age" : 34');
+      expect(upd.args.edited).toBe('{"_id":"66a1","age":35}');
     });
   });
 });

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -13,12 +13,12 @@ describe('docToShell', () => {
       n: { $numberInt: '7' },
       name: 'Acme',
     });
-    expect(out).toContain('"_id": ObjectId("507f1f77bcf86cd799439011")');
-    expect(out).toContain('"createdAt": ISODate("2025-01-04T00:00:00.000Z")');
-    expect(out).toContain('"big": NumberLong("9007199254740993")');
-    expect(out).toContain('"price": NumberDecimal("12.50")');
-    expect(out).toContain('"n": NumberInt(7)');
-    expect(out).toContain('"name": "Acme"');
+    expect(out).toContain('"_id" : ObjectId("507f1f77bcf86cd799439011")');
+    expect(out).toContain('"createdAt" : ISODate("2025-01-04T00:00:00.000Z")');
+    expect(out).toContain('"big" : NumberLong("9007199254740993")');
+    expect(out).toContain('"price" : NumberDecimal("12.50")');
+    expect(out).toContain('"n" : NumberInt(7)');
+    expect(out).toContain('"name" : "Acme"');
   });
 
   it('renders canonical $date ($numberLong) as ISODate', () => {

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -52,7 +52,10 @@ export function docToShell(v: any, indent = 0): string {
     }
     if (ks.length === 0) return '{}';
     return `{\n${ks
-      .map((k) => `${padIn}${JSON.stringify(k)}: ${docToShell(v[k], indent + 1)}`)
+      // `" : "` (not `": "`) to match how the results grid renders documents —
+      // the same document must not look different in the grid and the editor.
+      // See DataGrid's `jsonPunct(' : ')`.
+      .map((k) => `${padIn}${JSON.stringify(k)} : ${docToShell(v[k], indent + 1)}`)
       .join(',\n')}\n${pad}}`;
   }
 

--- a/src/locales/de/documents.json
+++ b/src/locales/de/documents.json
@@ -186,7 +186,7 @@
       "noId": "Aktualisierung nicht möglich: Dieses Dokument hat keine _id."
     },
     "hints": {
-      "shellTypes": "Shell-Typen werden unterstützt (z. B. {{example}}). Beim Bearbeiten wird das gesamte Dokument ersetzt."
+      "shellTypes": "Shell-Typen werden unterstützt (z. B. {{example}}). Es werden nur die Felder geschrieben, die du änderst; alles, was hier nicht angezeigt wird, bleibt unberührt."
     },
     "labels": {
       "document": "Dokument"

--- a/src/locales/en/documents.json
+++ b/src/locales/en/documents.json
@@ -334,7 +334,7 @@
       "syntaxError": "syntax error"
     },
     "hints": {
-      "shellTypes": "Shell types are supported (e.g. {{example}}). Editing replaces the entire document."
+      "shellTypes": "Shell types are supported (e.g. {{example}}). Only the fields you change are written; anything not shown here is left untouched."
     },
     "labels": {
       "document": "Document"

--- a/src/locales/zh-Hans/documents.json
+++ b/src/locales/zh-Hans/documents.json
@@ -319,7 +319,7 @@
       "syntaxError": "语法错误"
     },
     "hints": {
-      "shellTypes": "支持 Shell 类型（例如 {{example}}）。编辑会替换整个文档。"
+      "shellTypes": "支持 Shell 类型（例如 {{example}}）。仅写入你修改的字段；此处未显示的内容保持不变。"
     },
     "labels": {
       "document": "文档"


### PR DESCRIPTION
## Summary

Closes #275 — editing a document loaded under a projection deleted every field the projection had left out.

Root cause is three links, none of them in the editor UI:

1. `query.rs` applies `.projection()` server-side, so a result row is a **partial view** of the document
2. the edit modal is opened with that row verbatim as `targetDoc`
3. saving called `coll.replace_one(filter, replacement)` — a **full document replacement**

Querying with `{ "age": 1 }` and saving therefore left a document containing only `_id` and `age`.

## Fix

`update_document` now takes the document **as loaded** and **as edited**; the backend computes a field-level `$set`/`$unset` diff. A field that was never shown appears in neither side, so no operator mentions it and the stored value is untouched — correct by construction rather than by special-casing projections. It also stops a save from clobbering concurrent edits to fields the user never looked at.

Sub-documents recurse into **dotted paths**. That matters: a projection can target `{"address.city": 1}`, and `$set`-ing the whole `address` object would delete `street`/`zip`/`country` — the same bug one level down.

Also in here:

- The editor footer claimed *"Editing replaces the entire document"*, which this makes false — now says only changed fields are written (all three locales).
- Separate formatting fix in its own commit: the grid rendered `"key" : value` while the editor rendered `"key": value`, so the same document looked different in each. Reported alongside the bug.

## Deliberately unchanged

- **`WriteOp::ReplaceOne`** stays. It sits outside the confirm-required set; moving to `UpdateMany` would start demanding destructive confirmation for a single-document edit.
- **Arrays are still replaced whole.** A `$slice`/`$elemMatch` projection returns a partial array that cannot be distinguished from a genuinely short one, so that case remains lossy. Documented at `build_field_update` rather than left implicit — fixing it needs the projection threaded down to the save path.

## Verification

- 10 unit tests on the diff, **written before the implementation** (projected edit, unchanged doc, add, remove, nested set, nested unset, `_id` immutability, arrays, type change, new sub-document)
- Integration test against a real MongoDB 7 seeding a full document, loading a `{ "age": 1 }` projection, editing it, and asserting `name`/`tier`/`roles` survive
- **Verified in both directions:** temporarily restoring `replace_one` makes those assertions fail with exactly the reported symptom (`name: Null`); the fix makes them pass
- 651 backend tests (integration active against live Mongo), 1425 frontend, `tsc` clean, `i18n:check` clean, 0 clippy errors