### PR TITLE
fix(query): keep 64-bit integer literals exact instead of rounding them

### DIFF
--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -533,3 +533,46 @@ describe('preserveBigIntegers — only rewrites in value position (#318 review)'
     );
   });
 });
+
+// #318 review, round 2: a comment between the delimiter and the value left the
+// literal unrewritten, so a commented query kept rounding silently.
+describe('preserveBigIntegers — comments (#318 review)', () => {
+  const longOf = (text: string, key = 'counter') => parseShellJson(text)[key].$numberLong;
+
+  it('sees past a block comment before the value', () => {
+    expect(longOf('{counter: /* copied from shell */ 9007199254740993}')).toBe(
+      '9007199254740993'
+    );
+  });
+
+  it('sees past a line comment before the value', () => {
+    expect(longOf('{counter: // note\n 9007199254740993}')).toBe('9007199254740993');
+  });
+
+  it('still reads a sign correctly across a comment', () => {
+    expect(parseShellJson('{a: /* c */ -9007199254740993}').a.$numberLong).toBe(
+      '-9007199254740993'
+    );
+  });
+
+  it('does not mistake a comment for an operand when judging a binary minus', () => {
+    expect(preserveBigIntegers('{a: 1 /* c */ - 9007199254740992}')).toBe(
+      '{a: 1 /* c */ - 9007199254740992}'
+    );
+  });
+
+  it('does not mistake // inside a string for a comment', () => {
+    // The reason placement is judged on tracked tokens rather than by scanning
+    // the emitted text backwards: a URL would otherwise look like a comment and
+    // suppress a rewrite that should happen.
+    const parsed = parseShellJson('{url: "http://x.com", counter: 9007199254740993}');
+    expect(parsed.url).toBe('http://x.com');
+    expect(parsed.counter.$numberLong).toBe('9007199254740993');
+  });
+
+  it('still recognises a regex that follows a comment', () => {
+    const parsed = parseShellJson('{a: /* c */ /x/i, b: 9007199254740993}');
+    expect(parsed.a.$regularExpression.pattern).toBe('x');
+    expect(parsed.b.$numberLong).toBe('9007199254740993');
+  });
+});

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ObjectId, Long, Decimal128, Int32 } from 'bson';
-import { docToShell, shellToEjson, parseShellJson, parseQueryObject, shellDocErrorKey, shellDocErrorParams, type ShellDocNotices } from '../shellDoc';
+import { docToShell, shellToEjson, parseShellJson, parseQueryObject, preserveBigIntegers, shellDocErrorKey, shellDocErrorParams, type ShellDocNotices } from '../shellDoc';
 
 describe('docToShell', () => {
   it('renders EJSON-shaped values as shell constructors', () => {
@@ -476,5 +476,60 @@ describe('parseShellJson — 64-bit integer literals (#317)', () => {
     expect(Object.keys(parseShellJson('{"9007199254740993": 1}'))).toEqual([
       '9007199254740993',
     ]);
+  });
+});
+
+// #318 review: the rewrite originally fired wherever a big integer appeared,
+// but the text around a literal decides what it means. Rewriting outside value
+// position ate operators and wrapped constructor arguments in themselves.
+describe('preserveBigIntegers — only rewrites in value position (#318 review)', () => {
+  it('leaves a spaced binary minus intact', () => {
+    // Was rewritten to `{a: 1 NumberLong("-9007199254740992")}`, which stopped
+    // parsing altogether — a valid query broken by a precision fix.
+    expect(preserveBigIntegers('{a: 1 - 9007199254740992}')).toBe(
+      '{a: 1 - 9007199254740992}'
+    );
+    expect(() => parseShellJson('{a: 1 - 9007199254740992}')).not.toThrow();
+  });
+
+  it('leaves other arithmetic operands alone', () => {
+    // Rewriting these would leave the parser doing arithmetic on a Long.
+    expect(preserveBigIntegers('{a: 1 + 9007199254740992}')).toBe(
+      '{a: 1 + 9007199254740992}'
+    );
+  });
+
+  it('does not wrap a constructor argument in another constructor', () => {
+    // `NumberLong(NumberLong("…"))` is not a thing. The quoted spelling is the
+    // exact one, and it is untouched because it is inside a string.
+    expect(preserveBigIntegers('{a: NumberLong(9007199254740993)}')).toBe(
+      '{a: NumberLong(9007199254740993)}'
+    );
+    expect(parseShellJson('{a: NumberLong("9007199254740993")}').a.$numberLong).toBe(
+      '9007199254740993'
+    );
+  });
+
+  it('leaves a parenthesised expression alone', () => {
+    expect(preserveBigIntegers('{a: (9007199254740993)}')).toBe(
+      '{a: (9007199254740993)}'
+    );
+  });
+
+  it('still treats a genuine leading minus as a sign', () => {
+    // The distinction is whether anything that could end an operand precedes
+    // the minus — here it is the `:`, so the minus belongs to the number.
+    expect(preserveBigIntegers('{a: -9007199254740993}')).toBe(
+      '{a: NumberLong("-9007199254740993")}'
+    );
+  });
+
+  it('rewrites after the punctuation that starts a value', () => {
+    expect(preserveBigIntegers('{a: [1, 9007199254740993]}')).toBe(
+      '{a: [1, NumberLong("9007199254740993")]}'
+    );
+    expect(preserveBigIntegers('counter: 9007199254740993')).toBe(
+      'counter: NumberLong("9007199254740993")'
+    );
   });
 });

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -602,3 +602,40 @@ describe('preserveBigIntegers — numeric keys with comments (#318 review)', () 
     ).toBe('9007199254740993');
   });
 });
