### PR TITLE
fix(results): stop the explain tab reopening on every later run

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1483,7 +1483,7 @@ function Workspace() {
         };
         setTabs(prev => [...prev, newTab as QueryTab]);
       } else {
-        setTabs(prev => prev.map(t => t.id === tabId ? { ...t, loading: true, error: null } : t));
+        setTabs(prev => prev.map(t => t.id === tabId ? { ...t, loading: true, error: null, resultsTab: 'results' } : t));
       }
       dispatchWorkspace({ type: 'open_tab', tabId }, newTab ? { tab: newTab } : undefined);
 
@@ -2985,7 +2985,11 @@ function Workspace() {
 
   const handleExecuteQuery = async (tab: QueryTab, query: { filter: string; sort: string; projection: string; limit: number; skip: number }) => {
     // Update the tab's loading state
-    setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, loading: true, error: null } : t));
+    // Back to Results for a run: the user asked for rows, so show them. The
+    // grid remounts while loading, and the tab now outlives that remount, so
+    // without this a run started from Explain would hide its own results
+    // behind the plan (#325 review).
+    setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, loading: true, error: null, resultsTab: 'results' } : t));
 
     try {
       const resultStrs = await invoke<string[]>('execute_mql_query', {
@@ -3093,7 +3097,11 @@ function Workspace() {
       }
     }
 
-    setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, loading: true, error: null } : t));
+    // Back to Results for a run: the user asked for rows, so show them. The
+    // grid remounts while loading, and the tab now outlives that remount, so
+    // without this a run started from Explain would hide its own results
+    // behind the plan (#325 review).
+    setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, loading: true, error: null, resultsTab: 'results' } : t));
 
     try {
       const resultStrs = await invoke<string[]>('execute_aggregate', {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import {
   renameShellSession,
   retargetShellSessionDatabase,
 } from './lib/mongoshSession';
-import { DataGrid, type ViewMode } from './components/DataGrid';
+import { DataGrid, type ViewMode, type ResultsTab } from './components/DataGrid';
 import { ConnectionManager } from './components/ConnectionManager';
 import { WatchPanel } from './components/WatchPanel';
 import { SettingsView, type SettingsTabId, MONGO_TOOLS_DIR_KEY } from './components/SettingsModal';
@@ -147,6 +147,9 @@ export interface QueryTab {
   // Results view mode, kept on the tab so it survives the grid remounting on
   // every run and the tab being switched away (#218).
   viewMode?: ViewMode;
+  // Which results tab is showing, kept on the tab for the same reason as
+  // viewMode: the grid remounts on every run (#281).
+  resultsTab?: ResultsTab;
   // What the results pager last asked for. The values travel with the revision
   // so the builder can never observe a new revision beside a stale page size —
   // see DocumentViewer's pagerRequest prop.
@@ -699,6 +702,9 @@ function Workspace() {
   }, []);
   const handleViewModeChange = useCallback((tabId: string, mode: ViewMode) => {
     setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, viewMode: mode } : t)));
+  }, []);
+  const handleResultsTabChange = useCallback((tabId: string, resultsTab: ResultsTab) => {
+    setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, resultsTab } : t)));
   }, []);
   const handleChatMessagesChange = useCallback((tabId: string, messages: ChatMessage[]) => {
     const prev = tabChatCache.current.get(tabId);
@@ -4199,6 +4205,8 @@ function Workspace() {
                     limit={tab.lastQuery?.limit ?? 50}
                     viewMode={tab.viewMode ?? 'json'}
                     onViewModeChange={(mode) => handleViewModeChange(tab.id, mode)}
+                    activeTab={tab.resultsTab ?? 'results'}
+                    onActiveTabChange={(t) => handleResultsTabChange(tab.id, t)}
                     onCreateSuggestedIndex={s => handleCreateSuggestedIndex(tab, s)}
                     {...(!tab.lastAggregate ? {
                       onPageChange: (newSkip: number) => handlePageChange(tab, newSkip),

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -828,27 +828,39 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // visit to Explain every subsequent run reopened it and the Results tab had
   // to be clicked again each time (#281). The results effect below was already
   // guarded this way and so could not push back.
-  // Only skipped for a controlled caller, which owns the tab: overriding the
-  // choice it just handed us is the bug. An uncontrolled caller has expressed
-  // no preference, so opening a plan it passed at mount stays helpful.
-  const skipMountExplainSwitch = React.useRef(controlledActiveTab !== undefined);
+  // Both switches below compare against the previous value rather than counting
+  // mounts.
+  //
+  // A one-shot flag looks equivalent and is not: StrictMode runs each effect
+  // twice on mount, and the first setup spends the flag, so the replayed setup
+  // sees a guard that is already gone and fires anyway. That put this bug
+  // straight back for anyone running the app in development (#325 review).
+  // Comparing values is idempotent — a replay is simply not a change — so the
+  // guard survives however many times React chooses to run the effect.
+  //
+  // The seed carries the earlier decision. A controlled caller owns the tab, so
+  // mount must not override the choice it just handed us; an uncontrolled one
+  // has expressed no preference, and its long-standing contract is that a plan
+  // passed at mount opens it.
+  const lastExplainResult = React.useRef<string | null | undefined>(
+    controlledActiveTab !== undefined ? explainResult : undefined
+  );
   useEffect(() => {
-    if (skipMountExplainSwitch.current) {
-      skipMountExplainSwitch.current = false;
-      return;
-    }
+    const previous = lastExplainResult.current;
+    lastExplainResult.current = explainResult;
+    if (previous === explainResult) return;
     if (explainResult) {
       setActiveTab('explain');
     }
   }, [explainResult]);
 
-  // Automatically switch to results tab when new query results (documents) are loaded (skipping mount)
-  const isFirstRender = React.useRef(true);
+  // Switch to results when a new set of documents arrives — seeded with the
+  // current set so arriving at one does not count as a change.
+  const lastDocuments = React.useRef(documents);
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
+    const previous = lastDocuments.current;
+    lastDocuments.current = documents;
+    if (previous === documents) return;
     setActiveTab('results');
   }, [documents]);
 

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -60,6 +60,11 @@ interface DataGridProps {
    *  props to keep the old self-managed behaviour (MongoShell does). */
   viewMode?: ViewMode;
   onViewModeChange?: (mode: ViewMode) => void;
+  /** Which results tab is showing. Owned by the caller for the same reason as
+   *  viewMode above — the grid remounts on every run, so a tab kept here is a
+   *  choice the user loses (#281). Omit both to self-manage. */
+  activeTab?: ResultsTab;
+  onActiveTabChange?: (tab: ResultsTab) => void;
   /**
    * Drop the control bar — the Results/Explain tabs, the view-mode switcher and
    * the row actions — and render the documents alone.
@@ -83,6 +88,9 @@ interface DataGridProps {
 }
 
 export type ViewMode = 'table' | 'tree' | 'json' | 'chart';
+
+/** Which pane of the results area is showing. */
+export type ResultsTab = 'results' | 'explain' | 'query';
 
 interface ExplainNode {
   name: string;
@@ -549,6 +557,8 @@ export const DataGrid: React.FC<DataGridProps> = ({
   onPageChange,
   onPageSizeChange,
   viewMode: controlledViewMode,
+  activeTab: controlledActiveTab,
+  onActiveTabChange,
   onViewModeChange,
   onCreateSuggestedIndex,
   connectionMode,
@@ -653,7 +663,17 @@ export const DataGrid: React.FC<DataGridProps> = ({
     setUncontrolledViewMode(mode);
     onViewModeChange?.(mode);
   };
-  const [activeTab, setActiveTab] = useState<'results' | 'explain' | 'query'>('results');
+  // Which results tab is showing, owned by the caller for the same reason
+  // `viewMode` is: the grid remounts on every run, so state kept here is state
+  // the user loses. Left uncontrolled it behaves as before, for callers with
+  // nothing to persist it to.
+  const [uncontrolledActiveTab, setUncontrolledActiveTab] =
+    useState<ResultsTab>('results');
+  const activeTab = controlledActiveTab ?? uncontrolledActiveTab;
+  const setActiveTab = (tab: ResultsTab) => {
+    setUncontrolledActiveTab(tab);
+    onActiveTabChange?.(tab);
+  };
   // Chromeless callers have no tabs to switch and no explain plan to show.
   const effectiveTab = chromeless ? 'results' : activeTab;
 
@@ -800,8 +820,23 @@ export const DataGrid: React.FC<DataGridProps> = ({
     setCollapsedFolds(new Set());
   }, [documents]);
 
-  // Automatically switch to explain tab when a new explain result is received
+  // Switch to the explain tab when a NEW plan arrives — not merely because one
+  // exists.
+  //
+  // Without the mount guard this fired every time the grid remounted, which is
+  // once per run. A plan is not cleared when a query re-runs, so after a single
+  // visit to Explain every subsequent run reopened it and the Results tab had
+  // to be clicked again each time (#281). The results effect below was already
+  // guarded this way and so could not push back.
+  // Only skipped for a controlled caller, which owns the tab: overriding the
+  // choice it just handed us is the bug. An uncontrolled caller has expressed
+  // no preference, so opening a plan it passed at mount stays helpful.
+  const skipMountExplainSwitch = React.useRef(controlledActiveTab !== undefined);
   useEffect(() => {
+    if (skipMountExplainSwitch.current) {
+      skipMountExplainSwitch.current = false;
+      return;
+    }
     if (explainResult) {
       setActiveTab('explain');
     }

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1605,3 +1605,59 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     getSelection.mockRestore();
   });
 });
+
+// #281: after one visit to Explain, every subsequent run reopened it — the
+// Results tab had to be clicked again each time. The grid remounts on every run
+// (the pane renders `{loading ? <spinner/> : <DataGrid/>}`), a plan is not
+// cleared when a query re-runs, and the explain auto-switch had no mount guard,
+// so it fired on each remount while the results effect was already guarded.
+describe('DataGrid — the explain tab does not hijack later runs (#281)', () => {
+  const plan = JSON.stringify({ queryPlanner: { winningPlan: { stage: 'COLLSCAN' } } });
+
+  it('stays on results when the grid remounts with an existing plan', () => {
+    const { unmount } = render(
+      <DataGrid documents={mockDocuments} explainResult={plan} activeTab="results" />
+    );
+    unmount();
+    // The remount a re-run causes, with the plan still hanging around.
+    render(<DataGrid documents={mockDocuments} explainResult={plan} activeTab="results" />);
+    expect(screen.getByTestId('json-view')).toBeInTheDocument();
+  });
+
+  it('still opens explain when a plan actually arrives', () => {
+    // The guard must not cost the behaviour it guards: a plan showing up after
+    // mount is a real event and should switch.
+    const onActiveTabChange = vi.fn();
+    const { rerender } = render(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={null}
+        activeTab="results"
+        onActiveTabChange={onActiveTabChange}
+      />
+    );
+    rerender(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={plan}
+        activeTab="results"
+        onActiveTabChange={onActiveTabChange}
+      />
+    );
+    expect(onActiveTabChange).toHaveBeenCalledWith('explain');
+  });
+
+  it('reports the tab the user picks so it can outlive the grid', () => {
+    const onActiveTabChange = vi.fn();
+    render(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={plan}
+        activeTab="results"
+        onActiveTabChange={onActiveTabChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /explain/i }));
+    expect(onActiveTabChange).toHaveBeenCalledWith('explain');
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 
 // Monaco renders the Query Code panel; mock it as a plain textarea (same shape
@@ -1686,5 +1687,72 @@ describe('DataGrid — a run started from Explain shows its results (#325 review
     // honours the tab it is given, and nothing here switches back.
     render(<DataGrid documents={mockDocuments} explainResult={plan} activeTab="explain" />);
     expect(screen.queryByTestId('json-view')).not.toBeInTheDocument();
+  });
+});
+
+// #325 review: StrictMode runs every effect twice on mount, and a one-shot
+// guard is spent by the first setup — so the replayed setup saw an already-gone
+// guard and fired anyway. The app mounts under StrictMode in development, so
+// the bug was fully back there.
+//
+// These assert on `onActiveTabChange` rather than on what is rendered. With a
+// controlled tab the rendered panel is unaffected by a stray switch — the
+// controlled prop still wins that render — so the damage travels out through
+// the callback, which is what the caller persists and hands back next time.
+describe('DataGrid — tab guards survive StrictMode replay (#325 review)', () => {
+  const plan = JSON.stringify({ queryPlanner: { winningPlan: { stage: 'COLLSCAN' } } });
+
+  const renderStrict = (ui: React.ReactElement) =>
+    render(<React.StrictMode>{ui}</React.StrictMode>);
+
+  it('does not announce an explain switch when it merely remounts', () => {
+    const onActiveTabChange = vi.fn();
+    renderStrict(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={plan}
+        activeTab="results"
+        onActiveTabChange={onActiveTabChange}
+      />
+    );
+    expect(onActiveTabChange).not.toHaveBeenCalledWith('explain');
+  });
+
+  it('does not announce a results switch either', () => {
+    // The documents guard had the same shape, so its replay could have pushed
+    // the tab the other way and lost a deliberate Explain selection.
+    const onActiveTabChange = vi.fn();
+    renderStrict(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={plan}
+        activeTab="explain"
+        onActiveTabChange={onActiveTabChange}
+      />
+    );
+    expect(onActiveTabChange).not.toHaveBeenCalledWith('results');
+  });
+
+  it('still opens explain when a plan genuinely arrives', () => {
+    const onActiveTabChange = vi.fn();
+    const { rerender } = renderStrict(
+      <DataGrid
+        documents={mockDocuments}
+        explainResult={null}
+        activeTab="results"
+        onActiveTabChange={onActiveTabChange}
+      />
+    );
+    rerender(
+      <React.StrictMode>
+        <DataGrid
+          documents={mockDocuments}
+          explainResult={plan}
+          activeTab="results"
+          onActiveTabChange={onActiveTabChange}
+        />
+      </React.StrictMode>
+    );
+    expect(onActiveTabChange).toHaveBeenCalledWith('explain');
   });
 });

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1661,3 +1661,30 @@ describe('DataGrid — the explain tab does not hijack later runs (#281)', () =>
     expect(onActiveTabChange).toHaveBeenCalledWith('explain');
   });
 });
+
+// #325 review: the tab now outlives the loading remount, so a run started from
+// Explain would have kept showing the plan and hidden its own results — the
+// documents effect deliberately skips mount, so nothing would correct it.
+describe('DataGrid — a run started from Explain shows its results (#325 review)', () => {
+  const plan = JSON.stringify({ queryPlanner: { winningPlan: { stage: 'COLLSCAN' } } });
+
+  it('shows rows when the caller resets the tab for a run', () => {
+    // Sitting on Explain.
+    const { unmount } = render(
+      <DataGrid documents={mockDocuments} explainResult={plan} activeTab="explain" />
+    );
+    expect(screen.getByTestId('explain-panel')).toBeInTheDocument();
+    // A run: the grid unmounts while loading, and App resets the tab because
+    // the user asked for rows.
+    unmount();
+    render(<DataGrid documents={mockDocuments} explainResult={plan} activeTab="results" />);
+    expect(screen.getByTestId('json-view')).toBeInTheDocument();
+  });
+
+  it('would hide them if the caller kept the tab on explain', () => {
+    // Pins why the App-side reset is required rather than optional: the grid
+    // honours the tab it is given, and nothing here switches back.
+    render(<DataGrid documents={mockDocuments} explainResult={plan} activeTab="explain" />);
+    expect(screen.queryByTestId('json-view')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/resultsTabReset.test.ts
+++ b/src/components/__tests__/resultsTabReset.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+// #325 review: the results tab is persisted on the tab so it survives the grid
+// remounting on every run. That persistence is what makes this necessary —
+// a run started from Explain would otherwise hide its own rows behind the plan,
+// because the grid's documents effect skips the mount it remounts into.
+describe('a run that loads documents returns to the Results tab (#325 review)', () => {
+  it('resets resultsTab wherever an existing tab starts loading', () => {
+    const app = readFileSync('src/App.tsx', 'utf8');
+    // Patches to an EXISTING tab (`...t,`) — creating a fresh tab needs no
+    // reset, since it has no persisted tab to carry over.
+    const patches = [...app.matchAll(/\{ \.\.\.t, [^}]*loading: true[^}]*\}/g)].map((m) => m[0]);
+    expect(patches.length).toBeGreaterThan(0);
+    for (const patch of patches) {
+      expect(patch).toContain("resultsTab: 'results'");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

After one visit to Explain, every subsequent run reopened it — the Results tab had to be clicked again each time, exactly as reported.

## Cause

Two things combining, neither sufficient alone.

**The grid remounts on every run.** The results pane renders `{loading ? <spinner/> : <DataGrid/>}`, so a run unmounts and remounts it. That is the same remount that already forced `viewMode` to be lifted out of the grid in #218 — the comment describing it is still in the props. The tab, though, stayed in local state, so the user's choice died with the component.

**The explain auto-switch had no mount guard.** A plan is not cleared when a query re-runs, so on each remount the effect saw a truthy `explainResult` and reopened Explain. The results effect beside it was already guarded against mount and so could not push back.

So: remount → tab resets → explain effect fires → Explain. Every run, forever, after a single visit.

## Fix

The tab is now owned by the caller, exactly as `viewMode` is, and survives the remount.

The auto-switch is skipped at mount **only when the caller controls the tab**. That distinction matters and is not defensive coding:

- A controlled caller owns the choice, and overriding what it just handed us is the bug.
- An uncontrolled caller has expressed no preference, so passing a plan still opens it — a contract the existing tests state outright (*"Explain result is provided, so it should auto-switch to explain tab"*).

My first attempt guarded unconditionally and broke four existing tests. They were right and the guard was too broad; keeping their contract is what led to the narrower rule.

## Related issue

Closes #281.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [x] `npm run i18n:check` passes
- [ ] `cargo test` — no backend change
- [ ] Manually verified in the running app (`npm run tauri dev`)

Three tests: staying on results when the grid remounts with an existing plan, still opening explain when a plan actually arrives, and reporting the user's choice so it can outlive the grid. All three fail on `dev` — the first with the reported symptom, the explain panel showing where the results should be.

Full suite: **1702 passed, 5 failed** — the same 5 that fail on a clean `dev`. Unrelated, left alone.

Not manually verified. The repro in the issue is four steps and worth walking once.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
