### PR TITLE
test: give waitFor a budget the suite can actually meet

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,23 @@
 import '@testing-library/jest-dom';
+import { configure } from '@testing-library/react';
+
+// `waitFor` defaults to a 1s budget (see @testing-library/dom's config), which
+// is too tight for this suite on a busy machine: 102 test files under jsdom,
+// each `waitFor` waiting on React effects plus promise chains. CI has failed
+// intermittently on assertions *inside* `waitFor` — App's cross-window
+// connection coherence, MongoShell's session survival, App's session restore —
+// each of which passes in isolation and on the next run.
+//
+// Two call sites had already been patched one at a time with `{ timeout: 2000 }`
+// and `{ timeout: 5000 }`, which is the same problem showing through. Raising
+// the default treats the whole class instead.
+//
+// This cannot mask a real failure: `waitFor` polls until the condition holds or
+// the budget runs out, so a longer budget changes only how long a genuinely
+// broken expectation takes to report — not whether it reports. It is kept well
+// under vitest's own `testTimeout` so a failure still surfaces as the
+// assertion error rather than as "test timed out".
+configure({ asyncUtilTimeout: 3000 });
 
 // Mock ResizeObserver for jsdom testing environment
 class MockResizeObserver {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    // Above the raised `asyncUtilTimeout` in src/test/setup.ts, so a `waitFor`
+    // that genuinely never settles reports its own assertion error instead of
+    // being cut short by vitest. The default 5s was already below the
+    // `{ timeout: 5000 }` override in Sidebar.test.tsx.
+    testTimeout: 15000,
     setupFiles: './src/test/setup.ts',
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Fixes the intermittent frontend CI failures — including the one on #303.

## Evidence

#303 changes **one Rust line** (removing an unused import) and its frontend job failed on:

```
FAIL src/components/__tests__/App.test.tsx > ... > (f) a fresh local connect survives
     an unrelated connections-changed broadcast ...
AssertionError: expected false to be true
```

I re-ran that job with **no code change** and it passed. That test also passes 3/3 in isolation locally and 2/2 for the whole file, and the same file is green on other branches' runs.

Three different tests have done this recently — App's cross-window connection coherence, App's session restore, MongoShell's session survival — always passing in isolation and on the next attempt.

## Cause

Every one of those failing assertions sits inside `waitFor`, which defaults to a **1 second** budget (`@testing-library/dom/dist/config.js:15`). That's tight for this suite: 102 jsdom test files, and each `waitFor` is waiting on React effects plus promise chains. The CI run that failed reported **139s of test time** — the runner was saturated.

Two call sites had already been patched individually:

```
src/components/__tests__/Sidebar.test.tsx:1678:  { timeout: 5000 },
src/components/__tests__/App.test.tsx:1098:     { timeout: 2000 }
```

That's the same problem being worked around one site at a time. There are **375 `waitFor` calls across 34 files**, so the default is what should change.

## Why this can't hide a real bug

`waitFor` polls until the condition holds or the budget expires. A longer budget changes only *how long a genuinely failing assertion takes to report* — never whether it reports. I checked rather than asserting it: a `waitFor` wrapped around `expect(1).toBe(2)` still fails with

```
AssertionError: expected 1 to be 2
```

and not a test timeout.

I also confirmed no test in the suite relies on `waitFor` timing out as its assertion, which would have made a longer budget cost real time.

## Why `testTimeout` moves too

`asyncUtilTimeout` must stay under vitest's `testTimeout`, or a stuck `waitFor` gets cut short and its useful assertion error is replaced by "test timed out". The default was 5s — already **below** Sidebar's own `{ timeout: 5000 }` override, so that test could never have reported its own failure properly. Now 3s under a 15s ceiling.

## Verification

- 1530 passed / 4 skipped, clean across **three** ordinary runs
- clean across **two more runs with four concurrent suites** competing for the machine — the condition that provoked the failures
- `tsc --noEmit` clean

## Not addressed here

The Rust suite has the same class of problem, with two causes I've confirmed but not fixed:

- `workspace.rs:2924` — a 500 ms debounce followed by `sleep(700ms)`, so 200 ms of headroom
- `db/mongotools.rs` `wait_for_task` — polls 500×20 ms then returns **silently**, so a timeout surfaces as a confusing assertion failure instead of "timed out"

Happy to do those next if wanted; they're independent of this change.