+
+// #318 review, round 4: the mirror of the binary-minus case. Checking only what
+// PRECEDES a literal caught `{a: 1 + N}` but not `{a: N + 1}`.
+describe('preserveBigIntegers — literal as a left-hand operand (#318 review)', () => {
+  it('leaves a literal that an operator follows alone', () => {
+    // Rewriting made this `NumberLong("…") + 1`, and JS concatenated the long's
+    // toString — the query silently became the STRING "90071992547409931".
+    expect(preserveBigIntegers('{limit: 9007199254740993 + 1}')).toBe(
+      '{limit: 9007199254740993 + 1}'
+    );
+    expect(typeof parseShellJson('{limit: 9007199254740993 + 1}').limit).toBe('number');
+  });
+
+  it('does the same when a comment sits before the operator', () => {
+    expect(preserveBigIntegers('{a: 9007199254740993 /* c */ + 1}')).toBe(
+      '{a: 9007199254740993 /* c */ + 1}'
+    );
+  });
+
+  it('still rewrites where a value legitimately ends', () => {
+    // `}`, `]`, `,` and end-of-input all end a value; a trailing comment is
+    // skipped to find them.
+    expect(parseShellJson('{a: 9007199254740993}').a.$numberLong).toBe('9007199254740993');
+    expect(parseShellJson('{a: [9007199254740993, 1]}').a[0].$numberLong).toBe(
+      '9007199254740993'
+    );
+    expect(parseShellJson('{a: 9007199254740993, b: 1}').a.$numberLong).toBe(
+      '9007199254740993'
+    );
+    expect(parseShellJson('counter: 9007199254740993').counter.$numberLong).toBe(
+      '9007199254740993'
+    );
+    expect(parseShellJson('{a: 9007199254740993 /* trailing */}').a.$numberLong).toBe(
+      '9007199254740993'
+    );
+  });
+});

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -400,3 +400,81 @@ describe('parseShellJson — regex flags BSON cannot carry (#312)', () => {
     expect(notices.droppedRegexFlags).toEqual([]);
   });
 });
