### PR TITLE
fix(audit): unwind a failed append, and hold the lock through key rotation

### DIFF
--- a/src-tauri/src/audit/envelope.rs
+++ b/src-tauri/src/audit/envelope.rs
@@ -321,6 +321,11 @@ impl AuditSession {
     }
 
     /// Reopen using a lock handed over by [`Self::close_retaining_lock`].
+    /// Take the log's cross-process lock without opening this session.
+    pub fn acquire_retained_lock(&self) -> Result<RetainedLock, String> {
+        self.log.acquire_retained_lock()
+    }
+
     pub fn open_retaining(&self, key: [u8; 32], lock: RetainedLock) -> Result<LoadReport, String> {
         let (events, report) = self.log.open_retaining(&key, lock)?;
         self.seed_index(key, events, &report)?;

--- a/src-tauri/src/audit/log.rs
+++ b/src-tauri/src/audit/log.rs
@@ -600,16 +600,31 @@ impl AuditLog {
         }
 
         let (framed, next) = encode_record(key, open.seq + 1, &open.head, event)?;
-        open.file
+        // Where the file ended before this frame. A failed append has to leave it
+        // exactly here: `seq` and `head` are only advanced after the fsync below,
+        // so bytes left behind by a half-written frame would be followed by the
+        // *next* append reusing this same sequence number. The reload then finds
+        // either a duplicate sequence or a frame that fails authentication, and
+        // seals the log — or reads the leftovers as a torn tail and drops every
+        // good record after them.
+        let start = open
+            .file
             .seek(SeekFrom::End(0))
             .map_err(|e| format!("seek {}: {e}", self.path.display()))?;
-        open.file
-            .write_all(&framed)
-            .map_err(|e| format!("append {}: {e}", self.path.display()))?;
+        if let Err(e) = open.file.write_all(&framed) {
+            let cause = format!("append {}: {e}", self.path.display());
+            return Err(rewind_failed_append(open, start, cause));
+        }
         // The point of the whole design: durability per event, not per batch.
-        open.file
-            .sync_data()
-            .map_err(|e| format!("fsync {}: {e}", self.path.display()))?;
+        //
+        // A failure here is ambiguous — the bytes may or may not have reached the
+        // platter — so the frame is removed rather than kept. This call already
+        // reports the event as unrecorded, and a log that matches its counter
+        // matters more than a record nobody was told about.
+        if let Err(e) = open.file.sync_data() {
+            let cause = format!("fsync {}: {e}", self.path.display());
+            return Err(rewind_failed_append(open, start, cause));
+        }
 
         open.seq += 1;
         open.head = next;
@@ -724,6 +739,18 @@ impl AuditLog {
         slot.take().map(|open| RetainedLock(open.lock))
     }
 
+    /// Take the cross-process lock without opening a session.
+    ///
+    /// Key rotation rewrites the log and its state sidecar even when this
+    /// instance has no session — auditing switched off, or another instance
+    /// already owns the log. In that second case the rotation previously ran with
+    /// no lock at all: the owning instance kept appending under the old key, and
+    /// its next state write landed on top of the freshly rotated sidecar, leaving
+    /// a log that authenticates against neither key.
+    pub fn acquire_retained_lock(&self) -> Result<RetainedLock, String> {
+        self.acquire_lock().map(RetainedLock)
+    }
+
     /// Recover the log using a lock that is already held.
     pub fn open_retaining(
         &self,
@@ -731,6 +758,24 @@ impl AuditLog {
         lock: RetainedLock,
     ) -> Result<(Vec<AuditEvent>, LoadReport), String> {
         self.open_inner(key, Some(lock))
+    }
+}
+
+/// Undo a frame that failed to land, or seal the session if it cannot be undone.
+///
+/// Returns the error to report. Sealing is the fallback because the alternative —
+/// carrying on with an unaccounted tail — turns one lost event into a log that
+/// refuses to load at all.
+fn rewind_failed_append(open: &mut Open, start: u64, cause: String) -> String {
+    match open.file.set_len(start).and_then(|()| open.file.sync_data()) {
+        Ok(()) => cause,
+        Err(e) => {
+            let reason = format!(
+                "{cause}; the partial record could not be removed either ({e}), so the log now                  ends in bytes no counter accounts for"
+            );
+            open.sealed_reason = Some(reason.clone());
+            format!("audit log is sealed: {reason}")
+        }
     }
 }
 
@@ -1256,6 +1301,102 @@ mod tests {
             events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
             ["e3", "e4"]
         );
+    }
+
+    #[test]
+    fn a_leftover_partial_frame_breaks_the_next_append() {
+        // The hazard the rewind below exists to prevent, demonstrated first:
+        // bytes left in the file while `seq` and `head` stay behind, then another
+        // append on top of them reusing the same sequence number.
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 2);
+        {
+            let mut slot = log.open.lock().unwrap();
+            let open = slot.as_mut().unwrap();
+            open.file.seek(SeekFrom::End(0)).unwrap();
+            open.file.write_all(&[0xAB; 40]).unwrap();
+            open.file.sync_data().unwrap();
+        }
+        log.append(&KEY, &event("e3", 1_003)).expect("append lands on disk");
+        log.close();
+
+        let reopened = AuditLog::new(path.clone());
+        let (events, report) = reopened.open(&KEY).expect("load");
+        assert!(
+            report.integrity_error.is_some() || events.len() < 3,
+            "a tail nothing accounts for must not read back as a healthy log: {report:?}"
+        );
+    }
+
+    #[test]
+    fn a_failed_append_leaves_the_file_at_its_previous_length() {
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 2);
+        let before = fs::metadata(&path).unwrap().len();
+
+        // Stand in for a `write_all` that errors halfway: bytes on disk, `seq`
+        // and `head` not yet advanced. This is the state `append` unwinds from.
+        {
+            let mut slot = log.open.lock().unwrap();
+            let open = slot.as_mut().unwrap();
+            open.file.seek(SeekFrom::End(0)).unwrap();
+            open.file.write_all(&[0xAB; 40]).unwrap();
+            open.file.sync_data().unwrap();
+            assert!(fs::metadata(&path).unwrap().len() > before);
+
+            let reported = rewind_failed_append(open, before, "simulated write failure".into());
+            assert_eq!(
+                reported, "simulated write failure",
+                "a clean rewind reports the original cause, not a seal"
+            );
+            assert!(
+                open.sealed_reason.is_none(),
+                "a clean rewind must not seal the session"
+            );
+        }
+        assert_eq!(
+            fs::metadata(&path).unwrap().len(),
+            before,
+            "the partial frame must be gone"
+        );
+
+        // And the session is still usable: the next append takes the sequence
+        // the failed one never consumed.
+        log.append(&KEY, &event("e3", 1_003)).expect("append after rewind");
+        log.close();
+
+        let reopened = AuditLog::new(path.clone());
+        let (events, report) = reopened.open(&KEY).expect("load");
+        assert!(report.integrity_error.is_none(), "{report:?}");
+        assert_eq!(
+            events.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["e1", "e2", "e3"]
+        );
+    }
+
+    #[test]
+    fn the_rotation_lock_excludes_another_instance() {
+        // Key rotation rewrites the log and its sidecar even with no session of
+        // its own. It must not be able to do that while another instance holds
+        // the log — hence taking the same lock, and failing if it is taken.
+        let dir = tempdir().unwrap();
+        let (log, path) = log_with(dir.path(), 1);
+
+        let rotator = AuditLog::new(path.clone());
+        let err = match rotator.acquire_retained_lock() {
+            Ok(_) => panic!("must not get the lock while another instance records"),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains("another MQLens instance"),
+            "the message should say why rotation cannot proceed: {err}"
+        );
+
+        log.close();
+        let held = rotator
+            .acquire_retained_lock()
+            .expect("available once the other instance releases it");
+        drop(held);
     }
 
     #[test]

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -166,12 +166,30 @@ pub fn hold_for_rotation(
     app: &tauri::AppHandle,
     state: &AppState,
 ) -> Result<AuditRotationGuard, String> {
+    hold_for_rotation_at(state, connections::get_audit_log_path(app))
+}
+
+/// The path-taking half, so the no-session branch is reachable from tests
+/// without an `AppHandle`.
+fn hold_for_rotation_at(
+    state: &AppState,
+    log_path: std::path::PathBuf,
+) -> Result<AuditRotationGuard, String> {
     if let Some(lock) = suspend_for_rotation(state) {
         return Ok(AuditRotationGuard::Session(lock));
     }
-    AuditSession::new(connections::get_audit_log_path(app))
+    // `suspend_for_rotation` clears the degradation reason before it discovers
+    // there is no session to suspend, so bailing out here would leave the vault
+    // unlocked, auditing inactive, and nothing left to say why — the Activity
+    // panel would show "unknown reason" after a password change it refused to
+    // make. The acquisition error is the live reason, so record that.
+    AuditSession::new(log_path)
         .acquire_retained_lock()
         .map(AuditRotationGuard::LockOnly)
+        .map_err(|e| {
+            set_degraded(state, Some(e.clone()));
+            e
+        })
 }
 
 pub fn suspend_for_rotation(state: &AppState) -> Option<RetainedLock> {
@@ -327,5 +345,93 @@ mod retention_tests {
         assert_eq!(clamp_retention_days(30), 30);
         let cutoff = retention_cutoff_ms(1, 86_400_000 * 10);
         assert_eq!(cutoff, 86_400_000 * 9);
+    }
+}
+
+#[cfg(test)]
+mod rotation_lock_tests {
+    use super::*;
+    use crate::audit::envelope::AuditPolicy;
+    use crate::audit::level::AuditLevel;
+    use tempfile::tempdir;
+
+    const KEY: [u8; 32] = [9u8; 32];
+
+    fn policy() -> AuditPolicy {
+        AuditPolicy {
+            enabled: true,
+            level: AuditLevel::C,
+            include_payloads: false,
+            retention_days: 30,
+        }
+    }
+
+    #[test]
+    fn a_suspended_session_hands_its_own_lock_through() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.log.enc");
+        let state = AppState::new();
+        let session = AuditSession::new(path.clone());
+        session.open(KEY).expect("open");
+        session.set_policy(policy());
+        *state.audit.lock().unwrap() = Some(session);
+
+        match hold_for_rotation_at(&state, path) {
+            Ok(AuditRotationGuard::Session(_)) => {}
+            other => panic!("expected the session's lock to be carried through: {:?}", other.is_ok()),
+        }
+        assert!(
+            state.audit.lock().unwrap().is_none(),
+            "the session must be suspended for the rotation"
+        );
+    }
+
+    #[test]
+    fn no_session_takes_the_lock_purely_for_exclusion() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.log.enc");
+        let state = AppState::new();
+
+        match hold_for_rotation_at(&state, path) {
+            Ok(AuditRotationGuard::LockOnly(_)) => {}
+            other => panic!("expected a lock-only guard: {:?}", other.is_ok()),
+        }
+        assert!(
+            degraded_reason(&state).is_none(),
+            "taking the lock successfully is not a degraded state"
+        );
+    }
+
+    #[test]
+    fn a_refused_rotation_still_explains_why_auditing_is_inactive() {
+        // `suspend_for_rotation` clears the degradation reason before it finds
+        // there is no session, so without care a refused password change leaves
+        // the Activity panel saying "inactive" with nothing to show for it.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("audit.log.enc");
+
+        // Another instance owns the log.
+        let owner = AuditSession::new(path.clone());
+        owner.open(KEY).expect("owner opens");
+
+        let state = AppState::new();
+        set_degraded(&state, Some("an earlier reason".into()));
+
+        let err = hold_for_rotation_at(&state, path.clone())
+            .err()
+            .expect("must refuse while another instance holds the log");
+        assert!(
+            err.contains("another MQLens instance"),
+            "the error should name the cause: {err}"
+        );
+        assert_eq!(
+            degraded_reason(&state).as_deref(),
+            Some(err.as_str()),
+            "the live reason must survive the refusal"
+        );
+
+        // And once the other instance lets go, rotation can proceed.
+        owner.close();
+        assert!(hold_for_rotation_at(&state, path).is_ok());
     }
 }

