### PR TITLE
fix(query): run regex queries carrying a /g flag instead of rejecting them

### DIFF
--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -67,6 +67,11 @@ import { defineConfig } from 'i18next-cli';
  * `t(updateCheckResultLabel(updateCheck.result))` in SettingsModal.tsx — the
  * key comes from a function's return value, not a string literal the
  * extractor's static analysis can see.
+ *
+ * `documents:documentViewer.errors.unsupportedRegexFlag` is the same story as
+ * its two siblings at the end of the list: reached through `shellDocErrorKey`,
+ * with its `{{flag}}` filled in from `shellDocErrorParams`. Any future
+ * ShellDocErrorCode needs an entry here too, or extraction prunes it.
  */
 export default defineConfig({
   locales: ['en'],
@@ -275,6 +280,7 @@ export default defineConfig({
       // wrapper.
       'documents:documentViewer.errors.invalidQuery',
       'documents:documentViewer.errors.queryMustBeObject',
+      'documents:documentViewer.errors.unsupportedRegexFlag',
     ],
   },
 });

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -5,7 +5,7 @@ import { QueryEditor } from './QueryEditor';
 import { FindQueryBar } from './FindQueryBar';
 import { useCollectionSchema } from '../lib/useCollectionSchema';
 import { collectionRef, type GeneratedQuery } from '../lib/mongoCommand';
-import { parseShellJson, parseQueryObject, shellDocErrorKey, type ShellDocNotices } from '../lib/shellDoc';
+import { parseShellJson, parseQueryObject, shellDocErrorKey, shellDocErrorParams, type ShellDocNotices } from '../lib/shellDoc';
 import {
   loadCollectionQueries,
   saveQuery,
@@ -793,7 +793,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         // Our own parse failures carry a code and get a translated message;
         // errors from the underlying parser only have an English message.
         shellDocErrorKey(e)
-          ? td(shellDocErrorKey(e)!)
+          ? td(shellDocErrorKey(e)!, shellDocErrorParams(e))
           : td('documentViewer.errors.invalidJsonSyntax', { message: e.message }),
       );
     }
@@ -935,7 +935,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       // the Run and Explain paths follow.
       const key = shellDocErrorKey(err);
       setFilterError(
-        key ? td(key) : err instanceof Error ? err.message : String(err)
+        key ? td(key, shellDocErrorParams(err)) : err instanceof Error ? err.message : String(err)
       );
     }
     // `td` too: switching the interface language re-renders this component but
@@ -1362,7 +1362,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
         // Our own parse failures carry a code and get a translated message;
         // errors from the underlying parser only have an English message.
         shellDocErrorKey(e)
-          ? td(shellDocErrorKey(e)!)
+          ? td(shellDocErrorKey(e)!, shellDocErrorParams(e))
           : td('documentViewer.errors.invalidJsonSyntax', { message: e.message }),
       );
     }
@@ -1433,7 +1433,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       // `disabled` guard, only the trigger does — so this path has to map our
       // own parse errors to a translated message like the two above it.
       const key = shellDocErrorKey(e);
-      setError(key ? td(key) : e.message || String(e));
+      setError(key ? td(key, shellDocErrorParams(e)) : e.message || String(e));
     } finally {
       setExplainLoading(false);
     }

--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -5,7 +5,7 @@ import { QueryEditor } from './QueryEditor';
 import { FindQueryBar } from './FindQueryBar';
 import { useCollectionSchema } from '../lib/useCollectionSchema';
 import { collectionRef, type GeneratedQuery } from '../lib/mongoCommand';