+
+// #317: a bare integer past 2^53 was evaluated as a JS number during parsing,
+// so it reached the server rounded — `{counter: 9007199254740993}` became
+// ...992 and matched a different document, with no error and nothing on screen.
+describe('parseShellJson — 64-bit integer literals (#317)', () => {
+  const longAt = (text: string, key = 'counter') =>
+    parseShellJson(text)[key].$numberLong;
+
+  it('keeps an integer past 2^53 exact, in strict JSON and in shell syntax', () => {
+    expect(longAt('{"counter": 9007199254740993}')).toBe('9007199254740993');
+    expect(longAt('{counter: 9007199254740993}')).toBe('9007199254740993');
+  });
+
+  it('keeps a negative one exact, sign and all', () => {
+    expect(longAt('{counter: -9007199254740993}')).toBe('-9007199254740993');
+  });
+
+  it('reaches values nested in arrays and operators', () => {
+    expect(parseShellJson('{a: {$gt: 9007199254740993}}').a.$gt.$numberLong).toBe(
+      '9007199254740993'
+    );
+    expect(parseShellJson('{a: [9007199254740993]}').a[0].$numberLong).toBe(
+      '9007199254740993'
+    );
+  });
+
+  it('works alongside other shell syntax in the same query', () => {
+    // The mixed case is the one a strict-JSON fast path cannot reach, which is
+    // why this is fixed in the parser's input rather than at a call site.
+    const parsed = parseShellJson('{a: 9007199254740993, name: /x/i}');
+    expect(parsed.a.$numberLong).toBe('9007199254740993');
+    expect(parsed.name.$regularExpression.pattern).toBe('x');
+  });
+
+  it('handles the extremes of the 64-bit range', () => {
+    expect(longAt('{counter: 9223372036854775807}')).toBe('9223372036854775807');
+    expect(longAt('{counter: -9223372036854775808}')).toBe('-9223372036854775808');
+  });
+
+  it('leaves ordinary numbers exactly as they were', () => {
+    // The rewrite must be invisible to every query that does not need it —
+    // no `{a: 42}` quietly becoming a long.
+    expect(parseShellJson('{a: 42}')).toEqual({ a: 42 });
+    expect(parseShellJson('{a: 0}')).toEqual({ a: 0 });
+    expect(parseShellJson('{a: 1.5}')).toEqual({ a: 1.5 });
+    expect(parseShellJson('{a: 9007199254740991}')).toEqual({ a: 9007199254740991 });
+  });
+
+  it('leaves values that deliberately spell a double alone', () => {
+    // A fraction or an exponent is the user choosing a double; rewriting it
+    // would change the type they asked for.
+    expect(parseShellJson('{a: 1e30}').a).toBe(1e30);
+    expect(typeof parseShellJson('{a: 9007199254740993.5}').a).toBe('number');
+  });
+
+  it('does not touch digits inside strings or regexes', () => {
+    expect(parseShellJson('{note: "9007199254740993"}')).toEqual({
+      note: '9007199254740993',
+    });
+    expect(parseShellJson('{p: /9007199254740993/}').p.$regularExpression.pattern).toBe(
+      '9007199254740993'
+    );
+  });
+
+  it('leaves a value too large for a 64-bit long alone', () => {
+    // There is no lossless form to rewrite into, so it stays as it is rather
+    // than being truncated into a different wrong number.
+    expect(typeof parseShellJson('{a: 99999999999999999999999999}').a).toBe('number');
+  });
+
+  it('rewrites the value, not a numeric key', () => {
+    // `NumberLong("…")` is not valid in key position. A field name that long
+    // is written quoted in practice, and that path is exact.
+    expect(Object.keys(parseShellJson('{"9007199254740993": 1}'))).toEqual([
+      '9007199254740993',
+    ]);
+  });
+});

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -639,3 +639,30 @@ describe('preserveBigIntegers — literal as a left-hand operand (#318 review)',
     );
   });
 });
+
+// #318 review, round 5. Two findings assumed these were supported shell syntax.
+// They are not — the parser rejects both outright, with or without a big
+// integer — so neither query can run and the rewrite cannot be observed.
+//
+// Pinned rather than guarded, the same way the `d`/`v` regex flags are: adding
+// handling for syntax nothing accepts would be dead code that implies support
+// we do not have. If a parser upgrade ever makes these reachable, these tests
+// fail and the decision gets made deliberately instead of by accident.
+describe('parseShellJson — syntax this parser does not accept (#318 review)', () => {
+  it('rejects template literals, integer or not', () => {
+    expect(() => parseShellJson('{note: `hello`}')).toThrow();
+    expect(() => parseShellJson('{note: `[9007199254740993]`}')).toThrow();
+  });
+
+  it('rejects index expressions, integer or not', () => {
+    expect(() => parseShellJson('{a: [1][0]}')).toThrow();
+    expect(() => parseShellJson('{a: [9007199254740993][0] + 1}')).toThrow();
+  });
+
+  it('but does accept the arithmetic the operand rules are built around', () => {
+    // The contrast that makes the two above worth pinning: arithmetic really is
+    // supported, which is why the left/right operand cases were real bugs.
+    expect(parseShellJson('{a: 1 + 2}')).toEqual({ a: 3 });
+    expect(parseShellJson('{a: [1, 2]}')).toEqual({ a: [1, 2] });
+  });
+});

--- a/src/lib/__tests__/shellDoc.test.ts
+++ b/src/lib/__tests__/shellDoc.test.ts
@@ -576,3 +576,29 @@ describe('preserveBigIntegers — comments (#318 review)', () => {
     expect(parsed.b.$numberLong).toBe('9007199254740993');
   });
 });
