### PR TITLE
fix(results): copy every row on select-all, not just the mounted ones

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1136,10 +1136,41 @@ export const DataGrid: React.FC<DataGridProps> = ({
     if (!selection || selection.isCollapsed || !container) return null;
     const endpoint = (node: Node | null, offset: number) =>
       node && container.contains(node) ? jsonEndpointOf(node, offset) : null;
-    return {
+    const ends = {
       anchor: endpoint(selection.anchorNode, selection.anchorOffset),
       focus: endpoint(selection.focusNode, selection.focusOffset),
     };
+    if (ends.anchor || ends.focus) return ends;
+    // Neither end sits on a row, which is what a select-all looks like: its
+    // endpoints land on <body>, outside the view entirely. Only treat that as
+    // "everything" once the selection is confirmed to ENCLOSE the view —
+    // clamping any unresolvable endpoint to the view's bounds would claim rows
+    // for selections that merely pass nearby, or that live somewhere else in
+    // the UI altogether (#320).
+    if (!enclosesJsonView(selection, container)) return ends;
+    return {
+      anchor: { row: 0, offset: 0 },
+      // Past the end of any line; the copy clamps it to the real length.
+      focus: { row: Math.max(visibleJsonLines.length - 1, 0), offset: Number.MAX_SAFE_INTEGER },
+    };
+  };
+
+  /** Does the selection start at or before the view and end at or after it? */
+  const enclosesJsonView = (selection: Selection, container: HTMLElement): boolean => {
+    if (selection.rangeCount === 0) return false;
+    const contents = document.createRange();
+    contents.selectNodeContents(container);
+    try {
+      const range = selection.getRangeAt(0);
+      return (
+        range.compareBoundaryPoints(Range.START_TO_START, contents) <= 0 &&
+        range.compareBoundaryPoints(Range.END_TO_END, contents) >= 0
+      );
+    } catch {
+      // Ranges in different documents cannot be compared; treat as no match
+      // rather than assuming the view is covered.
+      return false;
+    }
   };
 
   /** The two endpoints in document order, or null if neither resolved. */
@@ -1171,12 +1202,28 @@ export const DataGrid: React.FC<DataGridProps> = ({
   const handleJsonCopy = (e: React.ClipboardEvent<HTMLDivElement>) => {
     const tracked = jsonRangeOf(jsonSelectionRef.current);
     if (!tracked) return;
+    // Stand aside only when the browser can be trusted to copy this exactly,
+    // which takes both signals agreeing.
+    //
+    // The live selection still spanning everything tracked says nothing was
+    // dragged out of range. That alone was the old test, and a select-all slips
+    // straight through it: its span covers the tracked rows on paper while the
+    // DOM holds only a screenful (#320).
+    //
+    // So the rows must also actually be there. react-window renders a
+    // contiguous window, so finding both ends means everything between them is
+    // present too.
     const ends = selectedJsonEnds();
     const live = ends && jsonRangeOf(ends);
-    // Step in only when rows really were lost. While everything the user
-    // selected is still mounted, the browser's own copy is exact and ours can
-    // only approximate it.
-    if (live && live.start.row <= tracked.start.row && live.end.row >= tracked.end.row) return;
+    const spansAll = !!live && live.start.row <= tracked.start.row && live.end.row >= tracked.end.row;
+    const container = jsonViewRef.current;
+    const wanted = tracked.end.row - tracked.start.row + 1;
+    const allMounted =
+      !!container &&
+      container.querySelectorAll('[data-json-line]').length >= wanted &&
+      !!container.querySelector(`[data-json-line="${tracked.start.row}"]`) &&
+      !!container.querySelector(`[data-json-line="${tracked.end.row}"]`);
+    if (spansAll && allMounted) return;
     const text = visibleJsonLines
       .slice(tracked.start.row, tracked.end.row + 1)
       .map((line, i) => {

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1097,16 +1097,25 @@ export const DataGrid: React.FC<DataGridProps> = ({
     const row = el?.closest('[data-json-line]') ?? null;
     const index = Number(row?.getAttribute('data-json-line'));
     if (!row || !Number.isInteger(index)) return null;
-    let chars = 0;
-    const walker = document.createTreeWalker(row, NodeFilter.SHOW_TEXT);
-    for (let text = walker.nextNode(); text; text = walker.nextNode()) {
-      if (text === node) return { row: index, offset: chars + offset };
-      chars += text.textContent?.length ?? 0;
+    // Measure with a Range rather than counting text nodes by hand, because
+    // `offset` means different things depending on what `node` is: characters
+    // when it is a text node, but a CHILD INDEX when the boundary lands on an
+    // element — which happens readily, e.g. clicking in the padding to the
+    // right of a row's text. Range.setEnd applies each rule correctly, and the
+    // text before that point is then just the range's length.
+    //
+    // Hand-counting had to guess at the element case and chose either the start
+    // or the end of the line, so an endpoint there could drop the final line or
+    // pull in a whole one nobody selected (#322 review).
+    const range = document.createRange();
+    range.selectNodeContents(row);
+    try {
+      range.setEnd(node!, offset);
+    } catch {
+      // Boundary outside this row, so nothing meaningful to measure.
+      return { row: index, offset: 0 };
     }
-    // An endpoint on an element rather than a text node: its offset counts
-    // child nodes, not characters, so fall back to the whole line instead of
-    // trimming at a position that does not mean what it appears to.
-    return { row: index, offset: node === row ? 0 : chars };
+    return { row: index, offset: range.toString().length };
   };
 
   /**

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -369,6 +369,12 @@ const RenderTreeNode: React.FC<{ node: ExplainNode }> = ({ node }) => {
 
 // Lightweight, data-only descriptor for one rendered JSON line (no React nodes,
 // so building thousands of them stays cheap; content is rendered lazily per row).
+/** One end of a selection: the row it sits on and how far into that row. */
+interface JsonEndpoint {
+  row: number;
+  offset: number;
+}
+
 interface JsonLine {
   num: number;
   depth: number;
@@ -1068,50 +1074,76 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // lets the range CONTRACT: during a drag the anchor is fixed and only the
   // focus moves, so a span that could only grow kept lines the user had dragged
   // back over and deselected, and then copied them (#319 review).
-  const jsonSelectionRef = React.useRef<{ anchor: number | null; focus: number | null }>({
-    anchor: null,
-    focus: null,
-  });
+  const jsonSelectionRef = React.useRef<{
+    anchor: JsonEndpoint | null;
+    focus: JsonEndpoint | null;
+  }>({ anchor: null, focus: null });
 
-  const jsonLineIndexOf = (node: Node | null): number | null => {
+  /**
+   * The row an endpoint sits on, plus how far into that row's text it falls.
+   *
+   * The offset is what lets a partial endpoint be trimmed later. Without it the
+   * rebuild had only row numbers, so a drag starting mid-value and ending
+   * mid-value put the leading key and trailing text of both endpoint lines on
+   * the clipboard as well (#319 review).
+   *
+   * Counting characters across the row's text nodes works because a row's
+   * rendered text is exactly `jsonLineText`: the gutter's line number is a
+   * ::before pseudo-element and the fold control and row actions are icons, so
+   * none of them contribute text.
+   */
+  const jsonEndpointOf = (node: Node | null, offset: number): JsonEndpoint | null => {
     const el = node instanceof Element ? node : (node?.parentElement ?? null);
-    const attr = el?.closest('[data-json-line]')?.getAttribute('data-json-line');
-    if (attr == null) return null;
-    const index = Number(attr);
-    return Number.isInteger(index) ? index : null;
+    const row = el?.closest('[data-json-line]') ?? null;
+    const index = Number(row?.getAttribute('data-json-line'));
+    if (!row || !Number.isInteger(index)) return null;
+    let chars = 0;
+    const walker = document.createTreeWalker(row, NodeFilter.SHOW_TEXT);
+    for (let text = walker.nextNode(); text; text = walker.nextNode()) {
+      if (text === node) return { row: index, offset: chars + offset };
+      chars += text.textContent?.length ?? 0;
+    }
+    // An endpoint on an element rather than a text node: its offset counts
+    // child nodes, not characters, so fall back to the whole line instead of
+    // trimming at a position that does not mean what it appears to.
+    return { row: index, offset: node === row ? 0 : chars };
   };
 
   /**
-   * The row each end of the live selection sits on, or null where it cannot be
-   * resolved.
+   * Both ends of the live selection, each resolved on its own.
    *
-   * Each end is resolved on its own, which is the crux of this mechanism rather
-   * than defensive coding. Once the drag passes the first window, the row
-   * holding the anchor is exactly what react-window unmounts — so requiring
-   * both ends to resolve threw away every update from the moment tracking
-   * started to matter, freezing the range at the first screenful (#319 review).
-   *
-   * An end the browser has relocated to a surviving ancestor resolves to no row
-   * and is reported as null rather than guessed at; the caller keeps the last
-   * row that end was actually seen on.
+   * Resolving them independently is the crux of this mechanism rather than
+   * defensive coding. Once the drag passes the first window, the row holding
+   * the anchor is exactly what react-window unmounts — so requiring both to
+   * resolve threw away every update from the moment tracking started to
+   * matter, freezing the range at the first screenful (#319 review).
    */
-  const selectedJsonEnds = (): { anchor: number | null; focus: number | null } | null => {
+  const selectedJsonEnds = (): {
+    anchor: JsonEndpoint | null;
+    focus: JsonEndpoint | null;
+  } | null => {
     const selection = document.getSelection();
     const container = jsonViewRef.current;
     if (!selection || selection.isCollapsed || !container) return null;
-    const rowOf = (node: Node | null) =>
-      node && container.contains(node) ? jsonLineIndexOf(node) : null;
-    return { anchor: rowOf(selection.anchorNode), focus: rowOf(selection.focusNode) };
+    const endpoint = (node: Node | null, offset: number) =>
+      node && container.contains(node) ? jsonEndpointOf(node, offset) : null;
+    return {
+      anchor: endpoint(selection.anchorNode, selection.anchorOffset),
+      focus: endpoint(selection.focusNode, selection.focusOffset),
+    };
   };
 
-  const jsonRangeOf = (ends: { anchor: number | null; focus: number | null }) => {
-    const rows = [ends.anchor, ends.focus].filter((row): row is number => row !== null);
-    return rows.length ? { min: Math.min(...rows), max: Math.max(...rows) } : null;
+  /** The two endpoints in document order, or null if neither resolved. */
+  const jsonRangeOf = (ends: { anchor: JsonEndpoint | null; focus: JsonEndpoint | null }) => {
+    const ordered = [ends.anchor, ends.focus]
+      .filter((end): end is JsonEndpoint => end !== null)
+      .sort((a, b) => a.row - b.row || a.offset - b.offset);
+    return ordered.length ? { start: ordered[0], end: ordered[ordered.length - 1] } : null;
   };
 
   useEffect(() => {
     if (viewMode !== 'json') return;
-    // Each end keeps the last row it was seen on, so an end that scrolls out of
+    // Each end keeps the last place it was seen, so an end that scrolls out of
     // the DOM is remembered while the other stays free to move in either
     // direction — extending the selection or pulling it back.
     const onSelectionChange = () => {
@@ -1133,23 +1165,31 @@ export const DataGrid: React.FC<DataGridProps> = ({
     const ends = selectedJsonEnds();
     const live = ends && jsonRangeOf(ends);
     // Step in only when rows really were lost. While everything the user
-    // selected is still mounted, the browser's own copy is better than ours:
-    // it honours a partial line at either end, which whole-line rebuilding
-    // cannot.
-    if (live && live.min <= tracked.min && live.max >= tracked.max) return;
+    // selected is still mounted, the browser's own copy is exact and ours can
+    // only approximate it.
+    if (live && live.start.row <= tracked.start.row && live.end.row >= tracked.end.row) return;
     const text = visibleJsonLines
-      .slice(tracked.min, tracked.max + 1)
-      .map((line) => {
+      .slice(tracked.start.row, tracked.end.row + 1)
+      .map((line, i) => {
         const folded = line.foldId !== undefined && collapsedFolds.has(line.foldId);
         const suffix = folded ? ` … ${line.closeChar ?? ''}${line.hasComma ? ',' : ''}` : '';
-        return '  '.repeat(line.depth) + jsonLineText(line) + suffix;
+        const body = jsonLineText(line) + suffix;
+        const first = i === 0;
+        const last = tracked.start.row + i === tracked.end.row;
+        const from = first ? Math.min(tracked.start.offset, body.length) : 0;
+        const to = last ? Math.min(tracked.end.offset, body.length) : body.length;
+        // Indentation is added for readability, not copied — on screen it is
+        // padding, so no row's text contains it. That makes it a reasonable
+        // aid for a line taken whole and an intrusion on a line the selection
+        // only clipped, so a trimmed line goes without.
+        const whole = from === 0 && to === body.length;
+        return (whole ? '  '.repeat(line.depth) : '') + body.slice(from, to);
       })
       .join('\n');
     if (!text) return;
     e.clipboardData.setData('text/plain', text);
     e.preventDefault();
   };
-
   const toggleFold = (id: number) => {
     setCollapsedFolds((prev) => {
       const next = new Set(prev);

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1375,3 +1375,99 @@ describe('DataGrid — copying a JSON selection that scrolled (#311)', () => {
     getSelection.mockRestore();
   });
 });
+
+// #319 review: with only row indices recorded, the rebuild emitted whole
+// endpoint lines — so a drag starting mid-value and ending mid-value put the
+// leading key and trailing text of those lines on the clipboard too.
+describe('DataGrid — trimming partial endpoints of a rebuilt copy (#319 review)', () => {
+  const openJsonView = () => {
+    render(<DataGrid documents={[{ _id: 1, name: 'Alice', city: 'Paris', n: 2 }]} />);
+    fireEvent.click(screen.getByRole('button', { name: /json/i }));
+    return screen.getByTestId('json-view');
+  };
+
+  /** An endpoint at a character offset inside a row's own text. */
+  const endpointIn = (view: HTMLElement, row: number, offset: number) => {
+    const el = view.querySelector(`[data-json-line="${row}"]`)!;
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    let seen = 0;
+    for (let text = walker.nextNode(); text; text = walker.nextNode()) {
+      const len = text.textContent?.length ?? 0;
+      if (seen + len >= offset) return { node: text, offset: offset - seen };
+      seen += len;
+    }
+    return { node: el, offset: 0 };
+  };
+
+  it('trims the first and last lines to what was actually selected', () => {
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+    const rowText = (i: number) =>
+      view.querySelector(`[data-json-line="${i}"]`)!.textContent ?? '';
+
+    // Start four characters into row 1 and stop four characters into row 3.
+    const from = endpointIn(view, 1, 4);
+    const to = endpointIn(view, 3, 4);
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: from.node,
+      anchorOffset: from.offset,
+      focusNode: to.node,
+      focusOffset: to.offset,
+    } as unknown as Selection);
+    document.dispatchEvent(new Event('selectionchange'));
+
+    // Row 1 has since scrolled away, so the rebuild takes over.
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: view.querySelector('[data-json-line="3"]'),
+      anchorOffset: 0,
+      focusNode: view.querySelector('[data-json-line="3"]'),
+      focusOffset: 0,
+    } as unknown as Selection);
+
+    const setData = vi.fn();
+    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    expect(setData).toHaveBeenCalledTimes(1);
+    const lines = setData.mock.calls[0][1].split('\n');
+
+    expect(lines).toHaveLength(3);
+    // The first line starts where the drag did, not at the key.
+    expect(lines[0]).toBe(rowText(1).slice(4));
+    expect(lines[0]).not.toBe(rowText(1));
+    // The last line stops where the drag did, not at the end of the value.
+    expect(lines[2]).toBe(rowText(3).slice(0, 4));
+    getSelection.mockRestore();
+  });
+
+  it('keeps whole lines, indentation included, when the ends are not partial', () => {
+    const view = openJsonView();
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    fireEvent.mouseDown(view);
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: view.querySelector('[data-json-line="0"]'),
+      anchorOffset: 0,
+      focusNode: view.querySelector('[data-json-line="3"]'),
+      focusOffset: 0,
+    } as unknown as Selection);
+    document.dispatchEvent(new Event('selectionchange'));
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: view.querySelector('[data-json-line="3"]'),
+      anchorOffset: 0,
+      focusNode: view.querySelector('[data-json-line="3"]'),
+      focusOffset: 0,
+    } as unknown as Selection);
+
+    const setData = vi.fn();
+    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    const lines = setData.mock.calls[0][1].split('\n');
+    // Nested rows keep the indent that a whole-line copy should carry.
+    expect(lines[1].startsWith('  ')).toBe(true);
+    getSelection.mockRestore();
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1471,3 +1471,59 @@ describe('DataGrid — trimming partial endpoints of a rebuilt copy (#319 review
     getSelection.mockRestore();
   });
 });
+
+// #322 review: a selection boundary can land on an ELEMENT, in which case its
+// offset counts child nodes rather than characters — clicking in the padding
+// right of a row's text does exactly that. Hand-counting text nodes had to
+// guess there, and chose either the start or the end of the line.
+describe('DataGrid — element selection boundaries (#322 review)', () => {
+  const openJsonView = () => {
+    render(<DataGrid documents={[{ _id: 1, name: 'Alice', city: 'Paris', n: 2 }]} />);
+    fireEvent.click(screen.getByRole('button', { name: /json/i }));
+    return screen.getByTestId('json-view');
+  };
+
+  it('measures a boundary that sits past a row\'s last child', () => {
+    const view = openJsonView();
+    const rowText = (i: number) =>
+      view.querySelector(`[data-json-line="${i}"]`)!.textContent ?? '';
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    const startRow = view.querySelector('[data-json-line="1"]')!;
+    const endRow = view.querySelector('[data-json-line="3"]')!;
+
+    fireEvent.mouseDown(view);
+    // Both ends land on the row elements, offset counting children: 0 children
+    // in at the start, every child in at the end — i.e. the whole of row 3.
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: startRow,
+      anchorOffset: 0,
+      focusNode: endRow,
+      focusOffset: endRow.childNodes.length,
+    } as unknown as Selection);
+    document.dispatchEvent(new Event('selectionchange'));
+
+    // Row 1 scrolls away, so the rebuild takes over.
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: endRow,
+      anchorOffset: 0,
+      focusNode: endRow,
+      focusOffset: 0,
+    } as unknown as Selection);
+
+    const setData = vi.fn();
+    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    expect(setData).toHaveBeenCalledTimes(1);
+    const lines = setData.mock.calls[0][1].split('\n');
+
+    // The end boundary is past every child of row 3, so that line is whole —
+    // previously the "descendant element" branch was the only one that gave a
+    // non-zero offset, and a boundary on the row itself collapsed to 0, which
+    // truncated the last line to nothing.
+    expect(lines).toHaveLength(3);
+    expect(lines[2].trim()).toBe(rowText(3));
+    getSelection.mockRestore();
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1527,3 +1527,81 @@ describe('DataGrid — element selection boundaries (#322 review)', () => {
     getSelection.mockRestore();
   });
 });
+// #320: a select-all puts its endpoints on <body>, outside the view, so no row
+// resolved, nothing was tracked, and the copy fell through to the browser —
+// which holds only the mounted rows. Same silent truncation as #311, on the
+// more natural way to copy a whole result set.
+describe('DataGrid — select-all copies every row (#320)', () => {
+  const manyDocs = Array.from({ length: 40 }, (_, i) => ({ _id: i, name: `n${i}` }));
+
+  const openJsonView = () => {
+    render(<DataGrid documents={manyDocs} />);
+    fireEvent.click(screen.getByRole('button', { name: /json/i }));
+    return screen.getByTestId('json-view');
+  };
+
+  /** A selection whose range encloses the whole document, as Cmd+A produces. */
+  const selectAll = () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.body);
+    return {
+      isCollapsed: false,
+      anchorNode: document.body,
+      anchorOffset: 0,
+      focusNode: document.body,
+      focusOffset: document.body.childNodes.length,
+      rangeCount: 1,
+      getRangeAt: () => range,
+    } as unknown as Selection;
+  };
+
+  it('rebuilds every line, not just the mounted ones', () => {
+    const view = openJsonView();
+    const mounted = view.querySelectorAll('[data-json-line]').length;
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    getSelection.mockReturnValue(selectAll());
+    document.dispatchEvent(new Event('selectionchange'));
+
+    const setData = vi.fn();
+    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+
+    expect(setData).toHaveBeenCalledTimes(1);
+    const lines = setData.mock.calls[0][1].split('\n');
+    // 40 documents is far more than a screenful, so this only passes if the
+    // rebuild reached rows the DOM never held.
+    expect(lines.length).toBeGreaterThan(mounted);
+    expect(lines[0]).toBe('{');
+    getSelection.mockRestore();
+  });
+
+  it('ignores a selection that does not enclose the view', () => {
+    // The trap in the obvious fix: treating any unresolvable endpoint as the
+    // view's bounds would claim rows for selections living elsewhere in the UI.
+    const view = openJsonView();
+    const elsewhere = document.createElement('div');
+    elsewhere.textContent = 'unrelated';
+    document.body.appendChild(elsewhere);
+    const range = document.createRange();
+    range.selectNodeContents(elsewhere);
+    const getSelection = vi.spyOn(document, 'getSelection');
+
+    getSelection.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: elsewhere,
+      anchorOffset: 0,
+      focusNode: elsewhere,
+      focusOffset: 1,
+      rangeCount: 1,
+      getRangeAt: () => range,
+    } as unknown as Selection);
+    document.dispatchEvent(new Event('selectionchange'));
+
+    const setData = vi.fn();
+    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    expect(setData).not.toHaveBeenCalled();
+
+    elsewhere.remove();
+    getSelection.mockRestore();
+  });
+});


### PR DESCRIPTION
> **Stacked on #322.** That PR restores the partial-endpoint trimming that was written for #319 but missed the merge; this builds on the same selection code. Review or merge #322 first — the diff here will shrink to one commit once it lands.

## Summary

A select-all followed by copy pasted only the rows near the viewport — the same silent truncation as #311, on arguably the more natural way to copy a whole result set.

## Cause

The #311 fix records the selection's endpoints as a drag moves, mapping each to the row it sits on. A select-all never produces endpoints on a row:

```
anchorNode: BODY
view.contains(anchorNode): false
anchor closest [data-json-line]: none
```

So nothing was tracked, and the copy correctly fell through to the browser — which only has the mounted rows.

## Fix, and the trap avoided

Endpoints that resolve to no row are treated as "everything" **only once the selection is confirmed to enclose the view**, by comparing range boundary points.

The obvious fix — treat any unresolvable endpoint as the view's first/last row — is wrong, and I flagged it as the trap when filing #320. It would claim rows for selections that merely pass nearby, or that live somewhere else in the UI entirely. There is a test for exactly that case.

**The copy guard needed widening to match**, which was the non-obvious part. It previously stood aside whenever the live selection still spanned everything tracked — and a select-all satisfies that on paper while the DOM holds a screenful. Deferring to the browser now also requires the rows to actually be mounted. react-window renders a contiguous window, so finding both ends means everything between them is present too.

Both signals are kept rather than swapping one for the other: the span check still catches a drag pulled back out of range, and the mounted check catches a range the DOM never held.

## What remains unverified

#320 said a native Cmd+A should be reproduced by hand before fixing, and that has **not** happened — I cannot drive the real app from here. What is measured is that jsdom's select-all lands its endpoints on `<body>`, which is what the fix keys off.

Two things still want a real click-through:

1. Whether a native Cmd+A in the app produces an enclosing range over this view, or is scoped somewhere else entirely.
2. Whether anything intercepts Cmd+A in that pane.

If it turns out Cmd+A is scoped differently, the enclosure test simply will not match and behaviour falls back to today's — so this is safe to land ahead of that check, but it is not proof the reported case is fixed.

## Related issue

Closes #320.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [x] `npm run i18n:check` passes
- [ ] `cargo test` — no backend change
- [ ] Manually verified in the running app (`npm run tauri dev`)

Two tests: a 40-document select-all rebuilding more lines than were ever mounted, and a selection elsewhere in the UI being left alone. The first fails on the previous code with no rebuild at all.

Full suite: **1695 passed, 5 failed** — the same 5 that fail on a clean `dev`. Unrelated, left alone.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
