### PR TITLE
fix(results): copy the whole JSON selection, not just the last screenful

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1073,21 +1073,32 @@ export const DataGrid: React.FC<DataGridProps> = ({
     return Number.isInteger(index) ? index : null;
   };
 
-  /** Row indices the live DOM selection still covers, or null if it has none. */
+  /**
+   * Row indices for whichever selection endpoints can still be resolved.
+   *
+   * Each end is resolved on its own, and that is the crux of this whole
+   * mechanism rather than defensive coding. Once the drag passes the first
+   * window, the row holding the anchor is exactly what react-window unmounts —
+   * so requiring both ends to resolve threw away every update from the moment
+   * tracking started to matter, freezing the range at the first screenful
+   * (#319 review).
+   *
+   * An endpoint the browser has relocated to a surviving ancestor resolves to
+   * no row and is skipped rather than guessed at; the other end still extends
+   * the range, and the lost end was already recorded while it was mounted.
+   */
   const selectedJsonRange = (): { min: number; max: number } | null => {
     const selection = document.getSelection();
     const container = jsonViewRef.current;
     if (!selection || selection.isCollapsed || !container) return null;
-    if (
-      !container.contains(selection.anchorNode) ||
-      !container.contains(selection.focusNode)
-    ) {
-      return null;
+    const indices: number[] = [];
+    for (const node of [selection.anchorNode, selection.focusNode]) {
+      if (!node || !container.contains(node)) continue;
+      const index = jsonLineIndexOf(node);
+      if (index !== null) indices.push(index);
     }
-    const anchor = jsonLineIndexOf(selection.anchorNode);
-    const focus = jsonLineIndexOf(selection.focusNode);
-    if (anchor === null || focus === null) return null;
-    return { min: Math.min(anchor, focus), max: Math.max(anchor, focus) };
+    if (indices.length === 0) return null;
+    return { min: Math.min(...indices), max: Math.max(...indices) };
   };
 
   useEffect(() => {

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -477,6 +477,9 @@ const JsonRow = ({
         line.isDocRoot && line.docIndex > 0 && 'border-t border-border',
         findHighlightClass(line.num)
       )}
+      // Lets a copy reconstruct the selected range from the line data even
+      // after virtualization has unmounted the rows it started on (#311).
+      data-json-line={index}
       data-doc-even={line.docIndex % 2 === 0}
       onContextMenu={(e) => openCtxMenu(e, documents[line.docIndex], line.kind === 'scalar' ? line.keyName ?? undefined : undefined, line.value)}
     >
@@ -1046,6 +1049,84 @@ export const DataGrid: React.FC<DataGridProps> = ({
       case 'close':
         return `${line.bracket || '}'}${comma}`;
     }
+  };
+
+  // ── Copying a selection that scrolled (#311) ──────────────────────────────
+  //
+  // The JSON view is virtualized, so dragging a selection downwards unmounts
+  // the rows it started on. The browser's selection lives in the DOM, so those
+  // rows are simply gone by the time Cmd+C runs and only the last screenful is
+  // copied — silently, which is the worst part: the paste looks like a
+  // successful copy of the wrong thing.
+  //
+  // The extent is therefore recorded as the drag happens, while both ends are
+  // still mounted, and the copy is rebuilt from the line data rather than from
+  // the DOM.
+  const jsonViewRef = React.useRef<HTMLDivElement | null>(null);
+  const jsonSelectionRef = React.useRef<{ min: number; max: number } | null>(null);
+
+  const jsonLineIndexOf = (node: Node | null): number | null => {
+    const el = node instanceof Element ? node : (node?.parentElement ?? null);
+    const attr = el?.closest('[data-json-line]')?.getAttribute('data-json-line');
+    if (attr == null) return null;
+    const index = Number(attr);
+    return Number.isInteger(index) ? index : null;
+  };
+
+  /** Row indices the live DOM selection still covers, or null if it has none. */
+  const selectedJsonRange = (): { min: number; max: number } | null => {
+    const selection = document.getSelection();
+    const container = jsonViewRef.current;
+    if (!selection || selection.isCollapsed || !container) return null;
+    if (
+      !container.contains(selection.anchorNode) ||
+      !container.contains(selection.focusNode)
+    ) {
+      return null;
+    }
+    const anchor = jsonLineIndexOf(selection.anchorNode);
+    const focus = jsonLineIndexOf(selection.focusNode);
+    if (anchor === null || focus === null) return null;
+    return { min: Math.min(anchor, focus), max: Math.max(anchor, focus) };
+  };
+
+  useEffect(() => {
+    if (viewMode !== 'json') return;
+    // Widen rather than replace: the whole point is to remember rows the
+    // selection used to reach, so each event can only grow the range. A new
+    // drag clears it on mousedown.
+    const onSelectionChange = () => {
+      const range = selectedJsonRange();
+      if (!range) return;
+      const seen = jsonSelectionRef.current;
+      jsonSelectionRef.current = seen
+        ? { min: Math.min(seen.min, range.min), max: Math.max(seen.max, range.max) }
+        : range;
+    };
+    document.addEventListener('selectionchange', onSelectionChange);
+    return () => document.removeEventListener('selectionchange', onSelectionChange);
+  }, [viewMode]);
+
+  const handleJsonCopy = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    const tracked = jsonSelectionRef.current;
+    if (!tracked) return;
+    const live = selectedJsonRange();
+    // Step in only when rows really were lost. While everything the user
+    // selected is still mounted, the browser's own copy is better than ours:
+    // it honours a partial line at either end, which whole-line rebuilding
+    // cannot.
+    if (live && live.min <= tracked.min && live.max >= tracked.max) return;
+    const text = visibleJsonLines
+      .slice(tracked.min, tracked.max + 1)
+      .map((line) => {
+        const folded = line.foldId !== undefined && collapsedFolds.has(line.foldId);
+        const suffix = folded ? ` … ${line.closeChar ?? ''}${line.hasComma ? ',' : ''}` : '';
+        return '  '.repeat(line.depth) + jsonLineText(line) + suffix;
+      })
+      .join('\n');
+    if (!text) return;
+    e.clipboardData.setData('text/plain', text);
+    e.preventDefault();
   };
 
   const toggleFold = (id: number) => {
@@ -1748,7 +1829,15 @@ export const DataGrid: React.FC<DataGridProps> = ({
             <div>{t('dataGrid.empty.noDocuments')}</div>
           </div>
         ) : viewMode === 'json' ? (
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background font-mono text-xs leading-relaxed" data-testid="json-view">
+          <div
+            ref={jsonViewRef}
+            // A fresh drag starts a fresh extent; without this the range would
+            // only ever grow across unrelated selections.
+            onMouseDown={() => { jsonSelectionRef.current = null; }}
+            onCopy={handleJsonCopy}
+            className="flex min-h-0 min-w-0 flex-1 flex-col bg-background font-mono text-xs leading-relaxed"
+            data-testid="json-view"
+          >
             <div className="min-h-0 flex-1 min-w-0 overflow-auto">
               <List<JsonRowExtra>
                 rowCount={visibleJsonLines.length}

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1063,7 +1063,15 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // still mounted, and the copy is rebuilt from the line data rather than from
   // the DOM.
   const jsonViewRef = React.useRef<HTMLDivElement | null>(null);
-  const jsonSelectionRef = React.useRef<{ min: number; max: number } | null>(null);
+  // The two ends of the selection, each remembered independently at the last
+  // row it was seen on. Modelling the ends rather than a min/max span is what
+  // lets the range CONTRACT: during a drag the anchor is fixed and only the
+  // focus moves, so a span that could only grow kept lines the user had dragged
+  // back over and deselected, and then copied them (#319 review).
+  const jsonSelectionRef = React.useRef<{ anchor: number | null; focus: number | null }>({
+    anchor: null,
+    focus: null,
+  });
 
   const jsonLineIndexOf = (node: Node | null): number | null => {
     const el = node instanceof Element ? node : (node?.parentElement ?? null);
@@ -1074,54 +1082,56 @@ export const DataGrid: React.FC<DataGridProps> = ({
   };
 
   /**
-   * Row indices for whichever selection endpoints can still be resolved.
+   * The row each end of the live selection sits on, or null where it cannot be
+   * resolved.
    *
-   * Each end is resolved on its own, and that is the crux of this whole
-   * mechanism rather than defensive coding. Once the drag passes the first
-   * window, the row holding the anchor is exactly what react-window unmounts —
-   * so requiring both ends to resolve threw away every update from the moment
-   * tracking started to matter, freezing the range at the first screenful
-   * (#319 review).
+   * Each end is resolved on its own, which is the crux of this mechanism rather
+   * than defensive coding. Once the drag passes the first window, the row
+   * holding the anchor is exactly what react-window unmounts — so requiring
+   * both ends to resolve threw away every update from the moment tracking
+   * started to matter, freezing the range at the first screenful (#319 review).
    *
-   * An endpoint the browser has relocated to a surviving ancestor resolves to
-   * no row and is skipped rather than guessed at; the other end still extends
-   * the range, and the lost end was already recorded while it was mounted.
+   * An end the browser has relocated to a surviving ancestor resolves to no row
+   * and is reported as null rather than guessed at; the caller keeps the last
+   * row that end was actually seen on.
    */
-  const selectedJsonRange = (): { min: number; max: number } | null => {
+  const selectedJsonEnds = (): { anchor: number | null; focus: number | null } | null => {
     const selection = document.getSelection();
     const container = jsonViewRef.current;
     if (!selection || selection.isCollapsed || !container) return null;
-    const indices: number[] = [];
-    for (const node of [selection.anchorNode, selection.focusNode]) {
-      if (!node || !container.contains(node)) continue;
-      const index = jsonLineIndexOf(node);
-      if (index !== null) indices.push(index);
-    }
-    if (indices.length === 0) return null;
-    return { min: Math.min(...indices), max: Math.max(...indices) };
+    const rowOf = (node: Node | null) =>
+      node && container.contains(node) ? jsonLineIndexOf(node) : null;
+    return { anchor: rowOf(selection.anchorNode), focus: rowOf(selection.focusNode) };
+  };
+
+  const jsonRangeOf = (ends: { anchor: number | null; focus: number | null }) => {
+    const rows = [ends.anchor, ends.focus].filter((row): row is number => row !== null);
+    return rows.length ? { min: Math.min(...rows), max: Math.max(...rows) } : null;
   };
 
   useEffect(() => {
     if (viewMode !== 'json') return;
-    // Widen rather than replace: the whole point is to remember rows the
-    // selection used to reach, so each event can only grow the range. A new
-    // drag clears it on mousedown.
+    // Each end keeps the last row it was seen on, so an end that scrolls out of
+    // the DOM is remembered while the other stays free to move in either
+    // direction — extending the selection or pulling it back.
     const onSelectionChange = () => {
-      const range = selectedJsonRange();
-      if (!range) return;
+      const ends = selectedJsonEnds();
+      if (!ends) return;
       const seen = jsonSelectionRef.current;
-      jsonSelectionRef.current = seen
-        ? { min: Math.min(seen.min, range.min), max: Math.max(seen.max, range.max) }
-        : range;
+      jsonSelectionRef.current = {
+        anchor: ends.anchor ?? seen.anchor,
+        focus: ends.focus ?? seen.focus,
+      };
     };
     document.addEventListener('selectionchange', onSelectionChange);
     return () => document.removeEventListener('selectionchange', onSelectionChange);
   }, [viewMode]);
 
   const handleJsonCopy = (e: React.ClipboardEvent<HTMLDivElement>) => {
-    const tracked = jsonSelectionRef.current;
+    const tracked = jsonRangeOf(jsonSelectionRef.current);
     if (!tracked) return;
-    const live = selectedJsonRange();
+    const ends = selectedJsonEnds();
+    const live = ends && jsonRangeOf(ends);
     // Step in only when rows really were lost. While everything the user
     // selected is still mounted, the browser's own copy is better than ours:
     // it honours a partial line at either end, which whole-line rebuilding
@@ -1842,9 +1852,13 @@ export const DataGrid: React.FC<DataGridProps> = ({
         ) : viewMode === 'json' ? (
           <div
             ref={jsonViewRef}
-            // A fresh drag starts a fresh extent; without this the range would
-            // only ever grow across unrelated selections.
-            onMouseDown={() => { jsonSelectionRef.current = null; }}
+            // A fresh drag starts fresh tracking. Primary button only: a
+            // right-click opens a menu over an existing selection rather than
+            // replacing it, so resetting there threw away the recorded range
+            // just before the copy that needed it (#319 review).
+            onMouseDown={(e) => {
+              if (e.button === 0) jsonSelectionRef.current = { anchor: null, focus: null };
+            }}
             onCopy={handleJsonCopy}
             className="flex min-h-0 min-w-0 flex-1 flex-col bg-background font-mono text-xs leading-relaxed"
             data-testid="json-view"

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1205,3 +1205,103 @@ describe('find does not leak folds from a stale active index (#280 review round 
     expect(foldState('c')).toBe('closed');
   });
 });
+
+// #311: the JSON view is virtualized, so dragging a selection downwards
+// unmounts the rows it started on. The browser's selection lives in the DOM, so
+// by the time Cmd+C runs only the last screenful is left — and it copies
+// silently, which is the worst part: the paste looks like a successful copy of
+// the wrong thing.
+describe('DataGrid — copying a JSON selection that scrolled (#311)', () => {
+  const openJsonView = () => {
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /json/i }));
+    return screen.getByTestId('json-view');
+  };
+
+  /** A selection anchored on one rendered row and focused on another. */
+  const selectionSpanning = (view: HTMLElement, from: number, to: number) =>
+    ({
+      isCollapsed: false,
+      anchorNode: view.querySelector(`[data-json-line="${from}"]`),
+      focusNode: view.querySelector(`[data-json-line="${to}"]`),
+    }) as unknown as Selection;
+
+  const copyFrom = (view: HTMLElement) => {
+    const setData = vi.fn();
+    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    return setData;
+  };
+
+  it('rebuilds the full range from line data when rows were unmounted', () => {
+    const view = openJsonView();
+    expect(view.querySelectorAll('[data-json-line]').length).toBeGreaterThanOrEqual(4);
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    fireEvent.mouseDown(view);
+    // The drag reached rows 0-3 while all of them were still mounted.
+    getSelection.mockReturnValue(selectionSpanning(view, 0, 3));
+    document.dispatchEvent(new Event('selectionchange'));
+    // Scrolling has since dropped the top of that range; only 2-3 survive.
+    getSelection.mockReturnValue(selectionSpanning(view, 2, 3));
+
+    const setData = copyFrom(view);
+    expect(setData).toHaveBeenCalledTimes(1);
+    const [mime, text] = setData.mock.calls[0];
+    expect(mime).toBe('text/plain');
+    // All four lines, not just the two the DOM still had.
+    expect(text.split('\n')).toHaveLength(4);
+    expect(text).toContain('"Alice Smith"');
+    getSelection.mockRestore();
+  });
+
+  it('leaves the browser alone when the whole selection is still mounted', () => {
+    // Whole-line rebuilding cannot honour a partial line at either end, so it
+    // must not take over a copy the browser can do exactly.
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue(selectionSpanning(view, 1, 2));
+    document.dispatchEvent(new Event('selectionchange'));
+
+    expect(copyFrom(view)).not.toHaveBeenCalled();
+    getSelection.mockRestore();
+  });
+
+  it('starts a fresh extent on the next drag', () => {
+    // Without the mousedown reset the range would only ever grow, so an
+    // unrelated later selection would copy everything since the first one.
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue(selectionSpanning(view, 0, 4));
+    document.dispatchEvent(new Event('selectionchange'));
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue(selectionSpanning(view, 3, 4));
+    document.dispatchEvent(new Event('selectionchange'));
+
+    expect(copyFrom(view)).not.toHaveBeenCalled();
+    getSelection.mockRestore();
+  });
+
+  it('ignores a selection that is not in the JSON view', () => {
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: outside,
+      focusNode: outside,
+    } as unknown as Selection);
+    document.dispatchEvent(new Event('selectionchange'));
+
+    expect(copyFrom(view)).not.toHaveBeenCalled();
+    outside.remove();
+    getSelection.mockRestore();
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1284,6 +1284,46 @@ describe('DataGrid — copying a JSON selection that scrolled (#311)', () => {
     getSelection.mockRestore();
   });
 
+  it('lets the range contract when the drag reverses (#319 review)', () => {
+    // Dragging past a line and then back over it deselects it. A range that
+    // could only grow kept those lines and copied them anyway — silently
+    // adding text the user had explicitly removed, with every row mounted.
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue(selectionSpanning(view, 0, 3));
+    document.dispatchEvent(new Event('selectionchange'));
+    // Reversing: the anchor stays on row 0, the focus comes back to row 1.
+    getSelection.mockReturnValue(selectionSpanning(view, 0, 1));
+    document.dispatchEvent(new Event('selectionchange'));
+
+    // Nothing was lost, so the browser's own copy stands — and it is the
+    // contracted one.
+    expect(copyFrom(view)).not.toHaveBeenCalled();
+    getSelection.mockRestore();
+  });
+
+  it('keeps the tracked range through a right-click (#319 review)', () => {
+    // Right-clicking opens a menu over an existing selection rather than
+    // replacing it. Resetting on any button threw the range away immediately
+    // before the copy that needed it, so the fix only worked for Cmd+C.
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    fireEvent.mouseDown(view, { button: 0 });
+    getSelection.mockReturnValue(selectionSpanning(view, 0, 3));
+    document.dispatchEvent(new Event('selectionchange'));
+    getSelection.mockReturnValue(selectionSpanning(view, 2, 3));
+
+    fireEvent.mouseDown(view, { button: 2 });
+
+    const setData = copyFrom(view);
+    expect(setData).toHaveBeenCalledTimes(1);
+    expect(setData.mock.calls[0][1].split('\n')).toHaveLength(4);
+    getSelection.mockRestore();
+  });
+
   it('leaves the browser alone when the whole selection is still mounted', () => {
     // Whole-line rebuilding cannot honour a partial line at either end, so it
     // must not take over a copy the browser can do exactly.

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1254,6 +1254,36 @@ describe('DataGrid — copying a JSON selection that scrolled (#311)', () => {
     getSelection.mockRestore();
   });
 
+  it('keeps extending after the anchor row is unmounted (#319 review)', () => {
+    // The sequence that actually happens, which the test below it originally
+    // skipped: the drag records a range, THEN scrolling unmounts the row the
+    // anchor sits on, and the drag continues. Resolving the two endpoints
+    // together discarded every update from that point on, so the range froze
+    // at the first screenful — the exact case this feature exists for.
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+    // A node the browser is left holding once its row is gone.
+    const detached = document.createElement('span');
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue(selectionSpanning(view, 0, 1));
+    document.dispatchEvent(new Event('selectionchange'));
+
+    // Row 0 has scrolled away; only the focus end still resolves.
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: detached,
+      focusNode: view.querySelector('[data-json-line="3"]'),
+    } as unknown as Selection);
+    document.dispatchEvent(new Event('selectionchange'));
+
+    const setData = copyFrom(view);
+    expect(setData).toHaveBeenCalledTimes(1);
+    // 0 through 3 — the far end was still picked up with the anchor gone.
+    expect(setData.mock.calls[0][1].split('\n')).toHaveLength(4);
+    getSelection.mockRestore();
+  });
+
   it('leaves the browser alone when the whole selection is still mounted', () => {
     // Whole-line rebuilding cannot honour a partial line at either end, so it
     // must not take over a copy the browser can do exactly.


### PR DESCRIPTION
## Summary

Selecting a range in the JSON view by dragging downwards, then copying, pasted only the last screenful.

The cause is virtualization: the JSON view renders through react-window, so scrolling unmounts the rows the drag started on. The browser's selection lives in the DOM, so by the time Cmd+C runs those rows no longer exist and only what is still on screen reaches the clipboard.

**The silence is the worst part.** Nothing fails, and the paste looks like a successful copy of the wrong thing — a user selecting a few hundred lines has no way to tell except by reading what they pasted.

## Approach

The extent of the selection is recorded *as the drag happens*, while both ends are still mounted, and a copy is rebuilt from the line data rather than from the DOM.

- Rows carry a `data-json-line` index, so a selection endpoint maps back to the line it came from.
- A `selectionchange` listener only ever *widens* the recorded range — that is the whole point, since the rows it reached are about to disappear.
- The copied text is built with the existing `jsonLineText`, the same function the find bar searches, so what lands on the clipboard matches what is on screen. Folded rows keep their `… }` suffix.

## Two deliberate limits

**It only takes over when rows were actually lost.** While the whole selection is still mounted, the browser's own copy is better than ours — it honours a partial line at either end, and whole-line reconstruction cannot. Intervening there would make a working case worse.

**A mousedown clears the recorded extent.** Without that the range could only ever grow, so a later unrelated selection would copy everything back to the first one.

## What this does not change

Per-document copy, "Copy document JSON", "Copy value" and "Copy field name" all still work as before; this is only about a dragged range.

## Related issue

Closes #311.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [x] `npm run i18n:check` passes
- [ ] `cargo test` — no backend change
- [ ] Manually verified in the running app (`npm run tauri dev`)

Four tests: the rebuild when rows were unmounted, the browser being left alone when everything is still mounted, the extent resetting on a new drag, and a selection outside the JSON view being ignored.

Worth noting the test conditions are real rather than simulated in one respect — react-window mounts only four rows under jsdom, so rows genuinely are missing from the DOM. What the tests stand in for is the *scroll*, by moving the reported selection endpoints.

Full suite: **1688 passed, 5 failed** — the same 5 that fail on a clean `dev` (Windows `spawn npx ENOENT`, locale number formatting in StatsCards and one ExportView assertion, a backend-constant grep). Unrelated, left alone.

Not manually run in the app. This one is worth a real click-through before merge: it is a mouse-driven interaction, and jsdom cannot reproduce a native drag-scroll-select.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