+
+// #318 review, round 3: the key check only skipped whitespace, so a comment
+// before the colon hid the fact that the digits were a property name.
+describe('preserveBigIntegers — numeric keys with comments (#318 review)', () => {
+  it('leaves a numeric key alone when a comment precedes its colon', () => {
+    // Rewrote to `NumberLong("…"): 1`, which is not a property key, so a valid
+    // query stopped parsing. The value-position guard hid this at the start of
+    // an object; after a comma there is nothing else to catch it.
+    const text = '{a: 1, 9007199254740992 /* note */: 1}';
+    expect(preserveBigIntegers(text)).toBe(text);
+    expect(parseShellJson(text)).toEqual({ a: 1, '9007199254740992': 1 });
+  });
+
+  it('does the same for a line comment before the colon', () => {
+    const text = '{a: 1, 9007199254740992 // n\n: 1}';
+    expect(preserveBigIntegers(text)).toBe(text);
+    expect(parseShellJson(text)).toEqual({ a: 1, '9007199254740992': 1 });
+  });
+
+  it('still rewrites a value that follows a comma and a comment', () => {
+    // The key fix must not swallow the value case that shares the position.
+    expect(
+      parseShellJson('{a: 1, counter: /* c */ 9007199254740993}').counter.$numberLong
+    ).toBe('9007199254740993');
+  });
+});

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -453,6 +453,107 @@ function endOfRegex(text: string, start: number): number {
   return -1;
 }
 
