### PR TITLE
perf(query): stop every keystroke re-rendering the results grid

### DIFF
--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -1439,6 +1439,31 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
     }
   };
 
+  // The context value must keep its identity while the user types.
+  //
+  // The results grid consumes this context, and it arrives as `children` — a
+  // subtree React would otherwise skip re-rendering when only this component's
+  // own state changes. Handing over a fresh `{ handleExplain, explainLoading }`
+  // on every render defeated exactly that: each keystroke gave every consumer a
+  // new value, so the whole grid re-rendered per character and typing slowed in
+  // proportion to how much data was loaded (#310).
+  //
+  // A plain useCallback would not help. `handleExplain` reads the query text,
+  // so it genuinely differs on every keystroke and honest dependencies would
+  // change its identity just as often. Keeping the newest implementation in a
+  // ref lets the exposed function stay constant instead, leaving `explainLoading`
+  // — which only flips when an explain actually runs — as the one thing that
+  // can wake a consumer.
+  const handleExplainRef = useRef(handleExplain);
+  useEffect(() => {
+    handleExplainRef.current = handleExplain;
+  });
+  const stableHandleExplain = React.useCallback(() => handleExplainRef.current(), []);
+  const documentViewerContextValue = useMemo(
+    () => ({ handleExplain: stableHandleExplain, explainLoading }),
+    [stableHandleExplain, explainLoading]
+  );
+
   const handleClearField = (field: 'filter' | 'projection' | 'sort') => {
     if (field === 'filter') setFilterQuery('');
     if (field === 'projection') setProjectionQuery('');
@@ -2017,7 +2042,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
 
             </div>
 
-          <DocumentViewerContext.Provider value={{ handleExplain, explainLoading }}>
+          <DocumentViewerContext.Provider value={documentViewerContextValue}>
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               {children}
             </div>

--- a/src/components/__tests__/DocumentViewer.test.tsx
+++ b/src/components/__tests__/DocumentViewer.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React, { type ReactElement } from 'react';
 import { render as rtlRender, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { DocumentViewer, builderStateToQuery } from '../DocumentViewer';
+import { DocumentViewer, DocumentViewerContext, builderStateToQuery } from '../DocumentViewer';
 import { DialogProvider } from '../dialogs/DialogProvider';
 
 const render = (ui: ReactElement) => rtlRender(<DialogProvider>{ui}</DialogProvider>);
@@ -1563,5 +1563,78 @@ describe('page size resync from the pager (#218)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Run' }));
     expect(onExecute).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
