### PR TITLE
fix(documents): share the grid's syntax colours with the document editor

### DIFF
--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { shellToEjson } from '../lib/shellDoc';
 import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
+import { DOC_LANGUAGE_ID, registerDocLanguage } from '../lib/monacoDocLanguage';
+import { registerMqlensMonacoThemes } from '../lib/monacoAppTheme';
 import { useEscapeClose } from '../lib/useEscapeClose';
 import {
   Dialog,
@@ -110,19 +112,22 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
           <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-border bg-background">
             <Editor
               height="100%"
-              defaultLanguage="javascript"
-              language="javascript"
+              // Not `javascript`: Monaco's JS tokenizer emits plain `string` for
+              // every quoted literal, so a key cannot be coloured differently
+              // from a string value and the editor could not match the grid.
+              // Nothing else is lost — this editor already disables suggestions
+              // and diagnostics, so the language was only ever doing highlighting.
+              defaultLanguage={DOC_LANGUAGE_ID}
+              language={DOC_LANGUAGE_ID}
               theme={theme}
               value={json}
               onChange={(v) => setJson(v ?? '')}
               wrapperProps={{ 'data-testid': 'document-json-input' }}
               onMount={(_editor, monaco) => {
-                monaco.languages.typescript?.javascriptDefaults?.setDiagnosticsOptions({
-                  noSemanticValidation: true,
-                  noSyntaxValidation: true,
-                  noSuggestionDiagnostics: true,
-                });
-                monaco.languages.json?.jsonDefaults?.setDiagnosticsOptions({ validate: false });
+                registerDocLanguage(monaco);
+                // The theme's token colours come from the same design tokens the
+                // grid uses, so both must be registered before the editor paints.
+                registerMqlensMonacoThemes(monaco);
               }}
               options={{
                 minimap: { enabled: false },

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FileJson } from 'lucide-react';
 import Editor from '@monaco-editor/react';
 import { useTranslation } from 'react-i18next';
@@ -6,7 +6,7 @@ import type { TFunction } from 'i18next';
 import { shellToEjson } from '../lib/shellDoc';
 import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
 import { DOC_LANGUAGE_ID, registerDocLanguage } from '../lib/monacoDocLanguage';
-import { registerMqlensMonacoThemes } from '../lib/monacoAppTheme';
+import { registerMqlensMonacoThemes, refreshMqlensMonacoTheme } from '../lib/monacoAppTheme';
 import { useEscapeClose } from '../lib/useEscapeClose';
 import {
   Dialog,
@@ -54,6 +54,30 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   const [saving, setSaving] = useState(false);
   const validationError = useMemo(() => validateDocument(json, t), [json, t]);
   const theme = useMonacoTheme();
+  const monacoRef = useRef<Parameters<
+    NonNullable<React.ComponentProps<typeof Editor>['onMount']>
+  >[1] | null>(null);
+
+  // `refreshMqlensMonacoTheme` builds *both* theme ids from whatever CSS
+  // variables are live at the time, so they are only correct immediately after a
+  // refresh. QueryEditor re-runs it on every theme change; without the same here
+  // the dialog kept the previous mode's colours — a dark editor in light mode —
+  // whenever the mode changed with no query editor mounted to refresh them.
+  //
+  // Gated on `isOpen`, and the handle is dropped on close: this component stays
+  // mounted while the dialog is shut, so an ungated effect redefined the global
+  // Monaco themes on every App render. That is wasted work, it can fight
+  // QueryEditor's own refresh, and it measurably destabilised unrelated tests.
+  useEffect(() => {
+    if (!isOpen) {
+      monacoRef.current = null;
+      return;
+    }
+    const monaco = monacoRef.current;
+    if (!monaco) return;
+    refreshMqlensMonacoTheme(monaco);
+    monaco.editor.setTheme(theme);
+  }, [isOpen, theme]);
   const monacoFontSize = useMonacoFontSize(12.5);
   useEscapeClose(isOpen, onClose);
 
@@ -124,10 +148,12 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
               onChange={(v) => setJson(v ?? '')}
               wrapperProps={{ 'data-testid': 'document-json-input' }}
               onMount={(_editor, monaco) => {
+                monacoRef.current = monaco;
                 registerDocLanguage(monaco);
                 // The theme's token colours come from the same design tokens the
                 // grid uses, so both must be registered before the editor paints.
                 registerMqlensMonacoThemes(monaco);
+                refreshMqlensMonacoTheme(monaco);
               }}
               options={{
                 minimap: { enabled: false },

--- a/src/lib/__tests__/monacoDocLanguage.test.ts
+++ b/src/lib/__tests__/monacoDocLanguage.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DOC_LANGUAGE_ID,
+  DOC_SYNTAX_TOKENS,
+  registerDocLanguage,
+  resetDocLanguageForTests,
+} from '../monacoDocLanguage';
+
+type Rule = [RegExp, string];
+
+/** Capture what the module registers, without pulling in real Monaco. */
+function fakeMonaco() {
+  const registered: string[] = [];
+  let tokenizer: { root: Rule[] } | undefined;
+  return {
+    monaco: {
+      languages: {
+        register: ({ id }: { id: string }) => registered.push(id),
+        setMonarchTokensProvider: (_id: string, provider: { tokenizer: { root: Rule[] } }) => {
+          tokenizer = provider.tokenizer;
+        },
+      },
+    } as never,
+    registered,
+    rules: () => tokenizer?.root ?? [],
+  };
+}
+
+/**
+ * Classify `text` the way Monarch would: walk left to right, taking the first
+ * rule that matches at the current offset.
+ */
+function tokenize(rules: Rule[], text: string): { text: string; token: string }[] {
+  const out: { text: string; token: string }[] = [];
+  let rest = text;
+  while (rest.length > 0) {
+    let matched = false;
+    for (const [pattern, token] of rules) {
+      const anchored = new RegExp(`^(?:${pattern.source})`, pattern.flags.replace('g', ''));
+      const m = anchored.exec(rest);
+      if (m && m[0].length > 0) {
+        out.push({ text: m[0], token });
+        rest = rest.slice(m[0].length);
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      rest = rest.slice(1);
+    }
+  }
+  return out;
+}
+
+describe('document editor language', () => {
+  beforeEach(() => resetDocLanguageForTests());
+
+  it('registers under its own id rather than reusing javascript', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    expect(f.registered).toEqual([DOC_LANGUAGE_ID]);
+  });
+
+  it('is idempotent, so every editor may call it', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    registerDocLanguage(f.monaco);
+    expect(f.registered).toHaveLength(1);
+  });
+
+  it('separates a key from a string value, which javascript mode cannot', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const tokens = tokenize(f.rules(), '"name" : "Ada"');
+    expect(tokens.find((t) => t.text === '"name"')?.token).toBe('key');
+    expect(tokens.find((t) => t.text === '"Ada"')?.token).toBe('string');
+  });
+
+  it('reads a bare mongosh key as a key', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const tokens = tokenize(f.rules(), 'name : "Ada"');
+    expect(tokens[0]).toEqual({ text: 'name', token: 'key' });
+  });
+
+  it('colours BSON constructors and their arguments separately', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const tokens = tokenize(f.rules(), 'ObjectId("507f1f77bcf86cd799439011")');
+    expect(tokens[0]).toEqual({ text: 'ObjectId', token: 'constructor' });
+    expect(tokens.find((t) => t.token === 'string')?.text).toBe('"507f1f77bcf86cd799439011"');
+  });
+
+  it('does not mistake a key named like a constructor for a call', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const tokens = tokenize(f.rules(), '"ObjectId" : 1');
+    expect(tokens[0]).toEqual({ text: '"ObjectId"', token: 'key' });
+  });
+
+  it('classifies literals and punctuation', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const kinds = (src: string) => tokenize(f.rules(), src).map((t) => t.token);
+    expect(kinds('true')).toContain('boolean');
+    expect(kinds('false')).toContain('boolean');
+    expect(kinds('null')).toContain('null');
+    expect(kinds('-12.5e3')).toContain('number');
+    expect(kinds('{},:')).toEqual(['delimiter', 'delimiter', 'delimiter', 'delimiter']);
+  });
+
+  it('keeps a half-typed string coloured', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const tokens = tokenize(f.rules(), '"unfinis');
+    expect(tokens[0]?.token).toBe('string');
+  });
+
+  it('maps every token to a design token the grid also uses', () => {
+    // The mapping is the single definition shared with the theme; a token
+    // without one would silently fall back to VS Code's colours.
+    const tokens = new Set(DOC_SYNTAX_TOKENS.map((t) => t.token));
+    for (const expected of ['key', 'string', 'number', 'boolean', 'null', 'constructor', 'delimiter']) {
+      expect(tokens.has(expected)).toBe(true);
+    }
+    for (const { cssToken, fallback } of DOC_SYNTAX_TOKENS) {
+      expect(cssToken).toMatch(/^(syntax-|muted-foreground)/);
+      expect(fallback).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+});

--- a/src/lib/__tests__/monacoDocLanguage.test.ts
+++ b/src/lib/__tests__/monacoDocLanguage.test.ts
@@ -9,9 +9,20 @@ import {
 type Rule = [RegExp, string];
 
 /** Capture what the module registers, without pulling in real Monaco. */
+type Pair = { open: string; close: string; notIn?: string[] };
+type Config = {
+  brackets?: [string, string][];
+  autoClosingPairs?: Pair[];
+  surroundingPairs?: Pair[];
+  indentationRules?: { increaseIndentPattern: RegExp; decreaseIndentPattern: RegExp };
+  wordPattern?: RegExp;
+  comments?: unknown;
+};
+
 function fakeMonaco() {
   const registered: string[] = [];
   let tokenizer: { root: Rule[] } | undefined;
+  let config: Config | undefined;
   return {
     monaco: {
       languages: {
@@ -19,10 +30,14 @@ function fakeMonaco() {
         setMonarchTokensProvider: (_id: string, provider: { tokenizer: { root: Rule[] } }) => {
           tokenizer = provider.tokenizer;
         },
+        setLanguageConfiguration: (_id: string, c: Config) => {
+          config = c;
+        },
       },
     } as never,
     registered,
     rules: () => tokenizer?.root ?? [],
+    config: () => config,
   };
 }
 
@@ -127,5 +142,44 @@ describe('document editor language', () => {
       expect(cssToken).toMatch(/^(syntax-|muted-foreground)/);
       expect(fallback).toMatch(/^#[0-9a-f]{6}$/i);
     }
+  });
+
+  it('keeps the editing behaviour the javascript language provided', () => {
+    // Switching language also drops its configuration, so auto-closing, bracket
+    // matching, folding and word selection have to be supplied here.
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const config = f.config();
+    expect(config).toBeDefined();
+
+    expect(config?.brackets).toEqual([
+      ['{', '}'],
+      ['[', ']'],
+      ['(', ')'],
+    ]);
+
+    // All three JavaScript quotings auto-close, as they did under javascript.
+    const closing = (config?.autoClosingPairs ?? []).map((p) => p.open);
+    expect(closing).toEqual(expect.arrayContaining(['{', '[', '(', '"', "'", '`']));
+
+    // A quote must not auto-close inside a string.
+    for (const quote of ['"', "'", '`']) {
+      const pair = config?.autoClosingPairs?.find((p) => p.open === quote);
+      expect(pair?.notIn).toContain('string');
+    }
+
+    // Selecting text and typing a quote should wrap it.
+    const surrounding = (config?.surroundingPairs ?? []).map((p) => p.open);
+    expect(surrounding).toEqual(expect.arrayContaining(['{', '[', '(', '"', "'", '`']));
+
+    expect(config?.indentationRules?.increaseIndentPattern.test('  "a": {')).toBe(true);
+    expect(config?.indentationRules?.decreaseIndentPattern.test('  },')).toBe(true);
+    expect(config?.wordPattern).toBeInstanceOf(RegExp);
+  });
+
+  it('does not offer comment toggling for a document literal', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    expect(f.config()?.comments).toBeUndefined();
   });
 });

