### PR TITLE
chore(tests): drop the unused AsyncWriteExt import

### DIFF
--- a/src-tauri/src/integration_tests.rs
+++ b/src-tauri/src/integration_tests.rs
@@ -752,7 +752,6 @@ mod integration {
 
     #[tokio::test]
     async fn it_gridfs_list_upload_download_and_delete_real() {
-        use futures::AsyncWriteExt;
         let Some((state, id, db)) = connect().await else {
             return;
         };


### PR DESCRIPTION
Clears the last rustc warning:

```
warning: unused import: `futures::AsyncWriteExt`
   --> src/integration_tests.rs:755:13
warning: `tauri-app` (lib test) generated 1 warning
```

The GridFS integration test used to write to the upload stream directly; it goes through `upload_gridfs_file_impl` now, which owns the stream writing. I checked it's genuinely dead rather than feature-gated — `AsyncWriteExt` appeared exactly once in the file (the import itself), and nothing there calls `write_all`, `flush` or `close`.

## Verification

Warning counts after the change:

| Command | Warnings |
|---|---|
| `cargo build` | 0 |
| `cargo build --tests` | 0 |
| `cargo test --no-run` | 0 |

712 tests pass.

## Unrelated, but worth flagging

`cargo clippy --all-targets` reports 52 lints. CI doesn't run clippy — the backend job only runs `cargo llvm-cov` — so nothing is gated on them, and I left them alone rather than widen this change.