### PR TITLE
feat(results): find within the loaded results with Cmd/Ctrl+F (#279)

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -14,7 +14,15 @@ import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } f
 import { copyValueToText } from '../lib/copyValue';
 import { ResultsFindBar } from './ResultsFindBar';
 import { registerResultsFindTarget } from '../lib/resultsFindShortcut';
-import { cellText, findMatches, isMatchAt, stepMatch, type FindCell } from '../lib/resultsFind';
+import { findMatches, isMatchAt, stepMatch, type FindCell } from '../lib/resultsFind';
+import {
+  bsonCallOf,
+  bsonValueText,
+  isBsonInstance,
+  jsonStringLiteral,
+  plainBsonShape,
+  tableValueText,
+} from '../lib/bsonDisplay';
 import type { ListImperativeAPI } from 'react-window';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -384,7 +392,12 @@ const jsonKeyNode = (k: string) => (
     {jsonPunct(' : ')}
   </>
 );
-const printableJsonString = (value: string): string => JSON.stringify(value);
+const printableJsonString = jsonStringLiteral;
+
+// Width of the table's row-number gutter, ahead of the first data column.
+// Shared by the header, the rows, the body's minWidth and find's horizontal
+// scrolling, all of which have to agree on where a column starts.
+const TABLE_ROW_NUMBER_WIDTH_PX = 48;
 
 // One row of the tree-table view (Key | Value | Type), data-only for cheap virtualization.
 interface TreeRow {
@@ -725,27 +738,40 @@ export const DataGrid: React.FC<DataGridProps> = ({
   const [findOpen, setFindOpen] = useState(false);
   const [findQuery, setFindQuery] = useState('');
   const [activeMatch, setActiveMatch] = useState(-1);
-  const resultsRootRef = React.useRef<HTMLDivElement>(null);
+  // The whole pane, toolbar included. Clicking a pane's view-mode or tab
+  // controls is how a user selects it before searching, so those controls have
+  // to be inside the element that routing tests against — a root starting at the
+  // results body would leave such a click pointing at no pane at all.
+  const paneRootRef = React.useRef<HTMLDivElement>(null);
   const jsonListRef = React.useRef<ListImperativeAPI | null>(null);
   const treeListRef = React.useRef<ListImperativeAPI | null>(null);
   const tableListRef = React.useRef<ListImperativeAPI | null>(null);
 
   // Several results panes can be mounted at once, so the shortcut is routed
   // rather than bound per instance — see resultsFindShortcut.
-  useEffect(
-    () =>
-      registerResultsFindTarget({
-        element: () => resultsRootRef.current,
-        open: () => setFindOpen(true),
-      }),
-    []
-  );
+  //
+  // Registered only while the results are actually showing: the find bar lives
+  // in the results tab, so claiming the key from the explain or code tab would
+  // swallow it and open a bar the user cannot see.
+  useEffect(() => {
+    if (effectiveTab !== 'results') return;
+    return registerResultsFindTarget({
+      element: () => paneRootRef.current,
+      open: () => setFindOpen(true),
+    });
+  }, [effectiveTab]);
 
   const closeFind = React.useCallback(() => {
     setFindOpen(false);
     setFindQuery('');
     setActiveMatch(-1);
   }, []);
+
+  // Leaving the results tab unmounts the bar, so drop the state with it rather
+  // than coming back to a query the user can no longer see being applied.
+  useEffect(() => {
+    if (effectiveTab !== 'results') closeFind();
+  }, [effectiveTab, closeFind]);
   // Collapsed rows in the tree-table view (separate id space from JSON folds).
   const [treeCollapsed, setTreeCollapsed] = useState<Set<number>>(new Set());
 
@@ -800,20 +826,13 @@ export const DataGrid: React.FC<DataGridProps> = ({
     return Array.from(keys);
   }, [documents]);
 
-  const isBsonObject = (val: any): boolean => {
-    if (val === null || val === undefined) return false;
-    return (
-      val instanceof ObjectId ||
-      val instanceof Date ||
-      val instanceof Long ||
-      val instanceof Decimal128 ||
-      val instanceof Int32 ||
-      val instanceof Double ||
-      val instanceof Binary ||
-      val instanceof Timestamp
-    );
-  };
+  // A value the grid gives a constructor call to. Delegates so this list cannot
+  // fall behind bsonDisplay's.
+  const isBsonObject = (val: any): boolean => isBsonInstance(val);
 
+  // Paints the shared display descriptor. Only the colours live here; what the
+  // text *is* comes from bsonDisplay, which local find reads too, so the two
+  // cannot disagree about what is on screen.
   const renderBsonValueNode = (val: any): React.ReactNode => {
     if (val === null) return <span className="text-syntax-null">null</span>;
     if (typeof val === 'boolean') return <span className="text-syntax-boolean font-bold">{val ? 'true' : 'false'}</span>;
@@ -822,68 +841,20 @@ export const DataGrid: React.FC<DataGridProps> = ({
       return <span className="text-syntax-string">{printableJsonString(val)}</span>;
     }
 
-    if (val instanceof ObjectId) {
+    const call = bsonCallOf(val);
+    if (call) {
       return (
         <>
-          <span className="text-syntax-boolean">ObjectId</span>(
-          <span className="text-syntax-string">{JSON.stringify(val.toString())}</span>)
-        </>
-      );
-    }
-    if (val instanceof Date) {
-      return (
-        <>
-          <span className="text-syntax-boolean">ISODate</span>(
-          <span className="text-syntax-string">{JSON.stringify(val.toISOString())}</span>)
-        </>
-      );
-    }
-    if (val instanceof Long) {
-      return (
-        <>
-          <span className="text-syntax-boolean">NumberLong</span>(
-          <span className="text-syntax-number">{val.toString()}</span>)
-        </>
-      );
-    }
-    if (val instanceof Decimal128) {
-      return (
-        <>
-          <span className="text-syntax-boolean">NumberDecimal</span>(
-          <span className="text-syntax-string">{JSON.stringify(val.toString())}</span>)
-        </>
-      );
-    }
-    if (val instanceof Int32) {
-      return (
-        <>
-          <span className="text-syntax-boolean">NumberInt</span>(
-          <span className="text-syntax-number">{val.toString()}</span>)
-        </>
-      );
-    }
-    if (val instanceof Double) {
-      return (
-        <>
-          <span className="text-syntax-boolean">Double</span>(
-          <span className="text-syntax-number">{val.toString()}</span>)
-        </>
-      );
-    }
-    if (val instanceof Binary) {
-      return (
-        <>
-          <span className="text-syntax-boolean">BinData</span>(
-          <span className="text-syntax-number">{val.sub_type}</span>, 
-          <span className="text-syntax-string">{JSON.stringify(val.toString('base64'))}</span>)
-        </>
-      );
-    }
-    if (val instanceof Timestamp) {
-      return (
-        <>
-          <span className="text-syntax-boolean">Timestamp</span>(
-          <span className="text-syntax-number">{val.toString()}</span>)
+          <span className="text-syntax-boolean">{call.ctor}</span>(
+          {call.args.map((arg, i) => (
+            <React.Fragment key={i}>
+              {i > 0 && ', '}
+              <span className={arg.kind === 'number' ? 'text-syntax-number' : 'text-syntax-string'}>
+                {arg.text}
+              </span>
+            </React.Fragment>
+          ))}
+          )
         </>
       );
     }
@@ -898,21 +869,17 @@ export const DataGrid: React.FC<DataGridProps> = ({
     if (typeof val === 'number') return <span className="text-syntax-number">{String(val)}</span>;
     if (typeof val === 'boolean') return <span className="text-syntax-boolean font-bold">{val ? 'true' : 'false'}</span>;
     if (typeof val === 'object') {
-      if (isBsonObject(val)) return renderBsonValueNode(val);
-      if (typeof val.$oid === 'string') return <span className="text-syntax-string">{val.$oid}</span>;
-      if (val.$date !== undefined) {
-        const s =
-          typeof val.$date === 'string'
-            ? val.$date
-            : val.$date?.$numberLong
-              ? new Date(Number(val.$date.$numberLong)).toISOString()
-              : JSON.stringify(val.$date);
-        return <span className="text-syntax-string">{s}</span>;
+      if (isBsonInstance(val)) return renderBsonValueNode(val);
+      const plain = plainBsonShape(val);
+      if (plain) {
+        return (
+          <span
+            className={plain.kind === 'number' ? 'text-syntax-number' : 'text-syntax-string'}
+          >
+            {plain.text}
+          </span>
+        );
       }
-      if (val.$numberLong !== undefined) return <span className="text-syntax-number">{String(val.$numberLong)}</span>;
-      if (val.$numberDecimal !== undefined) return <span className="text-syntax-number">{String(val.$numberDecimal)}</span>;
-      if (val.$numberInt !== undefined) return <span className="text-syntax-number">{String(val.$numberInt)}</span>;
-      if (val.$numberDouble !== undefined) return <span className="text-syntax-number">{String(val.$numberDouble)}</span>;
       return <span className="text-muted-foreground">{JSON.stringify(val)}</span>;
     }
     return <span>{String(val)}</span>;
@@ -1055,6 +1022,25 @@ export const DataGrid: React.FC<DataGridProps> = ({
     }
   };
 
+  // The text of one JSON line, mirroring renderJsonLineContent above: the quoted
+  // key, the separator, the value or bracket, and the trailing comma. Find
+  // searches exactly what that renderer paints, so a visible `ObjectId(`, a
+  // quote, or an escaped `\n` is matchable.
+  const jsonLineText = (line: JsonLine): string => {
+    const key = line.keyName !== null ? `"${line.keyName}" : ` : '';
+    const comma = line.hasComma ? ',' : '';
+    switch (line.kind) {
+      case 'scalar':
+        return `${key}${bsonValueText(line.value)}${comma}`;
+      case 'open':
+        return `${key}${line.bracket || '{'}`;
+      case 'empty':
+        return `${key}${line.brackets || '{}'}${comma}`;
+      case 'close':
+        return `${line.bracket || '}'}${comma}`;
+    }
+  };
+
   const toggleFold = (id: number) => {
     setCollapsedFolds((prev) => {
       const next = new Set(prev);
@@ -1152,40 +1138,56 @@ export const DataGrid: React.FC<DataGridProps> = ({
     setTreeCollapsed(new Set(treeDefaultCollapsed));
   }, [treeDefaultCollapsed]);
 
+  // The text of one tree row: all three columns, since all three are on screen.
+  // Container rows show their child count, so that label is searchable too.
+  const treeRowText = (row: TreeRow): string => {
+    const value =
+      row.kind === 'scalar'
+        ? bsonValueText(row.value)
+        : row.kind === 'array'
+          ? t('dataGrid.labels.elements', { count: row.childCount })
+          : t('dataGrid.labels.fields', { count: row.childCount });
+    return `${row.keyName} ${value} ${row.type}`;
+  };
+
   // Flatten the active view into searchable cells. Built from the *full* row
   // lists, not the visible ones: every view is virtualized and folds can hide a
   // row, so a match must be findable before it is rendered.
   const findCells = useMemo<FindCell[]>(() => {
     if (!findOpen) return [];
     if (viewMode === 'json') {
-      return jsonLines
-        .filter((line) => line.keyName !== null || line.value !== undefined)
-        .map((line) => ({
-          rowIndex: line.num,
-          text: cellText(line.keyName, line.value),
-          ancestors: line.ancestors,
-        }));
+      // Every line, brackets included: they are rendered, so they are findable.
+      return jsonLines.map((line) => ({
+        rowIndex: line.num,
+        text: jsonLineText(line),
+        ancestors: line.ancestors,
+      }));
     }
     if (viewMode === 'tree') {
       return treeRows.map((row) => ({
         rowIndex: row.num,
-        // The type column is on screen, so it is searchable too.
-        text: `${cellText(row.keyName, row.value)} ${row.type}`,
+        text: treeRowText(row),
         ancestors: row.ancestors,
       }));
     }
     if (viewMode === 'table') {
+      // The cell text only. The column name is in the header once, not in every
+      // cell, so including it would report a match per row for a heading that
+      // appears a single time.
       return documents.flatMap((doc, index) =>
         columns.map((col) => ({
           rowIndex: index,
           columnKey: col,
-          text: cellText(col, (doc as Record<string, unknown>)?.[col]),
+          text: tableValueText((doc as Record<string, unknown>)?.[col]),
         }))
       );
     }
     // Chart has no text to search.
     return [];
-  }, [findOpen, viewMode, jsonLines, treeRows, documents, columns]);
+    // jsonLineText/treeRowText are recreated each render but read only the rows
+    // and the translator, both of which are already dependencies.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [findOpen, viewMode, jsonLines, treeRows, documents, columns, t]);
 
   const findMatchList = useMemo(() => findMatches(findCells, findQuery), [findCells, findQuery]);
 
@@ -1309,7 +1311,10 @@ export const DataGrid: React.FC<DataGridProps> = ({
         className="flex items-center border-b border-border font-mono text-xs hover:bg-accent"
         onContextMenu={(e) => openCtxMenu(e, rawDoc)}
       >
-        <div className="flex h-full w-12 shrink-0 select-none items-center justify-center border-r border-border text-[10px] text-muted-foreground">
+        <div
+          className="flex h-full shrink-0 select-none items-center justify-center border-r border-border text-[10px] text-muted-foreground"
+          style={{ width: `${TABLE_ROW_NUMBER_WIDTH_PX}px` }}
+        >
           {index + 1}
         </div>
         {columns.map((col) => (
@@ -1335,6 +1340,40 @@ export const DataGrid: React.FC<DataGridProps> = ({
   };
 
 
+  // Bring the matched column into view as well as the matched row. The table
+  // scrolls in both directions once resized columns overflow, so a vertical jump
+  // alone can leave the highlighted cell off the side of the viewport while the
+  // counter says it is active.
+  //
+  // Which box actually scrolls sideways is not fixed — it is this wrapper or the
+  // virtualized List's own scroller, depending on overflow — so the one that can
+  // is found rather than assumed, the same way the header-sync listener does it.
+  const scrollTableColumnIntoView = React.useCallback(
+    (columnKey: string) => {
+      const wrapper = tableBodyRef.current;
+      if (!wrapper) return;
+      const candidates = [wrapper, ...Array.from(wrapper.querySelectorAll<HTMLElement>('*'))];
+      const scroller = candidates.find((el) => el.scrollWidth > el.clientWidth);
+      if (!scroller) return;
+
+      const columnIndex = columns.indexOf(columnKey);
+      if (columnIndex < 0) return;
+      // The row-number gutter is `w-12`, ahead of the first column.
+      const left =
+        TABLE_ROW_NUMBER_WIDTH_PX +
+        columns.slice(0, columnIndex).reduce((sum, col) => sum + colWidth(col), 0);
+      const right = left + colWidth(columnKey);
+
+      // Only move when the cell is actually outside the visible band, so
+      // stepping between matches in already-visible columns doesn't jiggle.
+      if (left < scroller.scrollLeft) scroller.scrollLeft = left;
+      else if (right > scroller.scrollLeft + scroller.clientWidth) {
+        scroller.scrollLeft = right - scroller.clientWidth;
+      }
+    },
+    [columns, colWidths]
+  );
+
   // Scroll after the visible lists recompute, so revealing a fold and jumping to
   // the row happen in the right order. `scrollToRow` throws on an out-of-range
   // index, so the row is looked up rather than assumed present.
@@ -1344,6 +1383,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
       if (activeFindMatch.rowIndex < documents.length) {
         tableListRef.current?.scrollToRow({ index: activeFindMatch.rowIndex, align: 'smart' });
       }
+      if (activeFindMatch.columnKey) scrollTableColumnIntoView(activeFindMatch.columnKey);
       return;
     }
     const rows = viewMode === 'json' ? visibleJsonLines : viewMode === 'tree' ? visibleTreeRows : [];
@@ -1351,7 +1391,14 @@ export const DataGrid: React.FC<DataGridProps> = ({
     if (index < 0) return;
     const list = viewMode === 'json' ? jsonListRef : treeListRef;
     list.current?.scrollToRow({ index, align: 'smart' });
-  }, [activeFindMatch, viewMode, visibleJsonLines, visibleTreeRows, documents.length]);
+  }, [
+    activeFindMatch,
+    viewMode,
+    visibleJsonLines,
+    visibleTreeRows,
+    documents.length,
+    scrollTableColumnIntoView,
+  ]);
 
   // Row-level highlighting: every view renders its values through its own
   // coloured spans, so marking the containing row or cell keeps one mechanism
@@ -1441,7 +1488,10 @@ export const DataGrid: React.FC<DataGridProps> = ({
     );
   };
   return (
-    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-background">
+    <div
+      ref={paneRootRef}
+      className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-background"
+    >
       {/* Control Bar — omitted for a chromeless render, where none of these
           controls have anything to act on. */}
       {!chromeless && (
@@ -1648,7 +1698,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
       )}
 
       {effectiveTab === 'results' ? (
-        <div ref={resultsRootRef} className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         {findOpen && (
           <ResultsFindBar
             query={findQuery}
@@ -1730,7 +1780,10 @@ export const DataGrid: React.FC<DataGridProps> = ({
                 className="flex h-6 shrink-0 select-none items-center overflow-hidden border-b border-border bg-sidebar text-ui-2xs font-bold uppercase tracking-wider text-muted-foreground"
                 style={{ scrollbarGutter: 'stable' }}
               >
-                <div className="flex items-center justify-center border-r border-border w-12 flex-shrink-0">
+                <div
+                  className="flex items-center justify-center border-r border-border flex-shrink-0"
+                  style={{ width: `${TABLE_ROW_NUMBER_WIDTH_PX}px` }}
+                >
                   #
                 </div>
                 {columns.map((col) => (
@@ -1764,7 +1817,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
                 rowHeight={getRowHeight()}
                 rowComponent={Row}
                 rowProps={{}}
-                style={{ height: '100%', width: '100%', minWidth: viewMode === 'table' ? `${columns.reduce((s, c) => s + colWidth(c), 0) + 48 + (hasRowActions ? 72 : 0)}px` : '100%' }}
+                style={{ height: '100%', width: '100%', minWidth: viewMode === 'table' ? `${columns.reduce((s, c) => s + colWidth(c), 0) + TABLE_ROW_NUMBER_WIDTH_PX + (hasRowActions ? 72 : 0)}px` : '100%' }}
               />
             </div>
           </div>

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -10,13 +10,14 @@ import Editor from '@monaco-editor/react';
 import { generateQueryCode, CODE_LANGUAGES, CODE_LANGUAGE_MONACO_IDS, type CodeLanguage, type QueryCodeSpec } from '../lib/queryCodeGen';
 import { suggestESRIndex, type IndexSuggestion } from '../lib/indexSuggestions';
 import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
-import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
+import { EJSON } from 'bson';
 import { copyValueToText } from '../lib/copyValue';
 import { ResultsFindBar } from './ResultsFindBar';
 import { registerResultsFindTarget } from '../lib/resultsFindShortcut';
 import { findMatches, isMatchAt, stepMatch, type FindCell } from '../lib/resultsFind';
 import {
   bsonCallOf,
+  bsonInstanceTypeLabel,
   bsonValueText,
   isBsonInstance,
   jsonStringLiteral,
@@ -738,6 +739,8 @@ export const DataGrid: React.FC<DataGridProps> = ({
   const [findOpen, setFindOpen] = useState(false);
   const [findQuery, setFindQuery] = useState('');
   const [activeMatch, setActiveMatch] = useState(-1);
+  // Bumped on every shortcut press so the bar refocuses even when already open.
+  const [findFocusToken, setFindFocusToken] = useState(0);
   // The whole pane, toolbar included. Clicking a pane's view-mode or tab
   // controls is how a user selects it before searching, so those controls have
   // to be inside the element that routing tests against — a root starting at the
@@ -757,7 +760,10 @@ export const DataGrid: React.FC<DataGridProps> = ({
     if (effectiveTab !== 'results') return;
     return registerResultsFindTarget({
       element: () => paneRootRef.current,
-      open: () => setFindOpen(true),
+      open: () => {
+        setFindOpen(true);
+        setFindFocusToken((token) => token + 1);
+      },
     });
   }, [effectiveTab]);
 
@@ -889,15 +895,11 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // so the JSON view can render a continuous, line-numbered, collapsible panel.
   // Approximate rendered character count of a scalar value (for horizontal width).
   const valueLen = (v: any): number => {
-    if (v === null) return 4;
-    if (typeof v === 'boolean') return v ? 4 : 5;
-    if (typeof v === 'number') return String(v).length;
-    if (typeof v === 'string') return printableJsonString(v).length;
-    if (v instanceof ObjectId) return 40;
-    if (v instanceof Date) return 36;
-    if (v instanceof Binary) return 64;
-    if (isBsonObject(v)) return String((v as any).toString?.() ?? '').length + 16;
-    return 12;
+    // Containers get lines of their own, so only their bracket is on this one.
+    if (v !== null && typeof v === 'object' && !isBsonObject(v)) return 12;
+    // Exact rather than estimated: the displayed text is now available, so the
+    // per-type guesses (40 for an ObjectId, 64 for any Binary) are gone.
+    return bsonValueText(v).length;
   };
 
   const { jsonLines, jsonMaxWidthPx } = useMemo<{ jsonLines: JsonLine[]; jsonMaxWidthPx: number }>(() => {
@@ -1051,16 +1053,14 @@ export const DataGrid: React.FC<DataGridProps> = ({
   };
 
   // ── Tree-table view (Key | Value | Type) ──────────────────────────────────
+  // The Type column. BSON instances are labelled from bsonDisplay's ordered
+  // table — the same table that decides the value's constructor call — so the
+  // two columns of one row cannot contradict each other. The rest is
+  // JavaScript-level and belongs here.
   const bsonTypeLabel = (v: any): string => {
     if (v === null) return 'Null';
-    if (v instanceof ObjectId) return 'ObjectId';
-    if (v instanceof Date) return 'Date';
-    if (v instanceof Decimal128) return 'Decimal128';
-    if (v instanceof Long) return 'Int64';
-    if (v instanceof Int32) return 'Int32';
-    if (v instanceof Double) return 'Double';
-    if (v instanceof Binary) return 'Binary';
-    if (v instanceof Timestamp) return 'Timestamp';
+    const bson = bsonInstanceTypeLabel(v);
+    if (bson) return bson;
     if (Array.isArray(v)) return 'Array';
     if (typeof v === 'object') return 'Object';
     if (typeof v === 'boolean') return 'Boolean';
@@ -1708,6 +1708,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
             onNext={() => setActiveMatch((i) => stepMatch(findMatchList.length, i, 1))}
             onPrevious={() => setActiveMatch((i) => stepMatch(findMatchList.length, i, -1))}
             onClose={closeFind}
+            focusToken={findFocusToken}
           />
         )}
         {!documents || documents.length === 0 ? (

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -12,6 +12,10 @@ import { suggestESRIndex, type IndexSuggestion } from '../lib/indexSuggestions';
 import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
 import { EJSON, ObjectId, Long, Decimal128, Int32, Double, Binary, Timestamp } from 'bson';
 import { copyValueToText } from '../lib/copyValue';
+import { ResultsFindBar } from './ResultsFindBar';
+import { registerResultsFindTarget } from '../lib/resultsFindShortcut';
+import { cellText, findMatches, isMatchAt, stepMatch, type FindCell } from '../lib/resultsFind';
+import type { ListImperativeAPI } from 'react-window';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useThemeOptional } from '@/hooks/use-theme';
@@ -402,6 +406,9 @@ interface TreeRow {
 interface JsonRowExtra {
   lines: JsonLine[];
   collapsedFolds: Set<number>;
+  /** Highlight class for a matched line, or undefined. Module-scope row, so
+   *  the lookup is passed in rather than closed over. */
+  findHighlightClass: (rowId: number) => string | undefined;
   toggleFold: (id: number) => void;
   documents: Array<Record<string, any>>;
   openCtxMenu: (
@@ -430,6 +437,7 @@ const JsonRow = ({
   style,
   lines,
   collapsedFolds,
+  findHighlightClass,
   toggleFold,
   documents,
   openCtxMenu,
@@ -447,7 +455,8 @@ const JsonRow = ({
       className={cn(
         'flex items-center whitespace-pre hover:bg-accent',
         line.docIndex % 2 === 0 ? 'bg-background' : 'bg-card',
-        line.isDocRoot && line.docIndex > 0 && 'border-t border-border'
+        line.isDocRoot && line.docIndex > 0 && 'border-t border-border',
+        findHighlightClass(line.num)
       )}
       data-doc-even={line.docIndex % 2 === 0}
       onContextMenu={(e) => openCtxMenu(e, documents[line.docIndex], line.kind === 'scalar' ? line.keyName ?? undefined : undefined, line.value)}
@@ -709,6 +718,34 @@ export const DataGrid: React.FC<DataGridProps> = ({
   const [explainView, setExplainView] = useState<'visual' | 'json'>('visual');
   // Collapsed fold blocks in the JSON view, keyed by their generated fold id.
   const [collapsedFolds, setCollapsedFolds] = useState<Set<number>>(new Set());
+
+  // ── Local find over the loaded results (#279) ────────────────────────────
+  // Searches what is already on screen; the query filter above re-queries the
+  // server and is a different job.
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState('');
+  const [activeMatch, setActiveMatch] = useState(-1);
+  const resultsRootRef = React.useRef<HTMLDivElement>(null);
+  const jsonListRef = React.useRef<ListImperativeAPI | null>(null);
+  const treeListRef = React.useRef<ListImperativeAPI | null>(null);
+  const tableListRef = React.useRef<ListImperativeAPI | null>(null);
+
+  // Several results panes can be mounted at once, so the shortcut is routed
+  // rather than bound per instance — see resultsFindShortcut.
+  useEffect(
+    () =>
+      registerResultsFindTarget({
+        element: () => resultsRootRef.current,
+        open: () => setFindOpen(true),
+      }),
+    []
+  );
+
+  const closeFind = React.useCallback(() => {
+    setFindOpen(false);
+    setFindQuery('');
+    setActiveMatch(-1);
+  }, []);
   // Collapsed rows in the tree-table view (separate id space from JSON folds).
   const [treeCollapsed, setTreeCollapsed] = useState<Set<number>>(new Set());
 
@@ -1115,6 +1152,64 @@ export const DataGrid: React.FC<DataGridProps> = ({
     setTreeCollapsed(new Set(treeDefaultCollapsed));
   }, [treeDefaultCollapsed]);
 
+  // Flatten the active view into searchable cells. Built from the *full* row
+  // lists, not the visible ones: every view is virtualized and folds can hide a
+  // row, so a match must be findable before it is rendered.
+  const findCells = useMemo<FindCell[]>(() => {
+    if (!findOpen) return [];
+    if (viewMode === 'json') {
+      return jsonLines
+        .filter((line) => line.keyName !== null || line.value !== undefined)
+        .map((line) => ({
+          rowIndex: line.num,
+          text: cellText(line.keyName, line.value),
+          ancestors: line.ancestors,
+        }));
+    }
+    if (viewMode === 'tree') {
+      return treeRows.map((row) => ({
+        rowIndex: row.num,
+        // The type column is on screen, so it is searchable too.
+        text: `${cellText(row.keyName, row.value)} ${row.type}`,
+        ancestors: row.ancestors,
+      }));
+    }
+    if (viewMode === 'table') {
+      return documents.flatMap((doc, index) =>
+        columns.map((col) => ({
+          rowIndex: index,
+          columnKey: col,
+          text: cellText(col, (doc as Record<string, unknown>)?.[col]),
+        }))
+      );
+    }
+    // Chart has no text to search.
+    return [];
+  }, [findOpen, viewMode, jsonLines, treeRows, documents, columns]);
+
+  const findMatchList = useMemo(() => findMatches(findCells, findQuery), [findCells, findQuery]);
+
+  // A changed query starts from the first match rather than keeping a stale index.
+  useEffect(() => {
+    setActiveMatch(findMatchList.length > 0 ? 0 : -1);
+  }, [findMatchList]);
+
+  const activeFindMatch = activeMatch >= 0 ? findMatchList[activeMatch] : undefined;
+
+  // Open whatever folds hide the active match. The two views keep separate
+  // collapse state, so each is updated on its own.
+  useEffect(() => {
+    if (!activeFindMatch || activeFindMatch.ancestors.length === 0) return;
+    const reveal = (prev: Set<number>) => {
+      if (!activeFindMatch.ancestors.some((a) => prev.has(a))) return prev;
+      const next = new Set(prev);
+      for (const ancestor of activeFindMatch.ancestors) next.delete(ancestor);
+      return next;
+    };
+    if (viewMode === 'json') setCollapsedFolds(reveal);
+    else if (viewMode === 'tree') setTreeCollapsed(reveal);
+  }, [activeFindMatch, viewMode]);
+
   const visibleTreeRows = useMemo(
     () => treeRows.filter((r) => !r.ancestors.some((a) => treeCollapsed.has(a))),
     [treeRows, treeCollapsed]
@@ -1220,7 +1315,10 @@ export const DataGrid: React.FC<DataGridProps> = ({
         {columns.map((col) => (
           <div
             key={col}
-            className="flex h-full items-center truncate border-r border-border px-3 text-foreground"
+            className={cn(
+              'flex h-full items-center truncate border-r border-border px-3 text-foreground',
+              findHighlightClass(index, col)
+            )}
             style={{ width: `${colWidth(col)}px`, flexShrink: 0 }}
             onContextMenu={(e) => openCtxMenu(e, rawDoc, col, rawDoc[col])}
           >
@@ -1236,6 +1334,49 @@ export const DataGrid: React.FC<DataGridProps> = ({
     );
   };
 
+
+  // Scroll after the visible lists recompute, so revealing a fold and jumping to
+  // the row happen in the right order. `scrollToRow` throws on an out-of-range
+  // index, so the row is looked up rather than assumed present.
+  useEffect(() => {
+    if (!activeFindMatch) return;
+    if (viewMode === 'table') {
+      if (activeFindMatch.rowIndex < documents.length) {
+        tableListRef.current?.scrollToRow({ index: activeFindMatch.rowIndex, align: 'smart' });
+      }
+      return;
+    }
+    const rows = viewMode === 'json' ? visibleJsonLines : viewMode === 'tree' ? visibleTreeRows : [];
+    const index = rows.findIndex((row) => row.num === activeFindMatch.rowIndex);
+    if (index < 0) return;
+    const list = viewMode === 'json' ? jsonListRef : treeListRef;
+    list.current?.scrollToRow({ index, align: 'smart' });
+  }, [activeFindMatch, viewMode, visibleJsonLines, visibleTreeRows, documents.length]);
+
+  // Row-level highlighting: every view renders its values through its own
+  // coloured spans, so marking the containing row or cell keeps one mechanism
+  // across all three instead of threading a text range through each renderer.
+  const findMatchedRows = useMemo(
+    () => new Set(findMatchList.filter((m) => !m.columnKey).map((m) => m.rowIndex)),
+    [findMatchList]
+  );
+  const findMatchedCells = useMemo(
+    () =>
+      new Set(
+        findMatchList.filter((m) => m.columnKey).map((m) => `${m.rowIndex}:${m.columnKey}`)
+      ),
+    [findMatchList]
+  );
+  const findHighlightClass = (rowId: number, columnKey?: string): string | undefined => {
+    if (!findOpen || findQuery.trim() === '') return undefined;
+    const matched = columnKey
+      ? findMatchedCells.has(`${rowId}:${columnKey}`)
+      : findMatchedRows.has(rowId);
+    if (!matched) return undefined;
+    return isMatchAt(activeFindMatch, rowId, columnKey)
+      ? 'bg-warning/40 ring-1 ring-inset ring-warning'
+      : 'bg-warning/15';
+  };
 
   // Row height depends on viewMode and density
   const getRowHeight = () => {
@@ -1265,7 +1406,8 @@ export const DataGrid: React.FC<DataGridProps> = ({
         className={cn(
           'flex items-center border-b border-border font-mono text-[11.5px] hover:bg-accent',
           row.docIndex % 2 === 0 ? 'bg-background' : 'bg-card',
-          row.isDocRoot && row.docIndex > 0 && 'border-t border-border'
+          row.isDocRoot && row.docIndex > 0 && 'border-t border-border',
+          findHighlightClass(row.num)
         )}
         data-doc-even={row.docIndex % 2 === 0}
         onContextMenu={(e) => openCtxMenu(e, documents[row.docIndex], row.kind === 'scalar' ? row.keyName : undefined, row.value)}
@@ -1506,7 +1648,18 @@ export const DataGrid: React.FC<DataGridProps> = ({
       )}
 
       {effectiveTab === 'results' ? (
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <div ref={resultsRootRef} className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        {findOpen && (
+          <ResultsFindBar
+            query={findQuery}
+            onQueryChange={setFindQuery}
+            matchCount={findMatchList.length}
+            activeIndex={activeMatch}
+            onNext={() => setActiveMatch((i) => stepMatch(findMatchList.length, i, 1))}
+            onPrevious={() => setActiveMatch((i) => stepMatch(findMatchList.length, i, -1))}
+            onClose={closeFind}
+          />
+        )}
         {!documents || documents.length === 0 ? (
           <div className="flex flex-1 flex-col items-center justify-center p-8 text-muted-foreground">
             <ListFilter size={24} className="mb-2 text-muted-foreground" />
@@ -1517,11 +1670,13 @@ export const DataGrid: React.FC<DataGridProps> = ({
             <div className="min-h-0 flex-1 min-w-0 overflow-auto">
               <List<JsonRowExtra>
                 rowCount={visibleJsonLines.length}
+                listRef={jsonListRef}
                 rowHeight={getRowHeight()}
                 rowComponent={JsonRow}
                 rowProps={{
                   lines: visibleJsonLines,
                   collapsedFolds,
+                  findHighlightClass,
                   toggleFold,
                   documents,
                   openCtxMenu,
@@ -1551,6 +1706,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
             <div className="min-h-0 flex-1 min-w-0 overflow-hidden">
               <List<{}>
                 rowCount={visibleTreeRows.length}
+                listRef={treeListRef}
                 rowHeight={getRowHeight()}
                 rowComponent={TreeRowComponent}
                 rowProps={{}}
@@ -1604,6 +1760,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
             >
               <List<{}>
                 rowCount={documents.length}
+                listRef={tableListRef}
                 rowHeight={getRowHeight()}
                 rowComponent={Row}
                 rowProps={{}}

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1208,10 +1208,21 @@ export const DataGrid: React.FC<DataGridProps> = ({
 
   const findMatchList = useMemo(() => findMatches(findCells, findQuery), [findCells, findQuery]);
 
-  // A changed query starts from the first match rather than keeping a stale index.
-  useEffect(() => {
+  // A new match list starts from its first match. Done during render, not in an
+  // effect: an effect resets one render too late, and in that render the reveal
+  // effect below would take the *old* index into the *new* list and expand the
+  // folds around a match that is not the selected one. Nothing collapses those
+  // again, so they stayed open for the rest of the session.
+  //
+  // This is React's documented "adjusting state when props change" pattern — the
+  // render output is discarded and immediately retried, so no effect ever
+  // observes the stale index. Editing the query is the common way in, but a view
+  // switch or a new result set changes the list the same way.
+  const [matchListOfActive, setMatchListOfActive] = useState(findMatchList);
+  if (matchListOfActive !== findMatchList) {
+    setMatchListOfActive(findMatchList);
     setActiveMatch(findMatchList.length > 0 ? 0 : -1);
-  }, [findMatchList]);
+  }
 
   const activeFindMatch = activeMatch >= 0 ? findMatchList[activeMatch] : undefined;
 

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -395,6 +395,11 @@ const jsonKeyNode = (k: string) => (
 );
 const printableJsonString = jsonStringLiteral;
 
+// Row index for the table's header band. It is on screen and its field names are
+// searchable, but it is not a row in the virtualized list, so it addresses no
+// index there — stepping to it scrolls horizontally only.
+const TABLE_HEADER_ROW_INDEX = -1;
+
 // Width of the table's row-number gutter, ahead of the first data column.
 // Shared by the header, the rows, the body's minWidth and find's horizontal
 // scrolling, all of which have to agree on where a column starts.
@@ -1171,15 +1176,27 @@ export const DataGrid: React.FC<DataGridProps> = ({
       }));
     }
     if (viewMode === 'table') {
-      // The cell text only. The column name is in the header once, not in every
-      // cell, so including it would report a match per row for a heading that
-      // appears a single time.
-      return documents.flatMap((doc, index) =>
-        columns.map((col) => ({
-          rowIndex: index,
-          columnKey: col,
-          text: tableValueText((doc as Record<string, unknown>)?.[col]),
-        }))
+      // Each column header once, then the cell values. A field name shown only
+      // in the header has to be findable, but adding it to every cell's text
+      // would report a match per row for text that appears a single time — so it
+      // is indexed as the one thing it is, ahead of the rows it labels.
+      //
+      // The tree view's "Key"/"Value"/"Type" headings are deliberately not
+      // indexed: those are fixed chrome, whereas a table heading is a field name
+      // from the documents themselves.
+      const headers: FindCell[] = columns.map((col) => ({
+        rowIndex: TABLE_HEADER_ROW_INDEX,
+        columnKey: col,
+        text: col,
+      }));
+      return headers.concat(
+        documents.flatMap((doc, index) =>
+          columns.map((col) => ({
+            rowIndex: index,
+            columnKey: col,
+            text: tableValueText((doc as Record<string, unknown>)?.[col]),
+          }))
+        )
       );
     }
     // Chart has no text to search.
@@ -1380,7 +1397,10 @@ export const DataGrid: React.FC<DataGridProps> = ({
   useEffect(() => {
     if (!activeFindMatch) return;
     if (viewMode === 'table') {
-      if (activeFindMatch.rowIndex < documents.length) {
+      if (
+        activeFindMatch.rowIndex >= 0 &&
+        activeFindMatch.rowIndex < documents.length
+      ) {
         tableListRef.current?.scrollToRow({ index: activeFindMatch.rowIndex, align: 'smart' });
       }
       if (activeFindMatch.columnKey) scrollTableColumnIntoView(activeFindMatch.columnKey);
@@ -1790,7 +1810,10 @@ export const DataGrid: React.FC<DataGridProps> = ({
                 {columns.map((col) => (
                   <div
                     key={col}
-                    className="px-3 border-r border-border flex items-center truncate relative"
+                    className={cn(
+                      'px-3 border-r border-border flex items-center truncate relative',
+                      findHighlightClass(TABLE_HEADER_ROW_INDEX, col)
+                    )}
                     style={{ width: `${colWidth(col)}px`, flexShrink: 0 }}
                   >
                     {col}

--- a/src/components/ResultsFindBar.tsx
+++ b/src/components/ResultsFindBar.tsx
@@ -18,6 +18,13 @@ export interface ResultsFindBarProps {
   onNext: () => void;
   onPrevious: () => void;
   onClose: () => void;
+  /**
+   * Bumped by the parent whenever the shortcut is pressed, including while the
+   * bar is already open. Focusing only on mount left the caret wherever it was
+   * — a result row, a view-mode button — so the keypress opened nothing and the
+   * next keystrokes went elsewhere.
+   */
+  focusToken: number;
 }
 
 export const ResultsFindBar: React.FC<ResultsFindBarProps> = ({
@@ -28,16 +35,18 @@ export const ResultsFindBar: React.FC<ResultsFindBarProps> = ({
   onNext,
   onPrevious,
   onClose,
+  focusToken,
 }) => {
   const { t } = useTranslation('documents');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Opening the bar should put the caret in it; the shortcut that opens it is
-  // the same one users expect to type into immediately.
+  // Opening the bar should put the caret in it, and pressing the shortcut again
+  // should bring it back and select what is there — which is what an editor's
+  // find does. Runs on mount too, since the token starts at its first value.
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
-  }, []);
+  }, [focusToken]);
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {

--- a/src/components/ResultsFindBar.tsx
+++ b/src/components/ResultsFindBar.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { RESULTS_FIND_INPUT_ATTR } from '@/lib/resultsFindShortcut';
 
 export interface ResultsFindBarProps {
   query: string;
@@ -86,6 +87,9 @@ export const ResultsFindBar: React.FC<ResultsFindBarProps> = ({
         placeholder={t('dataGrid.find.placeholder')}
         aria-label={t('dataGrid.find.placeholder')}
         data-testid="results-find-input"
+        // Lets the shortcut route back to this pane instead of being suppressed
+        // as an ordinary text field; see RESULTS_FIND_INPUT_ATTR.
+        {...{ [RESULTS_FIND_INPUT_ATTR]: 'true' }}
         className="min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
       />
       <span

--- a/src/components/ResultsFindBar.tsx
+++ b/src/components/ResultsFindBar.tsx
@@ -1,0 +1,128 @@
+/**
+ * Find bar for the results pane (#279).
+ *
+ * Searches only what is already loaded — no re-query, no page change — so it is
+ * deliberately separate from the query filter above it.
+ */
+import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export interface ResultsFindBarProps {
+  query: string;
+  onQueryChange: (next: string) => void;
+  matchCount: number;
+  /** 0-based index of the active match, or -1 when none is selected. */
+  activeIndex: number;
+  onNext: () => void;
+  onPrevious: () => void;
+  onClose: () => void;
+}
+
+export const ResultsFindBar: React.FC<ResultsFindBarProps> = ({
+  query,
+  onQueryChange,
+  matchCount,
+  activeIndex,
+  onNext,
+  onPrevious,
+  onClose,
+}) => {
+  const { t } = useTranslation('documents');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Opening the bar should put the caret in it; the shortcut that opens it is
+  // the same one users expect to type into immediately.
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      if (event.shiftKey) onPrevious();
+      else onNext();
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+    }
+  };
+
+  const searched = query.trim() !== '';
+  const status = !searched
+    ? ''
+    : matchCount === 0
+      ? t('dataGrid.find.noMatches')
+      : t('dataGrid.find.count', {
+          current: activeIndex >= 0 ? activeIndex + 1 : 1,
+          total: matchCount,
+        });
+
+  return (
+    <div
+      className="flex shrink-0 items-center gap-2 border-b border-border bg-card px-3 py-1.5"
+      data-testid="results-find-bar"
+    >
+      <Search size={13} className="shrink-0 text-muted-foreground" />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder={t('dataGrid.find.placeholder')}
+        aria-label={t('dataGrid.find.placeholder')}
+        data-testid="results-find-input"
+        className="min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
+      />
+      <span
+        className="shrink-0 tabular-nums text-[11px] text-muted-foreground"
+        data-testid="results-find-status"
+      >
+        {status}
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-6 w-6 p-0"
+        disabled={matchCount === 0}
+        onClick={onPrevious}
+        title={t('dataGrid.find.previous')}
+        aria-label={t('dataGrid.find.previous')}
+        data-testid="results-find-prev"
+      >
+        <ChevronUp size={13} />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-6 w-6 p-0"
+        disabled={matchCount === 0}
+        onClick={onNext}
+        title={t('dataGrid.find.next')}
+        aria-label={t('dataGrid.find.next')}
+        data-testid="results-find-next"
+      >
+        <ChevronDown size={13} />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-6 w-6 p-0"
+        onClick={onClose}
+        title={t('dataGrid.find.close')}
+        aria-label={t('dataGrid.find.close')}
+        data-testid="results-find-close"
+      >
+        <X size={13} />
+      </Button>
+    </div>
+  );
+};

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1094,15 +1094,30 @@ describe('find bar focus and type/value agreement (#280 review round 2)', () => 
     expect(screen.getByTestId('results-find-input')).toHaveFocus();
   });
 
-  it('selects the existing query on reopening, so typing replaces it', () => {
+  it('selects the existing query when the shortcut is pressed from the field', () => {
+    // Dispatched from the input, which is where the event really comes from once
+    // the bar has focus. Pressing from document.body passed while the real path
+    // was suppressed as an ordinary text field.
     render(<DataGrid documents={mockDocuments} />);
     pressFind();
     const input = screen.getByTestId('results-find-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'Electronics' } });
 
-    pressFind();
+    fireEvent.keyDown(input, { key: 'f', metaKey: true });
     expect(input.selectionStart).toBe(0);
     expect(input.selectionEnd).toBe('Electronics'.length);
+  });
+
+  it('keeps the bar open and the query intact when pressed from the field', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    const input = screen.getByTestId('results-find-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Electronics' } });
+
+    fireEvent.keyDown(input, { key: 'f', metaKey: true });
+    expect(screen.getByTestId('results-find-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('results-find-input')).toHaveValue('Electronics');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 2');
   });
 
   it('labels a Timestamp consistently in the value and type columns', () => {

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1034,3 +1034,48 @@ describe('find scrolls the matched table column into view (#280 review)', () => 
     expect(scrollLeft).toBe(0);
   });
 });
+
+describe('find bar focus and type/value agreement (#280 review round 2)', () => {
+  beforeEach(() => resetResultsFindShortcutForTests());
+
+  const pressFind = () => fireEvent.keyDown(document.body, { key: 'f', metaKey: true });
+
+  it('brings focus back to the field when the bar is already open', () => {
+    // `setFindOpen(true)` is a no-op the second time, so focusing only on mount
+    // left the caret on whatever the user had clicked and the typing went there.
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    const input = screen.getByTestId('results-find-input');
+    expect(input).toHaveFocus();
+
+    const elsewhere = screen.getByRole('button', { name: /table/i });
+    elsewhere.focus();
+    expect(input).not.toHaveFocus();
+
+    pressFind();
+    expect(screen.getByTestId('results-find-input')).toHaveFocus();
+  });
+
+  it('selects the existing query on reopening, so typing replaces it', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    const input = screen.getByTestId('results-find-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Electronics' } });
+
+    pressFind();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe('Electronics'.length);
+  });
+
+  it('labels a Timestamp consistently in the value and type columns', () => {
+    // The value column renders from bsonDisplay's ordered table and the Type
+    // column used to have its own order, so one row read `Timestamp(…)` in Value
+    // and `Int64` in Type. The grid parses extended JSON, so the input is the
+    // `$timestamp` shape the backend actually sends.
+    render(<DataGrid documents={[{ ts: { $timestamp: { t: 1, i: 2 } } }]} />);
+    fireEvent.click(screen.getByRole('button', { name: /tree/i }));
+
+    expect(screen.getAllByText('Timestamp').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Int64')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -906,14 +906,52 @@ describe('find indexes what each view actually displays (#280 review)', () => {
     expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
   });
 
-  it('does not count the column name once per table cell', () => {
-    // The heading is in the header once, so matching it in every cell reported
-    // three matches for one visible occurrence.
+  it('finds a table column heading exactly once, not once per row', () => {
+    // Two defects met here: the heading was first counted in every cell (three
+    // matches for one visible occurrence), then not indexed at all (no matches
+    // for text plainly on screen). It is one cell, because it is one heading.
     render(<DataGrid documents={mockDocuments} />);
     fireEvent.click(screen.getByRole('button', { name: /table/i }));
     pressFind();
     search('category');
-    expect(screen.getByTestId('results-find-status')).toHaveTextContent(/no matches/i);
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
+  });
+
+  it('lists a heading match ahead of the rows it labels', () => {
+    // `name` is a heading and appears in no value, so a heading-only match must
+    // not depend on any row matching. Stepping stays within the single match.
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    pressFind();
+    search('name');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
+    fireEvent.click(screen.getByTestId('results-find-next'));
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
+  });
+
+  it('highlights the matched heading in the header band', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    pressFind();
+    search('category');
+
+    const header = screen.getByTestId('table-header');
+    const matched = Array.from(header.querySelectorAll('div')).filter((el) =>
+      el.className.includes('bg-warning')
+    );
+    expect(matched.length).toBe(1);
+    expect(matched[0].textContent).toContain('category');
+  });
+
+  it('does not crash stepping to a heading, which addresses no row', () => {
+    // The header band is not a row in the virtualized list, and `scrollToRow`
+    // throws on an out-of-range index.
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    pressFind();
+    search('price');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
+    expect(screen.getByTestId('results-find-bar')).toBeInTheDocument();
   });
 
   it('finds the table view’s ObjectId by the bare hex it displays', () => {

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -745,3 +745,132 @@ describe('view mode persistence (#218)', () => {
     expect(screen.getByRole('button', { name: /table/i }).className).toContain('bg-accent');
   });
 });
+
+describe('local find over the loaded results (#279)', () => {
+  // `fireEvent` wraps the dispatch in act(), so the state update flushes before
+  // the assertion. A raw dispatchEvent does not.
+  const pressFind = () => fireEvent.keyDown(document.body, { key: 'f', metaKey: true });
+
+  it('is closed until Cmd/Ctrl+F asks for it', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    expect(screen.queryByTestId('results-find-bar')).not.toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: 'f' });
+    expect(screen.queryByTestId('results-find-bar')).not.toBeInTheDocument();
+  });
+
+  it('opens on the shortcut and reports how many rows match', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+
+    const input = screen.getByTestId('results-find-input');
+    fireEvent.change(input, { target: { value: 'Electronics' } });
+    // Two documents are in Electronics, one line each in the JSON view.
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 2');
+  });
+
+  it('says so when nothing matches', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    fireEvent.change(screen.getByTestId('results-find-input'), {
+      target: { value: 'nothing-here' },
+    });
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent(/no matches/i);
+  });
+
+  it('steps through matches with the buttons, wrapping at the end', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    fireEvent.change(screen.getByTestId('results-find-input'), {
+      target: { value: 'Electronics' },
+    });
+
+    fireEvent.click(screen.getByTestId('results-find-next'));
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('2 of 2');
+    fireEvent.click(screen.getByTestId('results-find-next'));
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 2');
+    fireEvent.click(screen.getByTestId('results-find-prev'));
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('2 of 2');
+  });
+
+  it('steps with Enter and Shift+Enter from the input', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    const input = screen.getByTestId('results-find-input');
+    fireEvent.change(input, { target: { value: 'Electronics' } });
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('2 of 2');
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 2');
+  });
+
+  it('closes on Escape and forgets the query', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    const input = screen.getByTestId('results-find-input');
+    fireEvent.change(input, { target: { value: 'Electronics' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(screen.queryByTestId('results-find-bar')).not.toBeInTheDocument();
+    pressFind();
+    expect(screen.getByTestId('results-find-input')).toHaveValue('');
+  });
+
+  it('closes on the close button', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    fireEvent.click(screen.getByTestId('results-find-close'));
+    expect(screen.queryByTestId('results-find-bar')).not.toBeInTheDocument();
+  });
+
+  it('searches keys as well as values', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    fireEvent.change(screen.getByTestId('results-find-input'), { target: { value: 'category' } });
+    // The key appears once per document.
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 3');
+  });
+
+  it('finds an ObjectId by its hex, as the grid displays it', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    fireEvent.change(screen.getByTestId('results-find-input'), {
+      target: { value: '603d779f4f102e3a185c3221' },
+    });
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
+  });
+
+  it('searches the table view too', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    pressFind();
+    fireEvent.change(screen.getByTestId('results-find-input'), {
+      target: { value: 'Electronics' },
+    });
+    // One cell per matching document, in the category column.
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 2');
+  });
+
+  it('searches the tree view too', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /tree/i }));
+    pressFind();
+    fireEvent.change(screen.getByTestId('results-find-input'), {
+      target: { value: 'Electronics' },
+    });
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent(/of 2/);
+  });
+
+  it('recounts when the view changes, since each view has its own rows', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    fireEvent.change(screen.getByTestId('results-find-input'), { target: { value: 'price' } });
+    const inJson = screen.getByTestId('results-find-status').textContent;
+
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    // The table has one `price` cell per row plus no key text, so the count is
+    // allowed to differ — what matters is that it is recomputed, not stale.
+    expect(screen.getByTestId('results-find-status').textContent).toBeTruthy();
+    expect(inJson).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 
 // Monaco renders the Query Code panel; mock it as a plain textarea (same shape
@@ -35,6 +35,7 @@ vi.mock('@/hooks/use-theme', () => ({
 }));
 
 import { DataGrid, getExplainTree } from '../DataGrid';
+import { resetResultsFindShortcutForTests } from '@/lib/resultsFindShortcut';
 
 // Collect every node name in the tree (depth-first) for assertions.
 const collectNames = (node: any): string[] => [
@@ -872,5 +873,164 @@ describe('local find over the loaded results (#279)', () => {
     // allowed to differ — what matters is that it is recomputed, not stale.
     expect(screen.getByTestId('results-find-status').textContent).toBeTruthy();
     expect(inJson).toBeTruthy();
+  });
+});
+
+describe('find indexes what each view actually displays (#280 review)', () => {
+  beforeEach(() => resetResultsFindShortcutForTests());
+
+  const pressFind = () => fireEvent.keyDown(document.body, { key: 'f', metaKey: true });
+  const search = (value: string) =>
+    fireEvent.change(screen.getByTestId('results-find-input'), { target: { value } });
+
+  it('finds the constructor name the JSON view renders, not just the scalar', () => {
+    // The grid shows ObjectId("603d…"); "copy value" would yield the bare hex.
+    // Searching the copy text made a visible `ObjectId` unfindable.
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    search('ObjectId');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 3');
+  });
+
+  it('finds a quoted string, since the JSON view renders the quotes', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    pressFind();
+    search('"Alice Smith"');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
+  });
+
+  it('finds an escape sequence as the two characters on screen', () => {
+    render(<DataGrid documents={[{ note: 'first\nsecond' }]} />);
+    pressFind();
+    search('\\n');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
+  });
+
+  it('does not count the column name once per table cell', () => {
+    // The heading is in the header once, so matching it in every cell reported
+    // three matches for one visible occurrence.
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    pressFind();
+    search('category');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent(/no matches/i);
+  });
+
+  it('finds the table view’s ObjectId by the bare hex it displays', () => {
+    // The table renders the backend's {$oid} as plain hex, so unlike the JSON
+    // view a search for `ObjectId` finds nothing there — each view is indexed
+    // as it is drawn.
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    pressFind();
+    search('603d779f4f102e3a185c3221');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
+    search('ObjectId');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent(/no matches/i);
+  });
+
+  it('searches the tree view’s type column', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /tree/i }));
+    pressFind();
+    search('ObjectId');
+    // The key, the rendered value and the type label are all on screen.
+    expect(screen.getByTestId('results-find-status')).not.toHaveTextContent(/no matches/i);
+  });
+});
+
+describe('find shortcut routing across panes (#280 review)', () => {
+  beforeEach(() => resetResultsFindShortcutForTests());
+
+  it('routes to the pane whose toolbar was clicked', () => {
+    // The registered root used to start below the toolbar, so selecting a pane
+    // by its view-mode control pointed at no pane at all: with two mounted, the
+    // keypress went nowhere or to the wrong one.
+    const { container: paneA } = render(<DataGrid documents={mockDocuments} />);
+    const { container: paneB } = render(<DataGrid documents={mockDocuments} />);
+
+    const bTableButton = within(paneB).getAllByRole('button', { name: /table/i })[0];
+    fireEvent.pointerDown(bTableButton);
+    fireEvent.keyDown(document.body, { key: 'f', metaKey: true });
+
+    expect(within(paneB).queryByTestId('results-find-bar')).toBeInTheDocument();
+    expect(within(paneA).queryByTestId('results-find-bar')).not.toBeInTheDocument();
+  });
+
+  it('opens nothing when two panes are mounted and neither was selected', () => {
+    const { container: paneA } = render(<DataGrid documents={mockDocuments} />);
+    const { container: paneB } = render(<DataGrid documents={mockDocuments} />);
+
+    fireEvent.keyDown(document.body, { key: 'f', metaKey: true });
+
+    expect(within(paneA).queryByTestId('results-find-bar')).not.toBeInTheDocument();
+    expect(within(paneB).queryByTestId('results-find-bar')).not.toBeInTheDocument();
+  });
+
+  it('closes and clears the bar when the pane leaves the results tab', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.keyDown(document.body, { key: 'f', metaKey: true });
+    fireEvent.change(screen.getByTestId('results-find-input'), {
+      target: { value: 'Electronics' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /explain/i }));
+    expect(screen.queryByTestId('results-find-bar')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /results/i }));
+    expect(screen.queryByTestId('results-find-bar')).not.toBeInTheDocument();
+  });
+});
+
+describe('find scrolls the matched table column into view (#280 review)', () => {
+  beforeEach(() => resetResultsFindShortcutForTests());
+
+  it('scrolls horizontally so the highlighted cell is on screen', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    // jsdom has no layout, so the overflow the real table has is stubbed: the
+    // body is 1000px of content in a 300px viewport.
+    const body = screen.getByTestId('table-body-scroll');
+    let scrollLeft = 0;
+    Object.defineProperty(body, 'scrollWidth', { value: 1000, configurable: true });
+    Object.defineProperty(body, 'clientWidth', { value: 300, configurable: true });
+    Object.defineProperty(body, 'scrollLeft', {
+      get: () => scrollLeft,
+      set: (v: number) => {
+        scrollLeft = v;
+      },
+      configurable: true,
+    });
+
+    fireEvent.keyDown(document.body, { key: 'f', metaKey: true });
+    fireEvent.change(screen.getByTestId('results-find-input'), { target: { value: '349.5' } });
+
+    // `price` is the 4th column: 48px gutter + 3 × 180px = 588, ending at 768.
+    // Bringing its right edge into a 300px viewport means scrolling to 468.
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 1');
+    expect(scrollLeft).toBe(468);
+  });
+
+  it('leaves the scroll alone for a column already on screen', () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    const body = screen.getByTestId('table-body-scroll');
+    let scrollLeft = 0;
+    Object.defineProperty(body, 'scrollWidth', { value: 1000, configurable: true });
+    Object.defineProperty(body, 'clientWidth', { value: 900, configurable: true });
+    Object.defineProperty(body, 'scrollLeft', {
+      get: () => scrollLeft,
+      set: (v: number) => {
+        scrollLeft = v;
+      },
+      configurable: true,
+    });
+
+    fireEvent.keyDown(document.body, { key: 'f', metaKey: true });
+    fireEvent.change(screen.getByTestId('results-find-input'), { target: { value: '349.5' } });
+
+    expect(scrollLeft).toBe(0);
   });
 });

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1132,3 +1132,76 @@ describe('find bar focus and type/value agreement (#280 review round 2)', () => 
     expect(screen.queryByText('Int64')).not.toBeInTheDocument();
   });
 });
+
+describe('find does not leak folds from a stale active index (#280 review round 5)', () => {
+  beforeEach(() => resetResultsFindShortcutForTests());
+
+  // Folds at depth >= 2 start collapsed, so these three containers are closed
+  // until a match inside one of them is revealed.
+  const nested = [
+    {
+      g: {
+        a: { akey: 'xx-one', az: 'zz-one' },
+        b: { bkey: 'xx-two' },
+        c: { cz: 'zz-two' },
+      },
+    },
+  ];
+
+  const pressFind = () => fireEvent.keyDown(document.body, { key: 'f', metaKey: true });
+  const search = (value: string) =>
+    fireEvent.change(screen.getByTestId('results-find-input'), { target: { value } });
+
+  // Read the fold's own state rather than looking for its children. The lists
+  // are virtualized, so a descendant can be missing because it fell outside the
+  // rendered window — an absence that says nothing about whether the fold is
+  // open. The toggle's label does say it.
+  const foldState = (keyName: string): 'open' | 'closed' => {
+    const row = screen.getByTitle(keyName).closest('[data-doc-even]');
+    if (!row) throw new Error(`row for ${keyName} is not rendered`);
+    const button = row.querySelector('[data-testid="tree-fold-btn"]');
+    if (!button) throw new Error(`${keyName} has no fold toggle`);
+    const label = button.getAttribute('aria-label') ?? '';
+    if (/expand/i.test(label)) return 'closed';
+    if (/collapse/i.test(label)) return 'open';
+    throw new Error(`unrecognised fold label: ${label}`);
+  };
+
+  it('starts with the nested folds closed, so a reveal is observable', () => {
+    render(<DataGrid documents={nested} />);
+    fireEvent.click(screen.getByRole('button', { name: /tree/i }));
+    expect(foldState('a')).toBe('closed');
+    expect(foldState('b')).toBe('closed');
+  });
+
+  it('opens the fold holding the active match', () => {
+    render(<DataGrid documents={nested} />);
+    fireEvent.click(screen.getByRole('button', { name: /tree/i }));
+    pressFind();
+    search('xx');
+    expect(foldState('a')).toBe('open');
+    expect(screen.getByText('akey')).toBeInTheDocument();
+  });
+
+  it('does not open the fold at the previous index when the query changes', () => {
+    // `xx` matches inside a and b; stepping selects the second (b). `zz` then
+    // matches inside a and c, so index 1 of the new list is inside c. Resetting
+    // the index in an effect let the reveal run once with that stale index, and
+    // c stayed open for the rest of the session.
+    render(<DataGrid documents={nested} />);
+    fireEvent.click(screen.getByRole('button', { name: /tree/i }));
+    pressFind();
+
+    search('xx');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 2');
+    fireEvent.click(screen.getByTestId('results-find-next'));
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('2 of 2');
+
+    search('zz');
+    expect(screen.getByTestId('results-find-status')).toHaveTextContent('1 of 2');
+    // The first match is inside a, so a opens...
+    expect(foldState('a')).toBe('open');
+    // ...and c, which only the stale index pointed at, stays closed.
+    expect(foldState('c')).toBe('closed');
+  });
+});

--- a/src/lib/__tests__/bsonDisplay.test.ts
+++ b/src/lib/__tests__/bsonDisplay.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { Binary, Decimal128, Double, Int32, Long, ObjectId, Timestamp } from 'bson';
+import {
+  bsonCallOf,
+  bsonCallText,
+  bsonValueText,
+  isBsonInstance,
+  jsonStringLiteral,
+  plainBsonShape,
+  tableValueText,
+} from '../bsonDisplay';
+
+describe('bsonValueText — what the JSON and tree views display', () => {
+  it('shows BSON as the constructor call, not the bare scalar', () => {
+    // The distinction local find got wrong at first: "copy value" yields the
+    // hex, but the screen shows the call, so the call is what must be findable.
+    const oid = new ObjectId('507f1f77bcf86cd799439011');
+    expect(bsonValueText(oid)).toBe('ObjectId("507f1f77bcf86cd799439011")');
+    expect(bsonValueText(new Date('2026-08-27T10:00:00.000Z'))).toBe(
+      'ISODate("2026-08-27T10:00:00.000Z")',
+    );
+    expect(bsonValueText(Long.fromString('9007199254740993'))).toBe(
+      'NumberLong(9007199254740993)',
+    );
+    expect(bsonValueText(Decimal128.fromString('1.25'))).toBe('NumberDecimal("1.25")');
+    expect(bsonValueText(new Int32(7))).toBe('NumberInt(7)');
+    expect(bsonValueText(new Double(1.5))).toBe('Double(1.5)');
+  });
+
+  it('quotes and escapes strings the way the view renders them', () => {
+    expect(bsonValueText('Alice')).toBe('"Alice"');
+    // A newline is on screen as the two characters \n, so that is what a search
+    // for \n has to match.
+    expect(bsonValueText('a\nb')).toBe('"a\\nb"');
+    expect(bsonValueText('say "hi"')).toBe('"say \\"hi\\""');
+  });
+
+  it('leaves the bare literals bare', () => {
+    expect(bsonValueText(null)).toBe('null');
+    expect(bsonValueText(true)).toBe('true');
+    expect(bsonValueText(false)).toBe('false');
+    expect(bsonValueText(42)).toBe('42');
+    expect(bsonValueText(undefined)).toBe('');
+  });
+
+  it('gives BinData both of its displayed arguments', () => {
+    const bin = new Binary(Buffer.from('hi'), 0);
+    expect(bsonValueText(bin)).toBe(`BinData(0, ${JSON.stringify(bin.toString('base64'))})`);
+  });
+
+  it('renders a Timestamp through its own toString, as the view does', () => {
+    const ts = new Timestamp({ t: 1, i: 2 });
+    expect(bsonValueText(ts)).toBe(`Timestamp(${ts.toString()})`);
+  });
+});
+
+describe('bsonCallOf', () => {
+  it('describes the argument colour alongside its text', () => {
+    expect(bsonCallOf(new ObjectId('507f1f77bcf86cd799439011'))).toEqual({
+      ctor: 'ObjectId',
+      args: [{ text: '"507f1f77bcf86cd799439011"', kind: 'string' }],
+    });
+    expect(bsonCallOf(Long.fromString('42'))).toEqual({
+      ctor: 'NumberLong',
+      args: [{ text: '42', kind: 'number' }],
+    });
+  });
+
+  it('is null for values the grid does not call a constructor on', () => {
+    expect(bsonCallOf('plain')).toBeNull();
+    expect(bsonCallOf(7)).toBeNull();
+    expect(bsonCallOf({ city: 'Pforzheim' })).toBeNull();
+    expect(bsonCallOf({ $oid: '507f1f77bcf86cd799439011' })).toBeNull();
+    expect(bsonCallOf(null)).toBeNull();
+  });
+
+  it('agrees with isBsonInstance', () => {
+    for (const v of [new ObjectId(), new Date(), Long.fromString('1'), new Int32(1)]) {
+      expect(isBsonInstance(v)).toBe(true);
+    }
+    for (const v of [{ $oid: 'x' }, 'x', 1, null, undefined, { a: 1 }]) {
+      expect(isBsonInstance(v)).toBe(false);
+    }
+  });
+
+  it('joins multi-argument calls the way the renderer spaces them', () => {
+    expect(bsonCallText({ ctor: 'BinData', args: [
+      { text: '0', kind: 'number' },
+      { text: '"aGk="', kind: 'string' },
+    ] })).toBe('BinData(0, "aGk=")');
+  });
+});
+
+describe('plainBsonShape — the table view’s extended-JSON shapes', () => {
+  it('unwraps the shapes the backend sends', () => {
+    expect(plainBsonShape({ $oid: '507f1f77bcf86cd799439011' })).toEqual({
+      text: '507f1f77bcf86cd799439011',
+      kind: 'string',
+    });
+    expect(plainBsonShape({ $date: '2026-08-27T10:00:00.000Z' })).toEqual({
+      text: '2026-08-27T10:00:00.000Z',
+      kind: 'string',
+    });
+    expect(plainBsonShape({ $date: { $numberLong: '0' } })).toEqual({
+      text: '1970-01-01T00:00:00.000Z',
+      kind: 'string',
+    });
+    expect(plainBsonShape({ $numberLong: '42' })).toEqual({ text: '42', kind: 'number' });
+    expect(plainBsonShape({ $numberDecimal: '1.25' })).toEqual({ text: '1.25', kind: 'number' });
+    expect(plainBsonShape({ $numberInt: '7' })).toEqual({ text: '7', kind: 'number' });
+    expect(plainBsonShape({ $numberDouble: '1.5' })).toEqual({ text: '1.5', kind: 'number' });
+  });
+
+  it('is null for an ordinary object', () => {
+    expect(plainBsonShape({ city: 'Pforzheim' })).toBeNull();
+  });
+});
+
+describe('tableValueText — what the table view displays', () => {
+  it('shows strings unquoted, unlike the JSON view', () => {
+    // The same document reads differently in the two views, and find follows
+    // whichever one is on screen.
+    expect(tableValueText('Alice')).toBe('Alice');
+    expect(bsonValueText('Alice')).toBe('"Alice"');
+  });
+
+  it('shows the backend’s ObjectId as the bare hex the cell renders', () => {
+    expect(tableValueText({ $oid: '507f1f77bcf86cd799439011' })).toBe(
+      '507f1f77bcf86cd799439011',
+    );
+  });
+
+  it('still calls a constructor when the value is a real BSON instance', () => {
+    // renderColoredCell delegates those to renderBsonValueNode, so the text does too.
+    expect(tableValueText(new ObjectId('507f1f77bcf86cd799439011'))).toBe(
+      'ObjectId("507f1f77bcf86cd799439011")',
+    );
+  });
+
+  it('falls back to JSON for a nested container, as the muted cell does', () => {
+    expect(tableValueText({ city: 'Pforzheim' })).toBe('{"city":"Pforzheim"}');
+  });
+
+  it('is empty for an absent value', () => {
+    expect(tableValueText(null)).toBe('');
+    expect(tableValueText(undefined)).toBe('');
+  });
+});
+
+describe('jsonStringLiteral', () => {
+  it('is the quoting the JSON views use', () => {
+    expect(jsonStringLiteral('a"b')).toBe('"a\\"b"');
+  });
+});

--- a/src/lib/__tests__/bsonDisplay.test.ts
+++ b/src/lib/__tests__/bsonDisplay.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Binary, Decimal128, Double, Int32, Long, ObjectId, Timestamp } from 'bson';
 import {
   bsonCallOf,
+  bsonInstanceTypeLabel,
   bsonCallText,
   bsonValueText,
   isBsonInstance,
@@ -150,5 +151,31 @@ describe('tableValueText — what the table view displays', () => {
 describe('jsonStringLiteral', () => {
   it('is the quoting the JSON views use', () => {
     expect(jsonStringLiteral('a"b')).toBe('"a\\"b"');
+  });
+});
+
+describe('bsonInstanceTypeLabel — the tree’s Type column', () => {
+  it('names each BSON type the grid displays', () => {
+    expect(bsonInstanceTypeLabel(new ObjectId())).toBe('ObjectId');
+    expect(bsonInstanceTypeLabel(new Date())).toBe('Date');
+    expect(bsonInstanceTypeLabel(Decimal128.fromString('1.25'))).toBe('Decimal128');
+    expect(bsonInstanceTypeLabel(Long.fromString('42'))).toBe('Int64');
+    expect(bsonInstanceTypeLabel(new Int32(7))).toBe('Int32');
+    expect(bsonInstanceTypeLabel(new Double(1.5))).toBe('Double');
+    expect(bsonInstanceTypeLabel(new Binary(Buffer.from('hi'), 0))).toBe('Binary');
+  });
+
+  it('labels a Timestamp as Timestamp, not as its Long base class', () => {
+    // The label and the constructor call now come from one ordered list, so the
+    // Type column cannot say Int64 while the value says Timestamp(…).
+    const ts = new Timestamp({ t: 1, i: 2 });
+    expect(bsonInstanceTypeLabel(ts)).toBe('Timestamp');
+    expect(bsonValueText(ts)).toBe(`Timestamp(${ts.toString()})`);
+  });
+
+  it('is null for values the grid labels itself', () => {
+    for (const v of [null, undefined, 'text', 7, true, { a: 1 }, [1, 2]]) {
+      expect(bsonInstanceTypeLabel(v)).toBeNull();
+    }
   });
 });

--- a/src/lib/__tests__/resultsFind.test.ts
+++ b/src/lib/__tests__/resultsFind.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { ObjectId, Long } from 'bson';
+import { cellText, findMatches, stepMatch, isMatchAt, type FindCell } from '../resultsFind';
+
+const cell = (rowIndex: number, text: string, extra: Partial<FindCell> = {}): FindCell => ({
+  rowIndex,
+  text,
+  ...extra,
+});
+
+describe('cellText', () => {
+  it('joins the key and the value the way the grid shows them', () => {
+    expect(cellText('serviceName', 'token-srv')).toBe('serviceName token-srv');
+  });
+
+  it('renders BSON as the scalar a user would copy, not the EJSON wrapper', () => {
+    const oid = new ObjectId('507f1f77bcf86cd799439011');
+    expect(cellText('_id', oid)).toBe('_id 507f1f77bcf86cd799439011');
+    expect(cellText('big', Long.fromString('42'))).toBe('big 42');
+  });
+
+  it('handles the table view\'s plain extended-JSON shapes', () => {
+    expect(cellText('_id', { $oid: '507f1f77bcf86cd799439011' })).toBe(
+      '_id 507f1f77bcf86cd799439011',
+    );
+  });
+
+  it('copes with a missing key or a missing value', () => {
+    expect(cellText(null, 'lonely')).toBe('lonely');
+    expect(cellText('lonely', undefined)).toBe('lonely');
+    expect(cellText(null, undefined)).toBe('');
+  });
+
+  it('searches nested containers via their serialized form', () => {
+    expect(cellText('address', { city: 'Pforzheim' })).toContain('Pforzheim');
+  });
+});
+
+describe('findMatches', () => {
+  const cells = [
+    cell(0, 'serviceName token-srv'),
+    cell(1, 'serviceName auth-srv'),
+    cell(2, 'path /TOKEN'),
+  ];
+
+  it('finds matches case-insensitively, in view order', () => {
+    const found = findMatches(cells, 'token');
+    expect(found.map((m) => m.rowIndex)).toEqual([0, 2]);
+  });
+
+  it('ignores an empty or whitespace query', () => {
+    expect(findMatches(cells, '')).toEqual([]);
+    expect(findMatches(cells, '   ')).toEqual([]);
+  });
+
+  it('trims the query, so a stray space still matches', () => {
+    expect(findMatches(cells, '  auth ')).toHaveLength(1);
+  });
+
+  it('reports one match per cell, since a cell is what can be stepped to', () => {
+    // "srv" appears twice in this text; navigating to it twice would go nowhere.
+    expect(findMatches([cell(0, 'srv and srv again')], 'srv')).toHaveLength(1);
+  });
+
+  it('carries the folds that must be opened to reach the row', () => {
+    const found = findMatches([cell(7, 'deep value', { ancestors: [1, 4] })], 'deep');
+    expect(found[0].ancestors).toEqual([1, 4]);
+  });
+
+  it('defaults ancestors to empty for views without folding', () => {
+    expect(findMatches([cell(0, 'flat')], 'flat')[0].ancestors).toEqual([]);
+  });
+
+  it('keeps the column key so a table cell can be highlighted', () => {
+    const found = findMatches([cell(3, 'gold', { columnKey: 'tier' })], 'gold');
+    expect(found[0]).toMatchObject({ rowIndex: 3, columnKey: 'tier' });
+  });
+});
+
+describe('stepMatch', () => {
+  it('wraps forwards and backwards', () => {
+    expect(stepMatch(3, 0, 1)).toBe(1);
+    expect(stepMatch(3, 2, 1)).toBe(0);
+    expect(stepMatch(3, 0, -1)).toBe(2);
+  });
+
+  it('selects an end when nothing is active yet', () => {
+    expect(stepMatch(3, -1, 1)).toBe(0);
+    expect(stepMatch(3, -1, -1)).toBe(2);
+  });
+
+  it('reports no selection when there is nothing to step through', () => {
+    expect(stepMatch(0, -1, 1)).toBe(-1);
+    expect(stepMatch(0, 5, -1)).toBe(-1);
+  });
+});
+
+describe('isMatchAt', () => {
+  it('matches on row and column together', () => {
+    const m = { rowIndex: 2, columnKey: 'tier', ancestors: [] };
+    expect(isMatchAt(m, 2, 'tier')).toBe(true);
+    expect(isMatchAt(m, 2, 'name')).toBe(false);
+    expect(isMatchAt(m, 3, 'tier')).toBe(false);
+  });
+
+  it('treats a column-less cell as its own identity', () => {
+    const m = { rowIndex: 2, ancestors: [] };
+    expect(isMatchAt(m, 2)).toBe(true);
+    expect(isMatchAt(m, 2, 'tier')).toBe(false);
+  });
+
+  it('is false with no active match', () => {
+    expect(isMatchAt(undefined, 0)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/resultsFind.test.ts
+++ b/src/lib/__tests__/resultsFind.test.ts
@@ -1,39 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { ObjectId, Long } from 'bson';
-import { cellText, findMatches, stepMatch, isMatchAt, type FindCell } from '../resultsFind';
+import { findMatches, stepMatch, isMatchAt, type FindCell } from '../resultsFind';
 
 const cell = (rowIndex: number, text: string, extra: Partial<FindCell> = {}): FindCell => ({
   rowIndex,
   text,
   ...extra,
-});
-
-describe('cellText', () => {
-  it('joins the key and the value the way the grid shows them', () => {
-    expect(cellText('serviceName', 'token-srv')).toBe('serviceName token-srv');
-  });
-
-  it('renders BSON as the scalar a user would copy, not the EJSON wrapper', () => {
-    const oid = new ObjectId('507f1f77bcf86cd799439011');
-    expect(cellText('_id', oid)).toBe('_id 507f1f77bcf86cd799439011');
-    expect(cellText('big', Long.fromString('42'))).toBe('big 42');
-  });
-
-  it('handles the table view\'s plain extended-JSON shapes', () => {
-    expect(cellText('_id', { $oid: '507f1f77bcf86cd799439011' })).toBe(
-      '_id 507f1f77bcf86cd799439011',
-    );
-  });
-
-  it('copes with a missing key or a missing value', () => {
-    expect(cellText(null, 'lonely')).toBe('lonely');
-    expect(cellText('lonely', undefined)).toBe('lonely');
-    expect(cellText(null, undefined)).toBe('');
-  });
-
-  it('searches nested containers via their serialized form', () => {
-    expect(cellText('address', { city: 'Pforzheim' })).toContain('Pforzheim');
-  });
 });
 
 describe('findMatches', () => {

--- a/src/lib/__tests__/resultsFindShortcut.test.ts
+++ b/src/lib/__tests__/resultsFindShortcut.test.ts
@@ -51,6 +51,78 @@ describe('results find shortcut', () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  it('routes from the event target even when focus was moved away', () => {
+    // Sidebar has its own window-level Cmd/Ctrl+F that focuses the connection
+    // filter, so `document.activeElement` can already have left the pane by the
+    // time this runs. The event's target cannot be rewritten that way.
+    const a = pane();
+    const b = pane();
+    const row = document.createElement('div');
+    b.el.appendChild(row);
+
+    const stealer = document.createElement('button');
+    document.body.appendChild(stealer);
+    stealer.focus();
+
+    const event = pressFind(row);
+    expect(b.open).toHaveBeenCalledTimes(1);
+    expect(a.open).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('leaves the key alone when it comes from outside every pane', () => {
+    // A keypress aimed at another region — the sidebar tree, say — is that
+    // region's business, so the shortcut must not claim it even though a pane
+    // was pointed at earlier.
+    const p = pane();
+    const inside = document.createElement('div');
+    p.el.appendChild(inside);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+
+    // Point at the pane first, so only the target rule can rule it out.
+    outside.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    inside.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    outside.focus();
+
+    const event = pressFind(outside);
+    expect(p.open).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('claims the key ahead of a window listener registered earlier', () => {
+    // Sidebar's handler is registered during app mount, long before any pane
+    // exists, and stands down on defaultPrevented — so this one has to see the
+    // event first. Capture phase beats any bubble-phase listener.
+    const seen: boolean[] = [];
+    const earlier = (e: Event) => seen.push(e.defaultPrevented);
+    window.addEventListener('keydown', earlier);
+    try {
+      const p = pane();
+      const row = document.createElement('div');
+      p.el.appendChild(row);
+
+      pressFind(row);
+      expect(p.open).toHaveBeenCalledTimes(1);
+      expect(seen).toEqual([true]);
+    } finally {
+      window.removeEventListener('keydown', earlier);
+    }
+  });
+
+  it('still falls back to the pointed pane when nothing is focused', () => {
+    // Clicking a grid row focuses nothing, so the keypress targets the body and
+    // the pointer history is the only signal left.
+    const a = pane();
+    const b = pane();
+    b.el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+    const event = pressFind();
+    expect(b.open).toHaveBeenCalledTimes(1);
+    expect(a.open).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it('routes back to the pane from the find bar’s own input', () => {
     // The find input is a text field, so the blanket suppression swallowed the
     // second press — the one that reselects the query — and the browser's find

--- a/src/lib/__tests__/resultsFindShortcut.test.ts
+++ b/src/lib/__tests__/resultsFindShortcut.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+  RESULTS_FIND_INPUT_ATTR,
   registerResultsFindTarget,
   resetResultsFindShortcutForTests,
 } from '../resultsFindShortcut';
@@ -46,6 +47,30 @@ describe('results find shortcut', () => {
     document.body.appendChild(editor);
 
     const event = pressFind(inner);
+    expect(p.open).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('routes back to the pane from the find bar’s own input', () => {
+    // The find input is a text field, so the blanket suppression swallowed the
+    // second press — the one that reselects the query — and the browser's find
+    // opened instead.
+    const p = pane();
+    const input = document.createElement('input');
+    input.setAttribute(RESULTS_FIND_INPUT_ATTR, 'true');
+    p.el.appendChild(input);
+
+    const event = pressFind(input);
+    expect(p.open).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('still suppresses an ordinary input that happens to sit in the pane', () => {
+    const p = pane();
+    const other = document.createElement('input');
+    p.el.appendChild(other);
+
+    const event = pressFind(other);
     expect(p.open).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
   });

--- a/src/lib/__tests__/resultsFindShortcut.test.ts
+++ b/src/lib/__tests__/resultsFindShortcut.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  registerResultsFindTarget,
+  resetResultsFindShortcutForTests,
+} from '../resultsFindShortcut';
+
+function pane(): { el: HTMLElement; open: ReturnType<typeof vi.fn>; dispose: () => void } {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  const open = vi.fn();
+  const dispose = registerResultsFindTarget({ element: () => el, open });
+  return { el, open, dispose };
+}
+
+function pressFind(target: EventTarget = document.body): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'f',
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe('results find shortcut', () => {
+  beforeEach(() => resetResultsFindShortcutForTests());
+  afterEach(() => {
+    resetResultsFindShortcutForTests();
+    document.body.innerHTML = '';
+  });
+
+  it('opens the only mounted pane and claims the key', () => {
+    const p = pane();
+    const event = pressFind();
+    expect(p.open).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('leaves Monaco to its own find widget', () => {
+    const p = pane();
+    const editor = document.createElement('div');
+    editor.className = 'monaco-editor';
+    const inner = document.createElement('div');
+    editor.appendChild(inner);
+    document.body.appendChild(editor);
+
+    const event = pressFind(inner);
+    expect(p.open).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('leaves text fields alone', () => {
+    const p = pane();
+    for (const tag of ['input', 'textarea', 'select']) {
+      const field = document.createElement(tag);
+      document.body.appendChild(field);
+      pressFind(field);
+    }
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    document.body.appendChild(editable);
+    pressFind(editable);
+
+    expect(p.open).not.toHaveBeenCalled();
+  });
+
+  it('ignores keys that are not the find chord', () => {
+    const p = pane();
+    for (const init of [
+      { key: 'f' }, // no modifier
+      { key: 'g', metaKey: true },
+      { key: 'f', metaKey: true, altKey: true },
+    ]) {
+      document.body.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }),
+      );
+    }
+    expect(p.open).not.toHaveBeenCalled();
+  });
+
+  it('routes to the pane that holds focus', () => {
+    const a = pane();
+    const b = pane();
+    const input = document.createElement('button');
+    b.el.appendChild(input);
+    input.focus();
+
+    pressFind(input);
+    expect(b.open).toHaveBeenCalledTimes(1);
+    expect(a.open).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the pane last pointed at', () => {
+    const a = pane();
+    const b = pane();
+    b.el.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+
+    pressFind();
+    expect(b.open).toHaveBeenCalledTimes(1);
+    expect(a.open).not.toHaveBeenCalled();
+  });
+
+  it('opens nothing when several panes are mounted and none is indicated', () => {
+    // Better than opening a find bar in a pane the user was not looking at.
+    const a = pane();
+    const b = pane();
+    const event = pressFind();
+    expect(a.open).not.toHaveBeenCalled();
+    expect(b.open).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('stops listening once the last pane unregisters', () => {
+    const p = pane();
+    p.dispose();
+    const event = pressFind();
+    expect(p.open).not.toHaveBeenCalled();
+    // The browser's own find is left available again.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('forgets a disposed pane that had been pointed at', () => {
+    const a = pane();
+    const b = pane();
+    b.el.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    b.dispose();
+
+    pressFind();
+    // `a` is now the only pane, so it is unambiguous.
+    expect(a.open).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/bsonDisplay.ts
+++ b/src/lib/bsonDisplay.ts
@@ -43,6 +43,93 @@ export function jsonStringLiteral(value: string): string {
 }
 
 /**
+ * One BSON type the grid knows how to display, and everything it displays about
+ * it: the constructor call in the value column, and the type name in the tree's
+ * Type column.
+ *
+ * A single ordered list because the order is load-bearing and was got wrong
+ * twice. `Timestamp extends Long` and `UUID extends Binary` in the driver, so a
+ * base class tested first swallows its subclass — which is how a timestamp came
+ * to render as `NumberLong(…)`. Splitting the call and the label into two
+ * separately-ordered functions let the value column say `Timestamp(…)` while the
+ * Type column said `Int64` about the same row. Matching once, here, means they
+ * cannot disagree.
+ */
+interface BsonKind {
+  /** BSON type name, as the tree's Type column shows it. */
+  label: string;
+  matches: (val: unknown) => boolean;
+  call: (val: any) => BsonCall;
+}
+
+const BSON_KINDS: readonly BsonKind[] = [
+  {
+    label: "ObjectId",
+    matches: (v) => v instanceof ObjectId,
+    call: (v: ObjectId) => ({
+      ctor: "ObjectId",
+      args: [{ text: jsonStringLiteral(v.toString()), kind: "string" }],
+    }),
+  },
+  {
+    label: "Date",
+    matches: (v) => v instanceof Date,
+    call: (v: Date) => ({
+      ctor: "ISODate",
+      args: [{ text: jsonStringLiteral(v.toISOString()), kind: "string" }],
+    }),
+  },
+  {
+    label: "Decimal128",
+    matches: (v) => v instanceof Decimal128,
+    call: (v: Decimal128) => ({
+      ctor: "NumberDecimal",
+      args: [{ text: jsonStringLiteral(v.toString()), kind: "string" }],
+    }),
+  },
+  // Before Long: Timestamp extends it.
+  {
+    label: "Timestamp",
+    matches: (v) => v instanceof Timestamp,
+    call: (v: Timestamp) => ({
+      ctor: "Timestamp",
+      args: [{ text: v.toString(), kind: "number" }],
+    }),
+  },
+  {
+    label: "Int64",
+    matches: (v) => v instanceof Long,
+    call: (v: Long) => ({ ctor: "NumberLong", args: [{ text: v.toString(), kind: "number" }] }),
+  },
+  {
+    label: "Int32",
+    matches: (v) => v instanceof Int32,
+    call: (v: Int32) => ({ ctor: "NumberInt", args: [{ text: v.toString(), kind: "number" }] }),
+  },
+  {
+    label: "Double",
+    matches: (v) => v instanceof Double,
+    call: (v: Double) => ({ ctor: "Double", args: [{ text: v.toString(), kind: "number" }] }),
+  },
+  {
+    label: "Binary",
+    matches: (v) => v instanceof Binary,
+    call: (v: Binary) => ({
+      ctor: "BinData",
+      args: [
+        { text: String(v.sub_type), kind: "number" },
+        { text: jsonStringLiteral(v.toString("base64")), kind: "string" },
+      ],
+    }),
+  },
+];
+
+function bsonKindOf(val: unknown): BsonKind | undefined {
+  if (val === null || val === undefined) return undefined;
+  return BSON_KINDS.find((kind) => kind.matches(val));
+}
+
+/**
  * The constructor call for a BSON instance, or null when `val` is not one.
  *
  * Only real `bson` instances qualify. The table view holds the backend's plain
@@ -50,43 +137,18 @@ export function jsonStringLiteral(value: string): string {
  * [`plainBsonShape`].
  */
 export function bsonCallOf(val: unknown): BsonCall | null {
-  if (val instanceof ObjectId) {
-    return { ctor: "ObjectId", args: [{ text: jsonStringLiteral(val.toString()), kind: "string" }] };
-  }
-  if (val instanceof Date) {
-    return { ctor: "ISODate", args: [{ text: jsonStringLiteral(val.toISOString()), kind: "string" }] };
-  }
-  // Before Long: `Timestamp extends Long` in the driver, so testing the base
-  // class first would display every timestamp as `NumberLong(…)` — which is what
-  // the grid's renderer did before it read this descriptor.
-  if (val instanceof Timestamp) {
-    return { ctor: "Timestamp", args: [{ text: val.toString(), kind: "number" }] };
-  }
-  if (val instanceof Long) {
-    return { ctor: "NumberLong", args: [{ text: val.toString(), kind: "number" }] };
-  }
-  if (val instanceof Decimal128) {
-    return {
-      ctor: "NumberDecimal",
-      args: [{ text: jsonStringLiteral(val.toString()), kind: "string" }],
-    };
-  }
-  if (val instanceof Int32) {
-    return { ctor: "NumberInt", args: [{ text: val.toString(), kind: "number" }] };
-  }
-  if (val instanceof Double) {
-    return { ctor: "Double", args: [{ text: val.toString(), kind: "number" }] };
-  }
-  if (val instanceof Binary) {
-    return {
-      ctor: "BinData",
-      args: [
-        { text: String(val.sub_type), kind: "number" },
-        { text: jsonStringLiteral(val.toString("base64")), kind: "string" },
-      ],
-    };
-  }
-  return null;
+  const kind = bsonKindOf(val);
+  return kind ? kind.call(val) : null;
+}
+
+/**
+ * The BSON type name for an instance, or null when `val` is not one.
+ *
+ * The grid's own labeller handles the rest (Array, Object, the JavaScript
+ * primitives); this covers only the types whose display order matters.
+ */
+export function bsonInstanceTypeLabel(val: unknown): string | null {
+  return bsonKindOf(val)?.label ?? null;
 }
 
 /** The call as one string, matching the spans the renderer emits for it. */
@@ -96,7 +158,7 @@ export function bsonCallText(call: BsonCall): string {
 
 /** True for the BSON instances the grid gives a constructor call. */
 export function isBsonInstance(val: unknown): boolean {
-  return bsonCallOf(val) !== null;
+  return bsonKindOf(val) !== undefined;
 }
 
 /**

--- a/src/lib/bsonDisplay.ts
+++ b/src/lib/bsonDisplay.ts
@@ -1,0 +1,175 @@
+/**
+ * How the results grid displays a value, as data rather than as JSX.
+ *
+ * The grid renders values through React (`renderBsonValueNode`,
+ * `renderColoredCell`), which is fine for painting but useless for anything that
+ * needs the *text* — local find (#279) has to search what the user can see. The
+ * first cut of find borrowed `copyValueToText`, and that was wrong: "copy value"
+ * deliberately yields the bare scalar (`603d…` for an ObjectId) so it pastes into
+ * a query, while the grid displays the constructor call (`ObjectId("603d…")`).
+ * Searching for `ObjectId`, `ISODate` or a quoted string therefore found nothing
+ * even though those exact characters were on screen.
+ *
+ * So the display shape lives here once, as a descriptor. The renderers build
+ * their spans from it and the text builders join it into a string, which means
+ * the two cannot disagree about what is displayed — only about how it is
+ * coloured.
+ */
+import { Binary, Decimal128, Double, Int32, Long, ObjectId, Timestamp } from "bson";
+
+/** Whether an argument is painted with the string or the number colour. */
+export type BsonArgKind = "string" | "number";
+
+export interface BsonCallArg {
+  /** The argument exactly as displayed, quotes included where the grid quotes it. */
+  text: string;
+  kind: BsonArgKind;
+}
+
+/** A BSON value displayed as a mongosh-style constructor call. */
+export interface BsonCall {
+  ctor: string;
+  args: BsonCallArg[];
+}
+
+/**
+ * A string as the JSON views display it: quoted, with escapes made visible.
+ *
+ * Escaping is why find must use this — a newline inside a value is on screen as
+ * the two characters `\n`, so that is what a search for `\n` has to match.
+ */
+export function jsonStringLiteral(value: string): string {
+  return JSON.stringify(value);
+}
+
+/**
+ * The constructor call for a BSON instance, or null when `val` is not one.
+ *
+ * Only real `bson` instances qualify. The table view holds the backend's plain
+ * extended-JSON shapes instead and the grid displays those differently — see
+ * [`plainBsonShape`].
+ */
+export function bsonCallOf(val: unknown): BsonCall | null {
+  if (val instanceof ObjectId) {
+    return { ctor: "ObjectId", args: [{ text: jsonStringLiteral(val.toString()), kind: "string" }] };
+  }
+  if (val instanceof Date) {
+    return { ctor: "ISODate", args: [{ text: jsonStringLiteral(val.toISOString()), kind: "string" }] };
+  }
+  // Before Long: `Timestamp extends Long` in the driver, so testing the base
+  // class first would display every timestamp as `NumberLong(…)` — which is what
+  // the grid's renderer did before it read this descriptor.
+  if (val instanceof Timestamp) {
+    return { ctor: "Timestamp", args: [{ text: val.toString(), kind: "number" }] };
+  }
+  if (val instanceof Long) {
+    return { ctor: "NumberLong", args: [{ text: val.toString(), kind: "number" }] };
+  }
+  if (val instanceof Decimal128) {
+    return {
+      ctor: "NumberDecimal",
+      args: [{ text: jsonStringLiteral(val.toString()), kind: "string" }],
+    };
+  }
+  if (val instanceof Int32) {
+    return { ctor: "NumberInt", args: [{ text: val.toString(), kind: "number" }] };
+  }
+  if (val instanceof Double) {
+    return { ctor: "Double", args: [{ text: val.toString(), kind: "number" }] };
+  }
+  if (val instanceof Binary) {
+    return {
+      ctor: "BinData",
+      args: [
+        { text: String(val.sub_type), kind: "number" },
+        { text: jsonStringLiteral(val.toString("base64")), kind: "string" },
+      ],
+    };
+  }
+  return null;
+}
+
+/** The call as one string, matching the spans the renderer emits for it. */
+export function bsonCallText(call: BsonCall): string {
+  return `${call.ctor}(${call.args.map((a) => a.text).join(", ")})`;
+}
+
+/** True for the BSON instances the grid gives a constructor call. */
+export function isBsonInstance(val: unknown): boolean {
+  return bsonCallOf(val) !== null;
+}
+
+/**
+ * A value as the JSON and tree views display it.
+ *
+ * Mirrors `renderBsonValueNode`: `null`/booleans/numbers bare, strings quoted and
+ * escaped, BSON as a constructor call. An object or array reaching here is the
+ * renderer's own `String(val)` fallback — the views normally expand containers
+ * into their own rows rather than printing them.
+ */
+export function bsonValueText(val: unknown): string {
+  if (val === null) return "null";
+  if (val === undefined) return "";
+  if (typeof val === "boolean") return val ? "true" : "false";
+  if (typeof val === "number") return String(val);
+  if (typeof val === "string") return jsonStringLiteral(val);
+  const call = bsonCallOf(val);
+  if (call) return bsonCallText(call);
+  return String(val);
+}
+
+/** How the table view displays one of the backend's extended-JSON shapes. */
+export interface PlainShapeDisplay {
+  text: string;
+  /** `raw` is the muted JSON fallback for a shape with no special display. */
+  kind: "string" | "number" | "raw";
+}
+
+/**
+ * The display for a canonical extended-JSON shape, or null when `val` is an
+ * ordinary object.
+ *
+ * The table view renders the backend documents as they arrive, so an `_id`
+ * arrives as `{$oid: "…"}` and is displayed as the bare hex — not as
+ * `ObjectId("…")`, which is what the parsed views show. Both are mirrored, each
+ * for the view that produces it.
+ */
+export function plainBsonShape(val: Record<string, any>): PlainShapeDisplay | null {
+  if (typeof val.$oid === "string") return { text: val.$oid, kind: "string" };
+  if (val.$date !== undefined) {
+    if (typeof val.$date === "string") return { text: val.$date, kind: "string" };
+    if (val.$date?.$numberLong) {
+      return { text: new Date(Number(val.$date.$numberLong)).toISOString(), kind: "string" };
+    }
+    return { text: JSON.stringify(val.$date), kind: "string" };
+  }
+  if (val.$numberLong !== undefined) return { text: String(val.$numberLong), kind: "number" };
+  if (val.$numberDecimal !== undefined) {
+    return { text: String(val.$numberDecimal), kind: "number" };
+  }
+  if (val.$numberInt !== undefined) return { text: String(val.$numberInt), kind: "number" };
+  if (val.$numberDouble !== undefined) return { text: String(val.$numberDouble), kind: "number" };
+  return null;
+}
+
+/**
+ * A value as the table view displays it.
+ *
+ * Mirrors `renderColoredCell`. Strings are *unquoted* here — the table shows the
+ * raw text in a fixed-width cell — so the same value reads differently in the
+ * table than in the JSON view, and find follows whichever view is on screen.
+ */
+export function tableValueText(val: unknown): string {
+  if (val === null || val === undefined) return "";
+  if (typeof val === "string") return val;
+  if (typeof val === "number") return String(val);
+  if (typeof val === "boolean") return val ? "true" : "false";
+  if (typeof val === "object") {
+    const call = bsonCallOf(val);
+    if (call) return bsonCallText(call);
+    const plain = plainBsonShape(val as Record<string, any>);
+    if (plain) return plain.text;
+    return JSON.stringify(val);
+  }
+  return String(val);
+}

--- a/src/lib/i18n/__tests__/coverage.test.ts
+++ b/src/lib/i18n/__tests__/coverage.test.ts
@@ -292,6 +292,27 @@ const EXEMPT_HITS: Record<string, string[]> = {
   ],
 
   // ── Detector false positives ─────────────────────────────────────────────
+  // BSON type names shown in the tree view's Type column. Identifiers from the
+  // BSON specification rather than prose — `ObjectId`, `Int64` and `Binary` read
+  // the same in every locale, and the value column prints the matching
+  // constructor (`NumberLong(…)`) next to them. Same precedent as ExportView's
+  // format names above.
+  //
+  // They are newly *detected*, not newly untranslated: they lived in
+  // DataGrid.tsx as bare `return 'ObjectId'` statements, which the bare-return
+  // detector does not treat as prose. Collecting them into one ordered table —
+  // so a subclass cannot be labelled as its base class — put them behind
+  // `label:` properties, which the label-ish property detector does match.
+  'src/lib/bsonDisplay.ts': [
+    'label: "ObjectId"',
+    'label: "Date"',
+    'label: "Decimal128"',
+    'label: "Timestamp"',
+    'label: "Int64"',
+    'label: "Int32"',
+    'label: "Double"',
+    'label: "Binary"',
+  ],
   'src/lib/clusterHealth.ts': [
     // A backtick-quoted `new URL` inside a JSDoc comment, read as a template
     // literal — the comment blindness this file's header warns about.

--- a/src/lib/resultsFind.ts
+++ b/src/lib/resultsFind.ts
@@ -11,8 +11,6 @@
  * every view is virtualized: a match may sit outside the rendered window or
  * inside a collapsed fold, and neither exists as an element to scan.
  */
-import { copyValueToText } from "./copyValue";
-
 /** One searchable piece of a view, in that view's own row order. */
 export interface FindCell {
   /** Row index in the view's index space, used to scroll the match into view. */
@@ -31,21 +29,6 @@ export interface FindMatch {
   columnKey?: string;
   /** Folds to open before scrolling to it. Empty when nothing is collapsed. */
   ancestors: number[];
-}
-
-/**
- * Text for a key/value pair, matching what the grid shows and what "Copy value"
- * puts on the clipboard.
- *
- * Reuses `copyValueToText` rather than restating it: it already mirrors
- * `renderColoredCell`, and already handles both real BSON instances (line and
- * tree views) and the canonical extended-JSON shapes the table view holds.
- * Searching what the user would copy is the least surprising behaviour.
- */
-export function cellText(keyName: string | null | undefined, value: unknown): string {
-  const key = keyName ?? "";
-  const rendered = value === undefined ? "" : copyValueToText(value);
-  return key && rendered ? `${key} ${rendered}` : key || rendered;
 }
 
 /**

--- a/src/lib/resultsFind.ts
+++ b/src/lib/resultsFind.ts
@@ -1,0 +1,95 @@
+/**
+ * Local search over the results already on screen (#279).
+ *
+ * A query filter asks the server a question and replaces the result set; this
+ * only looks at what is already loaded. The three text-bearing views render
+ * differently — a virtualized line list, a key/value/type tree, a column table —
+ * so each one flattens itself into [`FindCell`]s and the matching happens here,
+ * once, against text rather than DOM.
+ *
+ * Searching the underlying values rather than the rendered DOM matters because
+ * every view is virtualized: a match may sit outside the rendered window or
+ * inside a collapsed fold, and neither exists as an element to scan.
+ */
+import { copyValueToText } from "./copyValue";
+
+/** One searchable piece of a view, in that view's own row order. */
+export interface FindCell {
+  /** Row index in the view's index space, used to scroll the match into view. */
+  rowIndex: number;
+  /** Column key, for the table view. Absent in the line and tree views. */
+  columnKey?: string;
+  /** The text to search, as the user sees it. */
+  text: string;
+  /** Folds that must be opened before this row is reachable. */
+  ancestors?: number[];
+}
+
+/** A cell containing the query, in view order. */
+export interface FindMatch {
+  rowIndex: number;
+  columnKey?: string;
+  /** Folds to open before scrolling to it. Empty when nothing is collapsed. */
+  ancestors: number[];
+}
+
+/**
+ * Text for a key/value pair, matching what the grid shows and what "Copy value"
+ * puts on the clipboard.
+ *
+ * Reuses `copyValueToText` rather than restating it: it already mirrors
+ * `renderColoredCell`, and already handles both real BSON instances (line and
+ * tree views) and the canonical extended-JSON shapes the table view holds.
+ * Searching what the user would copy is the least surprising behaviour.
+ */
+export function cellText(keyName: string | null | undefined, value: unknown): string {
+  const key = keyName ?? "";
+  const rendered = value === undefined ? "" : copyValueToText(value);
+  return key && rendered ? `${key} ${rendered}` : key || rendered;
+}
+
+/**
+ * Cells containing `query`, in view order. Case-insensitive.
+ *
+ * One match per cell: the cell is the unit the user navigates between and the
+ * unit that gets highlighted, so counting repeated occurrences inside a single
+ * cell would report matches that cannot be stepped to individually.
+ */
+export function findMatches(cells: readonly FindCell[], query: string): FindMatch[] {
+  const needle = query.trim().toLowerCase();
+  if (needle === "") return [];
+
+  const matches: FindMatch[] = [];
+  for (const cell of cells) {
+    if (cell.text.toLowerCase().includes(needle)) {
+      matches.push({
+        rowIndex: cell.rowIndex,
+        columnKey: cell.columnKey,
+        ancestors: cell.ancestors ?? [],
+      });
+    }
+  }
+  return matches;
+}
+
+/**
+ * Next active index when stepping by `delta`, wrapping at both ends.
+ *
+ * Returns -1 when there is nothing to step through, so callers can treat "no
+ * matches" and "no selection" the same way.
+ */
+export function stepMatch(count: number, active: number, delta: number): number {
+  if (count <= 0) return -1;
+  if (active < 0) return delta >= 0 ? 0 : count - 1;
+  return (((active + delta) % count) + count) % count;
+}
+
+/** True when `match` points at the cell identified by `rowIndex`/`columnKey`. */
+export function isMatchAt(
+  match: FindMatch | undefined,
+  rowIndex: number,
+  columnKey?: string,
+): boolean {
+  if (!match) return false;
+  return match.rowIndex === rowIndex && match.columnKey === columnKey;
+}

--- a/src/lib/resultsFindShortcut.ts
+++ b/src/lib/resultsFindShortcut.ts
@@ -48,22 +48,50 @@ function eventBelongsToAnEditor(target: EventTarget | null): boolean {
   return target.closest('[contenteditable="true"]') !== null;
 }
 
+/** The registered pane containing `node`, if any. */
+function paneContaining(node: EventTarget | null): Pane | undefined {
+  if (!(node instanceof Node)) return undefined;
+  for (const pane of panes.values()) {
+    const el = pane.element();
+    if (el && el.contains(node)) return pane;
+  }
+  return undefined;
+}
+
 /**
  * The pane the keypress is meant for.
  *
- * Focus is the strongest signal; a pointer press is the next best, because
- * clicking a row is the usual thing to do before searching it. With neither, a
- * single mounted pane is unambiguous — but several are not, so nothing opens
- * rather than all of them.
+ * The event's own target comes first, and reading focus second is not a
+ * preference but a necessity: `Sidebar` has its own window-level Cmd/Ctrl+F that
+ * focuses the connection filter, so by the time another listener reads
+ * `document.activeElement` it can already have been moved out of every pane,
+ * leaving a real keypress from inside a pane unroutable. The target is the one
+ * signal no other handler can rewrite.
+ *
+ * The pointer fallback then applies only when the keypress came from nothing in
+ * particular — the body, meaning no focused control — because clicking a grid row
+ * focuses nothing. Restricting it that way is what lets the sidebar keep the key
+ * while the user is working in the sidebar: that keypress targets a sidebar
+ * element, matches no pane, and this returns undefined, so the shortcut is never
+ * claimed and the sidebar's own handler runs.
+ *
+ * With several panes and no signal at all, nothing opens rather than all of them.
  */
-function targetPane(): Pane | undefined {
-  const active = document.activeElement;
-  if (active) {
-    for (const pane of panes.values()) {
-      const el = pane.element();
-      if (el && el.contains(active)) return pane;
-    }
-  }
+function targetPane(event: KeyboardEvent): Pane | undefined {
+  const fromTarget = paneContaining(event.target);
+  if (fromTarget) return fromTarget;
+
+  const fromFocus = paneContaining(document.activeElement);
+  if (fromFocus) return fromFocus;
+
+  // Anything else focused belongs to another region, and the key is its business.
+  const unfocused =
+    event.target === null ||
+    event.target === document.body ||
+    event.target === document ||
+    event.target === window;
+  if (!unfocused) return undefined;
+
   if (lastPointedId !== null) {
     const pane = panes.get(lastPointedId);
     if (pane?.element()) return pane;
@@ -72,13 +100,16 @@ function targetPane(): Pane | undefined {
 }
 
 function onKeyDown(event: KeyboardEvent): void {
+  // Someone ahead of us already claimed it.
+  if (event.defaultPrevented) return;
   if (event.key !== "f" && event.key !== "F") return;
   if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
   if (eventBelongsToAnEditor(event.target)) return;
 
-  const pane = targetPane();
+  const pane = targetPane(event);
   if (!pane) return;
-  // Only now: leaving the browser's own find available when no pane claims it.
+  // Only now: leaving the key to the browser — and to Sidebar's own Cmd/Ctrl+F,
+  // which stands down on defaultPrevented — when no pane claims it.
   event.preventDefault();
   pane.open();
 }
@@ -105,7 +136,11 @@ export function registerResultsFindTarget(pane: Pane): () => void {
   const id = nextId++;
   panes.set(id, pane);
   if (!listening && typeof window !== "undefined") {
-    window.addEventListener("keydown", onKeyDown);
+    // Capture: `Sidebar` registers its Cmd/Ctrl+F on window during app mount,
+    // long before any pane exists, so a bubble-phase listener here would always
+    // run second — after the sidebar had claimed the key and moved focus. In the
+    // capture phase this runs first, and the sidebar defers to defaultPrevented.
+    window.addEventListener("keydown", onKeyDown, true);
     window.addEventListener("pointerdown", onPointerDown, true);
     listening = true;
   }
@@ -113,7 +148,7 @@ export function registerResultsFindTarget(pane: Pane): () => void {
     panes.delete(id);
     if (lastPointedId === id) lastPointedId = null;
     if (panes.size === 0 && listening && typeof window !== "undefined") {
-      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keydown", onKeyDown, true);
       window.removeEventListener("pointerdown", onPointerDown, true);
       listening = false;
     }
@@ -123,7 +158,7 @@ export function registerResultsFindTarget(pane: Pane): () => void {
 /** Reset module state between tests. */
 export function resetResultsFindShortcutForTests(): void {
   if (listening && typeof window !== "undefined") {
-    window.removeEventListener("keydown", onKeyDown);
+    window.removeEventListener("keydown", onKeyDown, true);
     window.removeEventListener("pointerdown", onPointerDown, true);
   }
   panes.clear();

--- a/src/lib/resultsFindShortcut.ts
+++ b/src/lib/resultsFindShortcut.ts
@@ -12,6 +12,17 @@
  * Without that, every pane would open its own find bar on one keypress.
  */
 
+/**
+ * Marks the find bar's own input as belonging to the results pane.
+ *
+ * The suppression below deliberately leaves text fields alone, and the find
+ * input is a text field — so pressing the shortcut a second time, with the caret
+ * already in it, fell through to the browser's find. That is the common path:
+ * open the bar, press again to reselect. This attribute is the exception, and
+ * the constant is shared so the bar and this module cannot disagree on its name.
+ */
+export const RESULTS_FIND_INPUT_ATTR = "data-results-find-input";
+
 /** A registered results pane. */
 interface Pane {
   /** Its root element, used to decide which pane the user means. */
@@ -28,6 +39,9 @@ let listening = false;
 /** Editors and text fields keep their own find/typing behaviour. */
 function eventBelongsToAnEditor(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
+  // The find bar's own input is a text field but is not somebody else's: the
+  // shortcut pressed inside it means "search here again", not "leave me alone".
+  if (target.closest(`[${RESULTS_FIND_INPUT_ATTR}]`)) return false;
   if (target.closest(".monaco-editor")) return true;
   const tag = target.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;

--- a/src/lib/resultsFindShortcut.ts
+++ b/src/lib/resultsFindShortcut.ts
@@ -1,0 +1,119 @@
+/**
+ * Cmd/Ctrl+F routing for the results pane (#279).
+ *
+ * The app embeds Monaco in several places — the query bar, the aggregation
+ * builder, the document dialog — and Monaco binds Cmd+F to its own find widget.
+ * A plain `window` listener would steal that, so the key is only claimed when
+ * the event did not come from an editor or a text field.
+ *
+ * Several results panes can be mounted at once (the workspace splits into
+ * panes), so instances register here and exactly one is chosen: the pane
+ * containing focus, else the pane the user last pointed at, else the only one.
+ * Without that, every pane would open its own find bar on one keypress.
+ */
+
+/** A registered results pane. */
+interface Pane {
+  /** Its root element, used to decide which pane the user means. */
+  element: () => HTMLElement | null;
+  /** Called when this pane should open its find bar. */
+  open: () => void;
+}
+
+const panes = new Map<number, Pane>();
+let nextId = 1;
+let lastPointedId: number | null = null;
+let listening = false;
+
+/** Editors and text fields keep their own find/typing behaviour. */
+function eventBelongsToAnEditor(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if (target.closest(".monaco-editor")) return true;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  return target.closest('[contenteditable="true"]') !== null;
+}
+
+/**
+ * The pane the keypress is meant for.
+ *
+ * Focus is the strongest signal; a pointer press is the next best, because
+ * clicking a row is the usual thing to do before searching it. With neither, a
+ * single mounted pane is unambiguous — but several are not, so nothing opens
+ * rather than all of them.
+ */
+function targetPane(): Pane | undefined {
+  const active = document.activeElement;
+  if (active) {
+    for (const pane of panes.values()) {
+      const el = pane.element();
+      if (el && el.contains(active)) return pane;
+    }
+  }
+  if (lastPointedId !== null) {
+    const pane = panes.get(lastPointedId);
+    if (pane?.element()) return pane;
+  }
+  return panes.size === 1 ? [...panes.values()][0] : undefined;
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (event.key !== "f" && event.key !== "F") return;
+  if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
+  if (eventBelongsToAnEditor(event.target)) return;
+
+  const pane = targetPane();
+  if (!pane) return;
+  // Only now: leaving the browser's own find available when no pane claims it.
+  event.preventDefault();
+  pane.open();
+}
+
+function onPointerDown(event: Event): void {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  for (const [id, pane] of panes) {
+    const el = pane.element();
+    if (el && el.contains(target)) {
+      lastPointedId = id;
+      return;
+    }
+  }
+}
+
+/**
+ * Register a results pane. Returns a function that unregisters it.
+ *
+ * The listeners are installed with the first pane and removed with the last, so
+ * nothing is bound while no results are on screen.
+ */
+export function registerResultsFindTarget(pane: Pane): () => void {
+  const id = nextId++;
+  panes.set(id, pane);
+  if (!listening && typeof window !== "undefined") {
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("pointerdown", onPointerDown, true);
+    listening = true;
+  }
+  return () => {
+    panes.delete(id);
+    if (lastPointedId === id) lastPointedId = null;
+    if (panes.size === 0 && listening && typeof window !== "undefined") {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      listening = false;
+    }
+  };
+}
+
+/** Reset module state between tests. */
+export function resetResultsFindShortcutForTests(): void {
+  if (listening && typeof window !== "undefined") {
+    window.removeEventListener("keydown", onKeyDown);
+    window.removeEventListener("pointerdown", onPointerDown, true);
+  }
+  panes.clear();
+  lastPointedId = null;
+  listening = false;
+  nextId = 1;
+}

--- a/src/locales/de/documents.json
+++ b/src/locales/de/documents.json
@@ -317,6 +317,14 @@
         "sort": "Sortierung"
       }
     },
+    "find": {
+      "close": "Suche schließen (Esc)",
+      "count": "{{current}} von {{total}}",
+      "next": "Nächster Treffer (Enter)",
+      "noMatches": "Keine Treffer",
+      "placeholder": "In Ergebnissen suchen…",
+      "previous": "Vorheriger Treffer (Shift+Enter)"
+    },
     "labels": {
       "actions": "Aktionen",
       "docsCountEstimated_one": "~{{count}} Dokument",

--- a/src/locales/en/documents.json
+++ b/src/locales/en/documents.json
@@ -124,6 +124,14 @@
         "sort": "Sort"
       }
     },
+    "find": {
+      "close": "Close find (Esc)",
+      "count": "{{current}} of {{total}}",
+      "next": "Next match (Enter)",
+      "noMatches": "No matches",
+      "placeholder": "Find in results…",
+      "previous": "Previous match (Shift+Enter)"
+    },
     "labels": {
       "actions": "Actions",
       "docsCountEstimated_one": "~{{count}} doc",

--- a/src/locales/zh-Hans/documents.json
+++ b/src/locales/zh-Hans/documents.json
@@ -119,6 +119,14 @@
         "sort": "排序"
       }
     },
+    "find": {
+      "close": "关闭查找（Esc）",
+      "count": "第 {{current}} 个，共 {{total}} 个",
+      "next": "下一个匹配项（Enter）",
+      "noMatches": "无匹配项",
+      "placeholder": "在结果中查找…",
+      "previous": "上一个匹配项（Shift+Enter）"
+    },
     "labels": {
       "actions": "操作",
       "docsCountEstimated_other": "约 {{count}} 个文档",


### PR DESCRIPTION
Closes #279

## Why

The results pane had no way to look through what was already on screen. The query bar above it asks the server a new question and replaces the result set — the wrong tool when you only want to locate a value in the rows you are already looking at.

## What

`Cmd/Ctrl+F` opens a find bar over the loaded results, in **all four views** (JSON, tree, table, and the single-document view that shares the JSON renderer).

- **Matches against values, not the DOM.** Every view is virtualized, so a match may sit outside the rendered window or inside a collapsed fold — neither exists as an element to scan. Each view flattens itself into `FindCell`s and matching happens once, against text.
- **Reveals what it finds.** Stepping to a match opens the folds above it and scrolls it into view.
- **Searches what the user sees.** Text comes from `copyValueToText`, which already mirrors the grid's renderer, so BSON values are findable by the hex or number displayed (e.g. an `ObjectId` by its hex).
- **One match per cell** — the cell is the unit that gets highlighted and stepped to, so counting repeated occurrences inside one cell would report matches that cannot be navigated to individually.
- Active match and other matches are highlighted distinctly; `Enter` / `Shift+Enter` and the arrow buttons step with wraparound; `Escape` or the close button dismisses and clears the query.

## Shortcut routing

The app embeds Monaco in several places and Monaco binds `Cmd+F` to its own find widget, so the key is claimed only when the event did **not** come from an editor, input, textarea, select or `contenteditable`.

Several results panes can be mounted at once, so exactly one is chosen: the pane containing focus, else the pane last pointed at, else the only one. With several panes and no signal, **nothing** opens and `preventDefault` is never called, so the browser keeps the key rather than every pane opening its own bar.

## Tests

- `src/lib/__tests__/resultsFind.test.ts` — 18 tests (cell text, matching, wraparound stepping, match identity)
- `src/lib/__tests__/resultsFindShortcut.test.ts` — 9 tests (editor exclusion, pane selection by focus/pointer/uniqueness, listener lifecycle)
- `src/components/__tests__/DataGrid.test.tsx` — 12 new tests wiring it end to end: opens only on the modified key, counts matches, reports no-matches, steps by button and by Enter/Shift+Enter with wraparound, closes and clears on Escape and on the close button, finds keys as well as values, finds an `ObjectId` by hex, and searches the table and tree views.

`npx tsc --noEmit` clean, `npm run i18n:check` clean (en/de/zh-Hans). Full suite 1488 passed / 4 skipped, 9 of 10 consecutive runs clean; the one failure did not reproduce and matches pre-existing load-sensitive tests in this suite unrelated to this change.