+/** The range a BSON 64-bit long can hold. Outside it, there is nothing to preserve into. */
+const I64_MAX = 9223372036854775807n;
+const I64_MIN = -9223372036854775808n;
+
+/**
+ * Rewrite integer literals a JS number cannot hold into `NumberLong("…")`.
+ *
+ * The query parser evaluates a bare literal as a JS `number`, so anything past
+ * 2^53 is rounded before we ever see it: `{counter: 9007199254740993}` reached
+ * the server as `…992` and matched a different document, with no error and
+ * nothing on screen to say so (#317). The loss happens during parsing, so the
+ * only place to fix it is before parsing — hence a text pass.
+ *
+ * `NumberLong` is the right target rather than a workaround: the backend
+ * already produces a BSON Int64 for such a literal (serde_json reads it
+ * exactly, then bson maps it to Int64), so this restores the type the query
+ * always should have had. shellDoc then serializes canonically, because
+ * `containsLong` sees a Long, and the value survives to the server intact.
+ *
+ * Deliberately narrow — it only touches literals that are BOTH unrepresentable
+ * as a double AND expressible as a long:
+ *
+ * - Values inside strings and regex literals are the user's data, so those are
+ *   copied verbatim, exactly as `normalizePastedQuery` treats them.
+ * - Anything with a `.`, an exponent, or a `0x`/`0b`/`0o`/`n` suffix is left
+ *   alone. Those spell a double (or a form the parser handles itself) on
+ *   purpose, and rewriting them would change the user's chosen type.
+ * - Safe integers are left alone, so ordinary numbers keep serializing as they
+ *   always have — no `{a: 42}` suddenly becoming a long.
+ * - Object keys (`{123: 1}`) are skipped: a key is not a value, and
+ *   `NumberLong("…")` is not valid there.
+ * - Values beyond the i64 range are left alone. They cannot be a BSON long, so
+ *   there is no lossless form to rewrite them into; they stay as they are
+ *   rather than being silently truncated into a different wrong number.
+ */
+export function preserveBigIntegers(text: string): string {
+  let out = '';
+  let i = 0;
+  while (i < text.length) {
+    const c = text[i];
+    // Verbatim: a string's contents are data, not syntax.
+    if (c === '"' || c === "'") {
+      out += c;
+      i++;
+      while (i < text.length) {
+        if (text[i] === '\\') {
+          out += text[i] + (text[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += text[i];
+        if (text[i] === c) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    // Verbatim: digits inside a pattern are part of the pattern.
+    if (c === '/' && startsRegex(out)) {
+      const end = endOfRegex(text, i);
+      if (end !== -1) {
+        out += text.slice(i, end);
+        i = end;
+        continue;
+      }
+    }
+    if (c >= '0' && c <= '9') {
+      const prev = out[out.length - 1] ?? '';
+      // A digit run only starts a literal at a token boundary — `a1` and
+      // `1.5`'s tail are continuations, not new numbers.
+      if (!/[A-Za-z0-9_$.]/.test(prev)) {
+        let j = i;
+        while (j < text.length && text[j] >= '0' && text[j] <= '9') j++;
+        const digits = text.slice(i, j);
+        const after = text[j] ?? '';
+        const isPlainInteger = !/[.eExXbBoOn_]/.test(after);
+        // A key, not a value: `{123: 1}`.
+        const isKey = /^\s*:/.test(text.slice(j));
+        if (isPlainInteger && !isKey && !Number.isSafeInteger(Number(digits))) {
+          // Pull a unary minus in with the digits, so the long carries the
+          // sign rather than the parser negating a Long object.
+          const signed = /(^|[:,[(\s])-\s*$/.test(out);
+          const literal = (signed ? '-' : '') + digits;
+          const value = BigInt(literal);
+          if (value >= I64_MIN && value <= I64_MAX) {
+            if (signed) out = out.replace(/-\s*$/, '');
+            out += `NumberLong("${literal}")`;
+            i = j;
+            continue;
+          }
+        }
+      }
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
 /** Drop `;` off the end, but only when it is not inside a string. */
 function stripTrailingSemicolons(text: string): string {
   let cut = text.length;
@@ -486,7 +587,7 @@ function stripTrailingSemicolons(text: string): string {
 }
 
 export function parseShellJson(text: string, notices?: ShellDocNotices): any {
-  const trimmed = normalizePastedQuery(text).trim();
+  const trimmed = preserveBigIntegers(normalizePastedQuery(text)).trim();
   if (!trimmed) return {};
   // parseFilter signals "unparseable / not a valid query" by returning an empty
   // string rather than throwing (e.g. `{ _id }`, a half-typed field). Surface

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -515,22 +515,39 @@ const VALUE_STARTS_AFTER = ':,[';
  * Anywhere else the pre-existing behaviour is kept: an arithmetic operand
  * still rounds, which is worse than exact but far better than not parsing.
  */
-function classifyNumberPlacement(before: string): 'plain' | 'signed' | 'skip' {
-  const trimmed = before.replace(/\s*$/, '');
-  if (trimmed.endsWith('-')) {
-    const beforeMinus = trimmed.slice(0, -1).replace(/\s*$/, '');
-    const prev = beforeMinus[beforeMinus.length - 1] ?? '';
+function classifyNumberPlacement(
+  last: string,
+  prev: string,
+  out: string
+): 'plain' | 'signed' | 'skip' {
+  const startsValue = (ch: string) => ch === '' || VALUE_STARTS_AFTER.includes(ch);
+  if (last === '-') {
     // A minus is a sign only when nothing that could end an operand precedes
     // it; otherwise this is subtraction and the minus is not ours to take.
-    return prev === '' || VALUE_STARTS_AFTER.includes(prev) ? 'signed' : 'skip';
+    //
+    // It also has to still be at the end of the emitted text, since folding it
+    // into the literal means deleting it from there. A comment sitting between
+    // the two (`-/* note */5`) would make that deletion miss, so those are left
+    // alone rather than mangled — an exotic spelling of a rare case.
+    return startsValue(prev) && /-\s*$/.test(out) ? 'signed' : 'skip';
   }
-  const prev = trimmed[trimmed.length - 1] ?? '';
-  return prev === '' || VALUE_STARTS_AFTER.includes(prev) ? 'plain' : 'skip';
+  return startsValue(last) ? 'plain' : 'skip';
 }
 
 export function preserveBigIntegers(text: string): string {
   let out = '';
   let i = 0;
+  // The last two *syntactically meaningful* characters emitted — whitespace and
+  // comments do not count. Placement has to be judged on these rather than on
+  // the tail of `out`, because scanning `out` back would trip over the very
+  // things this pass copies verbatim (a `//` inside a URL string, a comment
+  // between the delimiter and the value).
+  let lastMeaningful = '';
+  let prevMeaningful = '';
+  const remember = (ch: string) => {
+    prevMeaningful = lastMeaningful;
+    lastMeaningful = ch;
+  };
   while (i < text.length) {
     const c = text[i];
     // Verbatim: a string's contents are data, not syntax.
@@ -550,14 +567,30 @@ export function preserveBigIntegers(text: string): string {
         }
         i++;
       }
+      remember('"');
+      continue;
+    }
+    // Comments are copied through but leave no syntactic trace, so they must
+    // be recognised BEFORE the regex branch — `/*` otherwise reads as a regex
+    // opener, and the closing `/` then looks like the token before the value,
+    // which left `{counter: /* note */ 9007199254740993}` unrewritten and
+    // still rounding (#318 review).
+    if (c === '/' && (text[i + 1] === '/' || text[i + 1] === '*')) {
+      const end =
+        text[i + 1] === '/'
+          ? (text.indexOf('\n', i) === -1 ? text.length : text.indexOf('\n', i))
+          : (text.indexOf('*/', i + 2) === -1 ? text.length : text.indexOf('*/', i + 2) + 2);
+      out += text.slice(i, end);
+      i = end;
       continue;
     }
     // Verbatim: digits inside a pattern are part of the pattern.
-    if (c === '/' && startsRegex(out)) {
+    if (c === '/' && startsRegex(lastMeaningful)) {
       const end = endOfRegex(text, i);
       if (end !== -1) {
         out += text.slice(i, end);
         i = end;
+        remember('/');
         continue;
       }
     }
@@ -574,7 +607,7 @@ export function preserveBigIntegers(text: string): string {
         // A key, not a value: `{123: 1}`.
         const isKey = /^\s*:/.test(text.slice(j));
         if (isPlainInteger && !isKey && !Number.isSafeInteger(Number(digits))) {
-          const placement = classifyNumberPlacement(out);
+          const placement = classifyNumberPlacement(lastMeaningful, prevMeaningful, out);
           if (placement !== 'skip') {
             // A unary minus comes along inside the long, so the parser is
             // never asked to negate a Long object.
@@ -584,6 +617,7 @@ export function preserveBigIntegers(text: string): string {
               if (placement === 'signed') out = out.replace(/-\s*$/, '');
               out += `NumberLong("${literal}")`;
               i = j;
+              remember('0');
               continue;
             }
           }
@@ -591,6 +625,7 @@ export function preserveBigIntegers(text: string): string {
       }
     }
     out += c;
+    if (!/\s/.test(c)) remember(c);
     i++;
   }
   return out;

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -498,6 +498,21 @@ const I64_MIN = -9223372036854775808n;
 const VALUE_STARTS_AFTER = ':,[';
 
 /**
+ * Characters that can follow a complete value: `{a: N}`, `[N]`, `[N, 1]`.
+ *
+ * The mirror of VALUE_STARTS_AFTER, and needed for the same reason from the
+ * other side. Checking only what precedes a literal caught `{a: 1 + N}` but
+ * not `{a: N + 1}`, where the literal is the LEFT operand — that became
+ * `NumberLong("…") + 1`, and JS concatenated the long's toString into the
+ * string "90071992547409931", turning a numeric query into a string one
+ * without a word (#318 review).
+ *
+ * It also subsumes the property-key case: `:` is not here, so `{123: 1}` is
+ * left alone by the same rule rather than a second special case.
+ */
+const VALUE_ENDS_BEFORE = ',}])';
+
+/**
  * Where does the literal we are about to read sit, and may we rewrite it?
  *
  * Rewriting anywhere a big integer appears is wrong, because the text around
@@ -633,9 +648,12 @@ export function preserveBigIntegers(text: string): string {
         const digits = text.slice(i, j);
         const after = text[j] ?? '';
         const isPlainInteger = !/[.eExXbBoOn_]/.test(after);
-        // A key, not a value: `{123: 1}`.
-        const isKey = text[skipTrivia(text, j)] === ':';
-        if (isPlainInteger && !isKey && !Number.isSafeInteger(Number(digits))) {
+        // Whatever follows must be able to end a value. One rule covers both a
+        // property key (`{123: 1}` — `:` cannot end a value) and a literal used
+        // as the left operand of an expression (`{a: N + 1}` — nor can `+`).
+        const next = text[skipTrivia(text, j)] ?? '';
+        const endsValue = next === '' || VALUE_ENDS_BEFORE.includes(next);
+        if (isPlainInteger && endsValue && !Number.isSafeInteger(Number(digits))) {
           const placement = classifyNumberPlacement(lastMeaningful, prevMeaningful, out);
           if (placement !== 'skip') {
             // A unary minus comes along inside the long, so the parser is

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -534,6 +534,38 @@ function classifyNumberPlacement(
   return startsValue(last) ? 'plain' : 'skip';
 }
 
+/** End of the comment starting at `i`, or -1 when none starts there. */
+function endOfComment(text: string, i: number): number {
+  if (text[i] !== '/') return -1;
+  if (text[i + 1] === '/') {
+    const nl = text.indexOf('\n', i);
+    return nl === -1 ? text.length : nl;
+  }
+  if (text[i + 1] === '*') {
+    const end = text.indexOf('*/', i + 2);
+    return end === -1 ? text.length : end + 2;
+  }
+  return -1;
+}
+
+/**
+ * First index at or after `from` holding something syntactically meaningful —
+ * whitespace and comments are both skipped.
+ *
+ * Looking only past whitespace is what let `{a: 1, 9007199254740992 /* n *\/: 1}`
+ * be mistaken for a value and rewritten into `NumberLong("…"): 1`, which is not
+ * a property key and stopped the query parsing (#318 review).
+ */
+function skipTrivia(text: string, from: number): number {
+  let k = from;
+  for (;;) {
+    while (k < text.length && /\s/.test(text[k])) k++;
+    const end = endOfComment(text, k);
+    if (end === -1) return k;
+    k = end;
+  }
+}
+
 export function preserveBigIntegers(text: string): string {
   let out = '';
   let i = 0;
@@ -575,13 +607,10 @@ export function preserveBigIntegers(text: string): string {
     // opener, and the closing `/` then looks like the token before the value,
     // which left `{counter: /* note */ 9007199254740993}` unrewritten and
     // still rounding (#318 review).
-    if (c === '/' && (text[i + 1] === '/' || text[i + 1] === '*')) {
-      const end =
-        text[i + 1] === '/'
-          ? (text.indexOf('\n', i) === -1 ? text.length : text.indexOf('\n', i))
-          : (text.indexOf('*/', i + 2) === -1 ? text.length : text.indexOf('*/', i + 2) + 2);
-      out += text.slice(i, end);
-      i = end;
+    const commentEnd = endOfComment(text, i);
+    if (commentEnd !== -1) {
+      out += text.slice(i, commentEnd);
+      i = commentEnd;
       continue;
     }
     // Verbatim: digits inside a pattern are part of the pattern.
@@ -605,7 +634,7 @@ export function preserveBigIntegers(text: string): string {
         const after = text[j] ?? '';
         const isPlainInteger = !/[.eExXbBoOn_]/.test(after);
         // A key, not a value: `{123: 1}`.
-        const isKey = /^\s*:/.test(text.slice(j));
+        const isKey = text[skipTrivia(text, j)] === ':';
         if (isPlainInteger && !isKey && !Number.isSafeInteger(Number(digits))) {
           const placement = classifyNumberPlacement(lastMeaningful, prevMeaningful, out);
           if (placement !== 'skip') {

--- a/src/lib/shellDoc.ts
+++ b/src/lib/shellDoc.ts
@@ -488,6 +488,46 @@ const I64_MIN = -9223372036854775808n;
  *   there is no lossless form to rewrite them into; they stay as they are
  *   rather than being silently truncated into a different wrong number.
  */
+/**
+ * Characters after which a fresh value may begin: `{a: N}`, `[N]`, `[1, N]`.
+ *
+ * Note what is NOT here. `(` is excluded so `NumberLong(9007199254740993)`
+ * keeps its own argument instead of becoming `NumberLong(NumberLong("…"))`,
+ * and arithmetic operators are excluded so an operand is left alone.
+ */
+const VALUE_STARTS_AFTER = ':,[';
+
+/**
+ * Where does the literal we are about to read sit, and may we rewrite it?
+ *
+ * Rewriting anywhere a big integer appears is wrong, because the text around
+ * it decides what it means. Three ways that bit (#318 review):
+ *
+ * - `{a: 1 - 9007199254740992}` — a spaced binary minus read as a sign, which
+ *   ate the operator and left `{a: 1 NumberLong("-…")}`, so a valid query
+ *   stopped parsing entirely.
+ * - `{a: 1 + 9007199254740992}` — an operand rewritten into a Long, leaving
+ *   the parser to do arithmetic on an object.
+ * - `{a: NumberLong(9007199254740993)}` — an argument rewritten inside the
+ *   very constructor that was already asking for a long.
+ *
+ * So this only says yes in value position, where a literal can stand alone.
+ * Anywhere else the pre-existing behaviour is kept: an arithmetic operand
+ * still rounds, which is worse than exact but far better than not parsing.
+ */
+function classifyNumberPlacement(before: string): 'plain' | 'signed' | 'skip' {
+  const trimmed = before.replace(/\s*$/, '');
+  if (trimmed.endsWith('-')) {
+    const beforeMinus = trimmed.slice(0, -1).replace(/\s*$/, '');
+    const prev = beforeMinus[beforeMinus.length - 1] ?? '';
+    // A minus is a sign only when nothing that could end an operand precedes
+    // it; otherwise this is subtraction and the minus is not ours to take.
+    return prev === '' || VALUE_STARTS_AFTER.includes(prev) ? 'signed' : 'skip';
+  }
+  const prev = trimmed[trimmed.length - 1] ?? '';
+  return prev === '' || VALUE_STARTS_AFTER.includes(prev) ? 'plain' : 'skip';
+}
+
 export function preserveBigIntegers(text: string): string {
   let out = '';
   let i = 0;
@@ -534,16 +574,18 @@ export function preserveBigIntegers(text: string): string {
         // A key, not a value: `{123: 1}`.
         const isKey = /^\s*:/.test(text.slice(j));
         if (isPlainInteger && !isKey && !Number.isSafeInteger(Number(digits))) {
-          // Pull a unary minus in with the digits, so the long carries the
-          // sign rather than the parser negating a Long object.
-          const signed = /(^|[:,[(\s])-\s*$/.test(out);
-          const literal = (signed ? '-' : '') + digits;
-          const value = BigInt(literal);
-          if (value >= I64_MIN && value <= I64_MAX) {
-            if (signed) out = out.replace(/-\s*$/, '');
-            out += `NumberLong("${literal}")`;
-            i = j;
-            continue;
+          const placement = classifyNumberPlacement(out);
+          if (placement !== 'skip') {
+            // A unary minus comes along inside the long, so the parser is
+            // never asked to negate a Long object.
+            const literal = (placement === 'signed' ? '-' : '') + digits;
+            const value = BigInt(literal);
+            if (value >= I64_MIN && value <= I64_MAX) {
+              if (placement === 'signed') out = out.replace(/-\s*$/, '');
+              out += `NumberLong("${literal}")`;
+              i = j;
+              continue;
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

`{counter: 9007199254740993}` reached the server as `…992` and matched a **different document** — no error, nothing on screen to say so. The query parser evaluates a bare literal as a JS `number`, so the value was gone before `EJSON.serialize` ever saw it. `containsLong` could not help: it only triggers on a real `Long`, and a bare literal never becomes one.

## Approach, and why not the #316 one

The loss happens *during* parsing, so the fix has to come *before* parsing: integer literals a double cannot hold are rewritten to `NumberLong("…")` on the way in.

#316 solved this for the export view by forwarding strict JSON verbatim. That works there, but it cannot reach the case that matters most here:

```
{counter: 9007199254740993, name: /acme/i}
```

That is not strict JSON, so a fast path skips it, and it is exactly the kind of query the shell-syntax work made possible. Fixing it at the parser's input instead covers **every** surface at once — filter, sort, projection, aggregation stage bodies, explain, and the generated mongosh command.

`NumberLong` is the honest target rather than a workaround. The backend already produces a BSON `Int64` for such a literal (`serde_json` reads it exactly, then `bson` maps it to `Int64`), so this restores the type the query always should have had.

## Deliberately narrow

It rewrites only literals that are **both** beyond a double's reach **and** expressible as a long:

| Input | Result | Why |
|---|---|---|
| `{counter: 9007199254740993}` | `NumberLong` | the bug |
| `{a: -9007199254740993}` | `NumberLong`, sign kept | |
| `{a: 42}`, `{a: 0}`, `{a: 9007199254740991}` | untouched | safe integers serialize exactly as before |
| `{a: 1.5}`, `{a: 1e30}` | untouched | the user spelled a double on purpose |
| `{note: "9007199254740993"}` | untouched | string contents are data |
| `{p: /9007199254740993/}` | untouched | pattern contents are data |
| `{a: 99999999999999999999999999}` | untouched | past i64 — no lossless form to move into, so it stays rather than being truncated into a different wrong number |
| `{9007199254740993: 1}` | untouched | `NumberLong(…)` is not valid in key position; such a field name is written quoted in practice, and that path is exact |

## Related issue

Closes #317.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [x] `npm run i18n:check` passes
- [ ] `cargo test` — no backend change
- [ ] Manually verified in the running app (`npm run tauri dev`)

11 new tests covering each row above, plus nesting in arrays and operators, the i64 extremes, and the mixed shell-syntax case.

Full suite: **1651 passed, 5 failed** — the same 5 that fail on a clean `dev` (Windows `spawn npx ENOENT`, locale number formatting in StatsCards and one ExportView assertion, a backend-constant grep). Unrelated, left alone.

Not manually run in the app.

## Note for the reviewer

Two consequences worth a deliberate look rather than being buried:

1. **A query containing a big integer now serializes canonically throughout**, so other numbers in it render as `{"$numberInt":"1"}`. That is the pre-existing `containsLong` behaviour, correct and handled by the backend, but this change makes it trigger more often.
2. **The strict-JSON fast path added to `ExportView` in #316 is now redundant for precision**, since the parser route is lossless. I left it alone to keep this PR to one concern — it is still a valid fast path — but it could be simplified away separately.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
