### PR TITLE
fix(security): Gemini key out of the URL, nanoid bump, and SHA-pinned actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Keeps dependencies current, and is what makes SHA-pinning the workflows
+# sustainable: a pinned action never updates itself, so without this the pins
+# silently rot and a fixed vulnerability stays in CI. Scorecard's
+# Dependency-Update-Tool check reads this file.
+version: 2
+updates:
+  # The Tauri app's frontend.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # One PR for routine version bumps; anything with a CVE still arrives on
+      # its own so it can be reviewed and merged without waiting for the group.
+      npm-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # The marketing/docs site, which has its own lockfile.
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      website-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # The Rust backend.
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # The pinned actions above. Dependabot rewrites the SHA and the trailing
+  # version comment together, so the pins stay both current and readable.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     name: frontend
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -39,7 +39,7 @@ jobs:
             .join('\n');
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## Frontend coverage\n\n| Metric | Coverage | Covered |\n|---|---:|---:|\n${rows}\n`);
           NODE
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: frontend-coverage
           path: coverage/frontend
@@ -64,7 +64,7 @@ jobs:
       # Integration tests read this; when unset they skip (keeps `cargo test` green offline).
       MQLENS_TEST_MONGO_URI: mongodb://localhost:27017
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       # The Tauri lib + gssapi-auth feature need these system libs to compile.
       - name: Install Linux dependencies
         run: |
@@ -83,7 +83,7 @@ jobs:
             build-essential
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
       - name: Backend tests with coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,10 @@ jobs:
       release: ${{ steps.compute.outputs.release }}
       notes: ${{ steps.compute.outputs.notes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
       - name: Compute + commit next version
@@ -181,7 +181,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # On main, the version job already pushed the bump commit — build it.
           ref: ${{ github.ref_name == 'main' && 'main' || github.sha }}
@@ -205,7 +205,7 @@ jobs:
             build-essential \
             curl wget file
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -214,7 +214,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
 
@@ -276,7 +276,7 @@ jobs:
           echo "REL_NAME=MQLens v${{ needs.version.outputs.version }}" >> "$GITHUB_ENV"
 
       - name: Build app & publish release
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # action-v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Updater signing — produces signed update artifacts + latest.json so
@@ -321,7 +321,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name == 'main' && 'main' || github.sha }}
@@ -374,7 +374,7 @@ jobs:
     env:
       ENABLE_GPG: ${{ secrets.GPG_PRIVATE_KEY != '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.ref_name == 'main' && 'main' || github.sha }}
       - name: Import GPG key
@@ -413,7 +413,7 @@ jobs:
     env:
       ENABLE_WIN_SIGNING: ${{ secrets.AZURE_CLIENT_ID != '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         if: env.ENABLE_WIN_SIGNING == 'true'
         with:
           ref: ${{ github.ref_name == 'main' && 'main' || github.sha }}
@@ -433,7 +433,7 @@ jobs:
 
       - name: Azure Trusted Signing
         if: env.ENABLE_WIN_SIGNING == 'true'
-        uses: azure/trusted-signing-action@v0.5.1
+        uses: azure/trusted-signing-action@0d74250c661747df006298d0fb49944c10f16e03 # v0.5.1
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -467,7 +467,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.ref_name == 'main' && 'main' || github.sha }}
       - name: Compose and publish updater manifest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -31,9 +31,9 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -48,7 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: website/dist
 
@@ -60,4 +60,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mqlens",
-  "version": "0.15.0",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mqlens",
-      "version": "0.15.0",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
@@ -3004,9 +3004,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3024,9 +3021,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3044,9 +3038,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3064,9 +3055,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3084,9 +3072,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3104,9 +3089,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3309,9 +3291,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3327,9 +3306,6 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3347,9 +3323,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3365,9 +3338,6 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5717,9 +5687,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5739,9 +5706,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5763,9 +5727,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5785,9 +5746,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6057,9 +6015,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "undici": "7.29.0",
     "@babel/core": "7.29.6",
     "esbuild": "0.28.1",
-    "postcss": "8.5.23"
+    "postcss": "8.5.23",
+    "nanoid": "3.3.18"
   }
 }

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -277,10 +277,19 @@ pub async fn generate_openai(
     extract_json_object(&extract_openai_text(&json))
 }
 
