### PR TITLE
fix(export): accept mongosh syntax in the filtered export query

### DIFF
--- a/src/components/ExportView.tsx
+++ b/src/components/ExportView.tsx
@@ -128,6 +128,32 @@ type FieldCheck =
   | { ok: false; value?: never; error: string };
 
 /**
+ * Does this text parse as strict JSON of the wanted shape?
+ *
+ * The parsed value is deliberately thrown away — only the answer is used, and
+ * the caller forwards the ORIGINAL TEXT. That is the whole point: `JSON.parse`
+ * is itself lossy for 64-bit integers, so round-tripping through it would
+ * corrupt the very values this check exists to protect.
+ *
+ * Text that is already strict JSON is exactly what the backend read before the
+ * fields learned mongosh syntax, so handing it over untouched keeps that path
+ * lossless. Routing it through the JS shell parser instead would silently
+ * round an unwrapped integer past 2^53 — `{"counter": 9007199254740993}`
+ * becomes `…992` and matches a different document (#316 review). Values the
+ * shell parser produces are unaffected: `NumberLong("…")` survives, because
+ * shellDoc serializes canonically whenever a Long is present.
+ */
+function isStrictJson(text: string, shape: 'object' | 'array'): boolean {
+  try {
+    const value = JSON.parse(text);
+    if (value === null || typeof value !== 'object') return false;
+    return shape === 'array' ? Array.isArray(value) : !Array.isArray(value);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Turn a parse failure into a message, preferring our own translated codes.
  *
  * Mirrors what the document view does with shellDocErrorKey: errors we raise
@@ -161,6 +187,7 @@ function parseErrorMessage(e: unknown, t: TFunc): string {
 function checkQueryObject(raw: string, t: TFunc): FieldCheck {
   const trimmed = raw.trim();
   if (trimmed === '' || trimmed === '{}') return { ok: true, value: '{}' };
+  if (isStrictJson(trimmed, 'object')) return { ok: true, value: trimmed };
   try {
     return { ok: true, value: JSON.stringify(parseQueryObject(trimmed)) };
   } catch (e) {
@@ -177,6 +204,7 @@ function checkQueryObject(raw: string, t: TFunc): FieldCheck {
 function checkPipeline(raw: string, t: TFunc): FieldCheck {
   const trimmed = raw.trim();
   if (trimmed === '' || trimmed === '[]') return { ok: true, value: '[]' };
+  if (isStrictJson(trimmed, 'array')) return { ok: true, value: trimmed };
   try {
     const value = parseShellJson(trimmed);
     if (!Array.isArray(value)) {

--- a/src/components/ExportView.tsx
+++ b/src/components/ExportView.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils';
 import { QueryEditor } from './QueryEditor';
 import { FindQueryBar } from './FindQueryBar';
 import { useCollectionSchema } from '../lib/useCollectionSchema';
+import { parseQueryObject, parseShellJson, shellDocErrorKey, shellDocErrorParams } from '../lib/shellDoc';
 
 /** File formats the export view can produce. */
 export type ExportFormat = 'json' | 'ndjson' | 'bson' | 'csv' | 'xlsx';
@@ -105,33 +106,74 @@ interface ExportViewProps {
 
 // Pure, module-scope validators — they can't call the useTranslation hook, so
 // the component passes its `t` in at each call site.
-type TFunc = (key: string) => string;
+type TFunc = (key: string, opts?: Record<string, unknown>) => string;
 
-/** Validate a JSON object string ('' and '{}' count as the empty object). */
-function checkJsonObject(raw: string, t: TFunc): { ok: boolean; error?: string } {
+/** What a validator reports: whether it parsed, why not, and the value to send. */
+interface FieldCheck {
+  ok: boolean;
+  error?: string;
+  /** Normalized Extended JSON for the backend — NOT the text the user typed. */
+  value: string;
+}
+
+/**
+ * Turn a parse failure into a message, preferring our own translated codes.
+ *
+ * Mirrors what the document view does with shellDocErrorKey: errors we raise
+ * ourselves carry a code with a catalog entry (in the `documents` namespace,
+ * which is where the shared parser's messages live), while the underlying
+ * parser's own errors are only available in English.
+ */
+function parseErrorMessage(e: unknown, t: TFunc): string {
+  const key = shellDocErrorKey(e);
+  if (key) return t(`documents:${key}`, shellDocErrorParams(e));
+  const message = e instanceof Error ? e.message : String(e);
+  return message || t('transfer:exportView.errors.invalidQuery');
+}
+
+/**
+ * Validate a find field the way the main query bar does.
+ *
+ * These were JSON.parse'd, so the export view rejected the very syntax the
+ * document view accepts — regex literals, ObjectId(…), unquoted keys, pasted
+ * smart quotes — and a filter that had just run could not be carried into an
+ * export (#314). Parsing with the shared shell parser closes that gap.
+ *
+ * The parsed result is returned as Extended JSON, because that is what has to
+ * reach the backend: the raw text used to be forwarded verbatim, which is why
+ * only strict JSON could work end to end. The backend already reads Extended
+ * JSON here (build_source → serde_json → BSON), the same as the find path, so
+ * this needs no change on that side.
+ *
+ * '' and '{}' both mean "no filter", matching the query bar's convention.
+ */
+function checkQueryObject(raw: string, t: TFunc): FieldCheck {
   const trimmed = raw.trim();
-  if (trimmed === '' || trimmed === '{}') return { ok: true };
+  if (trimmed === '' || trimmed === '{}') return { ok: true, value: '{}' };
   try {
-    const value = JSON.parse(trimmed);
-    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-      return { ok: false, error: t('transfer:exportView.errors.mustBeObject') };
-    }
-    return { ok: true };
-  } catch {
-    return { ok: false, error: t('transfer:exportView.errors.invalidJson') };
+    return { ok: true, value: JSON.stringify(parseQueryObject(trimmed)) };
+  } catch (e) {
+    return { ok: false, error: parseErrorMessage(e, t), value: '{}' };
   }
 }
 
-/** Validate a JSON array string ('' and '[]' count as the empty pipeline). */
-function checkJsonArray(raw: string, t: TFunc): { ok: boolean; error?: string } {
+/**
+ * Same, for the aggregation pipeline, which must be an array of stages.
+ *
+ * parseQueryObject is deliberately not reused: it rejects anything that is not
+ * a plain object, which is right for a filter and wrong for a pipeline.
+ */
+function checkPipeline(raw: string, t: TFunc): FieldCheck {
   const trimmed = raw.trim();
-  if (trimmed === '' || trimmed === '[]') return { ok: true };
+  if (trimmed === '' || trimmed === '[]') return { ok: true, value: '[]' };
   try {
-    const value = JSON.parse(trimmed);
-    if (!Array.isArray(value)) return { ok: false, error: t('transfer:exportView.errors.pipelineMustBeArray') };
-    return { ok: true };
-  } catch {
-    return { ok: false, error: t('transfer:exportView.errors.invalidJson') };
+    const value = parseShellJson(trimmed);
+    if (!Array.isArray(value)) {
+      return { ok: false, error: t('transfer:exportView.errors.pipelineMustBeArray'), value: '[]' };
+    }
+    return { ok: true, value: JSON.stringify(value) };
+  } catch (e) {
+    return { ok: false, error: parseErrorMessage(e, t), value: '[]' };
   }
 }
 
@@ -203,10 +245,10 @@ export const ExportView: React.FC<ExportViewProps> = ({
   const [previewError, setPreviewError] = React.useState<string | null>(null);
   const [previewing, setPreviewing] = React.useState(false);
 
-  const filterCheck = checkJsonObject(filter, t);
-  const sortCheck = checkJsonObject(sort, t);
-  const projectionCheck = checkJsonObject(projection, t);
-  const pipelineCheck = checkJsonArray(pipeline, t);
+  const filterCheck = checkQueryObject(filter, t);
+  const sortCheck = checkQueryObject(sort, t);
+  const projectionCheck = checkQueryObject(projection, t);
+  const pipelineCheck = checkPipeline(pipeline, t);
   const canExportFiltered =
     mode === 'aggregate'
       ? pipelineCheck.ok
@@ -236,7 +278,7 @@ export const ExportView: React.FC<ExportViewProps> = ({
     if (!onCountFilter || !filterCheck.ok) return;
     setCounting(true);
     setCountError(null);
-    onCountFilter(filter)
+    onCountFilter(filterCheck.value)
       .then((n) => setCount(n))
       .catch(() => setCountError(t('exportView.filtered.countFailed')))
       .finally(() => setCounting(false));
@@ -251,15 +293,20 @@ export const ExportView: React.FC<ExportViewProps> = ({
     return t('exportView.filtered.countNotRun');
   })();
 
+  // Ship the PARSED value, not the text in the editor. The backend reads
+  // Extended JSON, so forwarding raw text is what limited these fields to
+  // strict JSON (#314) — `{name: /a/i}` is a valid query but not valid JSON.
+  // Callers only reach this when the matching check is ok, so `value` is the
+  // real parse rather than the empty-object fallback.
   const buildQuery = (): FilteredExportQuery =>
     mode === 'aggregate'
-      ? { kind: 'aggregate', pipeline }
+      ? { kind: 'aggregate', pipeline: pipelineCheck.value }
       : {
           kind: 'find',
-          filter,
-          sort,
+          filter: filterCheck.value,
+          sort: sortCheck.value,
           // A field selection replaces the projection editor entirely.
-          projection: fieldSelectionActive ? '{}' : projection,
+          projection: fieldSelectionActive ? '{}' : projectionCheck.value,
           skip,
           limit,
         };
@@ -710,6 +757,7 @@ export const ExportView: React.FC<ExportViewProps> = ({
               <div className={editorShell(pipelineCheck.ok)}>
                 <QueryEditor
                   surface="aggStage"
+                  shellSyntax
                   value={pipeline}
                   onChange={setPipeline}
                   fields={fields}
@@ -732,10 +780,15 @@ export const ExportView: React.FC<ExportViewProps> = ({
                 onProjectionChange={setProjection}
                 onSortChange={setSort}
                 filterInvalid={!filterCheck.ok}
+                filterError={filterCheck.error}
                 projectionInvalid={!projectionCheck.ok}
                 sortInvalid={!sortCheck.ok}
                 fields={fields}
                 schema={schema}
+                // These fields parse mongosh syntax now, so the completions
+                // must offer it too — bare keys and ObjectId()/ISODate()
+                // rather than EJSON wrappers, matching the document view.
+                shellSyntax
               />
             </div>
           )}

--- a/src/components/ExportView.tsx
+++ b/src/components/ExportView.tsx
@@ -108,13 +108,24 @@ interface ExportViewProps {
 // the component passes its `t` in at each call site.
 type TFunc = (key: string, opts?: Record<string, unknown>) => string;
 
-/** What a validator reports: whether it parsed, why not, and the value to send. */
-interface FieldCheck {
-  ok: boolean;
-  error?: string;
-  /** Normalized Extended JSON for the backend — NOT the text the user typed. */
-  value: string;
-}
+/**
+ * What a validator reports: whether it parsed, why not, and the value to send.
+ *
+ * Deliberately a union rather than a struct with an always-present `value`. A
+ * failed check has NO value — an earlier version handed back `{}`/`[]` as a
+ * fallback, which reads as harmless and is not: `{}` is a filter that matches
+ * everything, so a malformed query silently became "the whole collection"
+ * instead of an error (#316 review). Making the field absent on failure means
+ * the type stops anyone reaching for it without checking `ok` first.
+ */
+type FieldCheck =
+  | {
+      ok: true;
+      /** Normalized Extended JSON for the backend — NOT the text the user typed. */
+      value: string;
+      error?: never;
+    }
+  | { ok: false; value?: never; error: string };
 
 /**
  * Turn a parse failure into a message, preferring our own translated codes.
@@ -153,7 +164,7 @@ function checkQueryObject(raw: string, t: TFunc): FieldCheck {
   try {
     return { ok: true, value: JSON.stringify(parseQueryObject(trimmed)) };
   } catch (e) {
-    return { ok: false, error: parseErrorMessage(e, t), value: '{}' };
+    return { ok: false, error: parseErrorMessage(e, t) };
   }
 }
 
@@ -169,11 +180,11 @@ function checkPipeline(raw: string, t: TFunc): FieldCheck {
   try {
     const value = parseShellJson(trimmed);
     if (!Array.isArray(value)) {
-      return { ok: false, error: t('transfer:exportView.errors.pipelineMustBeArray'), value: '[]' };
+      return { ok: false, error: t('transfer:exportView.errors.pipelineMustBeArray') };
     }
     return { ok: true, value: JSON.stringify(value) };
   } catch (e) {
-    return { ok: false, error: parseErrorMessage(e, t), value: '[]' };
+    return { ok: false, error: parseErrorMessage(e, t) };
   }
 }
 
@@ -249,7 +260,10 @@ export const ExportView: React.FC<ExportViewProps> = ({
   const sortCheck = checkQueryObject(sort, t);
   const projectionCheck = checkQueryObject(projection, t);
   const pipelineCheck = checkPipeline(pipeline, t);
-  const canExportFiltered =
+  // Gates every action that runs the filtered query — export, preview and
+  // field scan alike. Preview and scan used to ignore it, so a malformed
+  // query silently ran against the whole collection (#316 review).
+  const filteredQueryValid =
     mode === 'aggregate'
       ? pipelineCheck.ok
       : filterCheck.ok && sortCheck.ok && projectionCheck.ok;
@@ -296,20 +310,26 @@ export const ExportView: React.FC<ExportViewProps> = ({
   // Ship the PARSED value, not the text in the editor. The backend reads
   // Extended JSON, so forwarding raw text is what limited these fields to
   // strict JSON (#314) — `{name: /a/i}` is a valid query but not valid JSON.
-  // Callers only reach this when the matching check is ok, so `value` is the
-  // real parse rather than the empty-object fallback.
-  const buildQuery = (): FilteredExportQuery =>
-    mode === 'aggregate'
-      ? { kind: 'aggregate', pipeline: pipelineCheck.value }
-      : {
-          kind: 'find',
-          filter: filterCheck.value,
-          sort: sortCheck.value,
-          // A field selection replaces the projection editor entirely.
-          projection: fieldSelectionActive ? '{}' : projectionCheck.value,
-          skip,
-          limit,
-        };
+  //
+  // Returns undefined when the query does not parse, so a caller cannot get a
+  // runnable query out of unrunnable input. Every caller is already gated on
+  // `filteredQueryValid`; this is the backstop that makes a missed gate fail
+  // closed instead of quietly running against the whole collection.
+  const buildQuery = (): FilteredExportQuery | undefined => {
+    if (mode === 'aggregate') {
+      return pipelineCheck.ok ? { kind: 'aggregate', pipeline: pipelineCheck.value } : undefined;
+    }
+    if (!filterCheck.ok || !sortCheck.ok || !projectionCheck.ok) return undefined;
+    return {
+      kind: 'find',
+      filter: filterCheck.value,
+      sort: sortCheck.value,
+      // A field selection replaces the projection editor entirely.
+      projection: fieldSelectionActive ? '{}' : projectionCheck.value,
+      skip,
+      limit,
+    };
+  };
 
   const toggleField = (field: string) => {
     setSelectedFields((prev) => {
@@ -322,8 +342,13 @@ export const ExportView: React.FC<ExportViewProps> = ({
 
   const runScanFields = () => {
     if (!onScanFields) return;
+    // `mode` is always find or aggregate, so this always sends a query. Bail
+    // rather than fall back to undefined, which the scan reads as "sample the
+    // whole collection" — the opposite of what a malformed filter should do.
+    const query = buildQuery();
+    if (!query) return;
     setScanning(true);
-    onScanFields(mode === 'find' || mode === 'aggregate' ? buildQuery() : undefined)
+    onScanFields(query)
       .then((fs) => {
         setScannedFields(fs);
         setSelectedFields(new Set(fs));
@@ -339,10 +364,15 @@ export const ExportView: React.FC<ExportViewProps> = ({
 
   const runPreview = () => {
     if (!onPreview) return;
+    const scope: 'current' | 'full' | 'filtered' = filtered ? 'filtered' : 'full';
+    // A filtered preview without a parseable query would fall back to the
+    // whole collection, which is exactly the wrong answer to show someone.
+    // A 'full' preview has no query and is unaffected.
+    const query = scope === 'filtered' ? buildQuery() : undefined;
+    if (scope === 'filtered' && !query) return;
     setPreviewing(true);
     setPreviewError(null);
-    const scope: 'current' | 'full' | 'filtered' = filtered ? 'filtered' : 'full';
-    onPreview(format, scope, effectiveOptions, scope === 'filtered' ? buildQuery() : undefined)
+    onPreview(format, scope, effectiveOptions, query)
       .then((out) => setPreviewOutput(out))
       .catch((err) => setPreviewError(err instanceof Error ? err.message : String(err)))
       .finally(() => setPreviewing(false));
@@ -606,7 +636,7 @@ export const ExportView: React.FC<ExportViewProps> = ({
               type="button"
               variant="outline"
               size="sm"
-              disabled={!onScanFields || scanning}
+              disabled={!onScanFields || scanning || !filteredQueryValid}
               onClick={runScanFields}
               data-testid="export-scan-fields-btn"
             >
@@ -840,7 +870,7 @@ export const ExportView: React.FC<ExportViewProps> = ({
             <Button
               type="button"
               size="sm"
-              disabled={!canExportFiltered || !delimiterValid || noFieldsSelected}
+              disabled={!filteredQueryValid || !delimiterValid || noFieldsSelected}
               onClick={() => onExport(format, 'filtered', effectiveOptions, buildQuery())}
               data-testid="export-filtered-btn"
             >
@@ -866,7 +896,7 @@ export const ExportView: React.FC<ExportViewProps> = ({
             type="button"
             variant="outline"
             size="sm"
-            disabled={!onPreview || format === 'bson' || format === 'xlsx' || previewing}
+            disabled={!onPreview || format === 'bson' || format === 'xlsx' || previewing || (!!filtered && !filteredQueryValid)}
             onClick={runPreview}
             data-testid="export-preview-btn"
           >

--- a/src/components/__tests__/ExportView.test.tsx
+++ b/src/components/__tests__/ExportView.test.tsx
@@ -302,6 +302,35 @@ describe('ExportView', () => {
       expect(screen.getByText('Pipeline must be an array of stages')).toBeInTheDocument();
     });
 
+    it('forwards strict JSON untouched, preserving 64-bit integers (#316 review)', () => {
+      // A bare integer past 2^53 cannot survive a JS number. Strict JSON is
+      // what the backend read before these fields learned mongosh syntax, so
+      // it is handed over verbatim rather than re-serialized — otherwise
+      // 9007199254740993 silently becomes ...992 and matches another document.
+      const onExport = exportWith('{"counter":9007199254740993}');
+      expect(onExport.mock.calls[0][3].filter).toBe('{"counter":9007199254740993}');
+    });
+
+    it('preserves 64-bit integers in a strict-JSON pipeline too', () => {
+      const onExport = vi.fn();
+      renderExportView({ onExport, filtered: { kind: 'aggregate', pipeline: '[]' } });
+      const raw = '[{"$match":{"counter":9007199254740993}}]';
+      fireEvent.change(screen.getByTestId('export-filtered-pipeline-input'), {
+        target: { value: raw },
+      });
+      fireEvent.click(screen.getByTestId('export-filtered-btn'));
+      expect(onExport.mock.calls[0][3].pipeline).toBe(raw);
+    });
+
+    it('keeps NumberLong exact on the shell path as well', () => {
+      // The shell parser serializes canonically when a Long is present, so the
+      // mongosh spelling of a big integer is lossless through that route too.
+      const onExport = exportWith('{counter: NumberLong("9007199254740993")}');
+      expect(JSON.parse(onExport.mock.calls[0][3].filter)).toEqual({
+        counter: { $numberLong: '9007199254740993' },
+      });
+    });
+
     it('blocks preview and field scan while the query is malformed (#316 review)', async () => {
       // A failed check has no value, so nothing can fall back to `{}` — which
       // is a filter that matches everything. Before this, an invalid filter

--- a/src/components/__tests__/ExportView.test.tsx
+++ b/src/components/__tests__/ExportView.test.tsx
@@ -302,6 +302,53 @@ describe('ExportView', () => {
       expect(screen.getByText('Pipeline must be an array of stages')).toBeInTheDocument();
     });
 
+    it('blocks preview and field scan while the query is malformed (#316 review)', async () => {
+      // A failed check has no value, so nothing can fall back to `{}` — which
+      // is a filter that matches everything. Before this, an invalid filter
+      // silently previewed and scanned the ENTIRE collection.
+      const onPreview = vi.fn().mockResolvedValue('[]');
+      const onScanFields = vi.fn().mockResolvedValue(['a']);
+      renderExportView({ onPreview, onScanFields, filtered: { kind: 'find', filter: '{}' } });
+
+      fireEvent.change(screen.getByTestId('query-filter-input'), { target: { value: '{bad' } });
+
+      expect(screen.getByTestId('export-preview-btn')).toBeDisabled();
+      expect(screen.getByTestId('export-scan-fields-btn')).toBeDisabled();
+
+      // Even if a gate were missed, the handlers must refuse rather than run
+      // against everything.
+      fireEvent.click(screen.getByTestId('export-preview-btn'));
+      fireEvent.click(screen.getByTestId('export-scan-fields-btn'));
+      await waitFor(() => expect(screen.getByTestId('export-filtered-btn')).toBeDisabled());
+      expect(onPreview).not.toHaveBeenCalled();
+      expect(onScanFields).not.toHaveBeenCalled();
+    });
+
+    it('blocks preview and field scan on a malformed pipeline too', () => {
+      const onPreview = vi.fn().mockResolvedValue('[]');
+      const onScanFields = vi.fn().mockResolvedValue(['a']);
+      renderExportView({ onPreview, onScanFields, filtered: { kind: 'aggregate', pipeline: '[]' } });
+      fireEvent.change(screen.getByTestId('export-filtered-pipeline-input'), {
+        target: { value: '[{$match: ' },
+      });
+      expect(screen.getByTestId('export-preview-btn')).toBeDisabled();
+      expect(screen.getByTestId('export-scan-fields-btn')).toBeDisabled();
+    });
+
+    it('still previews and scans once the query parses', async () => {
+      const onPreview = vi.fn().mockResolvedValue('[]');
+      const onScanFields = vi.fn().mockResolvedValue(['a']);
+      renderExportView({ onPreview, onScanFields, filtered: { kind: 'find', filter: '{}' } });
+      fireEvent.change(screen.getByTestId('query-filter-input'), {
+        target: { value: '{name: /acme/i}' },
+      });
+      fireEvent.click(screen.getByTestId('export-scan-fields-btn'));
+      await waitFor(() => expect(onScanFields).toHaveBeenCalled());
+      expect(JSON.parse(onScanFields.mock.calls[0][0].filter)).toEqual({
+        name: { $regularExpression: { pattern: 'acme', options: 'i' } },
+      });
+    });
+
     it('reports an unsupported regex flag using the shared translated message', () => {
       // Cross-namespace lookup: the parser's error codes live in `documents`,
       // while this view's own catalog is `transfer`.

--- a/src/components/__tests__/ExportView.test.tsx
+++ b/src/components/__tests__/ExportView.test.tsx
@@ -227,6 +227,95 @@ describe('ExportView', () => {
     expect(screen.getByTestId('export-full-btn')).toBeEnabled();
   });
 
+  describe('shell syntax in the filtered card (#314)', () => {
+    // These fields were JSON.parse'd, so the export view rejected the syntax
+    // the document view accepts — a filter that had just run could not be
+    // carried over. They now share the query bar's parser, and what reaches
+    // the backend is the PARSED value rather than the typed text.
+    const exportWith = (value: string) => {
+      const onExport = vi.fn();
+      renderExportView({ onExport, filtered: { kind: 'find', filter: '{}' } });
+      fireEvent.change(screen.getByTestId('query-filter-input'), { target: { value } });
+      fireEvent.click(screen.getByTestId('export-filtered-btn'));
+      return onExport;
+    };
+
+    it('accepts a regex literal and sends it as Extended JSON', () => {
+      const onExport = exportWith('{name: /acme/i}');
+      expect(onExport).toHaveBeenCalled();
+      expect(JSON.parse(onExport.mock.calls[0][3].filter)).toEqual({
+        name: { $regularExpression: { pattern: 'acme', options: 'i' } },
+      });
+    });
+
+    it('accepts ObjectId() and unquoted keys', () => {
+      const onExport = exportWith('{_id: ObjectId("603d1f77bcf86cd799439011")}');
+      expect(JSON.parse(onExport.mock.calls[0][3].filter)).toEqual({
+        _id: { $oid: '603d1f77bcf86cd799439011' },
+      });
+    });
+
+    it('accepts a query pasted with smart quotes', () => {
+      const onExport = exportWith('{ tier: “gold” }');
+      expect(JSON.parse(onExport.mock.calls[0][3].filter)).toEqual({ tier: 'gold' });
+    });
+
+    it('still rejects genuinely malformed input and disables export', () => {
+      renderExportView({ filtered: { kind: 'find', filter: '{}' } });
+      fireEvent.change(screen.getByTestId('query-filter-input'), { target: { value: '{bad' } });
+      expect(screen.getByTestId('export-filtered-btn')).toBeDisabled();
+      expect(screen.getAllByText('Invalid query').length).toBeGreaterThan(0);
+    });
+
+    it('counts against the parsed filter, not the raw text', async () => {
+      const onCountFilter = vi.fn().mockResolvedValue(7);
+      renderExportView({ onCountFilter, filtered: { kind: 'find', filter: '{}' } });
+      fireEvent.change(screen.getByTestId('query-filter-input'), {
+        target: { value: '{name: /acme/i}' },
+      });
+      fireEvent.click(screen.getByTestId('export-filtered-count-btn'));
+      await waitFor(() => expect(onCountFilter).toHaveBeenCalled());
+      expect(JSON.parse(onCountFilter.mock.calls[0][0])).toEqual({
+        name: { $regularExpression: { pattern: 'acme', options: 'i' } },
+      });
+    });
+
+    it('accepts shell syntax in an aggregation pipeline', () => {
+      const onExport = vi.fn();
+      renderExportView({ onExport, filtered: { kind: 'aggregate', pipeline: '[]' } });
+      fireEvent.change(screen.getByTestId('export-filtered-pipeline-input'), {
+        target: { value: '[{$match: {name: /acme/i}}, {$limit: 10}]' },
+      });
+      fireEvent.click(screen.getByTestId('export-filtered-btn'));
+      expect(JSON.parse(onExport.mock.calls[0][3].pipeline)).toEqual([
+        { $match: { name: { $regularExpression: { pattern: 'acme', options: 'i' } } } },
+        { $limit: 10 },
+      ]);
+    });
+
+    it('rejects a pipeline that is not an array of stages', () => {
+      renderExportView({ filtered: { kind: 'aggregate', pipeline: '[]' } });
+      fireEvent.change(screen.getByTestId('export-filtered-pipeline-input'), {
+        target: { value: '{$match: {a: 1}}' },
+      });
+      expect(screen.getByTestId('export-filtered-btn')).toBeDisabled();
+      expect(screen.getByText('Pipeline must be an array of stages')).toBeInTheDocument();
+    });
+
+    it('reports an unsupported regex flag using the shared translated message', () => {
+      // Cross-namespace lookup: the parser's error codes live in `documents`,
+      // while this view's own catalog is `transfer`.
+      renderExportView({ filtered: { kind: 'find', filter: '{}' } });
+      fireEvent.change(screen.getByTestId('query-filter-input'), {
+        target: { value: '{name: /acme/y}' },
+      });
+      expect(screen.getByTestId('export-filtered-btn')).toBeDisabled();
+      expect(
+        screen.getByTestId('query-invalid-badge').getAttribute('title')
+      ).toContain('regex flag y');
+    });
+  });
+
   it('seeds the filter editor and keeps filtered export enabled by default', () => {
     renderExportView({ filtered: { kind: 'find', filter: '{}', matchCount: null } });
     const input = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;

--- a/src/locales/de/transfer.json
+++ b/src/locales/de/transfer.json
@@ -44,9 +44,8 @@
     },
     "errors": {
       "delimiterAscii": "Das Trennzeichen muss ein einzelnes ASCII-Zeichen sein.",
-      "mustBeObject": "Muss ein JSON-Objekt sein",
-      "invalidJson": "Ungültiges JSON",
-      "pipelineMustBeArray": "Pipeline muss ein JSON-Array von Stufen sein"
+      "pipelineMustBeArray": "Pipeline muss ein Array von Stufen sein",
+      "invalidQuery": "Ungültige Abfrage"
     },
     "fields": {
       "title": "Felder",

--- a/src/locales/en/transfer.json
+++ b/src/locales/en/transfer.json
@@ -116,9 +116,8 @@
     },
     "errors": {
       "delimiterAscii": "Delimiter must be a single ASCII character.",
-      "invalidJson": "Invalid JSON",
-      "mustBeObject": "Must be a JSON object",
-      "pipelineMustBeArray": "Pipeline must be a JSON array of stages"
+      "invalidQuery": "Invalid query",
+      "pipelineMustBeArray": "Pipeline must be an array of stages"
     },
     "fields": {
       "filterPlaceholder": "Filter fields",

--- a/src/locales/zh-Hans/transfer.json
+++ b/src/locales/zh-Hans/transfer.json
@@ -114,9 +114,8 @@
     },
     "errors": {
       "delimiterAscii": "分隔符必须是单个 ASCII 字符。",
-      "invalidJson": "JSON 无效",
-      "mustBeObject": "必须是一个 JSON 对象",
-      "pipelineMustBeArray": "管道必须是由阶段组成的 JSON 数组"
+      "pipelineMustBeArray": "管道必须是由阶段组成的数组",
+      "invalidQuery": "查询无效"
     },
     "fields": {
       "filterPlaceholder": "筛选字段",


### PR DESCRIPTION
## Summary

The export view validated its query fields with raw `JSON.parse`, entirely separate from the parser the main query bar uses. Syntax the document view accepts was rejected here, so a filter that had just run could not be carried into an export:

| Input | Query bar | Export (before) | Export (after) |
|---|---|---|---|
| `{name: /acme/i}` | ✅ | ❌ | ✅ |
| `{_id: ObjectId("603d…")}` | ✅ | ❌ | ✅ |
| `{createdAt: {$gte: ISODate("2024-01-01")}}` | ✅ | ❌ | ✅ |
| `{name: "Ada"}` (unquoted key) | ✅ | ❌ | ✅ |
| smart quotes pasted from a browser | ✅ | ❌ | ✅ |

Both the find fields and the aggregation pipeline now parse through the shared shell parser. The pipeline gets its own check rather than reusing `parseQueryObject`, which rejects anything that is not a plain object — right for a filter, wrong for a list of stages.

### The part that actually mattered

What reaches the backend is now the **parsed** value rather than the typed text. Forwarding raw text is precisely what limited these fields to strict JSON — `{name: /a/i}` is a valid query but not valid JSON, so only JSON survived the trip.

**No backend change is needed.** `build_source` already reads Extended JSON through `serde_json`, the same as the find path, so it accepts the normalized value as-is. That was the main open question in #314 and it resolved in the easy direction.

### Also

- Editor completions switch to shell syntax (bare keys, `ObjectId()`/`ISODate()`) so they match what the fields now accept.
- The filter field shows its parse reason on hover rather than only a badge, as the document view does. Errors we raise ourselves resolve through the `documents` catalog, where the shared parser's messages live.
- Dead keys `invalidJson` / `mustBeObject` removed; `pipelineMustBeArray` no longer says "JSON array".

This settles the wording question left open in #312: **"Invalid query" is now correct here** rather than the small regression it was, because the field really does take a query and not JSON. No label prop needed.

## Related issue

Closes #314.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [x] `npm run i18n:check` passes
- [ ] `cargo test` — no backend change
- [ ] Manually verified in the running app (`npm run tauri dev`)

8 new tests: regex literal, `ObjectId()`, smart quotes, malformed input still rejected, Count sending the parsed filter, shell syntax in a pipeline, non-array pipeline rejected, and the cross-namespace translated message for an unsupported regex flag.

Full suite: **1635 passed, 5 failed** — the same 5 that fail on a clean `dev` (Windows `spawn npx ENOENT`, locale number formatting in StatsCards and one ExportView seeding assertion, a backend-constant grep). Unrelated, left alone.

Not manually run in the app — worth a click-through of the filtered card before merge.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
