### PR TITLE
fix(theme): theme the editor from config, and put status colours on tokens

### DIFF
--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -6,7 +6,7 @@ import type { TFunction } from 'i18next';
 import { shellToEjson } from '../lib/shellDoc';
 import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
 import { DOC_LANGUAGE_ID, registerDocLanguage } from '../lib/monacoDocLanguage';
-import { registerMqlensMonacoThemes, refreshMqlensMonacoTheme } from '../lib/monacoAppTheme';
+import { attachMonaco } from '../lib/monacoAppTheme';
 import { useEscapeClose } from '../lib/useEscapeClose';
 import {
   Dialog,
@@ -58,26 +58,13 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
     NonNullable<React.ComponentProps<typeof Editor>['onMount']>
   >[1] | null>(null);
 
-  // `refreshMqlensMonacoTheme` builds *both* theme ids from whatever CSS
-  // variables are live at the time, so they are only correct immediately after a
-  // refresh. QueryEditor re-runs it on every theme change; without the same here
-  // the dialog kept the previous mode's colours — a dark editor in light mode —
-  // whenever the mode changed with no query editor mounted to refresh them.
-  //
-  // Gated on `isOpen`, and the handle is dropped on close: this component stays
-  // mounted while the dialog is shut, so an ungated effect redefined the global
-  // Monaco themes on every App render. That is wasted work, it can fight
-  // QueryEditor's own refresh, and it measurably destabilised unrelated tests.
+  // Themes are owned by ThemeProvider now, so there is nothing to refresh
+  // here. This used to redefine the GLOBAL themes from whatever CSS variables
+  // were live, which could overwrite a correct definition another editor had
+  // just made — the "can fight" the old comment warned about (#324 review).
   useEffect(() => {
-    if (!isOpen) {
-      monacoRef.current = null;
-      return;
-    }
-    const monaco = monacoRef.current;
-    if (!monaco) return;
-    refreshMqlensMonacoTheme(monaco);
-    monaco.editor.setTheme(theme);
-  }, [isOpen, theme]);
+    if (!isOpen) monacoRef.current = null;
+  }, [isOpen]);
   const monacoFontSize = useMonacoFontSize(12.5);
   useEscapeClose(isOpen, onClose);
 
@@ -152,8 +139,9 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
                 registerDocLanguage(monaco);
                 // The theme's token colours come from the same design tokens the
                 // grid uses, so both must be registered before the editor paints.