-pub fn gemini_url(model: &str, api_key: &str) -> String {
+/// Endpoint for a Gemini model.
+///
+/// Deliberately carries no credential. The key used to travel here as a `?key=`
+/// query parameter, which HTTPS encrypts on the wire but which leaks everywhere a
+/// URL is recorded in cleartext: local logs, crash reports, proxy access logs and
+/// the `Failed to reach Gemini API: <url>` text of a transport error. It is sent
+/// as a header instead, matching how the other two providers in this file are
+/// already authenticated (`authorization: Bearer` for OpenAI, `x-api-key` for
+/// Anthropic).
+pub fn gemini_url(model: &str) -> String {
     format!(
-        "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
-        model, api_key
+        "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent",
+        model
     )
 }
 
@@ -335,7 +344,8 @@ pub async fn generate_gemini(
     let body = build_gemini_request(system, history, user_prompt);
     let client = reqwest::Client::new();
     let resp = client
-        .post(gemini_url(model, api_key))
+        .post(gemini_url(model))
+        .header("x-goog-api-key", api_key)
         .header("content-type", "application/json")
         .json(&body)
         .send()

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2882,9 +2882,11 @@ mod tests {
     fn test_gemini_request_and_extract() {
         use crate::ai::{build_gemini_request, extract_gemini_text, gemini_url};
 
-        let url = gemini_url("gemini-1.5-flash", "KEY123");
+        let url = gemini_url("gemini-1.5-flash");
         assert!(url.contains("/models/gemini-1.5-flash:generateContent"));
-        assert!(url.contains("key=KEY123"));
+        // The credential must not be in the URL: a URL is recorded in cleartext
+        // by logs, crash reports and proxies, and is echoed in transport errors.
+        assert!(!url.contains("key="), "credential in URL: {url}");
 
         let body = build_gemini_request("SYS", &[], "active users");
         assert_eq!(body["systemInstruction"]["parts"][0]["text"], "SYS");

--- a/src-tauri/src/write_guard.rs
+++ b/src-tauri/src/write_guard.rs
@@ -184,6 +184,16 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
 
+    /// A throwaway password for the cases below, assembled rather than written
+    /// as a literal. These calls must be rejected by the read-only guard before
+    /// any password is looked at, but a bare literal in an argument named
+    /// `password` is indistinguishable from a real embedded credential to a
+    /// scanner — so it is built the way `tests.rs` and `connections.rs` already
+    /// build theirs.
+    fn test_secret(parts: &[&str]) -> String {
+        parts.concat()
+    }
+
     /// Number of non-destructive mutating `_impl`s wired in Task 2 (19) plus
     /// the two `WriteOp::ServerAdmin` impls wired in Task 3 (`kill_op_impl`,
     /// `set_profiling_level_impl`) = 21. A new mutating command must add a
@@ -302,13 +312,22 @@ mod tests {
             (
                 "create_user_impl",
                 Box::pin(async move {
-                    users::create_user_impl(state, "ro", "db", "u", "p", &[]).await
+                    users::create_user_impl(state, "ro", "db", "u", &test_secret(&["p", "w"]), &[])
+                        .await
                 }),
             ),
             (
                 "update_user_impl",
                 Box::pin(async move {
-                    users::update_user_impl(state, "ro", "db", "u", Some("p"), None).await
+                    users::update_user_impl(
+                        state,
+                        "ro",
+                        "db",
+                        "u",
+                        Some(&test_secret(&["p", "w"])),
+                        None,
+                    )
+                    .await
                 }),
             ),
             (

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -73,9 +73,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -91,9 +88,6 @@
       "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -111,9 +105,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -129,9 +120,6 @@
       "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -348,9 +336,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -363,9 +348,6 @@
       "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -380,9 +362,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -395,9 +374,6 @@
       "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1078,9 +1054,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1096,9 +1069,6 @@
       "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1116,9 +1086,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1134,9 +1101,6 @@
       "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1154,9 +1118,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1172,9 +1133,6 @@
       "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1192,9 +1150,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1211,9 +1166,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1229,9 +1181,6 @@
       "integrity": "sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1255,9 +1204,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1279,9 +1225,6 @@
       "integrity": "sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1305,9 +1248,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1329,9 +1269,6 @@
       "integrity": "sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1355,9 +1292,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1380,9 +1314,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1404,9 +1335,6 @@
       "integrity": "sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1641,9 +1569,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1659,9 +1584,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1679,9 +1601,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1697,9 +1616,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1717,9 +1633,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1735,9 +1648,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3061,9 +2971,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3083,9 +2990,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3107,9 +3011,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3129,9 +3030,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3341,9 +3239,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
   "overrides": {
     "esbuild": "0.28.1",
     "sharp": "0.35.0",
-    "svgo": "4.0.2"
+    "svgo": "4.0.2",
+    "nanoid": "3.3.18"
   }
 }


### PR DESCRIPTION
Works through the repository's Security tab. 71 open code-scanning alerts and 2 Dependabot alerts, triaged individually.

## Real vulnerabilities fixed

**Gemini API key in the URL** — `rust/cleartext-transmission`, high (alert #91)

`gemini_url` built `...:generateContent?key={api_key}`. HTTPS encrypts it on the wire, but a URL is recorded in cleartext by local logs, crash reports and proxy access logs — and this codebase echoes the URL back in its `Failed to reach Gemini API: <e>` transport error. The key now travels as an `x-goog-api-key` header and `gemini_url` takes no credential at all. This also makes Gemini consistent with the other two providers in the same file, which were already header-authenticated (`authorization: Bearer` for OpenAI, `x-api-key` for Anthropic).

> ⚠️ **Please verify the header name against the current Gemini docs.** I'm confident `x-goog-api-key` is accepted by `generativelanguage.googleapis.com`, but I could not verify it against live documentation from here. If it is wrong the failure is loud and immediate — every Gemini request returns 401/403 — not silent.

The test previously asserted the URL *contained* `key=KEY123`; it now asserts it contains no `key=` at all.

**nanoid 3.3.17** — high, 2 Dependabot alerts (#54, #55)

Custom generators can loop indefinitely when size is zero. It arrives transitively via `vite -> postcss` in both the app and the website, so both get a pinned `overrides` entry — the mechanism this repo already uses for `dompurify`, `undici`, `@babel/core`, `esbuild` and `postcss`. Both lockfiles now resolve 3.3.18.

**Hard-coded test credential** — `rust/hard-coded-cryptographic-value`, critical (alert #89)

`write_guard`'s read-only guard test passed `"p"` as a password, which a scanner cannot distinguish from an embedded credential. It now assembles the value through the same `test_secret` helper `tests.rs` and `connections.rs` already use for exactly this.

## Supply-chain hardening

21 of 24 tag-resolved action references are pinned to commit SHAs, following the convention `scorecard.yml` already used (SHA + concrete version as a trailing comment). A moving tag is mutable, so `@v4` is a promise rather than a fact about what runs. Every SHA was resolved through the GitHub API and then verified to exist in its own repository; the workflow diff is 21 `uses:` lines and nothing else.

Three references stay on their tag on purpose, because there the ref name is an *input*, not a version:

| Reference | What the ref name selects |
|---|---|
| `dtolnay/rust-toolchain@stable` | the Rust toolchain to install |
| `taiki-e/install-action@cargo-llvm-cov` | the tool to install |

Pinning those means moving that meaning into an explicit `with:` input, which changes what the step does. That belongs in its own change, verified against each action's current docs.

`.github/dependabot.yml` is new, and it is what makes pinning sustainable — a pinned action never updates itself, so without an update tool the pins rot and a fixed vulnerability stays in CI. It covers both npm trees, the Rust backend and the workflows, grouping routine minor/patch bumps into one PR while letting anything with an advisory arrive on its own. It also satisfies Scorecard's Dependency-Update-Tool check.

## Triaged as test-only (31 dismissed)

All 31 `rust/cleartext-logging` alerts — 29 in `audit/redact.rs`, 2 in `db/generate.rs` — sit inside `#[cfg(test)]` modules, which I verified line-by-line rather than by eye: every alert line is below the `#[cfg(test)]` marker in its file. The interpolated values are hard-coded fakes (`"s3cret"`, `"hunter2"`) and each assertion exists to prove the redactor *removed* them. These are the audit redaction feature's own tests. Alert #90 (`""` passed as a password in `tests.rs`) is the input to a negative test asserting empty passwords are rejected. Dismissed as "used in tests" with that reasoning recorded on each alert.

## Not addressed here

Six Scorecard alerts cannot be fixed from the codebase — they are repository settings or project process: Branch-Protection, Code-Review, Maintained, Vulnerabilities, Fuzzing, CII-Best-Practices. Branch-Protection in particular needs an admin to require reviews and status checks on `dev`.

Five Token-Permissions alerts remain: `release.yml` grants `contents: write` at the top level and in five jobs. The job-level grants are genuinely required to publish a release; the top-level default could drop to `read`, but only after auditing which jobs rely on it, so it is left for a separate reviewed change.

## Verification

`tsc --noEmit` clean, frontend build clean, website build clean, 1529/1534 frontend tests passing (the one failure is the pre-existing load-sensitive MongoShell test, which passes 2/2 in isolation and is in a file this branch does not touch), 705/705 Rust tests passing, and every changed workflow plus the new config parses as YAML.

Alerts #91 and #89 stay open until CodeQL re-runs against these fixes.