### PR TITLE
build(ci): build and test on Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - name: i18n catalog check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 22
       - name: Compute + commit next version
         id: compute
         shell: bash
@@ -213,7 +213,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       # See ci.yml: the ref name only sets `inputs.toolchain`'s default, so the


### PR DESCRIPTION
Unblocks the Dependabot npm group (#293).

## Why

#293 (35 npm updates) fails CI with:

```
TypeError: TEXT_ENCODINGS.union is not a function
```

That's `Set.prototype.union`, reached by the newer `execa`. It needs **Node 22**; `ci.yml` and `release.yml` pin Node 20. Nothing in the group can land until CI moves.

## Risk

Low. The app ships through Tauri and bundles no Node runtime — this affects the build and test tooling only, not what users run.

`website.yml` was **already on Node 22**, so this also removes a split where the site built on one Node version and the app on another.

## Verified

The full suite passes locally on Node 22.23.2 (1530 passed / 4 skipped), and `npm run build` succeeds. All four workflows still parse as YAML.