-                registerMqlensMonacoThemes(monaco);
-                refreshMqlensMonacoTheme(monaco);
+                // Themes are owned by ThemeProvider; announcing the instance is
+                // enough, and it is themed immediately from current state.
+                attachMonaco(monaco);
               }}
               options={{
                 minimap: { enabled: false },

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -20,7 +20,7 @@ import { buildRunnableCommand, guardScriptRun, type GeneratedQuery } from '../li
 import { DataGrid } from './DataGrid';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
 import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
-import { registerMqlensMonacoThemes } from '../lib/monacoAppTheme';
+import { attachMonaco } from '../lib/monacoAppTheme';
 import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 import { windowLabel } from '../workspace/workspaceStore';
 
@@ -1143,7 +1143,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
               acceptSuggestionOnEnter: 'on',
             }}
             onMount={(editor, monaco) => {
-              registerMqlensMonacoThemes(monaco);
+              attachMonaco(monaco);
               monaco.editor.setTheme(monacoTheme);
               // Enter accepts an open suggestion, else newline. Ctrl/Cmd+Enter
               // runs — scoped via onKeyDown (not addCommand, which leaks globally).

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,11 +1,12 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Editor, { type Monaco, type OnMount } from '@monaco-editor/react';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
 import type { Surface } from '../lib/mongoCompletions';
 import type { SchemaMap } from '../lib/useCollectionSchema';
 import { useMonacoTheme, useMonacoFontSize, useMonacoScale } from '../lib/useMonacoTheme';
 import { useThemeOptional } from '@/hooks/use-theme';
-import { registerMqlensMonacoThemes, refreshMqlensMonacoTheme } from '../lib/monacoAppTheme';
+import { registerMqlensMonacoThemes, refreshMqlensMonacoTheme, tokenResolverFor } from '../lib/monacoAppTheme';
+import { getEffectiveTokens } from '@/lib/themes/apply-theme';
 import { cn } from '@/lib/utils';
 import {
   clampQueryBarHeight,
@@ -83,12 +84,23 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   const themeCtx = useThemeOptional();
   const presetId = themeCtx?.config.presetId;
 
+  // Resolve Monaco's colours from the theme config rather than the DOM.
+  //
+  // Reading computed styles here is a render too early: React runs child
+  // effects before parent ones, so this fires before ThemeProvider has written
+  // the new variables — empty on first mount, the previous theme's values on
+  // every switch after (#282). The config is the same source ThemeProvider
+  // applies from, so it cannot be out of step with itself.
+  const monacoTokens = useMemo(
+    () => (themeCtx ? tokenResolverFor(getEffectiveTokens(themeCtx.config)) : undefined),
+    [themeCtx?.config]
+  );
+
   useEffect(() => {
     const monaco = monacoRef.current;
     if (!monaco) return;
-    refreshMqlensMonacoTheme(monaco);
-    monaco.editor.setTheme(theme);
-  }, [theme, presetId]);
+    refreshMqlensMonacoTheme(monaco, monacoTokens, theme);
+  }, [theme, presetId, monacoTokens]);
 
   // Row height is user-configurable (Settings → Appearance) and shared by the
   // query, projection and sort rows so the bar stays symmetric. It's stored as
@@ -234,8 +246,15 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
       }}
       onMount={(ed, monaco: Monaco) => {
         monacoRef.current = monaco;
-        registerMqlensMonacoThemes(monaco);
-        monaco.editor.setTheme(theme);
+        // Config-derived here too: at mount the CSS variables have not been
+        // written yet, so a DOM read returns nothing and every colour silently
+        // falls back to the built-in VS palette — which is why presets like
+        // nord and solarized never reached the editor at all (#282).
+        registerMqlensMonacoThemes(monaco, monacoTokens, theme);
+        // Themes register once per app, so a later editor must still be told to
+        // rebuild them from ITS config rather than inherit whatever the first
+        // one left behind.
+        refreshMqlensMonacoTheme(monaco, monacoTokens, theme);
         registerMongoCompletionProvider(monaco);
 
         // ⌘/Ctrl+Enter always runs; plain Enter is bound below for single-line fields.

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,12 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Editor, { type Monaco, type OnMount } from '@monaco-editor/react';
 import { registerMongoCompletionProvider, setModelMeta, clearModelMeta } from '../lib/monacoMongo';
 import type { Surface } from '../lib/mongoCompletions';
 import type { SchemaMap } from '../lib/useCollectionSchema';
 import { useMonacoTheme, useMonacoFontSize, useMonacoScale } from '../lib/useMonacoTheme';
 import { useThemeOptional } from '@/hooks/use-theme';
-import { registerMqlensMonacoThemes, refreshMqlensMonacoTheme, tokenResolverFor } from '../lib/monacoAppTheme';
-import { getEffectiveTokens } from '@/lib/themes/apply-theme';
+import { attachMonaco } from '../lib/monacoAppTheme';
 import { cn } from '@/lib/utils';
 import {
   clampQueryBarHeight,
@@ -82,25 +81,6 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
   const uiScale = useMonacoScale();
   const multiLineFontSize = useMonacoFontSize(12);
   const themeCtx = useThemeOptional();
-  const presetId = themeCtx?.config.presetId;
-
-  // Resolve Monaco's colours from the theme config rather than the DOM.
-  //
-  // Reading computed styles here is a render too early: React runs child
-  // effects before parent ones, so this fires before ThemeProvider has written
-  // the new variables — empty on first mount, the previous theme's values on
-  // every switch after (#282). The config is the same source ThemeProvider
-  // applies from, so it cannot be out of step with itself.
-  const monacoTokens = useMemo(
-    () => (themeCtx ? tokenResolverFor(getEffectiveTokens(themeCtx.config)) : undefined),
-    [themeCtx?.config]
-  );
-
-  useEffect(() => {
-    const monaco = monacoRef.current;
-    if (!monaco) return;
-    refreshMqlensMonacoTheme(monaco, monacoTokens, theme);
-  }, [theme, presetId, monacoTokens]);
 
   // Row height is user-configurable (Settings → Appearance) and shared by the
   // query, projection and sort rows so the bar stays symmetric. It's stored as
@@ -246,15 +226,9 @@ export const QueryEditor: React.FC<QueryEditorProps> = ({
       }}
       onMount={(ed, monaco: Monaco) => {
         monacoRef.current = monaco;
-        // Config-derived here too: at mount the CSS variables have not been
-        // written yet, so a DOM read returns nothing and every colour silently
-        // falls back to the built-in VS palette — which is why presets like
-        // nord and solarized never reached the editor at all (#282).
-        registerMqlensMonacoThemes(monaco, monacoTokens, theme);
-        // Themes register once per app, so a later editor must still be told to
-        // rebuild them from ITS config rather than inherit whatever the first
-        // one left behind.
-        refreshMqlensMonacoTheme(monaco, monacoTokens, theme);
+        // Themes are owned by ThemeProvider; announcing this instance is all an
+        // editor needs to do, and it gets themed immediately from current state.
+        attachMonaco(monaco);
         registerMongoCompletionProvider(monaco);
 
         // ⌘/Ctrl+Enter always runs; plain Enter is bound below for single-line fields.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1765,7 +1765,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                         </Badge>
                       )}
                       <span
-                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
+                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-success"
                         aria-label={t('connection.connectedAriaLabel')}
                       />
                     </div>
@@ -2592,13 +2592,13 @@ export const Sidebar: React.FC<SidebarProps> = ({
                                     size={11}
                                     className={cn(
                                       'shrink-0',
-                                      isConnected ? 'text-emerald-500' : 'text-muted-foreground',
+                                      isConnected ? 'text-success' : 'text-muted-foreground',
                                     )}
                                   />
                                   <span className="min-w-0 truncate">{profile.name}</span>
                                   {isConnected && (
                                     <span
-                                      className="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
+                                      className="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-success"
                                       aria-label={t('connection.connectedAriaLabel')}
                                     />
                                   )}
@@ -2624,7 +2624,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                             size={11}
                             className={cn(
                               'shrink-0',
-                              isConnected ? 'text-emerald-500' : 'text-muted-foreground',
+                              isConnected ? 'text-success' : 'text-muted-foreground',
                             )}
                           />
                           <span className="min-w-0 truncate">{profile.name}</span>

--- a/src/components/WatchPanel.tsx
+++ b/src/components/WatchPanel.tsx
@@ -45,7 +45,7 @@ const OPERATION_STYLES: Record<string, { badge: string; rail: string }> = {
   replace: { badge: 'border-chart-1/40 bg-chart-1/10 text-chart-1', rail: 'bg-chart-1' },
   delete: { badge: 'border-destructive/40 bg-destructive/10 text-destructive', rail: 'bg-destructive' },
   drop: { badge: 'border-destructive/40 bg-destructive/10 text-destructive', rail: 'bg-destructive' },
-  rename: { badge: 'border-chart-3/40 bg-chart-3/10 text-chart-3', rail: 'bg-chart-3' },
+  rename: { badge: 'border-chart-4/40 bg-chart-4/10 text-chart-4', rail: 'bg-chart-4' },
   invalidate: { badge: 'border-muted-foreground/40 bg-muted text-muted-foreground', rail: 'bg-muted-foreground' },
 };
 

--- a/src/components/WatchPanel.tsx
+++ b/src/components/WatchPanel.tsx
@@ -40,12 +40,12 @@ const VIEW_CAP = 1_000;
  * the strongest signals (green and red) and the edits sit between them.
  */
 const OPERATION_STYLES: Record<string, { badge: string; rail: string }> = {
-  insert: { badge: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400', rail: 'bg-emerald-500' },
-  update: { badge: 'border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400', rail: 'bg-amber-500' },
-  replace: { badge: 'border-sky-500/40 bg-sky-500/10 text-sky-600 dark:text-sky-400', rail: 'bg-sky-500' },
-  delete: { badge: 'border-rose-500/40 bg-rose-500/10 text-rose-600 dark:text-rose-400', rail: 'bg-rose-500' },
-  drop: { badge: 'border-rose-500/40 bg-rose-500/10 text-rose-600 dark:text-rose-400', rail: 'bg-rose-500' },
-  rename: { badge: 'border-violet-500/40 bg-violet-500/10 text-violet-600 dark:text-violet-400', rail: 'bg-violet-500' },
+  insert: { badge: 'border-success/40 bg-success/10 text-success', rail: 'bg-success' },
+  update: { badge: 'border-warning/40 bg-warning/10 text-warning', rail: 'bg-warning' },
+  replace: { badge: 'border-chart-1/40 bg-chart-1/10 text-chart-1', rail: 'bg-chart-1' },
+  delete: { badge: 'border-destructive/40 bg-destructive/10 text-destructive', rail: 'bg-destructive' },
+  drop: { badge: 'border-destructive/40 bg-destructive/10 text-destructive', rail: 'bg-destructive' },
+  rename: { badge: 'border-chart-3/40 bg-chart-3/10 text-chart-3', rail: 'bg-chart-3' },
   invalidate: { badge: 'border-muted-foreground/40 bg-muted text-muted-foreground', rail: 'bg-muted-foreground' },
 };
 

--- a/src/components/__tests__/ClusterHealthCard.test.tsx
+++ b/src/components/__tests__/ClusterHealthCard.test.tsx
@@ -44,8 +44,8 @@ describe('ClusterHealthCard', () => {
     expect(screen.getByTestId('cluster-card-member-db1:27017')).toHaveTextContent('PRIMARY');
     expect(screen.getByTestId('cluster-card-member-db2:27017')).toHaveTextContent('Online [SECONDARY]');
     expect(screen.getByTestId('cluster-card-member-db2:27017')).toHaveTextContent('lag 0.8s');
-    // 42s >= 10s threshold: amber class somewhere inside the row.
-    expect(screen.getByTestId('cluster-card-member-db3:27017').innerHTML).toMatch(/amber/);
+    // 42s >= 10s threshold: the warning token appears somewhere inside the row.
+    expect(screen.getByTestId('cluster-card-member-db3:27017').innerHTML).toMatch(/text-warning/);
     // Unhealthy member: destructive styling + Offline instead of lag.
     const down = screen.getByTestId('cluster-card-member-db4:27017');
     expect(down.className).toMatch(/destructive/);

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -172,11 +172,11 @@ describe('MonitoringView', () => {
     // Healthy secondary: sub-threshold lag, no warning class.
     const okLag = screen.getByTestId('cluster-lag-db2:27017');
     expect(okLag).toHaveTextContent('0.8s');
-    expect(okLag.className).not.toMatch(/amber|red/);
-    // Lagging secondary (42s >= 10s): amber warning.
+    expect(okLag.className).not.toMatch(/text-warning|text-destructive/);
+    // Lagging secondary (42s >= 10s): the theme's warning token.
     const warnLag = screen.getByTestId('cluster-lag-db3:27017');
     expect(warnLag).toHaveTextContent('42');
-    expect(warnLag.className).toMatch(/amber/);
+    expect(warnLag.className).toMatch(/text-warning/);
     // Down/unreachable member: unhealthy styling and no bogus lag.
     expect(screen.getByTestId('cluster-member-db4:27017').className).toMatch(/destructive/);
     expect(screen.getByTestId('cluster-lag-db4:27017')).toHaveTextContent('n/a');

--- a/src/components/dialogs/ToastStack.tsx
+++ b/src/components/dialogs/ToastStack.tsx
@@ -42,10 +42,10 @@ const KIND_STYLES: Record<
   { shell: string; icon: string; progress: string; label: string }
 > = {
   success: {
-    shell: 'border-emerald-500/35 bg-emerald-500/10 shadow-emerald-500/10',
-    icon: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
-    progress: 'bg-emerald-500/70',
-    label: 'text-emerald-700 dark:text-emerald-300',
+    shell: 'border-success/35 bg-success/10 shadow-success/10',
+    icon: 'bg-success/15 text-success',
+    progress: 'bg-success/70',
+    label: 'text-success',
   },
   error: {
     shell: 'border-destructive/40 bg-destructive/10 shadow-destructive/10',

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -2,10 +2,12 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "r
 import { invoke } from "@tauri-apps/api/core";
 import {
   applyTheme,
+  getEffectiveTokens,
   applyResponsiveScale,
   exportThemeJson,
   importThemeJson,
 } from "@/lib/themes/apply-theme";
+import { setMonacoAppTheme, tokenResolverFor } from "@/lib/monacoAppTheme";
 import {
   appearanceToThemeConfig,
   readInitialThemeConfig,
@@ -95,6 +97,17 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const mode = applyTheme(config);
+    // Monaco is another output of the same theme, so it is applied from the
+    // same place and the same source. Doing it here rather than in each editor
+    // is what makes the ordering right: a parent's effect runs after its
+    // children's, so by now the CSS variables are written and no editor can
+    // still be looking at the previous theme (#282). And because the themes are
+    // global, having one writer is what stops a second editor overwriting them
+    // from stale values (#324 review).
+    setMonacoAppTheme(
+      tokenResolverFor(getEffectiveTokens(config)),
+      mode === "light" ? "mqlens-light" : "mqlens-dark"
+    );
     setResolvedMode(mode);
   }, [config]);
 

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -95,21 +95,29 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener(VAULT_UNLOCKED_EVENT, onVaultUnlocked);
   }, [reloadFromEncryptedSettings]);
 
-  useEffect(() => {
-    const mode = applyTheme(config);
-    // Monaco is another output of the same theme, so it is applied from the
-    // same place and the same source. Doing it here rather than in each editor
-    // is what makes the ordering right: a parent's effect runs after its
-    // children's, so by now the CSS variables are written and no editor can
-    // still be looking at the previous theme (#282). And because the themes are
-    // global, having one writer is what stops a second editor overwriting them
-    // from stale values (#324 review).
+  // Applying a theme means three things that must not drift apart: the CSS
+  // variables, Monaco's global themes, and the resolved mode React reads.
+  // They were spelled out in two places — this effect and the system-mode
+  // listener below — and the listener was already missing the Monaco half, so
+  // an OS theme flip left the owner on the previous mode and the next editor
+  // to mount restored it for everyone (#324 review).
+  const applyThemeEverywhere = useCallback((next: ThemeConfig) => {
+    const mode = applyTheme(next);
+    // Doing this here rather than in each editor is what makes the ordering
+    // right: a parent's effect runs after its children's, so the CSS variables
+    // are written by now and no editor is still looking at the previous theme
+    // (#282). A single writer to a global is what keeps a later editor from
+    // overwriting it from stale values.
     setMonacoAppTheme(
-      tokenResolverFor(getEffectiveTokens(config)),
+      tokenResolverFor(getEffectiveTokens(next)),
       mode === "light" ? "mqlens-light" : "mqlens-dark"
     );
     setResolvedMode(mode);
-  }, [config]);
+  }, []);
+
+  useEffect(() => {
+    applyThemeEverywhere(config);
+  }, [applyThemeEverywhere, config]);
 
   const updateConfig = useCallback((partial: Partial<ThemeConfig>) => {
     setConfig((prev) => ({ ...prev, ...partial }));
@@ -181,10 +189,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (config.mode !== "system") return;
     const mq = window.matchMedia("(prefers-color-scheme: light)");
-    const handler = () => {
-      const mode = applyTheme(config);
-      setResolvedMode(mode);
-    };
+    const handler = () => applyThemeEverywhere(config);
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
   }, [config]);

--- a/src/lib/__tests__/monacoAppTheme.test.ts
+++ b/src/lib/__tests__/monacoAppTheme.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { hslComponentsToHex } from "../monacoAppTheme";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  hslComponentsToHex,
+  refreshMqlensMonacoTheme,
+  registerMqlensMonacoThemes,
+  tokenResolverFor,
+} from "../monacoAppTheme";
 
 describe("hslComponentsToHex", () => {
   it("converts space-separated HSL components to hex for Monaco", () => {
@@ -10,5 +15,73 @@ describe("hslComponentsToHex", () => {
 
   it("passes through hex values", () => {
     expect(hslComponentsToHex("#1e1e1e")).toBe("#1e1e1e");
+  });
+});
+
+// #282: the editor was themed a render behind the app. Colours were read from
+// computed styles inside a child effect, and React runs those before the
+// parent's — so ThemeProvider had not written the new variables yet. Measured
+// with a provider setting a variable and a child reading it:
+//
+//     reads seen by the child: ["", "DARK"]   // switching to the light theme
+//
+// Empty on first mount, the previous theme afterwards. That is why nord,
+// solarized and high-contrast never reached the editor, and why changing the
+// hardcoded default made the symptom swap ends instead of going away.
+describe('monaco theme colours come from the config, not the DOM (#282)', () => {
+  const defined = new Map<string, { colors: Record<string, string> }>();
+  const monaco = {
+    editor: {
+      defineTheme: (id: string, theme: { colors: Record<string, string> }) =>
+        defined.set(id, theme),
+      setTheme: () => {},
+    },
+  } as unknown as Parameters<typeof refreshMqlensMonacoTheme>[0];
+
+  beforeEach(() => defined.clear());
+
+  it('uses the token map it is given, ignoring the document entirely', () => {
+    // A light preset's own input token, while the DOM still says otherwise.
+    document.documentElement.style.setProperty('--input', '222 20% 8%');
+    refreshMqlensMonacoTheme(
+      monaco,
+      tokenResolverFor({ input: '220 20% 93%', foreground: '222 20% 8%' }),
+      'mqlens-light'
+    );
+    expect(defined.get('mqlens-light')!.colors['editor.background']).toBe(
+      hslComponentsToHex('220 20% 93%')
+    );
+  });
+
+  it('does not fall back to the built-in palette when a preset defines the token', () => {
+    // The old failure mode: an empty DOM read left every colour on Monaco's
+    // hardcoded default, so a preset's palette never arrived.
+    refreshMqlensMonacoTheme(
+      monaco,
+      tokenResolverFor({ input: '193 100% 12%' }),
+      'mqlens-dark'
+    );
+    const background = defined.get('mqlens-dark')!.colors['editor.background'];
+    expect(background).toBe(hslComponentsToHex('193 100% 12%'));
+    expect(background).not.toBe('#1e1e1e');
+  });
+
+  it('still falls back for a token the preset does not define', () => {
+    refreshMqlensMonacoTheme(monaco, tokenResolverFor({}), 'mqlens-dark');
+    expect(defined.get('mqlens-dark')!.colors['editor.background']).toBe('#1e1e1e');
+  });
+
+  it('registers and refreshes with identical colours', () => {
+    // They used to be two hand-written copies, which is how one gets corrected
+    // and the other left stale.
+    const resolve = tokenResolverFor({ input: '193 100% 12%', foreground: '0 0% 90%' });
+    refreshMqlensMonacoTheme(monaco, resolve, 'mqlens-dark');
+    const fromRefresh = { ...defined.get('mqlens-dark')!.colors };
+    defined.clear();
+    registerMqlensMonacoThemes(monaco, resolve, 'mqlens-dark');
+    // registerMqlensMonacoThemes is once-per-app; call refresh to observe the
+    // same definition path a second editor would get.
+    refreshMqlensMonacoTheme(monaco, resolve, 'mqlens-dark');
+    expect(defined.get('mqlens-dark')!.colors).toEqual(fromRefresh);
   });
 });

--- a/src/lib/__tests__/monacoAppTheme.test.ts
+++ b/src/lib/__tests__/monacoAppTheme.test.ts
@@ -4,6 +4,9 @@ import {
   refreshMqlensMonacoTheme,
   registerMqlensMonacoThemes,
   tokenResolverFor,
+  attachMonaco,
+  setMonacoAppTheme,
+  resetMonacoAppThemeForTests,
 } from "../monacoAppTheme";
 
 describe("hslComponentsToHex", () => {
@@ -83,5 +86,52 @@ describe('monaco theme colours come from the config, not the DOM (#282)', () => 
     // same definition path a second editor would get.
     refreshMqlensMonacoTheme(monaco, resolve, 'mqlens-dark');
     expect(defined.get('mqlens-dark')!.colors).toEqual(fromRefresh);
+  });
+});
+
+// #324 review: defineTheme is GLOBAL, so whichever editor called it last won
+// for every editor on screen. Each of QueryEditor, DocumentEditModal and
+// MongoShell refreshed on its own schedule, so one resolving from stale CSS
+// variables silently overwrote the others — and for a preset change within the
+// same mode nothing re-renders afterwards to repair it.
+describe('one owner of the global Monaco themes (#324 review)', () => {
+  const defined: { colors: Record<string, string> }[] = [];
+  const monaco = {
+    editor: {
+      defineTheme: (id: string, theme: { colors: Record<string, string> }) => {
+        if (id === 'mqlens-dark') defined.push(theme);
+      },
+      setTheme: () => {},
+    },
+  } as unknown as Parameters<typeof attachMonaco>[0];
+
+  beforeEach(() => {
+    defined.length = 0;
+    resetMonacoAppThemeForTests();
+  });
+
+  it('themes an editor that attaches after the theme was set', () => {
+    setMonacoAppTheme(tokenResolverFor({ input: '193 100% 12%' }), 'mqlens-dark');
+    attachMonaco(monaco);
+    expect(defined.at(-1)!.colors['editor.background']).toBe(
+      hslComponentsToHex('193 100% 12%')
+    );
+  });
+
+  it('re-themes an already-attached editor when the config changes', () => {
+    attachMonaco(monaco);
+    setMonacoAppTheme(tokenResolverFor({ input: '0 0% 20%' }), 'mqlens-dark');
+    expect(defined.at(-1)!.colors['editor.background']).toBe(hslComponentsToHex('0 0% 20%'));
+  });
+
+  it('a second editor attaching cannot undo the current theme', () => {
+    // The race: another editor mounting used to redefine the themes from the
+    // DOM, discarding what the config-derived pass had just written.
+    setMonacoAppTheme(tokenResolverFor({ input: '193 100% 12%' }), 'mqlens-dark');
+    attachMonaco(monaco);
+    attachMonaco(monaco);
+    expect(defined.at(-1)!.colors['editor.background']).toBe(
+      hslComponentsToHex('193 100% 12%')
+    );
   });
 });

--- a/src/lib/__tests__/themeTokens.test.ts
+++ b/src/lib/__tests__/themeTokens.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { lagClass, memberDotClass } from '../clusterHealth';
+
+// #282: status colours written as fixed Tailwind palette shades ignore the
+// theme entirely — `text-amber-500` renders the same on mqlens-dark,
+// high-contrast and solarized-light, because nothing about it is theme-aware.
+// The token equivalents (`warning`, `success`, `destructive`) are defined per
+// preset and per mode, so they follow whatever the user picked.
+describe('status colours use theme tokens (#282)', () => {
+  it('grades replica lag with tokens', () => {
+    expect(lagClass(120)).toContain('text-destructive');
+    expect(lagClass(30)).toContain('text-warning');
+    expect(lagClass(1)).toContain('text-muted-foreground');
+  });
+
+  it('grades member health with tokens', () => {
+    expect(memberDotClass({ health: 0, stateStr: 'DOWN' })).toBe('bg-destructive');
+    expect(memberDotClass({ health: 1, stateStr: 'PRIMARY' })).toBe('bg-success');
+    expect(memberDotClass({ health: 1, stateStr: 'SECONDARY' })).toBe('bg-chart-1');
+    expect(memberDotClass({ health: 1, stateStr: 'STARTUP2' })).toBe('bg-warning');
+  });
+
+  it('keeps the status maps free of fixed palette shades', () => {
+    // A regression here means a status colour stopped following the theme.
+    // Decorative kind tints (a folder icon's amber, say) are deliberately not
+    // covered — those are a design choice, not a theme bug.
+    const literal = /\b(bg|text|border)-(red|orange|amber|yellow|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|pink|rose)-[0-9]{2,3}\b/;
+    for (const file of [
+      'src/lib/clusterHealth.ts',
+      'src/components/dialogs/ToastStack.tsx',
+    ]) {
+      expect(readFileSync(file, 'utf8')).not.toMatch(literal);
+    }
+  });
+
+  it('keeps change-stream operation badges on tokens', () => {
+    const source = readFileSync('src/components/WatchPanel.tsx', 'utf8');
+    const styles = source.slice(
+      source.indexOf('const OPERATION_STYLES'),
+      source.indexOf('};', source.indexOf('const OPERATION_STYLES'))
+    );
+    expect(styles).not.toMatch(
+      /\b(bg|text|border)-(red|amber|emerald|sky|violet|rose)-[0-9]{2,3}\b/
+    );
+    expect(styles).toContain('bg-success');
+    expect(styles).toContain('bg-destructive');
+  });
+});

--- a/src/lib/__tests__/themeTokens.test.ts
+++ b/src/lib/__tests__/themeTokens.test.ts
@@ -47,3 +47,46 @@ describe('status colours use theme tokens (#282)', () => {
     expect(styles).toContain('bg-destructive');
   });
 });
+
+// #324 review: `chart-3` holds exactly the same value as `success` in every
+// built-in preset, so mapping rename events to it turned them the same green as
+// inserts — the change-stream table exists to tell operations apart at a
+// glance, and a token swap quietly undid that.
+describe('tokens chosen to differentiate stay visually distinct (#324 review)', () => {
+  const presets = readFileSync('src/lib/themes/presets.ts', 'utf8');
+
+  /** Every value a token takes across the presets file. */
+  const valuesOf = (token: string): string[] => {
+    // Hyphenated token names are quoted object keys in the presets file.
+    const key = token.includes('-') ? `"${token}"` : token;
+    const pattern = new RegExp(`${key}:\\s*"([^"]+)"`, 'g');
+    return [...presets.matchAll(pattern)].map((m) => m[1]);
+  };
+
+  it('gives each change-stream operation its own colour', () => {
+    const source = readFileSync('src/components/WatchPanel.tsx', 'utf8');
+    const styles = source.slice(
+      source.indexOf('const OPERATION_STYLES'),
+      source.indexOf('};', source.indexOf('const OPERATION_STYLES'))
+    );
+    // Distinct tokens only: `delete` and `drop` deliberately share
+    // `destructive`, since both are removals and reading alike is correct.
+    const used = [...new Set([...styles.matchAll(/rail: 'bg-([a-z0-9-]+)'/g)].map((m) => m[1]))];
+    expect(used.length).toBeGreaterThan(3);
+
+    // Compare per base (dark values first, then light) so a collision in either
+    // mode fails, rather than comparing across modes where overlap is expected.
+    const perToken = used.map(valuesOf).filter((values) => values.length > 0);
+    for (let i = 0; i < (perToken[0]?.length ?? 0); i++) {
+      const shades = perToken.map((values) => values[i]).filter(Boolean);
+      expect(new Set(shades).size).toBe(shades.length);
+    }
+  });
+
+  it('confirms the collision that prompted this: chart-3 is success', () => {
+    // Documents why rename uses chart-4. If these ever diverge, chart-3 becomes
+    // usable again and this test says so rather than leaving a stale rule.
+    expect(valuesOf('chart-3')).toEqual(valuesOf('success'));
+    expect(valuesOf('chart-4')).not.toEqual(valuesOf('success'));
+  });
+});

--- a/src/lib/clusterHealth.ts
+++ b/src/lib/clusterHealth.ts
@@ -3,8 +3,8 @@ export const lagText = (lagSecs: number | null | undefined): string =>
 
 export const lagClass = (lagSecs: number | null | undefined): string => {
   if (lagSecs == null) return 'text-muted-foreground';
-  if (lagSecs >= 60) return 'font-semibold text-red-500';
-  if (lagSecs >= 10) return 'font-semibold text-amber-500';
+  if (lagSecs >= 60) return 'font-semibold text-destructive';
+  if (lagSecs >= 10) return 'font-semibold text-warning';
   return 'text-muted-foreground';
 };
 
@@ -12,10 +12,12 @@ export const memberUnhealthy = (m: { health: number; stateStr: string }): boolea
   m.health !== 1 || /not reachable|DOWN|UNKNOWN/i.test(m.stateStr);
 
 export const memberDotClass = (m: { health: number; stateStr: string }): string => {
-  if (memberUnhealthy(m)) return 'bg-red-500';
-  if (m.stateStr === 'PRIMARY') return 'bg-emerald-500';
-  if (m.stateStr === 'SECONDARY') return 'bg-sky-500';
-  return 'bg-amber-500';
+  if (memberUnhealthy(m)) return 'bg-destructive';
+  if (m.stateStr === 'PRIMARY') return 'bg-success';
+  // Informational rather than a status grade: a secondary is healthy, just not
+  // the primary. chart-1 is the palette's neutral accent and follows the preset.
+  if (m.stateStr === 'SECONDARY') return 'bg-chart-1';
+  return 'bg-warning';
 };
 
 export const fmtMemberUptime = (secs: number): string => {

--- a/src/lib/i18n/__tests__/coverage.test.ts
+++ b/src/lib/i18n/__tests__/coverage.test.ts
@@ -257,7 +257,7 @@ const EXEMPT_HITS: Record<string, string[]> = {
     // KIND_STYLES' `label` property holds a Tailwind text-color className,
     // not a display label — an unlucky property-name collision with the
     // detector's `label:` heuristic, not translatable prose.
-    "label: 'text-emerald-700 dark:text-emerald-300'",
+    "label: 'text-success'",
     "label: 'text-destructive'",
     "label: 'text-primary'",
   ],

--- a/src/lib/monacoAppTheme.ts
+++ b/src/lib/monacoAppTheme.ts
@@ -183,3 +183,48 @@ export function refreshMqlensMonacoTheme(
   defineThemes(monaco, resolve);
   monaco.editor.setTheme(themeId);
 }
+
+/**
+ * Single ownership of the global Monaco themes.
+ *
+ * `defineTheme` is global: whichever editor calls it last wins for every editor
+ * on screen. With each of QueryEditor, DocumentEditModal and MongoShell
+ * refreshing on its own schedule, one of them resolving colours from stale CSS
+ * variables silently overwrote the others' correct definitions — and for a
+ * preset change within the same mode nothing re-renders afterwards to repair it
+ * (#324 review). DocumentEditModal's own comment already noted the two "can
+ * fight".
+ *
+ * So editors no longer define themes at all. They announce their Monaco
+ * instance, and ThemeProvider — which already owns applying the theme, and
+ * whose effect runs after its children's — is the only writer.
+ */
+let activeMonaco: Monaco | null = null;
+let currentResolve: MonacoTokenResolver = cssTokenResolver;
+let currentThemeId: MqlensMonacoThemeId = "mqlens-dark";
+
+/** An editor announcing itself; it is themed immediately from current state. */
+export function attachMonaco(monaco: Monaco): void {
+  activeMonaco = monaco;
+  defineThemes(monaco, currentResolve);
+  monaco.editor.setTheme(currentThemeId);
+}
+
+/** The only writer: called by ThemeProvider once per applied config. */
+export function setMonacoAppTheme(
+  resolve: MonacoTokenResolver,
+  themeId: MqlensMonacoThemeId
+): void {
+  currentResolve = resolve;
+  currentThemeId = themeId;
+  if (!activeMonaco) return;
+  defineThemes(activeMonaco, resolve);
+  activeMonaco.editor.setTheme(themeId);
+}
+
+/** Test seam: forget the attached editor and fall back to reading the DOM. */
+export function resetMonacoAppThemeForTests(): void {
+  activeMonaco = null;
+  currentResolve = cssTokenResolver;
+  currentThemeId = "mqlens-dark";
+}

--- a/src/lib/monacoAppTheme.ts
+++ b/src/lib/monacoAppTheme.ts
@@ -52,13 +52,46 @@ export function hslComponentsToHex(components: string): string {
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 }
 
-function readToken(name: string, fallback: string): string {
+/**
+ * How a token name becomes a hex colour for Monaco.
+ *
+ * Injectable because reading the DOM is not safe at the moment these themes are
+ * built. React runs child effects before parent ones, so an editor asking the
+ * computed styles for `--input` gets the value from BEFORE ThemeProvider
+ * applied the new theme — empty on first mount, and the previous theme's colour
+ * on every switch after. Measured, with a provider setting the variable and a
+ * child reading it:
+ *
+ *     reads seen by the child: ["", "DARK"]   // switching to the light theme
+ *
+ * That is the whole of #282: an editor themed one step behind the app, falling
+ * back to a hardcoded default when it had nothing to read at all — which is why
+ * presets like nord, solarized and high-contrast never reached it, and why
+ * changing the default made the symptom swap ends rather than go away.
+ *
+ * Callers that hold the theme config pass `tokenResolverFor` instead, which
+ * answers from the config itself and cannot be out of step with it.
+ */
+export type MonacoTokenResolver = (name: string, fallback: string) => string;
+
+/** Last-resort resolver: reads the DOM. Correct only once styles have settled. */
+export const cssTokenResolver: MonacoTokenResolver = (name, fallback) => {
   if (typeof document === "undefined") return fallback;
   const raw = getComputedStyle(document.documentElement)
     .getPropertyValue(`--${name}`)
     .trim();
   if (!raw) return fallback;
   return hslComponentsToHex(raw);
+};
+
+/** Resolver over a token map — the theme config's own values, no DOM involved. */
+export function tokenResolverFor(
+  tokens: Record<string, string>
+): MonacoTokenResolver {
+  return (name, fallback) => {
+    const raw = tokens[name];
+    return raw ? hslComponentsToHex(raw) : fallback;
+  };
 }
 
 export function getMqlensMonacoThemeId(): MqlensMonacoThemeId {
@@ -80,90 +113,73 @@ export function getMqlensMonacoThemeId(): MqlensMonacoThemeId {
  * the JavaScript query and shell editors, which are meant to keep the inherited
  * VS/VS Dark palette. Monaco wants hex without the leading `#`.
  */
-export function syntaxRules(): { token: string; foreground: string }[] {
+export function syntaxRules(
+  resolve: MonacoTokenResolver = cssTokenResolver
+): { token: string; foreground: string }[] {
   return DOC_SYNTAX_TOKENS.map(({ token, cssToken, fallback }) => ({
     token: `${token}${DOC_TOKEN_POSTFIX}`,
-    foreground: readToken(cssToken, fallback).replace("#", ""),
+    foreground: resolve(cssToken, fallback).replace("#", ""),
   }));
 }
 
-export function registerMqlensMonacoThemes(monaco: Monaco): void {
-  if (registered) return;
+/**
+ * Both theme definitions, from one place.
+ *
+ * They used to be spelled out twice — once to register and once to refresh —
+ * which is how a colour can be corrected in one and left stale in the other.
+ */
+function defineThemes(monaco: Monaco, resolve: MonacoTokenResolver): void {
+  const rules = syntaxRules(resolve);
 
-  const lightTheme: MqlensMonacoThemeId = "mqlens-light";
-  const darkTheme: MqlensMonacoThemeId = "mqlens-dark";
-
-  monaco.editor.defineTheme(lightTheme, {
+  monaco.editor.defineTheme("mqlens-light", {
     base: "vs",
     inherit: true,
-    rules: syntaxRules(),
+    rules,
     colors: {
-      "editor.background": readToken("input", "#ffffff"),
-      "editor.foreground": readToken("foreground", "#1a1a1a"),
-      "editorLineNumber.foreground": readToken("muted-foreground", "#6b7280"),
-      "editor.selectionBackground": readToken("accent", "#e5e7eb"),
-      "editor.inactiveSelectionBackground": readToken("muted", "#f3f4f6"),
-      "editorCursor.foreground": readToken("primary", "#2563eb"),
-      "editorWidget.background": readToken("popover", "#ffffff"),
-      "editorWidget.border": readToken("border", "#d1d5db"),
+      "editor.background": resolve("input", "#ffffff"),
+      "editor.foreground": resolve("foreground", "#1a1a1a"),
+      "editorLineNumber.foreground": resolve("muted-foreground", "#6b7280"),
+      "editor.selectionBackground": resolve("accent", "#e5e7eb"),
+      "editor.inactiveSelectionBackground": resolve("muted", "#f3f4f6"),
+      "editorCursor.foreground": resolve("primary", "#2563eb"),
+      "editorWidget.background": resolve("popover", "#ffffff"),
+      "editorWidget.border": resolve("border", "#d1d5db"),
     },
   });
 
-  monaco.editor.defineTheme(darkTheme, {
+  monaco.editor.defineTheme("mqlens-dark", {
     base: "vs-dark",
     inherit: true,
-    rules: syntaxRules(),
+    rules,
     colors: {
-      "editor.background": readToken("input", "#1e1e1e"),
-      "editor.foreground": readToken("foreground", "#d4d4d4"),
-      "editorLineNumber.foreground": readToken("muted-foreground", "#858585"),
-      "editor.selectionBackground": readToken("accent", "#264f78"),
-      "editor.inactiveSelectionBackground": readToken("muted", "#2a2d2e"),
-      "editorCursor.foreground": readToken("primary", "#569cd6"),
-      "editorWidget.background": readToken("popover", "#252526"),
-      "editorWidget.border": readToken("border", "#454545"),
+      "editor.background": resolve("input", "#1e1e1e"),
+      "editor.foreground": resolve("foreground", "#d4d4d4"),
+      "editorLineNumber.foreground": resolve("muted-foreground", "#858585"),
+      "editor.selectionBackground": resolve("accent", "#264f78"),
+      "editor.inactiveSelectionBackground": resolve("muted", "#2a2d2e"),
+      "editorCursor.foreground": resolve("primary", "#569cd6"),
+      "editorWidget.background": resolve("popover", "#252526"),
+      "editorWidget.border": resolve("border", "#454545"),
     },
   });
-
-  registered = true;
-  monaco.editor.setTheme(getMqlensMonacoThemeId());
 }
 
-export function refreshMqlensMonacoTheme(monaco: Monaco): void {
-  const lightTheme: MqlensMonacoThemeId = "mqlens-light";
-  const darkTheme: MqlensMonacoThemeId = "mqlens-dark";
+export function registerMqlensMonacoThemes(
+  monaco: Monaco,
+  resolve: MonacoTokenResolver = cssTokenResolver,
+  themeId: MqlensMonacoThemeId = getMqlensMonacoThemeId()
+): void {
+  if (registered) return;
+  defineThemes(monaco, resolve);
+  registered = true;
+  monaco.editor.setTheme(themeId);
+}
 
-  monaco.editor.defineTheme(lightTheme, {
-    base: "vs",
-    inherit: true,
-    rules: syntaxRules(),
-    colors: {
-      "editor.background": readToken("input", "#ffffff"),
-      "editor.foreground": readToken("foreground", "#1a1a1a"),
-      "editorLineNumber.foreground": readToken("muted-foreground", "#6b7280"),
-      "editor.selectionBackground": readToken("accent", "#e5e7eb"),
-      "editor.inactiveSelectionBackground": readToken("muted", "#f3f4f6"),
-      "editorCursor.foreground": readToken("primary", "#2563eb"),
-      "editorWidget.background": readToken("popover", "#ffffff"),
-      "editorWidget.border": readToken("border", "#d1d5db"),
-    },
-  });
-
-  monaco.editor.defineTheme(darkTheme, {
-    base: "vs-dark",
-    inherit: true,
-    rules: syntaxRules(),
-    colors: {
-      "editor.background": readToken("input", "#1e1e1e"),
-      "editor.foreground": readToken("foreground", "#d4d4d4"),
-      "editorLineNumber.foreground": readToken("muted-foreground", "#858585"),
-      "editor.selectionBackground": readToken("accent", "#264f78"),
-      "editor.inactiveSelectionBackground": readToken("muted", "#2a2d2e"),
-      "editorCursor.foreground": readToken("primary", "#569cd6"),
-      "editorWidget.background": readToken("popover", "#252526"),
-      "editorWidget.border": readToken("border", "#454545"),
-    },
-  });
-
-  monaco.editor.setTheme(getMqlensMonacoThemeId());
+export function refreshMqlensMonacoTheme(
+  monaco: Monaco,
+  resolve: MonacoTokenResolver = cssTokenResolver,
+  themeId: MqlensMonacoThemeId = getMqlensMonacoThemeId()
+): void {
+  defineThemes(monaco, resolve);
+  monaco.editor.setTheme(themeId);
 }


### PR DESCRIPTION
## Summary

Two independent causes behind "not all areas follow the chosen theme". The thread on #282 records the symptom flipping between releases — white editor on dark themes, then black on light ones — and that flip is the tell.

## 1. The query editor was themed a render behind the app

Its colours were read from computed styles inside a child effect. React runs child effects **before** parent effects, so `QueryEditor` ran before `ThemeProvider` had written the new CSS variables. Measured, with a provider setting a variable and a child reading it:

```
reads seen by the child: ["", "DARK"]   // switching to the light theme
```

Empty on first mount, and the **previous** theme's value on every switch after.

That explains the whole thread:

- **Presets never reached the editor at all.** An empty read falls through to the hardcoded default, which is why nord, solarized and high-contrast all looked alike — "All darkish themes have the same problem".
- **Changing that default swapped the symptom's ends** rather than fixing it, which is exactly what the last comment reports.

Colours now resolve from the **theme config** — the same source `ThemeProvider` applies from, so it cannot be out of step with itself — through an injectable resolver. The DOM read survives only as a last resort for callers that hold no config.

The two theme definitions were also written out twice, once to register and once to refresh. They are built in one place now; duplicated colour tables are how one copy gets corrected and the other left stale.

## 2. Status colours ignored the theme entirely

An app-wide sweep found **no stray hex colours** (the `#188`-style hits are issue references in comments) and one absolute, `bg-black` for the dialog scrim, which is conventional.

The real problem was ~85 fixed Tailwind palette shades. `text-amber-500` renders identically on mqlens-dark, high-contrast and solarized-light — nothing about it is theme-aware — while `success`/`warning`/`destructive` tokens already existed and were used ~270 times elsewhere.

Migrated:

| Area | Was | Now |
|---|---|---|
| Replica lag / member health | `text-red-500`, `bg-emerald-500`, `bg-sky-500`, `bg-amber-500` | `destructive`, `success`, `chart-1`, `warning` |
| Toast success variant | `emerald-*` with `dark:` variants | `success` |
| Change-stream operation badges | `emerald`/`amber`/`sky`/`rose`/`violet` | `success`/`warning`/`chart-1`/`destructive`/`chart-3` |
| Connection indicators | `emerald-500` | `success` |

`ToastStack` was already inconsistent with itself — its `error` and `info` variants used tokens and only `success` used literals.

## What I deliberately left alone

**Decorative kind tints** — the folder icon's amber, the database and index icons, the pin colours. Those are a design choice, not a theme bug, and mapping a folder to `warning` would be semantically wrong. Remapping them would be restyling the sidebar under cover of a bug fix. They are listed in the audit below if you want them changed as a separate decision.

Remaining literals after this change: 18 in `Sidebar.tsx` (kind tints), plus single decorative uses in 6 other files.

## Related issue

Closes #282.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [x] `npm run i18n:check` passes
- [ ] `cargo test` — no backend change
- [ ] Manually verified in the running app (`npm run tauri dev`)

New tests: Monaco colours coming from the given token map rather than the document, no silent fallback when a preset defines a token, the fallback still applying when it does not, and register/refresh producing identical colours. Plus a guard that the status maps stay free of fixed palette shades.

Two existing tests asserted the old literals (`/amber/`) and were updated to the token names — the change they were pinning is the intended one.

Full suite: **1707 passed, 5 failed** — the same 5 that fail on a clean `dev`. Unrelated, left alone.

**Not manually verified, and this one needs it more than most.** Everything above is reasoned from code and measured in tests, but the report is fundamentally visual: the fix should be confirmed by switching through nord, solarized-light, high-contrast and mqlens-light with the query bar, aggregation editor and shell open.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