--- a/src/lib/__tests__/monacoDocLanguage.test.ts
+++ b/src/lib/__tests__/monacoDocLanguage.test.ts
@@ -8,7 +8,8 @@ import {
 } from '../monacoDocLanguage';
 import { syntaxRules } from '../monacoAppTheme';
 
-type Rule = [RegExp, string];
+type Action = string | { token: string; next?: string };
+type Rule = [RegExp, Action];
 
 /** Capture what the module registers, without pulling in real Monaco. */
 type Pair = { open: string; close: string; notIn?: string[] };
@@ -23,7 +24,7 @@ type Config = {
 
 function fakeMonaco() {
   const registered: string[] = [];
-  let tokenizer: { root: Rule[] } | undefined;
+  let tokenizer: Record<string, Rule[]> | undefined;
   let postfix: string | undefined;
   let config: Config | undefined;
   return {
@@ -32,7 +33,7 @@ function fakeMonaco() {
         register: ({ id }: { id: string }) => registered.push(id),
         setMonarchTokensProvider: (
           _id: string,
-          provider: { tokenizer: { root: Rule[] }; tokenPostfix?: string },
+          provider: { tokenizer: Record<string, Rule[]>; tokenPostfix?: string },
         ) => {
           tokenizer = provider.tokenizer;
           postfix = provider.tokenPostfix;
@@ -43,7 +44,7 @@ function fakeMonaco() {
       },
     } as never,
     registered,
-    rules: () => tokenizer?.root ?? [],
+    rules: () => tokenizer ?? { root: [] },
     postfix: () => postfix,
     config: () => config,
   };
@@ -53,24 +54,34 @@ function fakeMonaco() {
  * Classify `text` the way Monarch would: walk left to right, taking the first
  * rule that matches at the current offset.
  */
-function tokenize(rules: Rule[], text: string): { text: string; token: string }[] {
+function tokenize(
+  tokenizer: Record<string, Rule[]>,
+  text: string,
+): { text: string; token: string }[] {
   const out: { text: string; token: string }[] = [];
+  const stack: string[] = [];
+  let state = 'root';
   let rest = text;
   while (rest.length > 0) {
     let matched = false;
-    for (const [pattern, token] of rules) {
+    for (const [pattern, action] of tokenizer[state] ?? []) {
       const anchored = new RegExp(`^(?:${pattern.source})`, pattern.flags.replace('g', ''));
       const m = anchored.exec(rest);
       if (m && m[0].length > 0) {
+        const token = typeof action === 'string' ? action : action.token;
+        const next = typeof action === 'string' ? undefined : action.next;
         out.push({ text: m[0], token });
         rest = rest.slice(m[0].length);
+        if (next === '@pop') state = stack.pop() ?? 'root';
+        else if (next) {
+          stack.push(state);
+          state = next.replace('@', '');
+        }
         matched = true;
         break;
       }
     }
-    if (!matched) {
-      rest = rest.slice(1);
-    }
+    if (!matched) rest = rest.slice(1);
   }
   return out;
 }
@@ -235,5 +246,49 @@ describe('document editor language', () => {
       // Hex without a leading '#', which is what Monaco expects.
       expect(rule.foreground).toMatch(/^[0-9a-f]{6}$/i);
     }
+  });
+
+  it('colours a quoted NumberLong argument as a number, matching the grid', () => {
+    // `docToShell` quotes it because a 64-bit value cannot survive as a JS
+    // number, but the grid renders it with `text-syntax-number`.
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const tokens = tokenize(f.rules(), 'NumberLong("9007199254740993")');
+    expect(tokens[0]).toEqual({ text: 'NumberLong', token: 'constructor' });
+    expect(tokens.find((t) => t.text.includes('9007199254740993'))?.token).toBe('number');
+  });
+
+  it('leaves an unquoted NumberInt argument as a number too', () => {
+    // No special case needed: it is emitted unquoted and the grid agrees.
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const tokens = tokenize(f.rules(), 'NumberInt(7)');
+    expect(tokens[0]).toEqual({ text: 'NumberInt', token: 'constructor' });
+    expect(tokens.find((t) => t.text === '7')?.token).toBe('number');
+  });
+
+  it('keeps string-valued constructors as strings, as the grid does', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    for (const src of [
+      'ObjectId("507f1f77bcf86cd799439011")',
+      'ISODate("2025-01-04T00:00:00.000Z")',
+      'NumberDecimal("12.50")',
+    ]) {
+      const tokens = tokenize(f.rules(), src);
+      expect(tokens[0]?.token).toBe('constructor');
+      expect(tokens.find((t) => t.token === 'string')).toBeDefined();
+      expect(tokens.find((t) => t.token === 'number')).toBeUndefined();
+    }
+  });
+
+  it('leaves the numeric-argument state on a half-typed call', () => {
+    // Otherwise an unterminated call would swallow the rest of the document
+    // while it is being written.
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    const tokens = tokenize(f.rules(), 'NumberLong(  , "later" : 1');
+    // The stray comma pops back to root, so the following text tokenizes normally.
+    expect(tokens.find((t) => t.text === '"later"')?.token).toBe('key');
   });
 });

--- a/src/lib/__tests__/monacoDocLanguage.test.ts
+++ b/src/lib/__tests__/monacoDocLanguage.test.ts
@@ -109,8 +109,34 @@ describe('document editor language', () => {
   it('does not mistake a key named like a constructor for a call', () => {
     const f = fakeMonaco();
     registerDocLanguage(f.monaco);
-    const tokens = tokenize(f.rules(), '"ObjectId" : 1');
-    expect(tokens[0]).toEqual({ text: '"ObjectId"', token: 'key' });
+    // Quoted: the constructor pattern cannot match at the opening quote.
+    expect(tokenize(f.rules(), '"ObjectId" : 1')[0]).toEqual({
+      text: '"ObjectId"',
+      token: 'key',
+    });
+    // Bare: only the following parenthesis separates a call from a field name,
+    // and the constructor rule is matched first.
+    expect(tokenize(f.rules(), 'ObjectId : "legacy"')[0]).toEqual({
+      text: 'ObjectId',
+      token: 'key',
+    });
+    expect(tokenize(f.rules(), 'ISODate: 1')[0]).toEqual({
+      text: 'ISODate',
+      token: 'key',
+    });
+  });
+
+  it('still reads a constructor call as a call, including with a space', () => {
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    expect(tokenize(f.rules(), 'ObjectId("abc")')[0]).toEqual({
+      text: 'ObjectId',
+      token: 'constructor',
+    });
+    expect(tokenize(f.rules(), 'ISODate ("2025-01-01")')[0]).toEqual({
+      text: 'ISODate',
+      token: 'constructor',
+    });
   });
 
   it('classifies literals and punctuation', () => {

--- a/src/lib/__tests__/monacoDocLanguage.test.ts
+++ b/src/lib/__tests__/monacoDocLanguage.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   DOC_LANGUAGE_ID,
   DOC_SYNTAX_TOKENS,
+  DOC_TOKEN_POSTFIX,
   registerDocLanguage,
   resetDocLanguageForTests,
 } from '../monacoDocLanguage';
+import { syntaxRules } from '../monacoAppTheme';
 
 type Rule = [RegExp, string];
 
@@ -22,13 +24,18 @@ type Config = {
 function fakeMonaco() {
   const registered: string[] = [];
   let tokenizer: { root: Rule[] } | undefined;
+  let postfix: string | undefined;
   let config: Config | undefined;
   return {
     monaco: {
       languages: {
         register: ({ id }: { id: string }) => registered.push(id),
-        setMonarchTokensProvider: (_id: string, provider: { tokenizer: { root: Rule[] } }) => {
+        setMonarchTokensProvider: (
+          _id: string,
+          provider: { tokenizer: { root: Rule[] }; tokenPostfix?: string },
+        ) => {
           tokenizer = provider.tokenizer;
+          postfix = provider.tokenPostfix;
         },
         setLanguageConfiguration: (_id: string, c: Config) => {
           config = c;
@@ -37,6 +44,7 @@ function fakeMonaco() {
     } as never,
     registered,
     rules: () => tokenizer?.root ?? [],
+    postfix: () => postfix,
     config: () => config,
   };
 }
@@ -207,5 +215,25 @@ describe('document editor language', () => {
     const f = fakeMonaco();
     registerDocLanguage(f.monaco);
     expect(f.config()?.comments).toBeUndefined();
+  });
+
+  it('scopes its tokens so theme rules cannot repaint other editors', () => {
+    // Monaco matches theme rules by token name across every language, so an
+    // unscoped `string` rule would also repaint the JavaScript query and shell
+    // editors. Monarch appends this suffix to each token.
+    const f = fakeMonaco();
+    registerDocLanguage(f.monaco);
+    expect(f.postfix()).toBe(DOC_TOKEN_POSTFIX);
+    expect(DOC_TOKEN_POSTFIX).toBe(`.${DOC_LANGUAGE_ID}`);
+  });
+
+  it('emits theme rules only for this language', () => {
+    const rules = syntaxRules();
+    expect(rules.length).toBe(DOC_SYNTAX_TOKENS.length);
+    for (const rule of rules) {
+      expect(rule.token.endsWith(DOC_TOKEN_POSTFIX)).toBe(true);
+      // Hex without a leading '#', which is what Monaco expects.
+      expect(rule.foreground).toMatch(/^[0-9a-f]{6}$/i);
+    }
   });
 });

--- a/src/lib/monacoAppTheme.ts
+++ b/src/lib/monacoAppTheme.ts
@@ -1,6 +1,6 @@
 import type { Monaco } from "@monaco-editor/react";
 
-import { DOC_SYNTAX_TOKENS } from "./monacoDocLanguage";
+import { DOC_SYNTAX_TOKENS, DOC_TOKEN_POSTFIX } from "./monacoDocLanguage";
 
 export type MqlensMonacoThemeId = "mqlens-light" | "mqlens-dark";
 
@@ -74,11 +74,15 @@ export function getMqlensMonacoThemeId(): MqlensMonacoThemeId {
  *
  * These were previously `rules: []`, so Monaco fell back to VS Code's built-in
  * colours and the same document looked different in the grid and the editor.
- * Monaco wants hex without the leading `#`.
+ *
+ * Every selector is scoped with `DOC_TOKEN_POSTFIX`: Monaco matches theme rules
+ * by token name across all languages, so a bare `string` rule would also repaint
+ * the JavaScript query and shell editors, which are meant to keep the inherited
+ * VS/VS Dark palette. Monaco wants hex without the leading `#`.
  */
-function syntaxRules(): { token: string; foreground: string }[] {
+export function syntaxRules(): { token: string; foreground: string }[] {
   return DOC_SYNTAX_TOKENS.map(({ token, cssToken, fallback }) => ({
-    token,
+    token: `${token}${DOC_TOKEN_POSTFIX}`,
     foreground: readToken(cssToken, fallback).replace("#", ""),
   }));
 }

--- a/src/lib/monacoAppTheme.ts
+++ b/src/lib/monacoAppTheme.ts
@@ -1,5 +1,7 @@
 import type { Monaco } from "@monaco-editor/react";
 
+import { DOC_SYNTAX_TOKENS } from "./monacoDocLanguage";
+
 export type MqlensMonacoThemeId = "mqlens-light" | "mqlens-dark";
 
 let registered = false;
@@ -66,6 +68,21 @@ export function getMqlensMonacoThemeId(): MqlensMonacoThemeId {
     : "mqlens-dark";
 }
 
+/**
+ * Token colours for both themes, read from the same design tokens the results
+ * grid uses.
+ *
+ * These were previously `rules: []`, so Monaco fell back to VS Code's built-in
+ * colours and the same document looked different in the grid and the editor.
+ * Monaco wants hex without the leading `#`.
+ */
+function syntaxRules(): { token: string; foreground: string }[] {
+  return DOC_SYNTAX_TOKENS.map(({ token, cssToken, fallback }) => ({
+    token,
+    foreground: readToken(cssToken, fallback).replace("#", ""),
+  }));
+}
+
 export function registerMqlensMonacoThemes(monaco: Monaco): void {
   if (registered) return;
 
@@ -75,7 +92,7 @@ export function registerMqlensMonacoThemes(monaco: Monaco): void {
   monaco.editor.defineTheme(lightTheme, {
     base: "vs",
     inherit: true,
-    rules: [],
+    rules: syntaxRules(),
     colors: {
       "editor.background": readToken("input", "#ffffff"),
       "editor.foreground": readToken("foreground", "#1a1a1a"),
@@ -91,7 +108,7 @@ export function registerMqlensMonacoThemes(monaco: Monaco): void {
   monaco.editor.defineTheme(darkTheme, {
     base: "vs-dark",
     inherit: true,
-    rules: [],
+    rules: syntaxRules(),
     colors: {
       "editor.background": readToken("input", "#1e1e1e"),
       "editor.foreground": readToken("foreground", "#d4d4d4"),
@@ -115,7 +132,7 @@ export function refreshMqlensMonacoTheme(monaco: Monaco): void {
   monaco.editor.defineTheme(lightTheme, {
     base: "vs",
     inherit: true,
-    rules: [],
+    rules: syntaxRules(),
     colors: {
       "editor.background": readToken("input", "#ffffff"),
       "editor.foreground": readToken("foreground", "#1a1a1a"),
@@ -131,7 +148,7 @@ export function refreshMqlensMonacoTheme(monaco: Monaco): void {
   monaco.editor.defineTheme(darkTheme, {
     base: "vs-dark",
     inherit: true,
-    rules: [],
+    rules: syntaxRules(),
     colors: {
       "editor.background": readToken("input", "#1e1e1e"),
       "editor.foreground": readToken("foreground", "#d4d4d4"),

--- a/src/lib/monacoDocLanguage.ts
+++ b/src/lib/monacoDocLanguage.ts
@@ -121,9 +121,11 @@ export function registerDocLanguage(monaco: Monaco): void {
     defaultToken: "",
     tokenizer: {
       root: [
-        // Constructor names first, so `ObjectId` is not read as a bare key.
+        // A constructor is a *call*, so require the parenthesis. Without it a
+        // document with a bare field named `ObjectId` — `ObjectId: "legacy"` —
+        // matched here before the bare-key rule and was coloured as a call.
         [
-          new RegExp(`\\b(?:${BSON_CONSTRUCTORS.join("|")})\\b`),
+          new RegExp(`\\b(?:${BSON_CONSTRUCTORS.join("|")})\\b(?=\\s*\\()`),
           "constructor",
         ],
 

--- a/src/lib/monacoDocLanguage.ts
+++ b/src/lib/monacoDocLanguage.ts
@@ -76,6 +76,47 @@ export function registerDocLanguage(monaco: Monaco): void {
   registered = true;
 
   monaco.languages.register({ id: DOC_LANGUAGE_ID });
+
+  // A Monaco language carries editing behaviour as well as colours, and leaving
+  // `javascript` dropped all of it: auto-closing braces and quotes, surrounding
+  // a selection with a quote, bracket matching, bracket-based folding (which the
+  // dialog enables) and word selection. Restored here, matching what the
+  // JavaScript configuration provided for this content.
+  //
+  // Comments are deliberately not configured: the buffer is a document literal,
+  // not code, so offering comment toggling would invite text the save path has no
+  // reason to accept.
+  monaco.languages.setLanguageConfiguration(DOC_LANGUAGE_ID, {
+    brackets: [
+      ["{", "}"],
+      ["[", "]"],
+      ["(", ")"],
+    ],
+    autoClosingPairs: [
+      { open: "{", close: "}" },
+      { open: "[", close: "]" },
+      { open: "(", close: ")" },
+      // `notIn: ["string"]` stops a quote auto-closing inside a string, which is
+      // why the tokenizer has to emit `string` for half-typed values too.
+      { open: '"', close: '"', notIn: ["string"] },
+      { open: "'", close: "'", notIn: ["string"] },
+      { open: "`", close: "`", notIn: ["string"] },
+    ],
+    surroundingPairs: [
+      { open: "{", close: "}" },
+      { open: "[", close: "]" },
+      { open: "(", close: ")" },
+      { open: '"', close: '"' },
+      { open: "'", close: "'" },
+      { open: "`", close: "`" },
+    ],
+    indentationRules: {
+      increaseIndentPattern: /[{[]\s*$/,
+      decreaseIndentPattern: /^\s*[}\]],?\s*$/,
+    },
+    // Without this, double-click selects across punctuation inside a document.
+    wordPattern: /(-?\d*\.\d\w*)|([^\s{}[\](),:"'`]+)/g,
+  });
   monaco.languages.setMonarchTokensProvider(DOC_LANGUAGE_ID, {
     defaultToken: "",
     tokenizer: {

--- a/src/lib/monacoDocLanguage.ts
+++ b/src/lib/monacoDocLanguage.ts
@@ -72,7 +72,20 @@ const BSON_CONSTRUCTORS = [
   "Code",
   "Decimal128",
   "Date",
+  "Long",
 ] as const;
+
+/**
+ * Constructors whose argument the grid colours as a *number* even though
+ * `docToShell` writes it quoted.
+ *
+ * A 64-bit value cannot survive as a JavaScript number, so `docToShell` emits
+ * `NumberLong("42")` deliberately — but `DataGrid` renders the same value as
+ * `NumberLong(` + `text-syntax-number` + `)`. Colouring the quoted argument as a
+ * number keeps the two agreeing. `NumberInt` needs no special case: it is emitted
+ * unquoted, so the ordinary number rule already matches what the grid does.
+ */
+const NUMERIC_ARGUMENT_CONSTRUCTORS = ["NumberLong", "Long"] as const;
 
 let registered = false;
 
@@ -136,6 +149,14 @@ export function registerDocLanguage(monaco: Monaco): void {
     tokenPostfix: DOC_TOKEN_POSTFIX,
     tokenizer: {
       root: [
+        // Before the general rule, so the argument state is entered.
+        [
+          new RegExp(
+            `\\b(?:${NUMERIC_ARGUMENT_CONSTRUCTORS.join("|")})\\b(?=\\s*\\()`,
+          ),
+          { token: "constructor", next: "@numericArgument" },
+        ],
+
         // A constructor is a *call*, so require the parenthesis. Without it a
         // document with a bare field named `ObjectId` — `ObjectId: "legacy"` —
         // matched here before the bare-key rule and was coloured as a call.
@@ -166,6 +187,20 @@ export function registerDocLanguage(monaco: Monaco): void {
         // Matches the grid's `jsonPunct`. Parentheses are left alone because the
         // grid renders a constructor's own parens in the default foreground.
         [/[{}[\],:]/, "delimiter"],
+      ],
+
+      // Inside `NumberLong(...)`: the quoted 64-bit value is coloured as a
+      // number, which is what the grid shows.
+      numericArgument: [
+        [/\(/, ""],
+        [/\s+/, ""],
+        [/"(?:[^"\\]|\\.)*"/, "number"],
+        [/'(?:[^'\\]|\\.)*'/, "number"],
+        [/-?\d+/, "number"],
+        [/\)/, { token: "", next: "@pop" }],
+        // Leave on anything unexpected, so a half-typed call cannot swallow the
+        // rest of the document while it is being written.
+        [/./, { token: "", next: "@pop" }],
       ],
     },
   });

--- a/src/lib/monacoDocLanguage.ts
+++ b/src/lib/monacoDocLanguage.ts
@@ -19,6 +19,20 @@ import type { Monaco } from "@monaco-editor/react";
 export const DOC_LANGUAGE_ID = "mqlens-doc";
 
 /**
+ * Suffix Monarch appends to every token this language emits, so `string` becomes
+ * `string.mqlens-doc`.
+ *
+ * Monaco theme rules match by token name across *all* languages, so unscoped
+ * rules for `string`/`number`/`delimiter` would also repaint the JavaScript query
+ * and shell editors, which inherit the VS/VS Dark palette. Scoping the rules to
+ * this suffix keeps them to the document editor.
+ *
+ * Monarch defaults `tokenPostfix` to `.<languageId>`; it is set explicitly below
+ * so the theme's dependency on it is visible rather than incidental.
+ */
+export const DOC_TOKEN_POSTFIX = `.${DOC_LANGUAGE_ID}`;
+
+/**
  * Monarch token → design token, with a fallback for when the CSS variable
  * cannot be read (SSR, tests).
  *
@@ -119,6 +133,7 @@ export function registerDocLanguage(monaco: Monaco): void {
   });
   monaco.languages.setMonarchTokensProvider(DOC_LANGUAGE_ID, {
     defaultToken: "",
+    tokenPostfix: DOC_TOKEN_POSTFIX,
     tokenizer: {
       root: [
         // A constructor is a *call*, so require the parenthesis. Without it a

--- a/src/lib/monacoDocLanguage.ts
+++ b/src/lib/monacoDocLanguage.ts
@@ -1,0 +1,119 @@
+/**
+ * Syntax highlighting for the document editor, sharing the results grid's colours.
+ *
+ * The grid renders documents with a React walker over *parsed* BSON values
+ * (`val instanceof ObjectId`, `typeof val === 'number'`) and colours them with
+ * the `--syntax-*` design tokens. An editor cannot reuse that: it has to colour
+ * raw text as it is typed, including text that is momentarily invalid, so there
+ * is no parsed value to inspect. A tokenizer is therefore unavoidable.
+ *
+ * What *is* avoidable is a second set of colours. Monaco's themes previously
+ * declared `rules: []`, so every editor fell back to VS Code's built-in token
+ * colours and the same document looked different in the grid and the editor.
+ * [`DOC_SYNTAX_TOKENS`] is the one place the mapping lives; the theme reads the
+ * design tokens through it, so the two surfaces cannot drift apart again.
+ */
+import type { Monaco } from "@monaco-editor/react";
+
+/** Language id for the mongosh-flavoured document text the editor holds. */
+export const DOC_LANGUAGE_ID = "mqlens-doc";
+
+/**
+ * Monarch token → design token, with a fallback for when the CSS variable
+ * cannot be read (SSR, tests).
+ *
+ * The design tokens are the same ones `DataGrid` applies as `text-syntax-*`
+ * classes, so a colour changes in both places at once. `delimiter` follows the
+ * grid's `jsonPunct`, which renders `:`, `,` and brackets in muted-foreground.
+ * Constructor *names* use `syntax-boolean` because the grid does
+ * (`<span className="text-syntax-boolean">ObjectId</span>`).
+ */
+export const DOC_SYNTAX_TOKENS: ReadonlyArray<{
+  token: string;
+  cssToken: string;
+  fallback: string;
+}> = [
+  { token: "key", cssToken: "syntax-key", fallback: "#7dd3fc" },
+  { token: "string", cssToken: "syntax-string", fallback: "#86efac" },
+  { token: "number", cssToken: "syntax-number", fallback: "#f59e0b" },
+  { token: "boolean", cssToken: "syntax-boolean", fallback: "#c4b5fd" },
+  { token: "null", cssToken: "syntax-null", fallback: "#8b93a1" },
+  { token: "constructor", cssToken: "syntax-boolean", fallback: "#c4b5fd" },
+  { token: "delimiter", cssToken: "muted-foreground", fallback: "#8b93a1" },
+];
+
+/** BSON helpers mongosh accepts, rendered as calls in the grid and the editor. */
+const BSON_CONSTRUCTORS = [
+  "ObjectId",
+  "ISODate",
+  "NumberLong",
+  "NumberDecimal",
+  "NumberInt",
+  "Timestamp",
+  "BinData",
+  "UUID",
+  "DBRef",
+  "MinKey",
+  "MaxKey",
+  "Code",
+  "Decimal128",
+  "Date",
+] as const;
+
+let registered = false;
+
+/**
+ * Register the document language. Idempotent, so every editor can call it.
+ *
+ * Tokenizes the format `docToShell` produces: quoted or bare keys, the three
+ * JavaScript string forms, numbers, `true`/`false`/`null`, and BSON constructor
+ * calls. A key is distinguished from a string value by the colon that follows
+ * it — which is why `language="javascript"` could not do this, as Monaco's
+ * JavaScript tokenizer emits plain `string` for every quoted literal.
+ */
+export function registerDocLanguage(monaco: Monaco): void {
+  if (registered) return;
+  registered = true;
+
+  monaco.languages.register({ id: DOC_LANGUAGE_ID });
+  monaco.languages.setMonarchTokensProvider(DOC_LANGUAGE_ID, {
+    defaultToken: "",
+    tokenizer: {
+      root: [
+        // Constructor names first, so `ObjectId` is not read as a bare key.
+        [
+          new RegExp(`\\b(?:${BSON_CONSTRUCTORS.join("|")})\\b`),
+          "constructor",
+        ],
+
+        // A quoted or bare identifier followed by `:` is a key, not a value.
+        [/"(?:[^"\\]|\\.)*"(?=\s*:)/, "key"],
+        [/'(?:[^'\\]|\\.)*'(?=\s*:)/, "key"],
+        [/`(?:[^`\\]|\\.)*`(?=\s*:)/, "key"],
+        [/[A-Za-z_$][\w$]*(?=\s*:)/, "key"],
+
+        // String values, in all three JavaScript quotings.
+        [/"(?:[^"\\]|\\.)*"/, "string"],
+        [/'(?:[^'\\]|\\.)*'/, "string"],
+        [/`(?:[^`\\]|\\.)*`/, "string"],
+        // Half-typed strings: colour them as strings rather than dropping to the
+        // default, so text does not flicker uncoloured while being written.
+        [/"[^"]*$/, "string"],
+        [/'[^']*$/, "string"],
+
+        [/\b(?:true|false)\b/, "boolean"],
+        [/\bnull\b/, "null"],
+        [/-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?/, "number"],
+
+        // Matches the grid's `jsonPunct`. Parentheses are left alone because the
+        // grid renders a constructor's own parens in the default foreground.
+        [/[{}[\],:]/, "delimiter"],
+      ],
+    },
+  });
+}
+
+/** Reset for tests, which register against a fresh Monaco stub each time. */
+export function resetDocLanguageForTests(): void {
+  registered = false;
+}


### PR DESCRIPTION
## Summary

The results grid and the edit dialog rendered the same document in different colours — the third grid-vs-editor mismatch reported, after the `" : "` separator and the stale "replaces the entire document" hint.

Root cause is structural: `monacoAppTheme.ts` declared both themes with **`rules: []`**, so every Monaco editor fell back to VS Code's built-in token colours and never read the `--syntax-*` design tokens the grid applies as `text-syntax-*` classes. The two surfaces were never sharing a palette.

## Why not just reuse the grid's renderer

Asked during review, and worth recording: the grid walks **parsed BSON values** (`val instanceof ObjectId`, `typeof val === 'number'`) and picks a colour per type. An editor has to colour **raw text as it is typed**, including text that is momentarily invalid, so there is no parsed value to inspect. Reusing that renderer would mean the edit box stops being editable.

So the **colours** are shared, not the renderer. `DOC_SYNTAX_TOKENS` is the single place the token-to-design-token mapping lives, and the theme builds its rules from it — which is what stops these two drifting again.

## Why a tokenizer was needed

`language="javascript"` cannot distinguish a key from a string value: Monaco's JavaScript tokenizer emits plain `string` for every quoted literal (`basic-languages/typescript/typescript.js:325-327`). The observed key colouring came from the TypeScript worker's semantic tokens, not from theme rules.

`mqlens-doc` tokenizes exactly what `docToShell` produces: quoted and bare keys, all three JavaScript string forms, numbers, `true`/`false`/`null`, and BSON constructor calls. It matches the grid down to the details — muted `jsonPunct` delimiters for `:`/`,`/brackets, `syntax-boolean` for constructor *names* with the argument as `syntax-string`, and constructor parens left in the default foreground.

**Nothing is lost by leaving `javascript`:** the dialog already sets `quickSuggestions: false`, `suggestOnTriggerCharacters: false` and disables all diagnostics, so the language was only ever doing highlighting.

## Verification

- 9 tests on the tokenizer, driving it through a Monaco stub and replaying Monarch's first-match-wins scan: key vs string value, bare keys, constructor + argument, a key *named* `ObjectId` (not a call), literals, punctuation, half-typed strings, and that every emitted token has a mapping — a token without one would silently revert to VS Code's colours.
- 1440 frontend tests, `tsc` clean, `i18n:check` clean.