--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -144,6 +144,36 @@ fn open_on_unlock_inner(
 /// Releasing it would let a second instance take the log and append under the
 /// old key while rotation swaps in the new-key file — on Unix that second
 /// process keeps writing to the unlinked old inode, so those events vanish.
+/// What a key rotation is holding on the audit log while it runs.
+pub enum AuditRotationGuard {
+    /// A session was suspended; its lock is carried through and the session is
+    /// reopened afterwards.
+    Session(RetainedLock),
+    /// There was no session to suspend, so the lock was taken purely to keep
+    /// other instances off the files. Released afterwards, and whether auditing
+    /// then reopens is decided by the settings as usual.
+    LockOnly(RetainedLock),
+}
+
+/// Hold the audit log for the duration of a key rotation.
+///
+/// Rotation rewrites `audit.log.enc` and its state sidecar, so it must exclude
+/// other instances whether or not *this* one is recording. When another instance
+/// owns the log this fails, and rotation must abort: rewriting the vault metadata
+/// while that instance keeps appending under the old key leaves activity history
+/// no password can open.
+pub fn hold_for_rotation(
+    app: &tauri::AppHandle,
+    state: &AppState,
+) -> Result<AuditRotationGuard, String> {
+    if let Some(lock) = suspend_for_rotation(state) {
+        return Ok(AuditRotationGuard::Session(lock));
+    }
+    AuditSession::new(connections::get_audit_log_path(app))
+        .acquire_retained_lock()
+        .map(AuditRotationGuard::LockOnly)
+}
+
 pub fn suspend_for_rotation(state: &AppState) -> Option<RetainedLock> {
     set_degraded(state, None);
     let mut slot = state.audit.lock_safe().ok()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2425,7 +2425,14 @@ async fn vault_change_password(
     // second instance take the log and append under the old key mid-rotation.
     // Everything fallible after this point runs inside `rotate`, so a failure
     // can reopen the session instead of leaving the app running unaudited.
-    let retained_audit_lock = audit::suspend_for_rotation(&state);
+    //
+    // Taken even when there is no session to suspend. `rotate` rewrites the log
+    // and its state sidecar either way, and without the lock an instance that
+    // *does* own the log keeps appending under the old key while its next state
+    // write lands on top of the rotated sidecar — leaving history that
+    // authenticates against neither password. If the lock cannot be taken the
+    // whole change aborts here, before any vault file is touched.
+    let audit_guard = audit::hold_for_rotation(&app_handle, &state)?;
 
     let rotate = || -> Result<(), String> {
         // Prepare every re-encrypted payload before overwriting any vault file:
@@ -2454,11 +2461,16 @@ async fn vault_change_password(
     // Reopen with the retained lock either way — on failure under `old_key`,
     // which is still the live vault key because it is only swapped below.
     let reopen_key = if rotated.is_ok() { new_key } else { old_key };
-    match retained_audit_lock {
-        Some(lock) => {
+    match audit_guard {
+        // There was a session: hand the same lock back so it never leaves this
+        // instance's hands.
+        audit::AuditRotationGuard::Session(lock) => {
             let _ = audit::resume_after_rotation(&app_handle, &state, reopen_key, lock);
         }
-        None => {
+        // There was none: release the lock first, then let the settings decide
+        // whether auditing opens — the same path as any other unlock.
+        audit::AuditRotationGuard::LockOnly(lock) => {
+            drop(lock);
             let _ = audit::open_on_unlock(&app_handle, &state, reopen_key);
         }
     }


### PR DESCRIPTION
Both P1 findings from the review of #305. I verified each against the code before changing anything — both are real.

## 1. A failed append left the log ahead of its own counter

`append` advances `seq`/`head` only *after* the fsync. So a `write_all` that errored partway, or a `sync_data` that failed after the bytes reached the platter, returned `Err` with **bytes in the file and the counter unchanged**.

The next append then encoded with the same `open.seq + 1`, seeked to `End(0)` — now past the leftovers — and wrote there. On the next load that reads back as either a duplicate sequence / failed authentication (log sealed) or a torn tail (every good record after it discarded). One failed write became a log that won't open.

`append` now captures the length before the frame and unwinds to it if either step fails:

- **`sync_data` failure is ambiguous** — the bytes may or may not have landed — so the frame is *removed* rather than kept. The call already reports the event as unrecorded, and a file matching its counter is worth more than a record nobody was told about.
- **If the unwind itself fails** there's no safe state left, so the session is sealed rather than permitted to append again.

## 2. Key rotation rewrote the audit files with no lock

`suspend_for_rotation` returns `None` when this instance has no `AuditSession` — auditing off, *or another instance already owns the log*. In that second case `vault_change_password` went on to read and replace `audit.log.enc` and its state sidecar **holding no lock at all**. The owning instance kept appending under the old key, and its next state write landed on top of the rotated sidecar, leaving history that authenticates against neither password.

`hold_for_rotation` now takes the lock either way and returns which case it is:

| Case | Behaviour |
|---|---|
| Session suspended | its lock is carried through, session reopened after — unchanged |
| No session | lock taken purely for exclusion, released after; the settings then decide whether auditing reopens — unchanged |
| Lock unavailable | **rotation aborts**, before any vault file is touched |

Aborting is the only safe option: rotating the metadata while another instance appends under the old key leaves activity history no password can open. The error names the cause ("another MQLens instance is already recording to the activity log").

## Tests

Three added, and I checked they discriminate rather than assuming:

- **the hazard** — a leftover tail followed by a normal append does *not* read back as a healthy log
- **the unwind** — restores the previous length, doesn't seal, and the session stays usable with the sequence the failed append never consumed. Neutralising the unwind fails this test:
  ```
  panicked at src/audit/log.rs:1359: assertion `left == right` failed: the partial frame must be gone
  ```
- **the rotation lock** — excludes a second instance with a message explaining why, and becomes available once the first releases

## Verification

`cargo build` warning-free, **715 tests pass** (712 + 3).

Worth noting for #305: these are pre-existing defects in the audit feature that shipped in this release train, not regressions introduced by it — so this wants to land on `dev` and be included before the release PR merges.