+  });
+});
+
+// #310: typing in the query bar became slow in proportion to how much data was
+// loaded. The results grid consumes DocumentViewerContext and arrives as
+// `children` — a subtree React skips when only DocumentViewer's own state
+// changes — but the provider was handed a fresh object literal every render, so
+// every keystroke re-rendered the whole grid.
+describe('DocumentViewer — typing does not re-render the results (#310)', () => {
+  const Consumer: React.FC<{ onRender: () => void }> = ({ onRender }) => {
+    // Stands in for DataGrid: consumes this context and triggers Explain
+    // through it, which is where the real Explain control lives too.
+    const ctx = React.useContext(DocumentViewerContext);
+    onRender();
+    return (
+      <button data-testid="results-stand-in" onClick={() => ctx?.handleExplain()}>
+        results
+      </button>
+    );
+  };
+
+  const mockOnExecute = vi.fn();
+  const mockOnExplain = vi.fn().mockResolvedValue('{}');
+
+  const renderWithResults = (onRender: () => void) =>
+    render(
+      <DocumentViewer
+        connectionName="test-conn"
+        databaseName="test-db"
+        collectionName="test-coll"
+        onExecute={mockOnExecute}
+        onExplain={mockOnExplain}
+        loading={false}
+      >
+        <Consumer onRender={onRender} />
+      </DocumentViewer>
+    );
+
+  it('leaves the context identity alone across keystrokes', () => {
+    const onRender = vi.fn();
+    renderWithResults(onRender);
+    expect(screen.getByTestId('results-stand-in')).toBeInTheDocument();
+
+    const before = onRender.mock.calls.length;
+    const filterInput = screen.getByTestId('query-filter-input');
+    fireEvent.change(filterInput, { target: { value: '{"a": 1}' } });
+    fireEvent.change(filterInput, { target: { value: '{"a": 12}' } });
+    fireEvent.change(filterInput, { target: { value: '{"a": 123}' } });
+
+    // Three keystrokes, no extra work in the results subtree.
+    expect(onRender.mock.calls.length).toBe(before);
+  });
+
+  it('still notifies consumers when the explain state actually changes', async () => {
+    // The memo must not freeze the value so hard that a real update is missed:
+    // explainLoading is the one field consumers legitimately need to see move.
+    const onRender = vi.fn();
+    renderWithResults(onRender);
+    const before = onRender.mock.calls.length;
+    fireEvent.click(screen.getByTestId('results-stand-in'));
+    await waitFor(() => expect(onRender.mock.calls.length).toBeGreaterThan(before));
+  });
+
+  it('runs the explain that was current when it was invoked', () => {
+    // The stable wrapper reads through a ref, so it must not pin the first
+    // render's closure and explain a stale query.
+    const onRender = vi.fn();
+    renderWithResults(onRender);
+    fireEvent.change(screen.getByTestId('query-filter-input'), {
+      target: { value: '{"tier": "gold"}' },
+    });
+    fireEvent.click(screen.getByTestId('results-stand-in'));
+    expect(mockOnExplain).toHaveBeenCalledWith(JSON.stringify({ tier: 'gold' }));
   });
 });


### PR DESCRIPTION
## Summary

Typing in the query bar slowed down in proportion to how much data was loaded.

The reporter's instinct was right — the results were re-rendering on every keystroke — but the mechanism is more specific than `onChange` being used at all, and the suggested fix would not have addressed it.

## What was actually happening

The results grid consumes `DocumentViewerContext`, and it reaches `DocumentViewer` as `children`. That subtree is one React deliberately skips when only the parent's own state changes, so typing should never have touched it.

The provider undid that:

```tsx
<DocumentViewerContext.Provider value={{ handleExplain, explainLoading }}>
```

A fresh object literal every render. Context consumers re-render on identity, not contents, so each keystroke handed the grid a new value and re-rendered all of it — the `children` bail-out never got a chance.

**A plain `useCallback` would not have fixed it.** `handleExplain` reads the query text, so it genuinely differs on every keystroke; honest dependencies would change its identity just as often. The newest implementation now lives in a ref and the exposed function stays constant, leaving `explainLoading` — which only moves when an explain actually runs — as the one thing that can wake a consumer.

## Measurement

Counting renders of a context consumer across three keystrokes:

| | renders |
|---|---|
| before | 5 |
| after | 2 |

One extra render per character, gone. The test asserts this directly rather than describing it, and fails on the previous code with `expected 5 to be 2`.

## Why not the suggested fix

The report proposed moving the input to `onBlur`. That would work by giving up live validation — the parse errors, the unsupported-regex-flag notice, and Run staying disabled on a malformed query all depend on `onChange` — and it would leave the underlying problem in place for anything else that re-renders this component. Fixing the context identity keeps the feedback and removes the cost.

The second half of the report ("make sure changes on the query input do not trigger rerenders in the query results section") is exactly right, and is what this does.

## Related issue

Closes #310.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore — performance
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [x] `npm run i18n:check` passes
- [ ] `cargo test` — no backend change
- [ ] Manually verified in the running app (`npm run tauri dev`)

Three tests: the render count across keystrokes, that consumers still see `explainLoading` change, and that the ref-backed callback explains the *current* query rather than pinning the first render's closure.

Full suite: **1694 passed, 5 failed** — the same 5 that fail on a clean `dev`. Unrelated, left alone.

Not manually verified. The render count is measured, but whether it *feels* fixed with a genuinely heavy result set is worth confirming by hand — and it is possible other work per keystroke remains that this did not reach.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