-import { parseShellJson, parseQueryObject, shellDocErrorKey } from '../lib/shellDoc';
+import { parseShellJson, parseQueryObject, shellDocErrorKey, type ShellDocNotices } from '../lib/shellDoc';
 import {
   loadCollectionQueries,
   saveQuery,
@@ -904,19 +904,32 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
 
   // The reason, not just the fact. A query that fails on a character the user
   // cannot see — a smart quote, a zero-width space pasted in from a browser —
-  // reads as correct on screen, and a bare "Invalid JSON" gives them nothing
+  // reads as correct on screen, and a bare "Invalid query" gives them nothing
   // to act on.
   const [filterError, setFilterError] = useState<string | null>(null);
+  // The query is fine and will run, but it does not mean quite what it says —
+  // a regex flag BSON cannot carry was dropped on the way to the server. Kept
+  // separate from `filterError` so it never blocks Run.
+  const [filterNotice, setFilterNotice] = useState<string | null>(null);
 
   useEffect(() => {
     try {
+      const notices: ShellDocNotices = { droppedRegexFlags: [] };
       if (filterQuery.trim()) {
-        parseQueryObject(filterQuery);
+        parseQueryObject(filterQuery, notices);
       }
       setIsFilterValid(true);
       setFilterError(null);
+      setFilterNotice(
+        notices.droppedRegexFlags.length
+          ? td('documentViewer.notices.regexFlagsIgnored', {
+              flags: notices.droppedRegexFlags.join(', '),
+            })
+          : null
+      );
     } catch (err) {
       setIsFilterValid(false);
+      setFilterNotice(null);
       // Our own parse failures carry a code and have a translated message;
       // only the underlying parser's errors are stuck in English. Same rule
       // the Run and Explain paths follow.
@@ -1851,6 +1864,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
                 }}
                 filterInvalid={!isFilterValid}
                 filterError={filterError}
+                filterNotice={filterNotice}
                 projectionInvalid={!isProjectionValid}
                 sortInvalid={!isSortValid}
                 fields={fields}

--- a/src/components/FindQueryBar.tsx
+++ b/src/components/FindQueryBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertCircle, ArrowUpDown, ChevronDown, ChevronRight, Eraser } from 'lucide-react';
+import { AlertCircle, AlertTriangle, ArrowUpDown, ChevronDown, ChevronRight, Eraser } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
@@ -21,14 +21,19 @@ export interface FindQueryBarProps {
   onFilterChange: (v: string) => void;
   onProjectionChange: (v: string) => void;
   onSortChange: (v: string) => void;
-  /** Mark a field's cell invalid (shows the destructive ring + "Invalid JSON"). */
+  /** Mark a field's cell invalid (shows the destructive ring + "Invalid query"). */
   filterInvalid?: boolean;
   projectionInvalid?: boolean;
   sortInvalid?: boolean;
   /** Why the filter would not parse. Shown on hover over the badge — the badge
-   *  itself has no room for it, and "Invalid JSON" on its own leaves a user
+   *  itself has no room for it, and "Invalid query" on its own leaves a user
    *  staring at a query that looks perfectly correct. */
   filterError?: string | null;
+  /** The filter parses and will run, but it had to be changed to be expressible
+   *  as BSON (a dropped regex flag). Advisory, never blocking — it renders as a
+   *  warning badge instead of the destructive one, and only when the filter is
+   *  otherwise valid. */
+  filterNotice?: string | null;
   fields: string[];
   schema?: SchemaMap;
   /** Emit mongosh-style completions (bare keys + ISODate()/ObjectId()) instead
@@ -88,6 +93,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
   onSortChange,
   filterInvalid = false,
   filterError,
+  filterNotice,
   projectionInvalid = false,
   sortInvalid = false,
   fields,
@@ -184,10 +190,22 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
       // look for its text.
       data-testid="query-invalid-badge"
     >
-      <AlertCircle size={10} /> {t('findQueryBar.errors.invalidJson')}
+      <AlertCircle size={10} /> {t('findQueryBar.errors.invalidQuery')}
     </span>
   );
   const invalidBadge = badge();
+
+  // Advisory sibling of `badge`: the query runs, so this is warning-coloured
+  // rather than destructive, and the detail lives in the tooltip the same way.
+  const noticeBadge = (message: string) => (
+    <span
+      className="inline-flex shrink-0 items-center gap-1 pr-1.5 font-mono text-[10px] text-warning whitespace-nowrap"
+      title={message}
+      data-testid="query-notice-badge"
+    >
+      <AlertTriangle size={10} /> {t('findQueryBar.notices.flagIgnored')}
+    </span>
+  );
 
   return (
     <div className="flex flex-col border-b border-border bg-muted/20">
@@ -212,7 +230,7 @@ export const FindQueryBar: React.FC<FindQueryBarProps> = ({
             schema={schema}
             data-testid="query-filter-input"
           />
-          {filterInvalid && badge(filterError)}
+          {filterInvalid ? badge(filterError) : filterNotice ? noticeBadge(filterNotice) : null}
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -159,7 +159,7 @@ describe('DocumentViewer Component', () => {
 
   it('accepts a query pasted with smart quotes, and says why when one will not parse', async () => {
     // The bug: a query copied out of a browser or a chat arrives with `“ ”`,
-    // which reads as correct on screen and was rejected as "Invalid JSON" with
+    // which reads as correct on screen and was rejected as "Invalid query" with
     // no reason given.
     render(
       <DocumentViewer
@@ -175,21 +175,58 @@ describe('DocumentViewer Component', () => {
     const filterInput = screen.getByTestId('query-filter-input');
     fireEvent.change(filterInput, { target: { value: 'domain: “account.test.com”' } });
     await waitFor(() => {
-      expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument();
+      expect(screen.queryByText('Invalid query')).not.toBeInTheDocument();
     });
 
     // And when something really is wrong, the badge carries the reason.
     fireEvent.change(filterInput, { target: { value: '{invalid' } });
-    const badge = await screen.findByText('Invalid JSON');
+    const badge = await screen.findByText('Invalid query');
     await waitFor(() => expect(badge.getAttribute('title')).toBeTruthy());
 
     // Our own failures have a translated message; only the parser's are stuck
     // in English. A bare `5` is not a query object.
     fireEvent.change(filterInput, { target: { value: '5' } });
     await waitFor(() =>
-      expect(screen.getByText('Invalid JSON').getAttribute('title')).not.toBe(
+      expect(screen.getByText('Invalid query').getAttribute('title')).not.toBe(
         'Query must be an object'
       )
+    );
+  });
+
+  it('runs a /g regex query and says the flag was ignored (#312)', async () => {
+    // The bug: `{"name": /test/g}` was rejected outright, and the badge said
+    // "Invalid JSON" — so the reporter concluded regex was unsupported. It runs
+    // now; `g` just cannot survive the trip to BSON, and the bar says so.
+    render(
+      <DocumentViewer
+        connectionName="test-conn"
+        databaseName="test-db"
+        collectionName="test-coll"
+        onExecute={mockOnExecute}
+        onExplain={mockOnExplain}
+        loading={false}
+      />
+    );
+
+    const filterInput = screen.getByTestId('query-filter-input');
+    fireEvent.change(filterInput, { target: { value: '{"name": /test/g}' } });
+
+    // Advisory, not an error: the query stays valid and Run stays enabled.
+    const notice = await screen.findByTestId('query-notice-badge');
+    expect(notice.getAttribute('title')).toContain('g');
+    expect(screen.queryByTestId('query-invalid-badge')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(mockOnExecute).toHaveBeenCalled());
+    const [{ filter }] = mockOnExecute.mock.calls.at(-1)!;
+    expect(JSON.parse(filter)).toEqual({
+      name: { $regularExpression: { pattern: 'test', options: '' } },
+    });
+
+    // A regex with only supported flags draws no notice at all.
+    fireEvent.change(filterInput, { target: { value: '{"name": /test/i}' } });
+    await waitFor(() =>
+      expect(screen.queryByTestId('query-notice-badge')).not.toBeInTheDocument()
     );
   });
 
@@ -210,13 +247,13 @@ describe('DocumentViewer Component', () => {
     // Type invalid JSON
     fireEvent.change(filterInput, { target: { value: '{invalid' } });
     await waitFor(() => {
-      expect(screen.getByText('Invalid JSON')).toBeInTheDocument();
+      expect(screen.getByText('Invalid query')).toBeInTheDocument();
     });
 
     // Fix to valid JSON
     fireEvent.change(filterInput, { target: { value: '{"key": "value"}' } });
     await waitFor(() => {
-      expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument();
+      expect(screen.queryByText('Invalid query')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/__tests__/ExportView.test.tsx
+++ b/src/components/__tests__/ExportView.test.tsx
@@ -273,7 +273,7 @@ describe('ExportView', () => {
       target: { value: '{bad' },
     });
     expect(screen.getByTestId('export-filtered-btn')).toBeDisabled();
-    expect(screen.getAllByText('Invalid JSON').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Invalid query').length).toBeGreaterThan(0);
   });
 
   it('counts matches only when the Count button is clicked', async () => {

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ObjectId, Long, Decimal128, Int32 } from 'bson';
-import { docToShell, shellToEjson, parseShellJson, parseQueryObject, type ShellDocNotices } from '../shellDoc';
+import { docToShell, shellToEjson, parseShellJson, parseQueryObject, shellDocErrorKey, shellDocErrorParams, type ShellDocNotices } from '../shellDoc';
 
 describe('docToShell', () => {
   it('renders EJSON-shaped values as shell constructors', () => {
@@ -306,10 +306,57 @@ describe('parseShellJson — regex flags BSON cannot carry (#312)', () => {
     expect(flagsOf('{"name": /test/g}')).not.toContain('s');
   });
 
-  it('reports every unsupported flag it removed', () => {
-    const notices: ShellDocNotices = { droppedRegexFlags: [] };
-    expect(flagsOf('{"name": /test/gy}', notices)).toBe('');
-    expect(notices.droppedRegexFlags).toEqual(['g', 'y']);
+  it('rejects sticky rather than silently widening the query (#315 review)', () => {
+    // `/foo/y` only matches at position 0, so reconstructing `/foo/` would run
+    // a BROADER query than the user wrote. Quietly widening a filter is the
+    // failure this path exists to avoid, so it refuses instead of guessing.
+    expect(() => parseShellJson('{"name": /test/y}')).toThrow(/\[y\]/);
+    expect(() => parseShellJson('{"name": /test/gy}')).toThrow(/\[y\]/);
+  });
+
+  it('surfaces the flag it rejected as a translatable code, not a raw message', () => {
+    try {
+      parseShellJson('{"name": /test/y}');
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(shellDocErrorKey(err)).toBe('documentViewer.errors.unsupportedRegexFlag');
+      expect(shellDocErrorParams(err)).toEqual({ flag: 'y' });
+    }
+  });
+
+  it('keeps the flag diagnosis through the braceless-retry path', () => {
+    // `name: /a/y` only parses on the wrapped retry, so the original "not an
+    // expression" error would otherwise mask the real reason.
+    expect(() => parseShellJson('name: /a/y')).toThrow(/\[y\]/);
+  });
+
+  it('rejects `d` and `v` at the parser, before flag handling is reached', () => {
+    // Documents why DROPPABLE_REGEX_FLAGS lists `d` even though nothing can
+    // exercise it: the parser's regex lexer refuses both flags outright. If a
+    // parser upgrade ever makes these reachable, this test fails and the flag
+    // policy above gets a deliberate second look rather than silently applying.
+    expect(() => parseShellJson('{"name": /test/d}')).toThrow(/Invalid regular expression flag/);
+    expect(() => parseShellJson('{"name": /test/v}')).toThrow(/Invalid regular expression flag/);
+  });
+
+  it('does not mistake a user field named _bsontype for a BSON value (#315 review)', () => {
+    // A document may legally contain a field called `_bsontype`, and treating
+    // any truthy value there as a BSON scalar made the walker skip the subtree.
+    // Narrowing the check to real BSON type tags is the correct reading either
+    // way — but note the reviewer's predicted symptom does NOT reproduce:
+    // EJSON refuses any plain object carrying a `_bsontype` field at all, with
+    // a version error, whether or not a regex is nested under it. So such a
+    // query fails identically before and after this change; the walker's early
+    // return was never what broke it. That EJSON limitation is pre-existing and
+    // separate from regex flags.
+    expect(() => parseShellJson('{meta: {_bsontype: "custom", name: /test/g}}')).toThrow(
+      /BSON version|bson types must be/
+    );
+    // What the narrowed check does buy: the walker no longer treats it as an
+    // opaque leaf, so a genuine BSON value beside it is still handled normally.
+    const parsed = parseShellJson('{_id: ObjectId("603d1f77bcf86cd799439011"), r: /a/g}');
+    expect(parsed._id.$oid).toBe('603d1f77bcf86cd799439011');
+    expect(parsed.r.$regularExpression.options).toBe('');
   });
 
   it('leaves flags MongoDB does support alone, and reports nothing', () => {

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ObjectId, Long, Decimal128, Int32 } from 'bson';
-import { docToShell, shellToEjson, parseShellJson, parseQueryObject } from '../shellDoc';
+import { docToShell, shellToEjson, parseShellJson, parseQueryObject, type ShellDocNotices } from '../shellDoc';
 
 describe('docToShell', () => {
   it('renders EJSON-shaped values as shell constructors', () => {
@@ -276,5 +276,80 @@ describe('parseShellJson — queries pasted from somewhere else', () => {
 
   it('keeps a straight quote found inside a smart-quoted run', () => {
     expect(parseShellJson('q: “say "hi"”')).toEqual({ q: 'say "hi"' });
+  });
+});
+
+// #312: `{"name": /test/g}` failed the whole find with "The regular expression
+// option [g] is not supported", which the query bar showed as "Invalid JSON" —
+// so the reporter concluded MQLens had no regex support at all.
+describe('parseShellJson — regex flags BSON cannot carry (#312)', () => {
+  const flagsOf = (text: string, notices?: ShellDocNotices) =>
+    parseShellJson(text, notices).name.$regularExpression.options;
+
+  it('runs a /g query instead of rejecting it, and drops the flag', () => {
+    const notices: ShellDocNotices = { droppedRegexFlags: [] };
+    expect(flagsOf('{"name": /test/g}', notices)).toBe('');
+    expect(notices.droppedRegexFlags).toEqual(['g']);
+  });
+
+  it('drops only the unsupported flag, keeping the rest of the pattern intact', () => {
+    const notices: ShellDocNotices = { droppedRegexFlags: [] };
+    const parsed = parseShellJson('{"name": /^a.c$/gi}', notices);
+    expect(parsed.name.$regularExpression).toEqual({ pattern: '^a.c$', options: 'i' });
+    expect(notices.droppedRegexFlags).toEqual(['g']);
+  });
+
+  it('drops `g` rather than translating it to `s` the way the driver does', () => {
+    // The Node driver (and so mongosh and Compass) serializes a native RegExp
+    // by mapping `global` onto `s` — dotAll — which silently makes `.` match
+    // newlines. Copying that would change which documents the filter matches.
+    expect(flagsOf('{"name": /test/g}')).not.toContain('s');
+  });
+
+  it('reports every unsupported flag it removed', () => {
+    const notices: ShellDocNotices = { droppedRegexFlags: [] };
+    expect(flagsOf('{"name": /test/gy}', notices)).toBe('');
+    expect(notices.droppedRegexFlags).toEqual(['g', 'y']);
+  });
+
+  it('leaves flags MongoDB does support alone, and reports nothing', () => {
+    for (const f of ['i', 'm', 'u', '']) {
+      const notices: ShellDocNotices = { droppedRegexFlags: [] };
+      expect(flagsOf(`{"name": /test/${f}}`, notices)).toBe(f);
+      expect(notices.droppedRegexFlags).toEqual([]);
+    }
+  });
+
+  it('reaches a regex nested in an operator and in an array', () => {
+    const notices: ShellDocNotices = { droppedRegexFlags: [] };
+    const parsed = parseShellJson('{tags: {$in: [/a/g, "b"]}}', notices);
+    expect(parsed.tags.$in[0].$regularExpression.options).toBe('');
+    expect(parsed.tags.$in[1]).toBe('b');
+    expect(notices.droppedRegexFlags).toEqual(['g']);
+  });
+
+  it('normalises through the braceless-retry path too', () => {
+    // `name: /test/g` is not a valid standalone expression, so it only parses
+    // on the wrapped retry — which re-parses from scratch and must still report.
+    const notices: ShellDocNotices = { droppedRegexFlags: [] };
+    expect(flagsOf('name: /test/g', notices)).toBe('');
+    expect(notices.droppedRegexFlags).toEqual(['g']);
+  });
+
+  it('leaves other BSON types untouched while normalising', () => {
+    // The walker rebuilds plain containers; ObjectId/Date/Long must pass through
+    // by reference, and a Long must still force canonical serialization.
+    const parsed = parseShellJson(
+      '{_id: ObjectId("603d1f77bcf86cd799439011"), n: NumberLong("9007199254740993"), r: /x/g}'
+    );
+    expect(parsed._id.$oid).toBe('603d1f77bcf86cd799439011');
+    expect(parsed.n.$numberLong).toBe('9007199254740993');
+    expect(parsed.r.$regularExpression.options).toBe('');
+  });
+
+  it('reports nothing for a query that was rejected', () => {
+    const notices: ShellDocNotices = { droppedRegexFlags: [] };
+    expect(() => parseQueryObject('[/a/g]', notices)).toThrow();
+    expect(notices.droppedRegexFlags).toEqual([]);
   });
 });

--- a/src/lib/i18n/__tests__/coverage.test.ts
+++ b/src/lib/i18n/__tests__/coverage.test.ts
@@ -324,6 +324,15 @@ const EXEMPT_HITS: Record<string, string[]> = {
     'label: "Double"',
     'label: "Binary"',
   ],
+  'src/lib/shellDoc.ts': [
+    // ShellDocError messages are deliberately English: they are what lands in
+    // logs and stack traces, and the UI never shows them. Each error instead
+    // carries a stable `code` (plus interpolation params) that the query bar
+    // maps to a catalog key via shellDocErrorKey/shellDocErrorParams — see the
+    // ShellDocErrorCode doc comment. The catalog value is
+    // documents:documentViewer.errors.unsupportedRegexFlag.
+    'MongoDB does not support the regular expression flag [${unsafe}]',
+  ],
   'src/lib/clusterHealth.ts': [
     // A backtick-quoted `new URL` inside a JSDoc comment, read as a template
     // literal — the comment blindness this file's header warns about.

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -105,9 +105,40 @@ function containsLong(v: any): boolean {
   return Object.values(v).some(containsLong);
 }
 
-// Regex options MongoDB understands. JavaScript accepts several more — `g`,
-// `y`, and the newer `d`/`v` — that have no BSON representation at all.
+// Regex options MongoDB understands, passed through untouched.
 const BSON_REGEX_FLAGS = 'imxlsu';
+
+// JS-only flags that cannot change which documents match, so dropping them is
+// safe. `g` ("keep scanning after the first hit") and `d` (capture-index
+// metadata) both describe how a JS engine walks a string, not what the pattern
+// accepts — the set of strings the regex matches is identical without them.
+//
+// Every other JS-only flag is NOT safe to drop, and is rejected below instead.
+// `y` (sticky) anchors the match at lastIndex, so a fresh `/foo/y` matches only
+// at position 0 while the reconstructed `/foo/` matches anywhere — silently
+// running a BROADER query than the user wrote. `v` (unicodeSets) changes how
+// character classes parse, so removing it can reinterpret the pattern outright.
+// Quietly widening a filter is the failure mode this whole path exists to
+// avoid, so where the semantics cannot be preserved we refuse rather than
+// guess. Rejecting is no worse than before: these already failed, just with a
+// BSON error nobody could act on.
+//
+// Of these only `y` is reachable today — the parser's own regex lexer rejects
+// `d` and `v` as invalid flags before we ever see them. They are listed anyway
+// so that a parser upgrade cannot silently turn `d` into a rejection or `v`
+// into a semantics change.
+const DROPPABLE_REGEX_FLAGS = 'gd';
+
+// Real BSON instances, by their `_bsontype` tag. Checked against this set
+// rather than for any truthy `_bsontype`, because a user's own document may
+// legitimately contain a field called `_bsontype` — `{meta: {_bsontype: "x",
+// name: /a/g}}` would otherwise be mistaken for a BSON scalar and skipped,
+// leaving the nested regex unnormalised for EJSON to reject. (UUID reports as
+// Binary, which it subclasses.)
+const BSON_TYPE_NAMES = new Set([
+  'Binary', 'BSONRegExp', 'BSONSymbol', 'Code', 'DBRef', 'Decimal128',
+  'Double', 'Int32', 'Long', 'MaxKey', 'MinKey', 'ObjectId', 'Timestamp',
+]);
 
 /**
  * Drop regex flags BSON cannot carry, reporting which ones went.
@@ -141,13 +172,26 @@ function normalizeRegexFlags(v: any, dropped: Set<string>): any {
     const flags: unknown = (v as RegExp).flags;
     // No flag string to reason about — leave it exactly as it is.
     if (typeof flags !== 'string') return v;
+    const unsafe = [...flags].find(
+      (f) => !BSON_REGEX_FLAGS.includes(f) && !DROPPABLE_REGEX_FLAGS.includes(f)
+    );
+    if (unsafe) {
+      throw new ShellDocError(
+        'unsupportedRegexFlag',
+        `MongoDB does not support the regular expression flag [${unsafe}]`,
+        { flag: unsafe }
+      );
+    }
     const kept = [...flags].filter((f) => BSON_REGEX_FLAGS.includes(f)).join('');
     if (kept === flags) return v;
     for (const f of flags) if (!kept.includes(f)) dropped.add(f);
     // `kept` is a subset of flags JS already accepted, so this cannot throw.
     return new RegExp((v as RegExp).source, kept);
   }
-  if (tag === '[object Date]' || (v as { _bsontype?: string })._bsontype) return v;
+  const bsontype: unknown = (v as { _bsontype?: unknown })._bsontype;
+  if (tag === '[object Date]' || (typeof bsontype === 'string' && BSON_TYPE_NAMES.has(bsontype))) {
+    return v;
+  }
   if (Array.isArray(v)) {
     let changed = false;
     const out = v.map((item) => {
@@ -193,14 +237,20 @@ function serializeQuery(v: any, dropped: Set<string>): any {
  * come from the underlying parser carry no code and still fall back to their
  * own message, which no amount of work here can localise.
  */
-export type ShellDocErrorCode = 'invalidQuery' | 'queryMustBeObject';
+export type ShellDocErrorCode =
+  | 'invalidQuery'
+  | 'queryMustBeObject'
+  | 'unsupportedRegexFlag';
 
 export class ShellDocError extends SyntaxError {
   readonly code: ShellDocErrorCode;
-  constructor(code: ShellDocErrorCode, message: string) {
+  /** Interpolation values for the translated message, e.g. `{ flag: 'y' }`. */
+  readonly params?: Record<string, string>;
+  constructor(code: ShellDocErrorCode, message: string, params?: Record<string, string>) {
     super(message);
     this.name = 'ShellDocError';
     this.code = code;
+    this.params = params;
   }
 }
 
@@ -209,7 +259,13 @@ export function shellDocErrorKey(err: unknown): string | null {
   const code = (err as ShellDocError | undefined)?.code;
   if (code === 'invalidQuery') return 'documentViewer.errors.invalidQuery';
   if (code === 'queryMustBeObject') return 'documentViewer.errors.queryMustBeObject';
+  if (code === 'unsupportedRegexFlag') return 'documentViewer.errors.unsupportedRegexFlag';
   return null;
+}
+
+/** Interpolation values to pass alongside `shellDocErrorKey`, if any. */
+export function shellDocErrorParams(err: unknown): Record<string, string> | undefined {
+  return (err as ShellDocError | undefined)?.params;
 }
 
 /**
@@ -465,8 +521,18 @@ export function parseShellJson(text: string, notices?: ShellDocNotices): any {
         const out = serializeQuery(attempt(`{${trimmed}}`), dropped);
         commit();
         return out;
-      } catch {
-        /* fall through to re-throw the original error */
+      } catch (retryErr) {
+        // The wrapped retry got further than the original attempt: it parsed,
+        // and failed only because the value cannot be represented in BSON.
+        // That is the diagnosis worth showing — re-throwing the original
+        // "not a valid expression" error would hide the real reason.
+        if (
+          retryErr instanceof ShellDocError &&
+          retryErr.code === 'unsupportedRegexFlag'
+        ) {
+          throw retryErr;
+        }
+        /* otherwise fall through to re-throw the original error */
       }
     }
     throw err;

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -104,8 +104,83 @@ function containsLong(v: any): boolean {
   if (Array.isArray(v)) return v.some(containsLong);
   return Object.values(v).some(containsLong);
 }
-function serializeQuery(v: any): any {
-  return EJSON.serialize(v, { relaxed: !containsLong(v) });
+
+// Regex options MongoDB understands. JavaScript accepts several more — `g`,
+// `y`, and the newer `d`/`v` — that have no BSON representation at all.
+const BSON_REGEX_FLAGS = 'imxlsu';
+
+/**
+ * Drop regex flags BSON cannot carry, reporting which ones went.
+ *
+ * `{name: /test/g}` is the query a user brings over from mongosh or Compass,
+ * and it used to fail the whole find with "The regular expression option [g]
+ * is not supported" — thrown by EJSON, the only strict validator in the stack.
+ *
+ * Compass runs that query by handing the native RegExp straight to the driver,
+ * whose serializer rewrites `g` to `s` (dotAll). So it runs, but matches by
+ * different rules than it reads — `.` starts crossing newlines — and Compass
+ * then fails to save it to history for exactly the reason we failed here,
+ * swallowing that error into a debug log.
+ *
+ * Neither behaviour is worth copying. `g` means "keep scanning after the first
+ * hit", which is meaningless when the server is selecting documents, so the
+ * flag is dropped rather than translated: the pattern keeps the semantics the
+ * user wrote. The caller gets the dropped flags so the query bar can say so,
+ * instead of the query quietly meaning something else.
+ *
+ * Only plain containers are rebuilt. BSON instances (ObjectId, Long, Binary,
+ * …) and Dates pass through by reference, and an untouched subtree keeps its
+ * original identity, so `containsLong` still walks the same graph.
+ */
+function normalizeRegexFlags(v: any, dropped: Set<string>): any {
+  if (v === null || typeof v !== 'object') return v;
+  // Tag-based, not `instanceof`: the query parser evaluates in a sandbox, so a
+  // value coming back out of it need not share this realm's prototypes.
+  const tag = Object.prototype.toString.call(v);
+  if (tag === '[object RegExp]') {
+    const flags: unknown = (v as RegExp).flags;
+    // No flag string to reason about — leave it exactly as it is.
+    if (typeof flags !== 'string') return v;
+    const kept = [...flags].filter((f) => BSON_REGEX_FLAGS.includes(f)).join('');
+    if (kept === flags) return v;
+    for (const f of flags) if (!kept.includes(f)) dropped.add(f);
+    // `kept` is a subset of flags JS already accepted, so this cannot throw.
+    return new RegExp((v as RegExp).source, kept);
+  }
+  if (tag === '[object Date]' || (v as { _bsontype?: string })._bsontype) return v;
+  if (Array.isArray(v)) {
+    let changed = false;
+    const out = v.map((item) => {
+      const next = normalizeRegexFlags(item, dropped);
+      if (next !== item) changed = true;
+      return next;
+    });
+    return changed ? out : v;
+  }
+  let changed = false;
+  const out: Record<string, unknown> = {};
+  for (const [k, val] of Object.entries(v)) {
+    const next = normalizeRegexFlags(val, dropped);
+    if (next !== val) changed = true;
+    out[k] = next;
+  }
+  return changed ? out : v;
+}
+
+/**
+ * What the parser had to change to make a query expressible as BSON.
+ *
+ * Not errors — the query still runs — but the user is told rather than left
+ * with a filter that means something slightly different from what they typed.
+ */
+export interface ShellDocNotices {
+  /** Regex flags dropped because BSON has no equivalent, e.g. `['g']`. */
+  droppedRegexFlags: string[];
+}
+
+function serializeQuery(v: any, dropped: Set<string>): any {
+  const normalized = normalizeRegexFlags(v, dropped);
+  return EJSON.serialize(normalized, { relaxed: !containsLong(normalized) });
 }
 /**
  * The two parse failures this module raises ITSELF, as stable codes.
@@ -354,7 +429,7 @@ function stripTrailingSemicolons(text: string): string {
   return cut === text.length ? text : text.slice(0, cut);
 }
 
-export function parseShellJson(text: string): any {
+export function parseShellJson(text: string, notices?: ShellDocNotices): any {
   const trimmed = normalizePastedQuery(text).trim();
   if (!trimmed) return {};
   // parseFilter signals "unparseable / not a valid query" by returning an empty
@@ -369,16 +444,27 @@ export function parseShellJson(text: string): any {
     }
     return result;
   };
+  // Collected per attempt: the braceless retry below re-parses from scratch, so
+  // notices from an attempt that then failed must not leak into the result.
+  const dropped = new Set<string>();
+  const commit = () => {
+    if (notices) notices.droppedRegexFlags = [...dropped];
+  };
   try {
-    return serializeQuery(attempt(trimmed));
+    const out = serializeQuery(attempt(trimmed), dropped);
+    commit();
+    return out;
   } catch (err) {
     // A braceless field list like `foo: 1` isn't a valid standalone expression;
     // wrap it into an object and retry. Bare values (a `$count` stage body of
     // `"n"`, a number, an array) parse on the first try, so they never reach
     // here. Anything still unparseable re-throws the original error.
     if (!/^[{[]/.test(trimmed)) {
+      dropped.clear();
       try {
-        return serializeQuery(attempt(`{${trimmed}}`));
+        const out = serializeQuery(attempt(`{${trimmed}}`), dropped);
+        commit();
+        return out;
       } catch {
         /* fall through to re-throw the original error */
       }
@@ -394,9 +480,12 @@ export function parseShellJson(text: string): any {
 // here lets the live validation flag the field and Run stay disabled. Empty
 // input is a valid empty query ({}). Not for aggregation stage bodies, which
 // can legitimately be non-objects (e.g. a `$count` body of "n").
-export function parseQueryObject(text: string): any {
-  const parsed = parseShellJson(text);
+export function parseQueryObject(text: string, notices?: ShellDocNotices): any {
+  const parsed = parseShellJson(text, notices);
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    // The query is rejected, so anything we noticed about it is moot — leaving
+    // it set would caption a filter that never ran.
+    if (notices) notices.droppedRegexFlags = [];
     throw new ShellDocError('queryMustBeObject', 'Query must be an object');
   }
   return parsed;

--- a/src/locales/de/documents.json
+++ b/src/locales/de/documents.json
@@ -118,6 +118,9 @@
       "runDisabled": "Abfragesyntax korrigieren, um sie auszuführen",
       "runPipelineToStage": "Pipeline bis Stufe {{n}} ausführen",
       "undoPipelineChange": "Pipeline-Änderung rückgängig machen"
+    },
+    "notices": {
+      "regexFlagsIgnored": "Das Regex-Flag {{flags}} hat in MongoDB keine Wirkung und wurde ignoriert."
     }
   },
   "findQueryBar": {
@@ -130,7 +133,7 @@
       "sort": "Sortierung"
     },
     "errors": {
-      "invalidJson": "Ungültiges JSON"
+      "invalidQuery": "Ungültige Abfrage"
     },
     "tooltips": {
       "clearFilter": "Filter leeren",
@@ -144,6 +147,9 @@
       "resetLimit": "Limit zurücksetzen",
       "resetSkip": "Skip zurücksetzen",
       "showOptions": "Projektion, Sortierung, Skip und Limit anzeigen"
+    },
+    "notices": {
+      "flagIgnored": "Flag ignoriert"
     }
   },
   "diffModal": {

--- a/src/locales/de/documents.json
+++ b/src/locales/de/documents.json
@@ -74,7 +74,8 @@
     "errors": {
       "invalidJsonSyntax": "Ungültige JSON-Syntax: {{message}}",
       "invalidQuery": "Ungültige Abfrage",
-      "queryMustBeObject": "Die Abfrage muss ein Objekt sein"
+      "queryMustBeObject": "Die Abfrage muss ein Objekt sein",
+      "unsupportedRegexFlag": "MongoDB unterstützt das Regex-Flag {{flag}} nicht."
     },
     "history": {
       "aggregateSummary_one": "aggregate · {{count}} Stufe",

--- a/src/locales/en/documents.json
+++ b/src/locales/en/documents.json
@@ -282,7 +282,8 @@
     "errors": {
       "invalidJsonSyntax": "Invalid JSON syntax: {{message}}",
       "invalidQuery": "Invalid query",
-      "queryMustBeObject": "The query must be an object"
+      "queryMustBeObject": "The query must be an object",
+      "unsupportedRegexFlag": "MongoDB does not support the regex flag {{flag}}."
     },
     "history": {
       "aggregateSummary_one": "aggregate · {{count}} stage",

--- a/src/locales/en/documents.json
+++ b/src/locales/en/documents.json
@@ -289,6 +289,9 @@
       "aggregateSummary_other": "aggregate · {{count}} stages",
       "findSummary": "find · {{filter}}"
     },
+    "notices": {
+      "regexFlagsIgnored": "Regex flag {{flags}} has no effect in MongoDB and was ignored."
+    },
     "pipeline": {
       "stageCount_one": "{{count}} stage",
       "stageCount_other": "{{count}} stages",
@@ -357,7 +360,7 @@
   },
   "findQueryBar": {
     "errors": {
-      "invalidJson": "Invalid JSON"
+      "invalidQuery": "Invalid query"
     },
     "labels": {
       "limit": "Limit",
@@ -366,6 +369,9 @@
       "query": "Query",
       "skip": "Skip",
       "sort": "Sort"
+    },
+    "notices": {
+      "flagIgnored": "Flag ignored"
     },
     "tooltips": {
       "clearFilter": "Clear Filter",

--- a/src/locales/zh-Hans/documents.json
+++ b/src/locales/zh-Hans/documents.json
@@ -269,7 +269,8 @@
     "errors": {
       "invalidJsonSyntax": "JSON 语法无效：{{message}}",
       "invalidQuery": "查询无效",
-      "queryMustBeObject": "查询必须是一个对象"
+      "queryMustBeObject": "查询必须是一个对象",
+      "unsupportedRegexFlag": "MongoDB 不支持正则表达式标志 {{flag}}。"
     },
     "history": {
       "aggregateSummary_other": "聚合 · {{count}} 个阶段",

--- a/src/locales/zh-Hans/documents.json
+++ b/src/locales/zh-Hans/documents.json
@@ -275,6 +275,9 @@
       "aggregateSummary_other": "聚合 · {{count}} 个阶段",
       "findSummary": "查询 · {{filter}}"
     },
+    "notices": {
+      "regexFlagsIgnored": "正则表达式标志 {{flags}} 在 MongoDB 中不起作用，已被忽略。"
+    },
     "pipeline": {
       "stageCount_other": "{{count}} 个阶段",
       "stageGroups": {
@@ -342,7 +345,7 @@
   },
   "findQueryBar": {
     "errors": {
-      "invalidJson": "JSON 无效"
+      "invalidQuery": "查询无效"
     },
     "labels": {
       "limit": "限制",
@@ -351,6 +354,9 @@
       "query": "查询",
       "skip": "跳过",
       "sort": "排序"
+    },
+    "notices": {
+      "flagIgnored": "已忽略标志"
     },
     "tooltips": {
       "clearFilter": "清除筛选条件",


### PR DESCRIPTION
## Summary

`{"name": /test/g}` failed the whole find with `The regular expression option [g] is not supported`, which the query bar showed as **"Invalid JSON"** — so the reporter concluded MQLens had no regex support at all. Regex literals did work (`/test/`, `/test/i`, `/test/m`, `/test/u` all parse today, with tests); only flags BSON cannot carry did not.

`EJSON.serialize` is the one strict flag validator in the stack, and it sees every query because the Tauri IPC boundary is a string.

Worth recording what Compass does, since "Compass can do it" was the premise of the report — both halves verified against the same `mongodb-query-parser@^5.0.1` / `bson@^7.3.2` this repo pins:

- **Run path:** Compass hands the native `RegExp` straight to the driver, and the BSON serializer maps `global` onto `s`. `/test/g` goes on the wire as `{pattern:"test", options:"s"}` — it runs, but `.` now matches newlines, so it matches by different rules than it reads.
- **Save path:** Compass serializes recent queries with `EJSON.stringify` (`my-queries-storage/src/storage-factories.ts`) and throws the *identical* `BSONError`, then swallows it — `catch (e) { debug('Failed to save recent query', e); }`. So the query silently vanishes from history.

Neither behaviour is worth copying. This PR drops flags outside BSON's `imxlsu` before serializing and reports them, so the query runs and the bar says what happened. `g` means "keep scanning after the first hit", which is meaningless when the server is selecting documents — so the flag is dropped rather than translated, and the pattern keeps the semantics the user wrote.

### Changes

- **`src/lib/shellDoc.ts`** — `normalizeRegexFlags` runs before `EJSON.serialize`; new exported `ShellDocNotices` carries the dropped flags out. Committed only on a successful parse, so the braceless-retry path (`name: /test/g`) cannot leak notices from a failed attempt, and `parseQueryObject` clears it when it rejects a non-object.
- **`FindQueryBar.tsx`** — advisory warning badge (`query-notice-badge`), rendered only when the filter is otherwise valid so it never blocks Run. Badge relabelled **"Invalid JSON" → "Invalid query"**: the bar has accepted shell syntax since #216, so the old wording was wrong on its own terms and is what sent this report down the wrong path.
- **`DocumentViewer.tsx`** — collects notices in the existing validation effect, kept separate from `filterError`.
- **Locales** — `en`, `de`, `zh-Hans`.

### Implementation notes

The walker is tag-based (`Object.prototype.toString`) rather than `instanceof`, because the query parser evaluates in a sandbox and values coming out of it need not share this realm's prototypes. It rebuilds only plain containers — ObjectId, Long, Binary and Date pass through by reference, and untouched subtrees keep their identity, so `containsLong` still walks the same graph and a `NumberLong` still forces canonical serialization.

## Related issue

Closes #312. Follow-up filed as #314 (Export view rejects shell syntax the main query bar accepts).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` passes (if backend touched) — no backend change; verified separately that `bson 2.15`'s `to_document` already decodes `$regularExpression` into a real `Bson::Regex`, so the existing Rust path needs nothing
- [ ] Manually verified in the running app (`npm run tauri dev`)

12 new tests. `shellDoc`: flag dropping, `$in`-array and nested cases, the braceless-retry path, BSON types surviving normalization, and explicitly that `g` is **not** translated to `s` the way the driver does. `DocumentViewer`: the query actually runs and sends `{"$regularExpression":{"pattern":"test","options":""}}`, and no notice appears for `/test/i`.

Full suite: **1623 passed, 5 failed**. Those 5 also fail on a clean `dev` — confirmed by stashing and re-running, identical set (Windows `spawn npx ENOENT` in the bundle test, locale formatting in StatsCards, a backend-constant grep in imageTypes, one ExportView seeding test). Unrelated, left alone.

Not manually run in the app — worth a click-through of the badge before merge.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
