### PR TITLE
fix(security): patch 6 Rust advisories, pin the last 3 actions, drop the blanket write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,17 @@ jobs:
             clang \
             libclang-dev \
             build-essential
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      # Pinned to the head of the action's `stable` branch. That branch name was
+      # never magic: the action reads `inputs.toolchain`, whose default differs
+      # per branch, and never looks at the ref it was called by — so the
+      # toolchain is stated here instead of being implied by the ref.
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
+      # Same shape: the `cargo-llvm-cov` tag only sets `inputs.tool`'s default.
+      - uses: taiki-e/install-action@419f0f955ea0cf384c06ae25b10b8d3bcba087da # cargo-llvm-cov tag
+        with:
+          tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,11 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# Read-only by default. Every job that publishes something asks for
+# `contents: write` itself, so a new job added later starts with no write access
+# rather than silently inheriting it from here.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Auto-versioning (main only): compute the next semver from Conventional
@@ -41,6 +44,9 @@ jobs:
   # so it doesn't re-trigger). Outputs the new version + whether to release.
   version:
     runs-on: ubuntu-22.04
+    # Commits the version bump and pushes the tag.
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.compute.outputs.version }}
       release: ${{ steps.compute.outputs.release }}
@@ -210,8 +216,11 @@ jobs:
           node-version: 20
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      # See ci.yml: the ref name only sets `inputs.toolchain`'s default, so the
+      # toolchain is passed explicitly now that the ref is a SHA.
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -1409,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1794,7 +1794,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2061,16 +2061,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2695,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3907,7 +3906,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4661,9 +4660,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -4900,9 +4899,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -5504,7 +5503,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5563,7 +5562,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6108,7 +6107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6910,7 +6909,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7319,7 +7318,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7374,7 +7373,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7891,7 +7890,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to #285, clearing the rest of the Security tab. Open code-scanning alerts went 71 → 17 with #285; this handles what was left.

## The one that mattered: 24 unnoticed Rust advisories

Scorecard's Vulnerabilities check (alert #56) reported **24 RUSTSEC advisories against `Cargo.lock`** — nothing was surfacing these, because Dependabot was only watching the npm trees. I resolved every advisory to its crate and first patched version through OSV rather than guessing, and **six are fixed by lockfile updates alone**:

| Advisory | Crate | Change | Issue |
|---|---|---|---|
| RUSTSEC-2026-0258 | h2 | 0.4.15 → 0.4.19 | unbounded empty DATA frames (remote DoS) |
| RUSTSEC-2026-0194 | quick-xml | 0.39.4 → 0.41.0 | quadratic runtime on duplicate attributes |
| RUSTSEC-2026-0195 | quick-xml | 0.41.0 | unbounded namespace allocation (memory exhaustion) |
| RUSTSEC-2026-0204 | crossbeam-epoch | 0.9.18 → 0.9.20 | invalid pointer dereference |
| RUSTSEC-2026-0221 | event-listener | 5.4.1 → 5.4.2 | `!Send` tags cross thread boundaries |
| RUSTSEC-2026-0190 | anyhow | 1.0.102 → 1.0.104 | unsoundness in `Error::downcast_mut()` |

`quick-xml` needed `plist 1.9.0 → 1.10.0` to raise its requirement; the rest were patch bumps. The `h2` one is the most worth having — the driver speaks HTTP/2, and unbounded empty DATA frames are a remote denial of service.

### The remaining 18 have no patched version

Not hidden, but stated so nobody re-litigates them later:

- **11 × gtk-rs / glib** (RUSTSEC-2024-0411…0420, 2024-0429) — reached through `tauri 2.11.2 → gtk 0.18.2 → glib ^0.18`. I verified this is not a choice we can make: forcing it fails resolution outright.
  ```
  error: failed to select a version for the requirement `glib = "^0.18"`
  candidate versions found which didn't match: 0.20.0
  required by package `gtk v0.18.2`
      ... which satisfies dependency `gtk = "^0.18"` of package `tauri v2.11.2`
  ```
  These move when Tauri moves. Ten of them are "no longer maintained" notices rather than exploitable defects.
- **5 × `unic-*` + `proc-macro-error`** — unmaintained-crate notices, no fix published. Reached via `urlpattern` (Tauri) and `glib-macros`/`gtk3-macros`.
- **RUSTSEC-2023-0071 (`rsa`, Marvin timing attack)** — no patched release exists at all. Arrives via `russh`/`ssh-key` for SSH tunnelling. Exploiting it requires precise timing measurement of RSA private-key operations; there is no version to move to, so it is an accepted risk rather than an oversight.

Alert #56 will therefore stay open with 18 instead of 24 — the check scores 0 while any remain.

## The last 3 action pins

#285 left these on their tags because the ref name looked load-bearing. It isn't, and I checked properly this time by reading each action's `action.yml` **at the pinned commit** rather than relying on docs or memory: neither action reads `github.action_ref` anywhere. The behaviour comes from an input whose *default* differs per branch/tag.

```yaml
# dtolnay/rust-toolchain, stable branch: inputs.toolchain default = stable
# taiki-e/install-action, cargo-llvm-cov tag: inputs.tool default = cargo-llvm-cov
```

So both are now pinned with the input stated explicitly — the step says what it installs instead of implying it through a ref. All 24 references are pinned now.

## Least privilege in release.yml

Top-level `contents: write` → `contents: read`. Five jobs already declared their own write; `version` was silently relying on the blanket grant to commit the version bump and push the tag, so it now asks for it explicitly.

**No job's effective permissions change** — but a job added later starts read-only instead of inheriting write. The five job-level grants are irreducible for a workflow that publishes releases, so those alerts are dismissed with that reasoning rather than left to look unexamined.

## Needs a human, not a commit

Four Scorecard checks cannot be fixed from the codebase:

- **Branch-Protection (#20, high)** — `dev` has protection, but Scorecard reports *no required status checks*. That's the one worth acting on: CI can currently be bypassed on merge. Requires an admin in repo settings. It also wants 2 approving reviews and CODEOWNERS, which may not suit this project's size.
- **Code-Review (#53, high)** — 1 of 17 changesets approved, i.e. self-merged PRs. Process, not code.
- **CII-Best-Practices (#54, low)** — needs an OpenSSF badge registration.
- **Fuzzing (#55, medium)** — no fuzz targets. Real work, worth its own issue if wanted.
- **Maintained (#52, high)** — "repository created in last 90 days". Resolves itself with time.

## Verification

`cargo build` clean, **705/705 Rust tests passing** after the dependency updates, and every advisory re-checked against the new lockfile programmatically (6 RESOLVED, glib confirmed still blocked). Both changed workflows parse as YAML; the workflow diff is 3 `uses:` lines plus the two permissions blocks.