### PR TITLE
fix(results): trim a rebuilt copy to the characters actually selected

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1097,16 +1097,25 @@ export const DataGrid: React.FC<DataGridProps> = ({
     const row = el?.closest('[data-json-line]') ?? null;
     const index = Number(row?.getAttribute('data-json-line'));
     if (!row || !Number.isInteger(index)) return null;
-    let chars = 0;
-    const walker = document.createTreeWalker(row, NodeFilter.SHOW_TEXT);
-    for (let text = walker.nextNode(); text; text = walker.nextNode()) {
-      if (text === node) return { row: index, offset: chars + offset };
-      chars += text.textContent?.length ?? 0;
+    // Measure with a Range rather than counting text nodes by hand, because
+    // `offset` means different things depending on what `node` is: characters
+    // when it is a text node, but a CHILD INDEX when the boundary lands on an
+    // element — which happens readily, e.g. clicking in the padding to the
+    // right of a row's text. Range.setEnd applies each rule correctly, and the
+    // text before that point is then just the range's length.
+    //
+    // Hand-counting had to guess at the element case and chose either the start
+    // or the end of the line, so an endpoint there could drop the final line or
+    // pull in a whole one nobody selected (#322 review).
+    const range = document.createRange();
+    range.selectNodeContents(row);
+    try {
+      range.setEnd(node!, offset);
+    } catch {
+      // Boundary outside this row, so nothing meaningful to measure.
+      return { row: index, offset: 0 };
     }
-    // An endpoint on an element rather than a text node: its offset counts
-    // child nodes, not characters, so fall back to the whole line instead of
-    // trimming at a position that does not mean what it appears to.
-    return { row: index, offset: node === row ? 0 : chars };
+    return { row: index, offset: range.toString().length };
   };
 
   /**

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -369,6 +369,12 @@ const RenderTreeNode: React.FC<{ node: ExplainNode }> = ({ node }) => {
 
 // Lightweight, data-only descriptor for one rendered JSON line (no React nodes,
 // so building thousands of them stays cheap; content is rendered lazily per row).
+/** One end of a selection: the row it sits on and how far into that row. */
+interface JsonEndpoint {
+  row: number;
+  offset: number;
+}
+
 interface JsonLine {
   num: number;
   depth: number;
@@ -1068,50 +1074,76 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // lets the range CONTRACT: during a drag the anchor is fixed and only the
   // focus moves, so a span that could only grow kept lines the user had dragged
   // back over and deselected, and then copied them (#319 review).
-  const jsonSelectionRef = React.useRef<{ anchor: number | null; focus: number | null }>({
-    anchor: null,
-    focus: null,
-  });
+  const jsonSelectionRef = React.useRef<{
+    anchor: JsonEndpoint | null;
+    focus: JsonEndpoint | null;
+  }>({ anchor: null, focus: null });
 
-  const jsonLineIndexOf = (node: Node | null): number | null => {
+  /**
+   * The row an endpoint sits on, plus how far into that row's text it falls.
+   *
+   * The offset is what lets a partial endpoint be trimmed later. Without it the
+   * rebuild had only row numbers, so a drag starting mid-value and ending
+   * mid-value put the leading key and trailing text of both endpoint lines on
+   * the clipboard as well (#319 review).
+   *
+   * Counting characters across the row's text nodes works because a row's
+   * rendered text is exactly `jsonLineText`: the gutter's line number is a
+   * ::before pseudo-element and the fold control and row actions are icons, so
+   * none of them contribute text.
+   */
+  const jsonEndpointOf = (node: Node | null, offset: number): JsonEndpoint | null => {
     const el = node instanceof Element ? node : (node?.parentElement ?? null);
-    const attr = el?.closest('[data-json-line]')?.getAttribute('data-json-line');
-    if (attr == null) return null;
-    const index = Number(attr);
-    return Number.isInteger(index) ? index : null;
+    const row = el?.closest('[data-json-line]') ?? null;
+    const index = Number(row?.getAttribute('data-json-line'));
+    if (!row || !Number.isInteger(index)) return null;
+    let chars = 0;
+    const walker = document.createTreeWalker(row, NodeFilter.SHOW_TEXT);
+    for (let text = walker.nextNode(); text; text = walker.nextNode()) {
+      if (text === node) return { row: index, offset: chars + offset };
+      chars += text.textContent?.length ?? 0;
+    }
+    // An endpoint on an element rather than a text node: its offset counts
+    // child nodes, not characters, so fall back to the whole line instead of
+    // trimming at a position that does not mean what it appears to.
+    return { row: index, offset: node === row ? 0 : chars };
   };
 
   /**
-   * The row each end of the live selection sits on, or null where it cannot be
-   * resolved.
+   * Both ends of the live selection, each resolved on its own.
    *
-   * Each end is resolved on its own, which is the crux of this mechanism rather
-   * than defensive coding. Once the drag passes the first window, the row
-   * holding the anchor is exactly what react-window unmounts — so requiring
-   * both ends to resolve threw away every update from the moment tracking
-   * started to matter, freezing the range at the first screenful (#319 review).
-   *
-   * An end the browser has relocated to a surviving ancestor resolves to no row
-   * and is reported as null rather than guessed at; the caller keeps the last
-   * row that end was actually seen on.
+   * Resolving them independently is the crux of this mechanism rather than
+   * defensive coding. Once the drag passes the first window, the row holding
+   * the anchor is exactly what react-window unmounts — so requiring both to
+   * resolve threw away every update from the moment tracking started to
+   * matter, freezing the range at the first screenful (#319 review).
    */
-  const selectedJsonEnds = (): { anchor: number | null; focus: number | null } | null => {
+  const selectedJsonEnds = (): {
+    anchor: JsonEndpoint | null;
+    focus: JsonEndpoint | null;
+  } | null => {
     const selection = document.getSelection();
     const container = jsonViewRef.current;
     if (!selection || selection.isCollapsed || !container) return null;
-    const rowOf = (node: Node | null) =>
-      node && container.contains(node) ? jsonLineIndexOf(node) : null;
-    return { anchor: rowOf(selection.anchorNode), focus: rowOf(selection.focusNode) };
+    const endpoint = (node: Node | null, offset: number) =>
+      node && container.contains(node) ? jsonEndpointOf(node, offset) : null;
+    return {
+      anchor: endpoint(selection.anchorNode, selection.anchorOffset),
+      focus: endpoint(selection.focusNode, selection.focusOffset),
+    };
   };
 
-  const jsonRangeOf = (ends: { anchor: number | null; focus: number | null }) => {
-    const rows = [ends.anchor, ends.focus].filter((row): row is number => row !== null);
-    return rows.length ? { min: Math.min(...rows), max: Math.max(...rows) } : null;
+  /** The two endpoints in document order, or null if neither resolved. */
+  const jsonRangeOf = (ends: { anchor: JsonEndpoint | null; focus: JsonEndpoint | null }) => {
+    const ordered = [ends.anchor, ends.focus]
+      .filter((end): end is JsonEndpoint => end !== null)
+      .sort((a, b) => a.row - b.row || a.offset - b.offset);
+    return ordered.length ? { start: ordered[0], end: ordered[ordered.length - 1] } : null;
   };
 
   useEffect(() => {
     if (viewMode !== 'json') return;
-    // Each end keeps the last row it was seen on, so an end that scrolls out of
+    // Each end keeps the last place it was seen, so an end that scrolls out of
     // the DOM is remembered while the other stays free to move in either
     // direction — extending the selection or pulling it back.
     const onSelectionChange = () => {
@@ -1133,23 +1165,31 @@ export const DataGrid: React.FC<DataGridProps> = ({
     const ends = selectedJsonEnds();
     const live = ends && jsonRangeOf(ends);
     // Step in only when rows really were lost. While everything the user
-    // selected is still mounted, the browser's own copy is better than ours:
-    // it honours a partial line at either end, which whole-line rebuilding
-    // cannot.
-    if (live && live.min <= tracked.min && live.max >= tracked.max) return;
+    // selected is still mounted, the browser's own copy is exact and ours can
+    // only approximate it.
+    if (live && live.start.row <= tracked.start.row && live.end.row >= tracked.end.row) return;
     const text = visibleJsonLines
-      .slice(tracked.min, tracked.max + 1)
-      .map((line) => {
+      .slice(tracked.start.row, tracked.end.row + 1)
+      .map((line, i) => {
         const folded = line.foldId !== undefined && collapsedFolds.has(line.foldId);
         const suffix = folded ? ` … ${line.closeChar ?? ''}${line.hasComma ? ',' : ''}` : '';
-        return '  '.repeat(line.depth) + jsonLineText(line) + suffix;
+        const body = jsonLineText(line) + suffix;
+        const first = i === 0;
+        const last = tracked.start.row + i === tracked.end.row;
+        const from = first ? Math.min(tracked.start.offset, body.length) : 0;
+        const to = last ? Math.min(tracked.end.offset, body.length) : body.length;
+        // Indentation is added for readability, not copied — on screen it is
+        // padding, so no row's text contains it. That makes it a reasonable
+        // aid for a line taken whole and an intrusion on a line the selection
+        // only clipped, so a trimmed line goes without.
+        const whole = from === 0 && to === body.length;
+        return (whole ? '  '.repeat(line.depth) : '') + body.slice(from, to);
       })
       .join('\n');
     if (!text) return;
     e.clipboardData.setData('text/plain', text);
     e.preventDefault();
   };
-
   const toggleFold = (id: number) => {
     setCollapsedFolds((prev) => {
       const next = new Set(prev);

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1375,3 +1375,99 @@ describe('DataGrid — copying a JSON selection that scrolled (#311)', () => {
     getSelection.mockRestore();
   });
 });
+
+// #319 review: with only row indices recorded, the rebuild emitted whole
+// endpoint lines — so a drag starting mid-value and ending mid-value put the
+// leading key and trailing text of those lines on the clipboard too.
+describe('DataGrid — trimming partial endpoints of a rebuilt copy (#319 review)', () => {
+  const openJsonView = () => {
+    render(<DataGrid documents={[{ _id: 1, name: 'Alice', city: 'Paris', n: 2 }]} />);
+    fireEvent.click(screen.getByRole('button', { name: /json/i }));
+    return screen.getByTestId('json-view');
+  };
+
+  /** An endpoint at a character offset inside a row's own text. */
+  const endpointIn = (view: HTMLElement, row: number, offset: number) => {
+    const el = view.querySelector(`[data-json-line="${row}"]`)!;
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    let seen = 0;
+    for (let text = walker.nextNode(); text; text = walker.nextNode()) {
+      const len = text.textContent?.length ?? 0;
+      if (seen + len >= offset) return { node: text, offset: offset - seen };
+      seen += len;
+    }
+    return { node: el, offset: 0 };
+  };
+
+  it('trims the first and last lines to what was actually selected', () => {
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+    const rowText = (i: number) =>
+      view.querySelector(`[data-json-line="${i}"]`)!.textContent ?? '';
+
+    // Start four characters into row 1 and stop four characters into row 3.
+    const from = endpointIn(view, 1, 4);
+    const to = endpointIn(view, 3, 4);
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: from.node,
+      anchorOffset: from.offset,
+      focusNode: to.node,
+      focusOffset: to.offset,
+    } as unknown as Selection);
+    document.dispatchEvent(new Event('selectionchange'));
+
+    // Row 1 has since scrolled away, so the rebuild takes over.
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: view.querySelector('[data-json-line="3"]'),
+      anchorOffset: 0,
+      focusNode: view.querySelector('[data-json-line="3"]'),
+      focusOffset: 0,
+    } as unknown as Selection);
+
+    const setData = vi.fn();
+    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    expect(setData).toHaveBeenCalledTimes(1);
+    const lines = setData.mock.calls[0][1].split('\n');
+
+    expect(lines).toHaveLength(3);
+    // The first line starts where the drag did, not at the key.
+    expect(lines[0]).toBe(rowText(1).slice(4));
+    expect(lines[0]).not.toBe(rowText(1));
+    // The last line stops where the drag did, not at the end of the value.
+    expect(lines[2]).toBe(rowText(3).slice(0, 4));
+    getSelection.mockRestore();
+  });
+
+  it('keeps whole lines, indentation included, when the ends are not partial', () => {
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: view.querySelector('[data-json-line="0"]'),
+      anchorOffset: 0,
+      focusNode: view.querySelector('[data-json-line="3"]'),
+      focusOffset: 0,
+    } as unknown as Selection);
+    document.dispatchEvent(new Event('selectionchange'));
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: view.querySelector('[data-json-line="3"]'),
+      anchorOffset: 0,
+      focusNode: view.querySelector('[data-json-line="3"]'),
+      focusOffset: 0,
+    } as unknown as Selection);
+
+    const setData = vi.fn();
+    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    const lines = setData.mock.calls[0][1].split('\n');
+    // Nested rows keep the indent that a whole-line copy should carry.
+    expect(lines[1].startsWith('  ')).toBe(true);
+    getSelection.mockRestore();
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1471,3 +1471,59 @@ describe('DataGrid — trimming partial endpoints of a rebuilt copy (#319 review
     getSelection.mockRestore();
   });
 });
+
+// #322 review: a selection boundary can land on an ELEMENT, in which case its
+// offset counts child nodes rather than characters — clicking in the padding
+// right of a row's text does exactly that. Hand-counting text nodes had to
+// guess there, and chose either the start or the end of the line.
+describe('DataGrid — element selection boundaries (#322 review)', () => {
+  const openJsonView = () => {
+    render(<DataGrid documents={[{ _id: 1, name: 'Alice', city: 'Paris', n: 2 }]} />);
+    fireEvent.click(screen.getByRole('button', { name: /json/i }));
+    return screen.getByTestId('json-view');
+  };
+
+  it('measures a boundary that sits past a row\'s last child', () => {
+    const view = openJsonView();
+    const rowText = (i: number) =>
+      view.querySelector(`[data-json-line="${i}"]`)!.textContent ?? '';
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    const startRow = view.querySelector('[data-json-line="1"]')!;
+    const endRow = view.querySelector('[data-json-line="3"]')!;
+
+    fireEvent.mouseDown(view);
+    // Both ends land on the row elements, offset counting children: 0 children
+    // in at the start, every child in at the end — i.e. the whole of row 3.
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: startRow,
+      anchorOffset: 0,
+      focusNode: endRow,
+      focusOffset: endRow.childNodes.length,
+    } as unknown as Selection);
+    document.dispatchEvent(new Event('selectionchange'));
+
+    // Row 1 scrolls away, so the rebuild takes over.
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: endRow,
+      anchorOffset: 0,
+      focusNode: endRow,
+      focusOffset: 0,
+    } as unknown as Selection);
+
+    const setData = vi.fn();
+    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    expect(setData).toHaveBeenCalledTimes(1);
+    const lines = setData.mock.calls[0][1].split('\n');
+
+    // The end boundary is past every child of row 3, so that line is whole —
+    // previously the "descendant element" branch was the only one that gave a
+    // non-zero offset, and a boundary on the row itself collapsed to 0, which
+    // truncated the last line to nothing.
+    expect(lines).toHaveLength(3);
+    expect(lines[2].trim()).toBe(rowText(3));
+    getSelection.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Restores a fix that was written and tested for #319 but did not make it into the merge. #319 landed at `ad5bbe7`; this was the commit after it, so the finding it addresses is currently unfixed on `dev`.

## The finding

Raised in review of the copy rebuild. With only row indices recorded, the rebuild emits **whole** endpoint lines — so a drag starting mid-value and ending mid-value puts the leading key and trailing text of those two lines on the clipboard as well.

The existing guard does not cover it. That guard stands the rebuild down while the whole selection is still mounted, precisely so the browser can honour partial ends — but this is the case where rows were *lost*, which is when the guard does not apply.

## Fix

Each end now records how far into its row's text it falls, and the first and last lines are sliced to match.

Counting characters across a row's text nodes is sound because a row's rendered text is exactly `jsonLineText` — verified: the gutter's line number is a `::before` pseudo-element, and the fold control and row actions are icons, so none of them contribute text.

**One judgement call worth surfacing:** indentation is *added* for readability rather than copied. On screen it is padding, so no row's text contains it. That makes it a reasonable aid for a line taken whole and an intrusion on a line the selection merely clipped, so a trimmed line now goes without it.

## Related

Follows #319. The review comment that prompted it was posted on #321 by mistake — that PR had accidentally been branched off #319 — and is explained in both places.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [x] `npm run i18n:check` passes
- [ ] `cargo test` — no backend change
- [ ] Manually verified in the running app (`npm run tauri dev`)

Two tests: partial ends trimmed to exactly what was selected, and whole lines keeping their indent. The first fails on `dev` with the whole line where the selected fragment belongs:

```
AssertionError: expected '  "_id" : 1,' to be '" : 1,'
```

Not manually verified — same caveat as #319, which this extends.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
