### PR TITLE
feat(documents): give each tab its own document edit

### DIFF
--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -143,7 +143,10 @@ pub async fn drop_collection_impl(
     confirmed: bool,
 ) -> Result<(), String> {
     let started = std::time::Instant::now();
-    crate::namespace_guard::ensure_namespace_idle(state, id, database, Some(collection))?;
+    // Held for the whole call rather than checked before it: a write starting
+    // in the gap between a check and the await would be accepted, and then
+    // recreate the collection this drop had just removed (#326 review).
+    let _claim = crate::namespace_guard::begin_collection_ddl(state, id, database, &[collection])?;
     let result = drop_collection_inner(state, id, database, collection, confirmed).await;
     crate::audit::maybe_record_result(
         state,
@@ -191,7 +194,8 @@ pub async fn rename_collection_impl(
     confirmed: bool,
 ) -> Result<(), String> {
     let started = std::time::Instant::now();
-    crate::namespace_guard::ensure_namespace_idle(state, id, database, Some(from))?;
+    // Both names: a write into the destination mid-rename is the same hazard.
+    let _claim = crate::namespace_guard::begin_collection_ddl(state, id, database, &[from, to])?;
     let result = rename_collection_inner(state, id, database, from, to, confirmed).await;
     crate::audit::maybe_record_result(
         state,
@@ -382,7 +386,7 @@ pub async fn drop_database_impl(
     confirmed: bool,
 ) -> Result<(), String> {
     let started = std::time::Instant::now();
-    crate::namespace_guard::ensure_namespace_idle(state, id, database, None)?;
+    let _claim = crate::namespace_guard::begin_database_ddl(state, id, &[database])?;
     let result = drop_database_inner(state, id, database, confirmed).await;
     crate::audit::maybe_record_result(
         state,
@@ -432,7 +436,8 @@ pub async fn rename_database_impl(
 ) -> Result<DatabaseRenameResult, String> {
     let started = std::time::Instant::now();
     // Every collection under it moves, so any write below the database blocks.
-    crate::namespace_guard::ensure_namespace_idle(state, id, from, None)?;
+    // Every collection under either name moves, so any write below one blocks.
+    let _claim = crate::namespace_guard::begin_database_ddl(state, id, &[from, to])?;
     let result = rename_database_inner(state, id, from, to, drop_source, confirmed).await;
     crate::audit::maybe_record_result(
         state,

--- a/src-tauri/src/db/ddl.rs
+++ b/src-tauri/src/db/ddl.rs
@@ -143,6 +143,7 @@ pub async fn drop_collection_impl(
     confirmed: bool,
 ) -> Result<(), String> {
     let started = std::time::Instant::now();
+    crate::namespace_guard::ensure_namespace_idle(state, id, database, Some(collection))?;
     let result = drop_collection_inner(state, id, database, collection, confirmed).await;
     crate::audit::maybe_record_result(
         state,
@@ -190,6 +191,7 @@ pub async fn rename_collection_impl(
     confirmed: bool,
 ) -> Result<(), String> {
     let started = std::time::Instant::now();
+    crate::namespace_guard::ensure_namespace_idle(state, id, database, Some(from))?;
     let result = rename_collection_inner(state, id, database, from, to, confirmed).await;
     crate::audit::maybe_record_result(
         state,
@@ -380,6 +382,7 @@ pub async fn drop_database_impl(
     confirmed: bool,
 ) -> Result<(), String> {
     let started = std::time::Instant::now();
+    crate::namespace_guard::ensure_namespace_idle(state, id, database, None)?;
     let result = drop_database_inner(state, id, database, confirmed).await;
     crate::audit::maybe_record_result(
         state,
@@ -428,8 +431,9 @@ pub async fn rename_database_impl(
     confirmed: bool,
 ) -> Result<DatabaseRenameResult, String> {
     let started = std::time::Instant::now();
-    let result =
-        rename_database_inner(state, id, from, to, drop_source, confirmed).await;
+    // Every collection under it moves, so any write below the database blocks.
+    crate::namespace_guard::ensure_namespace_idle(state, id, from, None)?;
+    let result = rename_database_inner(state, id, from, to, drop_source, confirmed).await;
     crate::audit::maybe_record_result(
         state,
         Some(id),

--- a/src-tauri/src/db/documents.rs
+++ b/src-tauri/src/db/documents.rs
@@ -343,6 +343,9 @@ pub async fn insert_document_impl(
     collection: &str,
     document: &str,
 ) -> Result<String, String> {
+    // Counted for the life of this call, so a rename or a drop of this
+    // namespace is refused while the insert is on its way (#326 review).
+    let _write = crate::namespace_guard::begin_document_write(state, id, database, collection)?;
     let started = std::time::Instant::now();
     let result = insert_document_inner(state, id, database, collection, document).await;
     crate::audit::maybe_record_result(
@@ -1070,6 +1073,7 @@ pub async fn update_document_impl(
     edited: &str,
     projection: Option<&str>,
 ) -> Result<u64, String> {
+    let _write = crate::namespace_guard::begin_document_write(state, id, database, collection)?;
     let started = std::time::Instant::now();
     let outcome = update_document_inner(
         state, id, database, collection, filter, original, edited, projection,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub mod monitoring;
 pub mod path_env;
 pub mod queries;
 pub mod ssh_tunnel;
+mod namespace_guard;
 mod state;
 pub mod toolsetup;
 pub mod updater;

--- a/src-tauri/src/namespace_guard.rs
+++ b/src-tauri/src/namespace_guard.rs
@@ -1,5 +1,5 @@
 //! Keeps a namespace from being renamed or dropped while a document write is
-//! in flight against it.
+//! in flight against it, and vice versa.
 //!
 //! The race is small and unrecoverable. An insert names its collection when it
 //! is sent; if a rename or a drop reaches MongoDB first, the server recreates
@@ -12,87 +12,156 @@
 //! a check in one renderer cannot know what another renderer has outstanding
 //! (#326 review). The frontend keeps its own check for immediate feedback;
 //! this is the one that is true.
+//!
+//! Reservations, not checks. Asking "is anything running?" and then awaiting
+//! the operation leaves exactly the gap it was meant to close — the answer is
+//! stale the moment the lock is released, and a write starting in that gap is
+//! the corruption again (#326 review). A document write and a DDL each claim
+//! the namespaces they name, for as long as they run, and each refuses to
+//! start while the other holds an overlapping claim. Document writes do not
+//! exclude each other: several inserts into one collection are ordinary.
 
 use crate::state::{AppState, LockExt};
-#[cfg(test)]
 use std::collections::HashMap;
 
-/// `connection/database/collection` — the granularity a write actually names.
-fn key(connection_id: &str, database: &str, collection: &str) -> String {
+/// `connection/database` — the scope a database rename or drop claims, and the
+/// prefix every collection under it shares.
+fn db_key(connection_id: &str, database: &str) -> String {
+    format!("{connection_id}/{database}")
+}
+
+/// `connection/database/collection` — the scope a write or a collection DDL
+/// claims.
+fn collection_key(connection_id: &str, database: &str, collection: &str) -> String {
     format!("{connection_id}/{database}/{collection}")
 }
 
-/// A write counted against its namespace for as long as this lives.
-///
-/// The count is released on drop, so it is released on every path out of the
-/// command — including the error paths and a panic. A guard that had to be
-/// released by hand would eventually be leaked by one of them, and a leak here
-/// means a namespace nobody can ever rename again.
-pub struct DocumentWriteGuard<'a> {
-    state: &'a AppState,
-    key: String,
+/// What is currently claimed, and by which kind of caller.
+#[derive(Default)]
+pub struct NamespaceLocks {
+    /// Document writes outstanding, by collection scope.
+    writes: HashMap<String, usize>,
+    /// Renames and drops in progress, by the scope each claimed — a collection
+    /// key or a database key.
+    ddl: HashMap<String, usize>,
 }
 
-impl Drop for DocumentWriteGuard<'_> {
+fn release(counts: &mut HashMap<String, usize>, key: &str) {
+    if let Some(count) = counts.get_mut(key) {
+        *count -= 1;
+        if *count == 0 {
+            counts.remove(key);
+        }
+    }
+}
+
+/// Held for the life of a call; releases its claims on drop.
+///
+/// Dropping is what releases them, so they are released on every path out —
+/// the error paths and a panic included. A claim released by hand is one some
+/// path eventually leaks, and a leak here is a namespace nobody can rename
+/// again.
+pub struct NamespaceClaim<'a> {
+    state: &'a AppState,
+    keys: Vec<String>,
+    ddl: bool,
+}
+
+impl Drop for NamespaceClaim<'_> {
     fn drop(&mut self) {
-        let Ok(mut writes) = self.state.document_writes.lock_safe() else {
-            // A poisoned lock means another thread panicked holding it. Nothing
-            // useful to do here, and panicking inside a drop would abort.
+        let Ok(mut locks) = self.state.namespaces.lock_safe() else {
+            // Another thread panicked holding the lock. Nothing useful to do,
+            // and panicking inside a drop would abort the process.
             return;
         };
-        if let Some(count) = writes.get_mut(&self.key) {
-            *count -= 1;
-            if *count == 0 {
-                writes.remove(&self.key);
+        for key in &self.keys {
+            if self.ddl {
+                release(&mut locks.ddl, key);
+            } else {
+                release(&mut locks.writes, key);
             }
         }
     }
 }
 
-/// Count a document write against its namespace until the returned guard drops.
+/// User-facing: a command's error text is rendered straight into the UI.
+const BUSY_WITH_SAVE: &str =
+    "A document is still being saved here. Wait for it to finish, then try again.";
+const BUSY_WITH_DDL: &str =
+    "This collection is being renamed or dropped. Wait for that to finish, then try again.";
+
+/// Claim a collection for one document write.
+///
+/// Refused while a rename or a drop holds this collection, or the database it
+/// is in.
 pub fn begin_document_write<'a>(
     state: &'a AppState,
     connection_id: &str,
     database: &str,
     collection: &str,
-) -> Result<DocumentWriteGuard<'a>, String> {
-    let key = key(connection_id, database, collection);
-    *state.document_writes.lock_safe()?.entry(key.clone()).or_insert(0) += 1;
-    Ok(DocumentWriteGuard { state, key })
+) -> Result<NamespaceClaim<'a>, String> {
+    let key = collection_key(connection_id, database, collection);
+    let mut locks = state.namespaces.lock_safe()?;
+    if locks.ddl.contains_key(&key) || locks.ddl.contains_key(&db_key(connection_id, database)) {
+        return Err(BUSY_WITH_DDL.to_string());
+    }
+    *locks.writes.entry(key.clone()).or_insert(0) += 1;
+    Ok(NamespaceClaim { state, keys: vec![key], ddl: false })
 }
 
-/// Refuse when a document write is outstanding against this namespace.
+/// Claim collections for a rename or a drop, for as long as it runs.
 ///
-/// `collection` is `None` for a database-level change, which moves or removes
-/// every collection under it — so any write below that database blocks it.
-pub fn ensure_namespace_idle(
-    state: &AppState,
+/// A rename claims both names: a write into the destination while the rename is
+/// in flight is the same hazard from the other side.
+pub fn begin_collection_ddl<'a>(
+    state: &'a AppState,
     connection_id: &str,
     database: &str,
-    collection: Option<&str>,
-) -> Result<(), String> {
-    let writes = state.document_writes.lock_safe()?;
-    let busy = match collection {
-        Some(collection) => writes.contains_key(&key(connection_id, database, collection)),
-        None => {
-            let prefix = format!("{connection_id}/{database}/");
-            writes.keys().any(|k| k.starts_with(&prefix))
+    collections: &[&str],
+) -> Result<NamespaceClaim<'a>, String> {
+    let database_scope = db_key(connection_id, database);
+    let keys: Vec<String> = collections
+        .iter()
+        .map(|c| collection_key(connection_id, database, c))
+        .collect();
+    let mut locks = state.namespaces.lock_safe()?;
+    for key in &keys {
+        if locks.writes.contains_key(key) {
+            return Err(BUSY_WITH_SAVE.to_string());
         }
-    };
-    if busy {
-        // User-facing: the frontend renders a command's error text directly.
-        return Err(
-            "A document is still being saved here. Wait for it to finish, then try again."
-                .to_string(),
-        );
+        if locks.ddl.contains_key(key) || locks.ddl.contains_key(&database_scope) {
+            return Err(BUSY_WITH_DDL.to_string());
+        }
     }
-    Ok(())
+    // Claimed only once every name is free, so a refusal leaves nothing behind.
+    for key in &keys {
+        *locks.ddl.entry(key.clone()).or_insert(0) += 1;
+    }
+    Ok(NamespaceClaim { state, keys, ddl: true })
 }
 
-/// Test-only view of the counts, so a test can assert a guard released.
-#[cfg(test)]
-pub fn outstanding(state: &AppState) -> HashMap<String, usize> {
-    state.document_writes.lock_safe().unwrap().clone()
+/// Claim whole databases for a rename or a drop: every collection under them
+/// moves or goes, so any write below one blocks it.
+pub fn begin_database_ddl<'a>(
+    state: &'a AppState,
+    connection_id: &str,
+    databases: &[&str],
+) -> Result<NamespaceClaim<'a>, String> {
+    let keys: Vec<String> = databases.iter().map(|d| db_key(connection_id, d)).collect();
+    let mut locks = state.namespaces.lock_safe()?;
+    for key in &keys {
+        let below = format!("{key}/");
+        if locks.writes.keys().any(|k| k.starts_with(&below)) {
+            return Err(BUSY_WITH_SAVE.to_string());
+        }
+        if locks.ddl.contains_key(key) || locks.ddl.keys().any(|k| k.starts_with(&below)) {
+            return Err(BUSY_WITH_DDL.to_string());
+        }
+    }
+    for key in &keys {
+        *locks.ddl.entry(key.clone()).or_insert(0) += 1;
+    }
+    Ok(NamespaceClaim { state, keys, ddl: true })
 }
 
 #[cfg(test)]
@@ -100,46 +169,92 @@ mod tests {
     use super::*;
 
     #[test]
-    fn a_write_blocks_its_own_namespace_and_its_database() {
+    fn a_write_blocks_its_collection_and_its_database() {
         let state = AppState::new();
         let _write = begin_document_write(&state, "conn-1", "sales", "customers").unwrap();
 
-        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_err());
-        // A database rename or drop moves every collection under it.
-        assert!(ensure_namespace_idle(&state, "conn-1", "sales", None).is_err());
+        assert!(begin_collection_ddl(&state, "conn-1", "sales", &["customers"]).is_err());
+        // A database rename or drop takes every collection under it.
+        assert!(begin_database_ddl(&state, "conn-1", &["sales"]).is_err());
 
         // Everything else is free: a neighbouring collection, another database,
-        // the same names on a different connection.
-        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("orders")).is_ok());
-        assert!(ensure_namespace_idle(&state, "conn-1", "other", None).is_ok());
-        assert!(ensure_namespace_idle(&state, "conn-2", "sales", Some("customers")).is_ok());
+        // the same names on another connection.
+        assert!(begin_collection_ddl(&state, "conn-1", "sales", &["orders"]).is_ok());
+        assert!(begin_database_ddl(&state, "conn-1", &["other"]).is_ok());
+        assert!(begin_collection_ddl(&state, "conn-2", "sales", &["customers"]).is_ok());
     }
 
     #[test]
-    fn the_namespace_frees_when_the_write_ends_however_it_ends() {
+    fn a_ddl_in_progress_blocks_a_write_starting_under_it() {
+        // The check-then-act gap: the DDL is awaited, so a write arriving after
+        // the old check and before MongoDB saw the rename was accepted, and then
+        // recreated the namespace the rename had just moved (#326 review).
+        let state = AppState::new();
+        let _rename =
+            begin_collection_ddl(&state, "conn-1", "sales", &["customers", "clients"]).unwrap();
+
+        assert!(begin_document_write(&state, "conn-1", "sales", "customers").is_err());
+        // Both names, because a write into the destination is the same hazard.
+        assert!(begin_document_write(&state, "conn-1", "sales", "clients").is_err());
+        assert!(begin_document_write(&state, "conn-1", "sales", "orders").is_ok());
+    }
+
+    #[test]
+    fn a_database_ddl_blocks_writes_to_every_collection_under_it() {
+        let state = AppState::new();
+        let _drop = begin_database_ddl(&state, "conn-1", &["sales"]).unwrap();
+
+        assert!(begin_document_write(&state, "conn-1", "sales", "customers").is_err());
+        assert!(begin_document_write(&state, "conn-1", "sales", "orders").is_err());
+        assert!(begin_document_write(&state, "conn-1", "other", "customers").is_ok());
+    }
+
+    #[test]
+    fn overlapping_ddl_is_refused_from_either_direction() {
+        let state = AppState::new();
+        let collection = begin_collection_ddl(&state, "conn-1", "sales", &["customers"]).unwrap();
+        // The database above it is not free while one of its collections is busy.
+        assert!(begin_database_ddl(&state, "conn-1", &["sales"]).is_err());
+        drop(collection);
+
+        let _database = begin_database_ddl(&state, "conn-1", &["sales"]).unwrap();
+        assert!(begin_collection_ddl(&state, "conn-1", "sales", &["customers"]).is_err());
+    }
+
+    #[test]
+    fn a_refused_claim_leaves_nothing_behind() {
+        let state = AppState::new();
+        let _write = begin_document_write(&state, "conn-1", "sales", "customers").unwrap();
+        // "orders" is free, "customers" is not: the whole claim is refused, and
+        // "orders" must not be left claimed by the attempt.
+        assert!(begin_collection_ddl(&state, "conn-1", "sales", &["orders", "customers"]).is_err());
+        assert!(begin_document_write(&state, "conn-1", "sales", "orders").is_ok());
+    }
+
+    #[test]
+    fn claims_release_however_the_call_ends() {
         let state = AppState::new();
         {
             let _write = begin_document_write(&state, "conn-1", "sales", "customers").unwrap();
-            assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_err());
+            assert!(begin_collection_ddl(&state, "conn-1", "sales", &["customers"]).is_err());
         }
-        // Released on drop, so it is released on the error paths too — a guard
-        // released by hand would eventually be leaked by one of them, and a leak
-        // here is a namespace nobody can rename again.
-        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_ok());
-        assert!(outstanding(&state).is_empty(), "no key should linger at zero");
+        assert!(begin_collection_ddl(&state, "conn-1", "sales", &["customers"]).is_ok());
+        let locks = state.namespaces.lock_safe().unwrap();
+        assert!(locks.writes.is_empty(), "no key should linger at zero");
+        assert!(locks.ddl.is_empty(), "no key should linger at zero");
     }
 
     #[test]
-    fn concurrent_writes_on_one_namespace_are_counted_not_replaced() {
+    fn document_writes_do_not_exclude_each_other() {
+        // Several inserts into one collection are ordinary; only DDL is exclusive.
         let state = AppState::new();
         let first = begin_document_write(&state, "conn-1", "sales", "customers").unwrap();
         let second = begin_document_write(&state, "conn-1", "sales", "customers").unwrap();
 
         drop(first);
         // Still one outstanding: the earlier one ending says nothing about it.
-        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_err());
-
+        assert!(begin_collection_ddl(&state, "conn-1", "sales", &["customers"]).is_err());
         drop(second);
-        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_ok());
+        assert!(begin_collection_ddl(&state, "conn-1", "sales", &["customers"]).is_ok());
     }
 }

--- a/src-tauri/src/namespace_guard.rs
+++ b/src-tauri/src/namespace_guard.rs
@@ -1,0 +1,145 @@
+//! Keeps a namespace from being renamed or dropped while a document write is
+//! in flight against it.
+//!
+//! The race is small and unrecoverable. An insert names its collection when it
+//! is sent; if a rename or a drop reaches MongoDB first, the server recreates
+//! that collection for the insert and the write lands in a namespace that was
+//! supposed to be gone — a drop half-undone, or one write split across two
+//! collections, with the UI reporting success against the new name.
+//!
+//! It belongs here rather than in the UI. Every window issues its commands
+//! through this same process, so this is the only place that sees all of them:
+//! a check in one renderer cannot know what another renderer has outstanding
+//! (#326 review). The frontend keeps its own check for immediate feedback;
+//! this is the one that is true.
+
+use crate::state::{AppState, LockExt};
+#[cfg(test)]
+use std::collections::HashMap;
+
+/// `connection/database/collection` — the granularity a write actually names.
+fn key(connection_id: &str, database: &str, collection: &str) -> String {
+    format!("{connection_id}/{database}/{collection}")
+}
+
+/// A write counted against its namespace for as long as this lives.
+///
+/// The count is released on drop, so it is released on every path out of the
+/// command — including the error paths and a panic. A guard that had to be
+/// released by hand would eventually be leaked by one of them, and a leak here
+/// means a namespace nobody can ever rename again.
+pub struct DocumentWriteGuard<'a> {
+    state: &'a AppState,
+    key: String,
+}
+
+impl Drop for DocumentWriteGuard<'_> {
+    fn drop(&mut self) {
+        let Ok(mut writes) = self.state.document_writes.lock_safe() else {
+            // A poisoned lock means another thread panicked holding it. Nothing
+            // useful to do here, and panicking inside a drop would abort.
+            return;
+        };
+        if let Some(count) = writes.get_mut(&self.key) {
+            *count -= 1;
+            if *count == 0 {
+                writes.remove(&self.key);
+            }
+        }
+    }
+}
+
+/// Count a document write against its namespace until the returned guard drops.
+pub fn begin_document_write<'a>(
+    state: &'a AppState,
+    connection_id: &str,
+    database: &str,
+    collection: &str,
+) -> Result<DocumentWriteGuard<'a>, String> {
+    let key = key(connection_id, database, collection);
+    *state.document_writes.lock_safe()?.entry(key.clone()).or_insert(0) += 1;
+    Ok(DocumentWriteGuard { state, key })
+}
+
+/// Refuse when a document write is outstanding against this namespace.
+///
+/// `collection` is `None` for a database-level change, which moves or removes
+/// every collection under it — so any write below that database blocks it.
+pub fn ensure_namespace_idle(
+    state: &AppState,
+    connection_id: &str,
+    database: &str,
+    collection: Option<&str>,
+) -> Result<(), String> {
+    let writes = state.document_writes.lock_safe()?;
+    let busy = match collection {
+        Some(collection) => writes.contains_key(&key(connection_id, database, collection)),
+        None => {
+            let prefix = format!("{connection_id}/{database}/");
+            writes.keys().any(|k| k.starts_with(&prefix))
+        }
+    };
+    if busy {
+        // User-facing: the frontend renders a command's error text directly.
+        return Err(
+            "A document is still being saved here. Wait for it to finish, then try again."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Test-only view of the counts, so a test can assert a guard released.
+#[cfg(test)]
+pub fn outstanding(state: &AppState) -> HashMap<String, usize> {
+    state.document_writes.lock_safe().unwrap().clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_write_blocks_its_own_namespace_and_its_database() {
+        let state = AppState::new();
+        let _write = begin_document_write(&state, "conn-1", "sales", "customers").unwrap();
+
+        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_err());
+        // A database rename or drop moves every collection under it.
+        assert!(ensure_namespace_idle(&state, "conn-1", "sales", None).is_err());
+
+        // Everything else is free: a neighbouring collection, another database,
+        // the same names on a different connection.
+        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("orders")).is_ok());
+        assert!(ensure_namespace_idle(&state, "conn-1", "other", None).is_ok());
+        assert!(ensure_namespace_idle(&state, "conn-2", "sales", Some("customers")).is_ok());
+    }
+
+    #[test]
+    fn the_namespace_frees_when_the_write_ends_however_it_ends() {
+        let state = AppState::new();
+        {
+            let _write = begin_document_write(&state, "conn-1", "sales", "customers").unwrap();
+            assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_err());
+        }
+        // Released on drop, so it is released on the error paths too — a guard
+        // released by hand would eventually be leaked by one of them, and a leak
+        // here is a namespace nobody can rename again.
+        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_ok());
+        assert!(outstanding(&state).is_empty(), "no key should linger at zero");
+    }
+
+    #[test]
+    fn concurrent_writes_on_one_namespace_are_counted_not_replaced() {
+        let state = AppState::new();
+        let first = begin_document_write(&state, "conn-1", "sales", "customers").unwrap();
+        let second = begin_document_write(&state, "conn-1", "sales", "customers").unwrap();
+
+        drop(first);
+        // Still one outstanding: the earlier one ending says nothing about it.
+        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_err());
+
+        drop(second);
+        assert!(ensure_namespace_idle(&state, "conn-1", "sales", Some("customers")).is_ok());
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -179,7 +179,7 @@ pub struct AppState {
     /// write and undo it — see `namespace_guard`. Shared by every window,
     /// which is the whole point, since a renderer only ever sees its own
     /// (#326 review).
-    pub document_writes: Mutex<HashMap<String, usize>>,
+    pub namespaces: Mutex<crate::namespace_guard::NamespaceLocks>,
     pub connection_meta: Mutex<HashMap<String, ConnectionMeta>>,
     /// Embedded MCP server lifecycle + settings (#98 Task 1): enablement,
     /// bound port, bearer token, rolling call log, and the live server
@@ -238,7 +238,7 @@ impl AppState {
             conn_uris: Mutex::new(HashMap::new()),
             workspace: Mutex::new(None),
             workspace_write_gen: Arc::new(AtomicU64::new(0)),
-            document_writes: Mutex::new(HashMap::new()),
+            namespaces: Mutex::new(Default::default()),
             connection_meta: Mutex::new(HashMap::new()),
             mcp: Arc::new(Mutex::new(mcp::McpControl::new())),
             audit: Arc::new(Mutex::new(None)),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -172,6 +172,14 @@ pub struct AppState {
     /// changes (`set_connection_meta` on connect, removed on
     /// `disconnect_db`). See `ConnectionMeta`'s doc comment for why this
     /// deliberately never holds a URI.
+    /// Document writes in flight, counted per `connection/database/collection`.
+    ///
+    /// A rename or a drop of a namespace with an outstanding write is refused:
+    /// if it landed first, the server would recreate the namespace for the
+    /// write and undo it — see `namespace_guard`. Shared by every window,
+    /// which is the whole point, since a renderer only ever sees its own
+    /// (#326 review).
+    pub document_writes: Mutex<HashMap<String, usize>>,
     pub connection_meta: Mutex<HashMap<String, ConnectionMeta>>,
     /// Embedded MCP server lifecycle + settings (#98 Task 1): enablement,
     /// bound port, bearer token, rolling call log, and the live server
@@ -230,6 +238,7 @@ impl AppState {
             conn_uris: Mutex::new(HashMap::new()),
             workspace: Mutex::new(None),
             workspace_write_gen: Arc::new(AtomicU64::new(0)),
+            document_writes: Mutex::new(HashMap::new()),
             connection_meta: Mutex::new(HashMap::new()),
             mcp: Arc::new(Mutex::new(mcp::McpControl::new())),
             audit: Arc::new(Mutex::new(None)),

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -64,6 +64,14 @@ pub struct TabModel {
     pub last_aggregate: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub builder_state: Option<serde_json::Value>,
+    /// An unsaved document edit, so moving this tab to another window carries
+    /// the text instead of discarding it (#326 review). The destination
+    /// materializes the tab from here, which is why the draft has to travel in
+    /// the model rather than in the move op. Opaque to this crate; see
+    /// `carriedDocumentEdit` in persistence.ts for what is deliberately left
+    /// behind — a save in flight belongs to the window that started it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub document_edit: Option<serde_json::Value>,
 }
 
 /// A node in the split-pane layout tree.
@@ -234,6 +242,8 @@ pub enum WorkspaceOp {
         last_aggregate: Option<Option<serde_json::Value>>,
         #[serde(default, deserialize_with = "deserialize_some")]
         builder_state: Option<Option<serde_json::Value>>,
+        #[serde(default, deserialize_with = "deserialize_some")]
+        document_edit: Option<Option<serde_json::Value>>,
     },
     /// Moves an already-open tab from wherever it currently lives (found by
     /// scanning ALL windows — the op itself doesn't name a source) into
@@ -859,7 +869,7 @@ fn apply_layout_op(ws: &mut Workspace, op: WorkspaceOp) {
                 }
             }
         }
-        WorkspaceOp::UpdateTabState { tab_id, last_query, last_aggregate, builder_state } => {
+        WorkspaceOp::UpdateTabState { tab_id, last_query, last_aggregate, builder_state, document_edit } => {
             if let Some(t) = ws.tabs.iter_mut().find(|t| &t.id == tab_id) {
                 // `patch` is `&Option<Value>` here: present-but-null (`Some(None)`
                 // on the op) clears the field; present-with-value sets it.
@@ -879,6 +889,15 @@ fn apply_layout_op(ws: &mut Workspace, op: WorkspaceOp) {
                 if let Some(patch) = builder_state {
                     if &t.builder_state != patch {
                         t.builder_state = patch.clone();
+                        changed = true;
+                    }
+                }
+                // Present-and-null is how closing an edit clears the draft, so
+                // a tab moved afterwards does not arrive carrying text the user
+                // already finished with.
+                if let Some(patch) = document_edit {
+                    if &t.document_edit != patch {
+                        t.document_edit = patch.clone();
                         changed = true;
                     }
                 }
@@ -1705,6 +1724,7 @@ mod tests {
             last_query: None,
             last_aggregate: None,
             builder_state: None,
+            document_edit: None,
         }
     }
 
@@ -1729,6 +1749,76 @@ mod tests {
         assert_eq!(ws.revision, rev_before + 1);
     }
 
+
+    /// #326 review: a tab moved to another window is rebuilt there from this
+    /// model, so an unsaved document edit has to live on the model or the move
+    /// discards it. Closing the edit sends an explicit null — absent would mean
+    /// "untouched" and leave a finished draft behind for the next move to carry.
+    #[test]
+    fn update_tab_state_carries_and_clears_a_document_edit() {
+        let mut ws = ws_with(&["t1"]);
+        ws.tabs.push(sample_tab("t1"));
+        let draft = serde_json::json!({
+            "mode": "edit",
+            "initialJson": "{\"_id\":\"1\"}",
+            "targetDoc": {"_id": "1"},
+            "draft": "{\"_id\":\"1\",\"name\":\"half typed\"}"
+        });
+
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: "t1".into(),
+                last_query: None,
+                last_aggregate: None,
+                builder_state: None,
+                document_edit: Some(Some(draft.clone())),
+            },
+        );
+        assert_eq!(ws.tabs[0].document_edit, Some(draft.clone()));
+        assert_eq!(ws.revision, 1);
+
+        // Re-sending the same draft changes nothing — a keystroke that lands on
+        // the same text must not bump the revision and wake every window.
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: "t1".into(),
+                last_query: None,
+                last_aggregate: None,
+                builder_state: None,
+                document_edit: Some(Some(draft)),
+            },
+        );
+        assert_eq!(ws.revision, 1);
+
+        // A patch that does not mention it leaves the draft alone.
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: "t1".into(),
+                last_query: Some(Some(serde_json::json!({"filter": "{}"}))),
+                last_aggregate: None,
+                builder_state: None,
+                document_edit: None,
+            },
+        );
+        assert!(ws.tabs[0].document_edit.is_some());
+
+        // Closing the edit clears it.
+        apply(
+            &mut ws,
+            WorkspaceOp::UpdateTabState {
+                tab_id: "t1".into(),
+                last_query: None,
+                last_aggregate: None,
+                builder_state: None,
+                document_edit: Some(None),
+            },
+        );
+        assert_eq!(ws.tabs[0].document_edit, None);
+    }
+
     #[test]
     fn update_tab_state_patches_selected_fields_only() {
         let mut ws = ws_with(&["t1"]);
@@ -1744,6 +1834,7 @@ mod tests {
                 last_query: None, // absent from the patch: untouched
                 last_aggregate: Some(Some(serde_json::json!([{"$match": {}}]))), // present: set
                 builder_state: None,
+                document_edit: None,
             },
         );
         let t = &ws.tabs[0];
@@ -1762,6 +1853,7 @@ mod tests {
                 last_query: None,
                 last_aggregate: Some(Some(serde_json::json!([{"$match": {}}]))),
                 builder_state: None,
+                document_edit: None,
             },
         );
         assert_eq!(ws.revision, rev_before);
@@ -1784,6 +1876,7 @@ mod tests {
                 last_query: None,
                 last_aggregate: Some(None), // explicit null: clear
                 builder_state: None,
+                document_edit: None,
             },
         );
         assert_eq!(ws.tabs[0].last_aggregate, None);
@@ -1804,6 +1897,7 @@ mod tests {
                 last_query: None, // absent: untouched, NOT cleared
                 last_aggregate: None,
                 builder_state: None,
+                document_edit: None,
             },
         );
         assert_eq!(ws.tabs[0].last_query, Some(serde_json::json!({"filter": "{}"})));
@@ -1822,6 +1916,7 @@ mod tests {
                 last_query: None,
                 last_aggregate: Some(None), // explicit null on an already-None field: no-op
                 builder_state: None,
+                document_edit: None,
             },
         );
         assert_eq!(ws.tabs[0].last_aggregate, None);
@@ -2094,6 +2189,7 @@ mod tests {
                 last_query: Some(serde_json::json!({ "filter": {} })),
                 last_aggregate: None,
                 builder_state: None,
+                document_edit: None,
             }
         }
 
@@ -2170,6 +2266,7 @@ mod tests {
                 last_query: Some(Some(patched_query.clone())),
                 last_aggregate: None,
                 builder_state: None,
+                document_edit: None,
             },
         );
 
@@ -3060,6 +3157,7 @@ mod broadcast {
                     last_query: Some(Some(serde_json::json!({"x": 1}))),
                     last_aggregate: None,
                     builder_state: None,
+                    document_edit: None,
                 },
             ),
         ];
@@ -3076,6 +3174,7 @@ mod broadcast {
                 last_query: None,
                 last_aggregate: None,
                 builder_state: None,
+                document_edit: None,
             });
             let payload = apply_and_describe(&mut ws, op, "main".into());
             let payload = payload.unwrap_or_else(|| panic!("`{name}` was expected to change state"));

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1185,8 +1185,28 @@ pub fn load_from_file(path: &Path) -> Option<Workspace> {
 /// mid-`fs::write` left a corrupt file that `load_from_file` would then fail
 /// to parse (or fail `validate`) on every future boot, until the user
 /// deleted it by hand.
+/// The workspace as it goes to disk: every in-progress document edit dropped.
+///
+/// A draft has to be in the store for a tab to change window — the destination
+/// builds the tab from there — but it does not have to outlive the session, and
+/// `workspace.json` is plaintext. Keeping an unsaved document body (its
+/// `targetDoc` is a whole document) in a file that sits on disk indefinitely is
+/// a bigger promise than the feature needs: the draft exists to survive a move,
+/// not a reinstall.
+///
+/// So it lives in memory, where every window reads it, and stops there. A
+/// restart opens with no editors, exactly as before drafts travelled at all
+/// (#326 review).
+fn without_document_edits(ws: &Workspace) -> Workspace {
+    let mut copy = ws.clone();
+    for tab in &mut copy.tabs {
+        tab.document_edit = None;
+    }
+    copy
+}
+
 pub fn save_to_file(path: &Path, ws: &Workspace) -> Result<(), String> {
-    let content = serde_json::to_string_pretty(ws)
+    let content = serde_json::to_string_pretty(&without_document_edits(ws))
         .map_err(|e| format!("Failed to serialize workspace: {}", e))?;
     let mut tmp_os = path.as_os_str().to_os_string();
     tmp_os.push(".tmp");
@@ -2916,6 +2936,50 @@ mod store {
             second, first,
             "second call must return the cached in-memory copy, not re-read the mutated file"
         );
+    }
+
+    /// #326 review: a draft has to reach the store so a tab can carry it to
+    /// another window, but `workspace.json` is plaintext and long-lived. The
+    /// document stays in memory, where every window reads it, and never lands
+    /// in the file.
+    #[test]
+    fn save_to_file_keeps_document_edits_out_of_the_file() {
+        let path = tmp_path("no-drafts-on-disk.json");
+        let mut ws = sample_ws();
+        ws.tabs.push(TabModel {
+            id: "a".into(),
+            tab_type: "collection".into(),
+            profile_id: "p1".into(),
+            profile_name: "Profile 1".into(),
+            db: "mydb".into(),
+            collection: "mycoll".into(),
+            index_name: None,
+            last_query: Some(serde_json::json!({"filter": "{}"})),
+            last_aggregate: None,
+            builder_state: None,
+            document_edit: Some(serde_json::json!({
+                "id": "edit-1",
+                "mode": "edit",
+                "draft": "{\"ssn\":\"not for the disk\"}"
+            })),
+        });
+
+        save_to_file(&path, &ws).unwrap();
+        let raw = fs::read_to_string(&path).unwrap();
+        assert!(
+            !raw.contains("not for the disk"),
+            "an unsaved document body must not be written to workspace.json:\n{raw}"
+        );
+        assert!(!raw.contains("documentEdit"), "the key itself should be absent too");
+
+        // Everything else still persists, and the in-memory copy is untouched:
+        // this is a serialization choice, not a mutation of the store.
+        let loaded = load_from_file(&path).unwrap();
+        assert_eq!(loaded.tabs[0].last_query, Some(serde_json::json!({"filter": "{}"})));
+        assert_eq!(loaded.tabs[0].document_edit, None);
+        assert!(ws.tabs[0].document_edit.is_some());
+
+        let _ = fs::remove_file(&path);
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3712,10 +3712,6 @@ function Workspace() {
   // debounces, so a keystroke is not a round trip. `carriedDocumentEdit`
   // decides what travels; `null` on close, since an absent key means
   // "untouched" and would leave a finished draft on the model.
-  const mirrorDocumentEdit = (tabId: string, edit: DocumentEdit | null) =>
-    mirrorUpdateTabState(tabId, activeConnectionsRef.current, {
-      documentEdit: edit ? carriedDocumentEdit(edit) : null,
-    });
   const openDocumentEdit = (
     tab: QueryTab,
     edit: Omit<DocumentEdit, 'id' | 'draft' | 'error' | 'saving'>
@@ -3728,7 +3724,6 @@ function Workspace() {
       saving: false,
     };
     setTabs(prev => prev.map(t => (t.id === tab.id ? { ...t, documentEdit: opened } : t)));
-    mirrorDocumentEdit(tab.id, opened);
   };
   /** Ends the tab's edit. With `editId`, only if that is still the edit open.
    *
@@ -3736,18 +3731,14 @@ function Workspace() {
    *  started a different one on the same tab — closing that would throw away a
    *  draft nobody finished with. The user's own Cancel passes no id: whatever
    *  is on screen is what they meant to close. */
-  const closeDocumentEdit = (tabId: string, editId?: string) => {
-    let closed = false;
+  const closeDocumentEdit = (tabId: string, editId?: string) =>
     setTabs(prev =>
       prev.map(t => {
         if (t.id !== tabId || !t.documentEdit) return t;
         if (editId !== undefined && t.documentEdit.id !== editId) return t;
-        closed = true;
         return { ...t, documentEdit: undefined };
       })
     );
-    if (closed) mirrorDocumentEdit(tabId, null);
-  };
   /** Updates one edit, named by its own id — never merely "this tab's edit".
    *
    *  Matching on the tab alone was not enough. The dialog is non-modal, so the
@@ -3763,19 +3754,48 @@ function Workspace() {
           : t
       )
     );
-  // Only the draft is mirrored as the user types. `error` and `saving` are the
-  // two fields `carriedDocumentEdit` drops anyway, so patching them is not
-  // worth a mirror.
-  //
-  // The mirror is computed here rather than inside the updater: a state updater
-  // has to stay pure, and React runs it twice in development, which would make
-  // this fire the IPC twice per keystroke.
   const setDocumentDraft = (tabId: string, draft: string) => {
     const edit = tabs.find(t => t.id === tabId)?.documentEdit;
     if (!edit) return;
     patchDocumentEdit(tabId, edit.id, { draft });
-    mirrorDocumentEdit(tabId, { ...edit, draft });
   };
+
+  // The backend's copy of each tab's edit, kept level with state from one place
+  // rather than announced by whoever changed it.
+  //
+  // Every handler above tried to predict its own mirror, and predicting is what
+  // went wrong: a `setTabs` updater runs when React chooses, so `closeDocumentEdit`
+  // decided whether to send the clear before knowing whether it had closed
+  // anything — and a close that sent nothing left an earlier debounced draft
+  // standing on the backend, ready for the next move to revive an edit the user
+  // had already finished with (#326 review). Reading committed state instead
+  // cannot be wrong about what happened, because it runs after it happened.
+  //
+  // The comparison is against what was last sent, so a re-render that leaves an
+  // edit untouched sends nothing, and a keystroke sends once. `updateTabState`
+  // debounces the rest.
+  const mirroredEditsRef = useRef<Map<string, string>>(new Map());
+  useEffect(() => {
+    const open = new Set<string>();
+    for (const tab of tabs) {
+      if (!tab.documentEdit) continue;
+      open.add(tab.id);
+      const carried = JSON.stringify(carriedDocumentEdit(tab.documentEdit));
+      if (mirroredEditsRef.current.get(tab.id) === carried) continue;
+      mirroredEditsRef.current.set(tab.id, carried);
+      mirrorUpdateTabState(tab.id, activeConnectionsRef.current, {
+        documentEdit: JSON.parse(carried),
+      });
+    }
+    for (const tabId of [...mirroredEditsRef.current.keys()]) {
+      if (open.has(tabId)) continue;
+      mirroredEditsRef.current.delete(tabId);
+      // Explicitly null, not absent: absent means "untouched" and would leave a
+      // finished draft on the model for the next move to carry.
+      mirrorUpdateTabState(tabId, activeConnectionsRef.current, { documentEdit: null });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabs]);
 
   const handleInsertDocument = (tab: QueryTab) => {
     openDocumentEdit(tab, { mode: 'insert', initialJson: "{\n  \n}", targetDoc: null });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,7 @@ import {
   moveTabToWindow,
   flushTabState,
   cancelTabState,
+  applyTabOp,
   hasPendingDocumentEdit,
   type WorkspaceChangedPayload,
   type ConnectionsChangedPayload,
@@ -2670,31 +2671,46 @@ function Workspace() {
             return;
           }
           unmirroredTabIdsRef.current.delete(action.tabId);
-          workspaceApply(actionToOp(action, persisted, activeConnections));
+          // Ordered on the tab, like the close below: reopening a collection
+          // reuses its id, and this must not overtake the close of the tab that
+          // had it (#326 review).
+          applyTabOp(
+            [toProfileSpaceId(action.tabId, activeConnections)],
+            actionToOp(action, persisted, activeConnections)
+          );
           return;
         }
         if (unmirroredTabIdsRef.current.has(action.tabId)) return;
-        workspaceApply(actionToOp(action, undefined, activeConnections));
+        applyTabOp(
+          [toProfileSpaceId(action.tabId, activeConnections)],
+          actionToOp(action, undefined, activeConnections)
+        );
         return;
       }
-      // A queued patch outlives its tab otherwise. Ids are deterministic, so
-      // closing and reopening the same collection reuses one — and a draft
-      // still inside the debounce would attach to the new model, restoring an
-      // editor the user closed (#326 review).
+      // Two things a close has to get right, both because tab ids are
+      // deterministic: close and reopen the same collection and the id comes
+      // back. A queued patch would attach to the new model, restoring an editor
+      // the user closed — so it is dropped. And a write already on its way
+      // would do the same, so the close is ordered behind it rather than racing
+      // it, and the reopen behind the close (#326 review).
       case 'close_tab':
         cancelTabState(toProfileSpaceId(action.tabId, activeConnections));
         if (unmirroredTabIdsRef.current.has(action.tabId)) {
           unmirroredTabIdsRef.current.delete(action.tabId);
           return;
         }
-        workspaceApply(actionToOp(action, undefined, activeConnections));
+        applyTabOp(
+          [toProfileSpaceId(action.tabId, activeConnections)],
+          actionToOp(action, undefined, activeConnections)
+        );
         return;
       case 'close_many': {
-        cancelTabState(action.tabIds.map(id => toProfileSpaceId(id, activeConnections)));
+        const closing = action.tabIds.map(id => toProfileSpaceId(id, activeConnections));
+        cancelTabState(closing);
         const tabIds = action.tabIds.filter(id => !unmirroredTabIdsRef.current.has(id));
         action.tabIds.forEach(id => unmirroredTabIdsRef.current.delete(id));
         if (tabIds.length === 0) return;
-        workspaceApply(actionToOp({ ...action, tabIds }, undefined, activeConnections));
+        applyTabOp(closing, actionToOp({ ...action, tabIds }, undefined, activeConnections));
         return;
       }
       case 'move_tab':

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2770,7 +2770,14 @@ function Workspace() {
       // so starting the flush buys no ordering: the move could take the store
       // first and snapshot the older draft, and the update landing afterwards
       // is not a cross-window op for the destination to reconcile.
-      await flushTabState(profileId);
+      if (!(await flushTabState(profileId))) {
+        // The write did not land, so the backend still holds the older model.
+        // Moving now would carry that instead — dropping the newest draft, or
+        // reviving an editor whose insert already succeeded for the destination
+        // to submit a second time (#326 review).
+        toast(t('toast.documentEditNotSynced'), 'error');
+        return false;
+      }
       if (!hasPendingDocumentEdit(profileId)) {
         // Settled: nothing new arrived while that was in flight.
         const still = tabsRef.current.find(x => x.id === tabId)?.documentEdit;
@@ -3782,6 +3789,10 @@ function Workspace() {
         t.documentEdit?.id === editId ? { ...t, documentEdit: { ...t.documentEdit, ...patch } } : t
       )
     );
+  /** The tab currently holding this edit, read live so a rename during a
+   *  request is followed rather than missed. */
+  const tabHoldingEdit = (editId: string): QueryTab | undefined =>
+    tabsRef.current.find(t => t.documentEdit?.id === editId);
   /** Ends the edit with this id, wherever it is. Used by a save that finished;
    *  the user's own Cancel closes what is on screen instead. */
   const closeEditById = (editId: string) =>
@@ -4224,8 +4235,13 @@ function Workspace() {
         collection,
         document: json,
       });
+      // Resolved BEFORE the close, and from the ref: a rename during the
+      // request moved this edit to a tab with a new id and namespace, and the
+      // captured one would refresh the collection this tab no longer is (#326
+      // review).
+      const insertedInto = tabHoldingEdit(edit.id) ?? tab;
       closeEditById(edit.id);
-      await refreshTabResults(tab);
+      await refreshTabResults(insertedInto);
       toast(t('toast.documentInsertedInto', { collection }), 'success', { title: t('toast.insertedTitle') });
       return;
     }
@@ -4268,8 +4284,9 @@ function Workspace() {
         ? (pipelineYieldsWholeDocuments(tab.lastAggregate) ? '{}' : null)
         : (tab.lastQuery?.projection ?? '{}'),
     });
+    const savedIn = tabHoldingEdit(edit.id) ?? tab;
     closeEditById(edit.id);
-    await refreshTabResults(tab);
+    await refreshTabResults(savedIn);
     toast(t('toast.documentSavedIn', { collection }), 'success', { title: t('toast.savedTitle') });
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,7 @@ import {
   moveTabToWindow,
   flushTabState,
   cancelTabState,
+  hasPendingDocumentEdit,
   type WorkspaceChangedPayload,
   type ConnectionsChangedPayload,
   type ConnectionEntry,
@@ -2747,17 +2748,39 @@ function Workspace() {
    *  and flushing it would put a write in front of every move that never used
    *  to be there. */
   const readyForWindowChange = async (tabId: string): Promise<boolean> => {
-    const edit = tabs.find(t => t.id === tabId)?.documentEdit;
-    if (edit?.saving) {
-      toast(t('toast.documentSaveInProgress'), 'error');
-      return false;
+    const profileId = toProfileSpaceId(tabId, activeConnections);
+    // Re-read on every pass, from the ref rather than the render closure: the
+    // await below is a gap the user can type, cancel or start a save in, and a
+    // check made before it describes a state the move no longer happens in
+    // (#326 review). Each pass either finds nothing left to send, or sends it
+    // and looks again.
+    for (let pass = 0; pass < 4; pass++) {
+      const edit = tabsRef.current.find(x => x.id === tabId)?.documentEdit;
+      if (edit?.saving) {
+        toast(t('toast.documentSaveInProgress'), 'error');
+        return false;
+      }
+      // Not `if (edit)`: cancelling one removes it from the tab immediately
+      // while its `document_edit: null` is still queued, so at that moment the
+      // tab has no edit and the backend still holds the draft the move would
+      // carry — an already-inserted document among them, offered to the
+      // destination to submit again.
+      if (!edit && !hasPendingDocumentEdit(profileId)) return true;
+      // Awaited, not merely called first. Both are separate backend commands,
+      // so starting the flush buys no ordering: the move could take the store
+      // first and snapshot the older draft, and the update landing afterwards
+      // is not a cross-window op for the destination to reconcile.
+      await flushTabState(profileId);
+      if (!hasPendingDocumentEdit(profileId)) {
+        // Settled: nothing new arrived while that was in flight.
+        const still = tabsRef.current.find(x => x.id === tabId)?.documentEdit;
+        if (!still?.saving) return true;
+      }
     }
-    // Awaited, not merely called first. Both are separate backend commands, so
-    // starting the flush buys no ordering: the move could take the store first
-    // and snapshot the older draft, and the update landing afterwards is not a
-    // cross-window op for the destination to reconcile (#326 review).
-    if (edit) await flushTabState(toProfileSpaceId(tabId, activeConnections));
-    return true;
+    // Four passes and the edit is still moving. Rather than carry a draft that
+    // may already be stale again, leave the tab where it is and say so.
+    toast(t('toast.documentSaveInProgress'), 'error');
+    return false;
   };
 
   const handleDetachTab = async (tabId: string) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ import {
   closeWorkspaceWindow,
   moveTabToWindow,
   flushTabState,
+  cancelTabState,
   type WorkspaceChangedPayload,
   type ConnectionsChangedPayload,
   type ConnectionEntry,
@@ -2675,7 +2676,12 @@ function Workspace() {
         workspaceApply(actionToOp(action, undefined, activeConnections));
         return;
       }
+      // A queued patch outlives its tab otherwise. Ids are deterministic, so
+      // closing and reopening the same collection reuses one — and a draft
+      // still inside the debounce would attach to the new model, restoring an
+      // editor the user closed (#326 review).
       case 'close_tab':
+        cancelTabState(toProfileSpaceId(action.tabId, activeConnections));
         if (unmirroredTabIdsRef.current.has(action.tabId)) {
           unmirroredTabIdsRef.current.delete(action.tabId);
           return;
@@ -2683,6 +2689,7 @@ function Workspace() {
         workspaceApply(actionToOp(action, undefined, activeConnections));
         return;
       case 'close_many': {
+        cancelTabState(action.tabIds.map(id => toProfileSpaceId(id, activeConnections)));
         const tabIds = action.tabIds.filter(id => !unmirroredTabIdsRef.current.has(id));
         action.tabIds.forEach(id => unmirroredTabIdsRef.current.delete(id));
         if (tabIds.length === 0) return;
@@ -2739,23 +2746,27 @@ function Workspace() {
    *  debounce behind. Only then: a tab with no edit has nothing at stake here,
    *  and flushing it would put a write in front of every move that never used
    *  to be there. */
-  const readyForWindowChange = (tabId: string): boolean => {
+  const readyForWindowChange = async (tabId: string): Promise<boolean> => {
     const edit = tabs.find(t => t.id === tabId)?.documentEdit;
     if (edit?.saving) {
       toast(t('toast.documentSaveInProgress'), 'error');
       return false;
     }
-    if (edit) flushTabState(toProfileSpaceId(tabId, activeConnections));
+    // Awaited, not merely called first. Both are separate backend commands, so
+    // starting the flush buys no ordering: the move could take the store first
+    // and snapshot the older draft, and the update landing afterwards is not a
+    // cross-window op for the destination to reconcile (#326 review).
+    if (edit) await flushTabState(toProfileSpaceId(tabId, activeConnections));
     return true;
   };
 
-  const handleDetachTab = (tabId: string) => {
-    if (!readyForWindowChange(tabId)) return;
+  const handleDetachTab = async (tabId: string) => {
+    if (!(await readyForWindowChange(tabId))) return;
     detachTabToNewWindow(toProfileSpaceId(tabId, activeConnections));
   };
 
-  const handleMoveTab = (tabId: string, targetWindowId: string) => {
-    if (!readyForWindowChange(tabId)) return;
+  const handleMoveTab = async (tabId: string, targetWindowId: string) => {
+    if (!(await readyForWindowChange(tabId))) return;
     moveTabToWindow(toProfileSpaceId(tabId, activeConnections), targetWindowId);
     // Final whole-branch review, Fix 4(b): the "Move to <window>" list is
     // built from `lastWorkspaceRef` (the last-known cross-window document),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -213,6 +213,13 @@ export interface QueryTab {
 /// `$addFields` — reshapes the row or replaces its identity, so its `_id` may be
 /// a group key rather than a document id and saving could hit an unrelated
 /// document.
+/** How long an edit stays frozen waiting for its tab's move to be reconciled.
+ *
+ *  A backstop, not a schedule: the freeze normally ends when the tab leaves
+ *  this window, which is immediate. This is only so a move that never lands
+ *  cannot leave an editor unusable for the rest of the session. */
+const WINDOW_CHANGE_LOCK_MS = 10_000;
+
 const DOCUMENT_PRESERVING_STAGES = new Set(['$match', '$sort', '$limit', '$skip']);
 
 /** True when every stage of `pipeline` leaves documents intact. */
@@ -1158,6 +1165,9 @@ function Workspace() {
   const [pendingSaves, setPendingSaves] = useState<
     Array<{ editId: string; tabId: string; connectionId: string; db: string; collection: string }>
   >([]);
+  // Tabs whose move has been dispatched and not yet reconciled away. Their
+  // edits are frozen for that window — see lockTabForWindowChange.
+  const [movingTabIds, setMovingTabIds] = useState<ReadonlySet<string>>(() => new Set());
   // Read after an await, where the render closure is already stale.
   const pendingSavesRef = useRef(pendingSaves);
   pendingSavesRef.current = pendingSaves;
@@ -2832,13 +2842,39 @@ function Workspace() {
     return false;
   };
 
+  /** Freezes a tab's edit from the moment its move is dispatched.
+   *
+   *  The move is fire-and-forget: the backend may already have taken the tab's
+   *  snapshot while this window still shows it, and it stays interactive until
+   *  the reconciliation broadcast removes it. Anything typed in that window is
+   *  mirrored under an id the destination no longer reconciles — text lost in
+   *  front of the user — and a save started there does not travel, since
+   *  `carriedDocumentEdit` drops `saving`, leaving the destination free to
+   *  submit the same insert again (#326 review).
+   *
+   *  Released when the tab leaves, and on a timer besides: a move that never
+   *  happens must not stand the editor down for the rest of the session. */
+  const lockTabForWindowChange = (tabId: string) => {
+    setMovingTabIds(prev => new Set(prev).add(tabId));
+    window.setTimeout(() => {
+      setMovingTabIds(prev => {
+        if (!prev.has(tabId)) return prev;
+        const next = new Set(prev);
+        next.delete(tabId);
+        return next;
+      });
+    }, WINDOW_CHANGE_LOCK_MS);
+  };
+
   const handleDetachTab = async (tabId: string) => {
     if (!(await readyForWindowChange(tabId))) return;
+    lockTabForWindowChange(tabId);
     detachTabToNewWindow(toProfileSpaceId(tabId, activeConnections));
   };
 
   const handleMoveTab = async (tabId: string, targetWindowId: string) => {
     if (!(await readyForWindowChange(tabId))) return;
+    lockTabForWindowChange(tabId);
     moveTabToWindow(toProfileSpaceId(tabId, activeConnections), targetWindowId);
     // Final whole-branch review, Fix 4(b): the "Move to <window>" list is
     // built from `lastWorkspaceRef` (the last-known cross-window document),
@@ -3842,10 +3878,26 @@ function Workspace() {
       prev.map(t => (t.documentEdit?.id === editId ? { ...t, documentEdit: undefined } : t))
     );
   const setDocumentDraft = (tabId: string, draft: string) => {
+    // Frozen: this tab is on its way to another window, and anything accepted
+    // here would be mirrored under an id the destination no longer reconciles.
+    // The dialog is read-only meanwhile; this is the same answer for anything
+    // that reaches the handler another way.
+    if (movingTabIds.has(tabId)) return;
     const edit = tabs.find(t => t.id === tabId)?.documentEdit;
     if (!edit) return;
     patchDocumentEdit(edit.id, { draft });
   };
+
+  // The freeze ends when reconciliation takes the tab, which is the event it
+  // was waiting for. The timer in  only matters if that
+  // never comes.
+  useEffect(() => {
+    setMovingTabIds(prev => {
+      if (prev.size === 0) return prev;
+      const stillHere = [...prev].filter(id => tabs.some(t => t.id === id));
+      return stillHere.length === prev.size ? prev : new Set(stillHere);
+    });
+  }, [tabs]);
 
   // The backend's copy of each tab's edit, kept level with state from one place
   // rather than announced by whoever changed it.
@@ -4254,6 +4306,10 @@ function Workspace() {
     const tab = activeTab;
     const edit = tab?.documentEdit;
     if (!tab || !edit) return;
+    // A save started after the move was dispatched does not travel — the
+    // destination is handed an edit with no save on it and would let the same
+    // insert be submitted again (#326 review).
+    if (movingTabIds.has(tab.id)) return;
     // Captured before the request: every line below names the edit that asked,
     // so a result arriving after the user has moved on — to another tab, or to
     // a different edit on this one — reaches that edit or nothing at all.
@@ -4971,6 +5027,7 @@ function Workspace() {
             json={activeTab?.documentEdit?.draft ?? ''}
             error={activeTab?.documentEdit?.error ?? null}
             saving={activeTab?.documentEdit?.saving ?? false}
+            frozen={activeTab ? movingTabIds.has(activeTab.id) : false}
             onJsonChange={(draft) => activeTab && setDocumentDraft(activeTab.id, draft)}
             onClose={() => activeTab && closeDocumentEdit(activeTab.id)}
             onSave={handleSaveDocument}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,13 +127,27 @@ import { FolderCode, KeyRound, Radio, X, ChevronsRight, XSquare, Play, Settings,
 import logoMark from './assets/logo-mark.svg';
 import { loadTabColors, saveTabColor, TAB_COLORS, tabColorCss, type TabColorId } from './lib/tabColors';
 
-/** An edit or insert in progress, with the text the user has typed so far. */
+/** An edit or insert in progress, with everything true of it while it lasts.
+ *
+ *  All of it lives here rather than in the dialog because the dialog is a view
+ *  of whichever tab is active: it unmounts when the user looks elsewhere and
+ *  remounts on the way back. The draft came here first (#277), and the error
+ *  and the pending save followed once it was clear they have the same lifetime
+ *  — each was patched into the dialog separately and each went wrong in the
+ *  same way, showing one tab's state on another or losing it in between (#326
+ *  review). An edit ends when this object is replaced or removed, which is what
+ *  makes "starting a new edit" and "clearing the last one's state" a single
+ *  act. */
 interface DocumentEdit {
   mode: 'insert' | 'edit';
   initialJson: string;
   targetDoc: Record<string, any> | null;
   /** Live text. Kept here so it outlives the dialog unmounting on a tab switch. */
   draft: string;
+  /** A save of THIS edit that failed, waiting to be seen by the tab that owns it. */
+  error: string | null;
+  /** True while this edit's save is in flight, so Save cannot fire twice. */
+  saving: boolean;
 }
 
 export interface QueryTab {
@@ -3644,14 +3658,30 @@ function Workspace() {
 
   // Only the active tab's edit is rendered, so opening one no longer replaces
   // another tab's work — each tab keeps its own until it is saved or closed.
-  const openDocumentEdit = (tab: QueryTab, edit: Omit<DocumentEdit, 'draft'>) =>
-    setTabs(prev => prev.map(t => (t.id === tab.id ? { ...t, documentEdit: { ...edit, draft: edit.initialJson } } : t)));
+  // Replacing the whole object is what starts a new edit, so nothing has to
+  // remember to clear the last one's error or pending save.
+  const openDocumentEdit = (tab: QueryTab, edit: Omit<DocumentEdit, 'draft' | 'error' | 'saving'>) =>
+    setTabs(prev =>
+      prev.map(t =>
+        t.id === tab.id
+          ? { ...t, documentEdit: { ...edit, draft: edit.initialJson, error: null, saving: false } }
+          : t
+      )
+    );
   const closeDocumentEdit = (tabId: string) =>
     setTabs(prev => prev.map(t => (t.id === tabId ? { ...t, documentEdit: undefined } : t)));
-  const setDocumentDraft = (tabId: string, draft: string) =>
+  /** Updates the named tab's edit if it still has one, and no other tab's.
+   *
+   *  The guard is what lets a save report its outcome without checking whether
+   *  the user has since closed the dialog or switched away: a result for an
+   *  edit that is over lands nowhere instead of resurrecting it. */
+  const patchDocumentEdit = (tabId: string, patch: Partial<DocumentEdit>) =>
     setTabs(prev =>
-      prev.map(t => (t.id === tabId && t.documentEdit ? { ...t, documentEdit: { ...t.documentEdit, draft } } : t))
+      prev.map(t =>
+        t.id === tabId && t.documentEdit ? { ...t, documentEdit: { ...t.documentEdit, ...patch } } : t
+      )
     );
+  const setDocumentDraft = (tabId: string, draft: string) => patchDocumentEdit(tabId, { draft });
 
   const handleInsertDocument = (tab: QueryTab) => {
     openDocumentEdit(tab, { mode: 'insert', initialJson: "{\n  \n}", targetDoc: null });
@@ -4006,10 +4036,30 @@ function Workspace() {
     }
   };
 
+  /** Runs a save and files its outcome against the edit that asked for it.
+   *
+   *  `tab.id` is captured before the request, not read from `activeTab` after
+   *  it, so a rejection that settles once the user has moved on is still
+   *  recorded on its own edit rather than on whichever one is now showing —
+   *  and is waiting there when they come back (#326 review). */
   const handleSaveDocument = async (json: string) => {
     const tab = activeTab;
-    const edit = tab?.documentEdit;
-    if (!tab || !edit) return;
+    if (!tab?.documentEdit) return;
+    patchDocumentEdit(tab.id, { saving: true, error: null });
+    try {
+      await saveDocument(tab, json);
+    } catch (err: any) {
+      patchDocumentEdit(tab.id, { error: String(err?.message || err) });
+    } finally {
+      // A no-op when the save closed the edit — `patchDocumentEdit` only
+      // touches a tab that still has one.
+      patchDocumentEdit(tab.id, { saving: false });
+    }
+  };
+
+  const saveDocument = async (tab: QueryTab, json: string) => {
+    const edit = tab.documentEdit;
+    if (!edit) return;
     const collection = tab.collection;
     if (edit.mode === 'insert') {
       await invoke('insert_document', {
@@ -4026,8 +4076,9 @@ function Workspace() {
 
     const target = edit.targetDoc;
     if (!target || target._id === undefined) {
-      // DocumentEditModal catches this and renders `err.message` straight into
-      // its error banner, so the text is user-facing copy, not a dev invariant.
+      // Caught by handleSaveDocument and filed on the edit, which the dialog
+      // renders straight into its error banner — so the text is user-facing
+      // copy, not a dev invariant.
       throw new Error(t('documents:editModal.errors.noId'));
     }
     // Send the document as loaded *and* as edited so the backend can apply only
@@ -4693,7 +4744,8 @@ function Workspace() {
             mode={activeTab?.documentEdit?.mode || 'insert'}
             initialJson={activeTab?.documentEdit?.initialJson || '{}'}
             json={activeTab?.documentEdit?.draft ?? ''}
-            editKey={activeTab?.id}
+            error={activeTab?.documentEdit?.error ?? null}
+            saving={activeTab?.documentEdit?.saving ?? false}
             onJsonChange={(draft) => activeTab && setDocumentDraft(activeTab.id, draft)}
             onClose={() => activeTab && closeDocumentEdit(activeTab.id)}
             onSave={handleSaveDocument}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1149,6 +1149,18 @@ function Workspace() {
       keys: Record<string, number>;
     } | null;
   } | null>(null);
+  // Document writes sent and not yet answered, one entry per request.
+  //
+  // Kept beside the tabs rather than on them because a request outlives the
+  // edit that started it: replace the edit, close the dialog, switch tabs, and
+  // the write is still out. Whatever wants to know whether a namespace is busy
+  // has to ask about requests (#326 review).
+  const [pendingSaves, setPendingSaves] = useState<
+    Array<{ editId: string; tabId: string; connectionId: string; db: string; collection: string }>
+  >([]);
+  // Read after an await, where the render closure is already stale.
+  const pendingSavesRef = useRef(pendingSaves);
+  pendingSavesRef.current = pendingSaves;
   const [indexMutationTrigger, setIndexMutationTrigger] = useState(0);
   const [collectionMutationTrigger, setCollectionMutationTrigger] = useState(0);
   const [sidebarFilterQuery, setSidebarFilterQuery] = useState('');
@@ -2717,13 +2729,24 @@ function Workspace() {
         if (unmirroredTabIdsRef.current.has(action.tabId)) return;
         workspaceApply(actionToOp(action, undefined, activeConnections));
         return;
+      // Ordered against both ids. A rename gives the tab a new id at once, so
+      // its draft is mirrored under the new one while `rename_tab` is still on
+      // its way: arriving first, that update finds no such tab and succeeds as
+      // a no-op, and the rename then carries only the older draft — text lost
+      // with nothing left pending to say so (#326 review).
       case 'rename_tab':
         if (unmirroredTabIdsRef.current.has(action.oldId)) {
           unmirroredTabIdsRef.current.delete(action.oldId);
           unmirroredTabIdsRef.current.add(action.newId);
           return;
         }
-        workspaceApply(actionToOp(action, undefined, activeConnections));
+        applyTabOp(
+          [
+            toProfileSpaceId(action.oldId, activeConnections),
+            toProfileSpaceId(action.newId, activeConnections),
+          ],
+          actionToOp(action, undefined, activeConnections)
+        );
         return;
       default:
         workspaceApply(actionToOp(action, undefined, activeConnections));
@@ -2772,7 +2795,10 @@ function Workspace() {
     // and looks again.
     for (let pass = 0; pass < 4; pass++) {
       const edit = tabsRef.current.find(x => x.id === tabId)?.documentEdit;
-      if (edit?.saving) {
+      // Asked of the requests, not of the edit on screen. A save whose edit has
+      // since been replaced is still a save this window cannot hand to another
+      // one, and the edit that replaced it says nothing about it (#326 review).
+      if (pendingSavesRef.current.some(s => s.tabId === tabId)) {
         toast(t('toast.documentSaveInProgress'), 'error');
         return false;
       }
@@ -4233,12 +4259,21 @@ function Workspace() {
     // a different edit on this one — reaches that edit or nothing at all.
     const editId = edit.id;
     patchDocumentEdit(editId, { saving: true, error: null });
+    // Recorded against the request, not the edit. The edit can be replaced
+    // while this runs — starting another one on the same tab is what the
+    // non-modal dialog is for — and everything that asks "is a save running
+    // here" would then be told no while the write was still out (#326 review).
+    setPendingSaves(prev => [
+      ...prev,
+      { editId, tabId: tab.id, connectionId: tab.connectionId, db: tab.db, collection: tab.collection },
+    ]);
     try {
       await saveDocument(tab, edit, json);
     } catch (err: any) {
       patchDocumentEdit(editId, { error: String(err?.message || err) });
     } finally {
       patchDocumentEdit(editId, { saving: false });
+      setPendingSaves(prev => prev.filter(s => s.editId !== editId));
     }
   };
 
@@ -4815,7 +4850,7 @@ function Workspace() {
       sidebar={
         <Sidebar
           onSelectCollection={handleSelectCollection}
-          openTabs={tabs}
+          pendingSaves={pendingSaves}
           isCollectionOpen={(connectionId, db, collection) =>
             collectionTabsMatching(tabs, { connectionId, db, collection }).length > 0
           }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ import {
   detachTabToNewWindow,
   closeWorkspaceWindow,
   moveTabToWindow,
+  flushTabState,
   type WorkspaceChangedPayload,
   type ConnectionsChangedPayload,
   type ConnectionEntry,
@@ -2721,11 +2722,40 @@ function Workspace() {
     setTabContextMenu({ tabId, x: e.clientX, y: e.clientY });
   };
 
+  /** Whether this tab can change window right now, and readies it if so.
+   *
+   *  A save in flight blocks the move. The request belongs to this window and
+   *  settles here, so it cannot travel — and `carriedDocumentEdit` drops
+   *  `saving` precisely because an arriving tab must not claim a request the
+   *  destination cannot finish. But that leaves the destination's Save enabled
+   *  over a document that is already being written, and the clear this window
+   *  sends on success is not a cross-window op, so the destination never learns
+   *  the insert happened: one more click and the document is written twice
+   *  (#326 review). Waiting for the save is the honest answer — it is brief,
+   *  and the alternative is a duplicate.
+   *
+   *  Otherwise a tab that holds an edit has its pending mirror flushed, so
+   *  what the destination reads is the draft as it stands rather than one
+   *  debounce behind. Only then: a tab with no edit has nothing at stake here,
+   *  and flushing it would put a write in front of every move that never used
+   *  to be there. */
+  const readyForWindowChange = (tabId: string): boolean => {
+    const edit = tabs.find(t => t.id === tabId)?.documentEdit;
+    if (edit?.saving) {
+      toast(t('toast.documentSaveInProgress'), 'error');
+      return false;
+    }
+    if (edit) flushTabState(toProfileSpaceId(tabId, activeConnections));
+    return true;
+  };
+
   const handleDetachTab = (tabId: string) => {
+    if (!readyForWindowChange(tabId)) return;
     detachTabToNewWindow(toProfileSpaceId(tabId, activeConnections));
   };
 
   const handleMoveTab = (tabId: string, targetWindowId: string) => {
+    if (!readyForWindowChange(tabId)) return;
     moveTabToWindow(toProfileSpaceId(tabId, activeConnections), targetWindowId);
     // Final whole-branch review, Fix 4(b): the "Move to <window>" list is
     // built from `lastWorkspaceRef` (the last-known cross-window document),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,7 @@ import {
   toProfileSpaceId,
   toLiveSpaceId,
   materializeArrivingTab,
+  carriedDocumentEdit,
   type PersistedWorkspace,
   type PersistedWindow,
   type PersistedTab,
@@ -3660,16 +3661,25 @@ function Workspace() {
   // another tab's work — each tab keeps its own until it is saved or closed.
   // Replacing the whole object is what starts a new edit, so nothing has to
   // remember to clear the last one's error or pending save.
-  const openDocumentEdit = (tab: QueryTab, edit: Omit<DocumentEdit, 'draft' | 'error' | 'saving'>) =>
-    setTabs(prev =>
-      prev.map(t =>
-        t.id === tab.id
-          ? { ...t, documentEdit: { ...edit, draft: edit.initialJson, error: null, saving: false } }
-          : t
-      )
-    );
-  const closeDocumentEdit = (tabId: string) =>
+  // Mirrored to the backend as it changes, because a tab moved to another
+  // window is rebuilt there from the backend's copy — an edit that never
+  // reached it is an edit the move discards (#326 review). `updateTabState`
+  // debounces, so a keystroke is not a round trip. `carriedDocumentEdit`
+  // decides what travels; `null` on close, since an absent key means
+  // "untouched" and would leave a finished draft on the model.
+  const mirrorDocumentEdit = (tabId: string, edit: DocumentEdit | null) =>
+    mirrorUpdateTabState(tabId, activeConnectionsRef.current, {
+      documentEdit: edit ? carriedDocumentEdit(edit) : null,
+    });
+  const openDocumentEdit = (tab: QueryTab, edit: Omit<DocumentEdit, 'draft' | 'error' | 'saving'>) => {
+    const opened: DocumentEdit = { ...edit, draft: edit.initialJson, error: null, saving: false };
+    setTabs(prev => prev.map(t => (t.id === tab.id ? { ...t, documentEdit: opened } : t)));
+    mirrorDocumentEdit(tab.id, opened);
+  };
+  const closeDocumentEdit = (tabId: string) => {
     setTabs(prev => prev.map(t => (t.id === tabId ? { ...t, documentEdit: undefined } : t)));
+    mirrorDocumentEdit(tabId, null);
+  };
   /** Updates the named tab's edit if it still has one, and no other tab's.
    *
    *  The guard is what lets a save report its outcome without checking whether
@@ -3681,7 +3691,18 @@ function Workspace() {
         t.id === tabId && t.documentEdit ? { ...t, documentEdit: { ...t.documentEdit, ...patch } } : t
       )
     );
-  const setDocumentDraft = (tabId: string, draft: string) => patchDocumentEdit(tabId, { draft });
+  // Only the draft is mirrored as the user types. `error` and `saving` are the
+  // two fields `carriedDocumentEdit` drops anyway, so patching them is not
+  // worth a mirror.
+  //
+  // The mirror is computed here rather than inside the updater: a state updater
+  // has to stay pure, and React runs it twice in development, which would make
+  // this fire the IPC twice per keystroke.
+  const setDocumentDraft = (tabId: string, draft: string) => {
+    patchDocumentEdit(tabId, { draft });
+    const edit = tabs.find(t => t.id === tabId)?.documentEdit;
+    if (edit) mirrorDocumentEdit(tabId, { ...edit, draft });
+  };
 
   const handleInsertDocument = (tab: QueryTab) => {
     openDocumentEdit(tab, { mode: 'insert', initialJson: "{\n  \n}", targetDoc: null });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4815,6 +4815,7 @@ function Workspace() {
       sidebar={
         <Sidebar
           onSelectCollection={handleSelectCollection}
+          openTabs={tabs}
           isCollectionOpen={(connectionId, db, collection) =>
             collectionTabsMatching(tabs, { connectionId, db, collection }).length > 0
           }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,6 +140,14 @@ import { loadTabColors, saveTabColor, TAB_COLORS, tabColorCss, type TabColorId }
  *  makes "starting a new edit" and "clearing the last one's state" a single
  *  act. */
 interface DocumentEdit {
+  /** Identifies THIS edit, so a result can tell whether it is still the one.
+   *
+   *  The tab id is not enough. The dialog is non-modal and draggable, so the
+   *  user can push it aside and start another insert on the same tab while the
+   *  first save is still running — and a completion matched on tab alone would
+   *  then clear the replacement's `saving`, write the old failure onto it, or
+   *  close it and take its draft with it (#326 review). */
+  id: string;
   mode: 'insert' | 'edit';
   initialJson: string;
   targetDoc: Record<string, any> | null;
@@ -150,6 +158,13 @@ interface DocumentEdit {
   /** True while this edit's save is in flight, so Save cannot fire twice. */
   saving: boolean;
 }
+
+/** A fresh identity for each edit, so a completion can name the one it belongs
+ *  to. Same fallback as `queryStore`'s, for environments without `randomUUID`. */
+const newEditId = (): string =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `edit-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
 export interface QueryTab {
   id: string;
@@ -3671,24 +3686,51 @@ function Workspace() {
     mirrorUpdateTabState(tabId, activeConnectionsRef.current, {
       documentEdit: edit ? carriedDocumentEdit(edit) : null,
     });
-  const openDocumentEdit = (tab: QueryTab, edit: Omit<DocumentEdit, 'draft' | 'error' | 'saving'>) => {
-    const opened: DocumentEdit = { ...edit, draft: edit.initialJson, error: null, saving: false };
+  const openDocumentEdit = (
+    tab: QueryTab,
+    edit: Omit<DocumentEdit, 'id' | 'draft' | 'error' | 'saving'>
+  ) => {
+    const opened: DocumentEdit = {
+      ...edit,
+      id: newEditId(),
+      draft: edit.initialJson,
+      error: null,
+      saving: false,
+    };
     setTabs(prev => prev.map(t => (t.id === tab.id ? { ...t, documentEdit: opened } : t)));
     mirrorDocumentEdit(tab.id, opened);
   };
-  const closeDocumentEdit = (tabId: string) => {
-    setTabs(prev => prev.map(t => (t.id === tabId ? { ...t, documentEdit: undefined } : t)));
-    mirrorDocumentEdit(tabId, null);
-  };
-  /** Updates the named tab's edit if it still has one, and no other tab's.
+  /** Ends the tab's edit. With `editId`, only if that is still the edit open.
    *
-   *  The guard is what lets a save report its outcome without checking whether
-   *  the user has since closed the dialog or switched away: a result for an
-   *  edit that is over lands nowhere instead of resurrecting it. */
-  const patchDocumentEdit = (tabId: string, patch: Partial<DocumentEdit>) =>
+   *  A save closes the dialog when it succeeds, and by then the user may have
+   *  started a different one on the same tab — closing that would throw away a
+   *  draft nobody finished with. The user's own Cancel passes no id: whatever
+   *  is on screen is what they meant to close. */
+  const closeDocumentEdit = (tabId: string, editId?: string) => {
+    let closed = false;
+    setTabs(prev =>
+      prev.map(t => {
+        if (t.id !== tabId || !t.documentEdit) return t;
+        if (editId !== undefined && t.documentEdit.id !== editId) return t;
+        closed = true;
+        return { ...t, documentEdit: undefined };
+      })
+    );
+    if (closed) mirrorDocumentEdit(tabId, null);
+  };
+  /** Updates one edit, named by its own id — never merely "this tab's edit".
+   *
+   *  Matching on the tab alone was not enough. The dialog is non-modal, so the
+   *  user can drag it aside and start another edit on the same tab while the
+   *  first save is in flight; the first result would then land on the second
+   *  edit, clearing a `saving` it never set or reporting a failure that was not
+   *  its own (#326 review). A result for an edit that is over lands nowhere. */
+  const patchDocumentEdit = (tabId: string, editId: string, patch: Partial<DocumentEdit>) =>
     setTabs(prev =>
       prev.map(t =>
-        t.id === tabId && t.documentEdit ? { ...t, documentEdit: { ...t.documentEdit, ...patch } } : t
+        t.id === tabId && t.documentEdit?.id === editId
+          ? { ...t, documentEdit: { ...t.documentEdit, ...patch } }
+          : t
       )
     );
   // Only the draft is mirrored as the user types. `error` and `saving` are the
@@ -3699,9 +3741,10 @@ function Workspace() {
   // has to stay pure, and React runs it twice in development, which would make
   // this fire the IPC twice per keystroke.
   const setDocumentDraft = (tabId: string, draft: string) => {
-    patchDocumentEdit(tabId, { draft });
     const edit = tabs.find(t => t.id === tabId)?.documentEdit;
-    if (edit) mirrorDocumentEdit(tabId, { ...edit, draft });
+    if (!edit) return;
+    patchDocumentEdit(tabId, edit.id, { draft });
+    mirrorDocumentEdit(tabId, { ...edit, draft });
   };
 
   const handleInsertDocument = (tab: QueryTab) => {
@@ -4065,22 +4108,23 @@ function Workspace() {
    *  and is waiting there when they come back (#326 review). */
   const handleSaveDocument = async (json: string) => {
     const tab = activeTab;
-    if (!tab?.documentEdit) return;
-    patchDocumentEdit(tab.id, { saving: true, error: null });
+    const edit = tab?.documentEdit;
+    if (!tab || !edit) return;
+    // Captured before the request: every line below names the edit that asked,
+    // so a result arriving after the user has moved on — to another tab, or to
+    // a different edit on this one — reaches that edit or nothing at all.
+    const editId = edit.id;
+    patchDocumentEdit(tab.id, editId, { saving: true, error: null });
     try {
-      await saveDocument(tab, json);
+      await saveDocument(tab, edit, json);
     } catch (err: any) {
-      patchDocumentEdit(tab.id, { error: String(err?.message || err) });
+      patchDocumentEdit(tab.id, editId, { error: String(err?.message || err) });
     } finally {
-      // A no-op when the save closed the edit — `patchDocumentEdit` only
-      // touches a tab that still has one.
-      patchDocumentEdit(tab.id, { saving: false });
+      patchDocumentEdit(tab.id, editId, { saving: false });
     }
   };
 
-  const saveDocument = async (tab: QueryTab, json: string) => {
-    const edit = tab.documentEdit;
-    if (!edit) return;
+  const saveDocument = async (tab: QueryTab, edit: DocumentEdit, json: string) => {
     const collection = tab.collection;
     if (edit.mode === 'insert') {
       await invoke('insert_document', {
@@ -4089,7 +4133,7 @@ function Workspace() {
         collection,
         document: json,
       });
-      closeDocumentEdit(tab.id);
+      closeDocumentEdit(tab.id, edit.id);
       await refreshTabResults(tab);
       toast(t('toast.documentInsertedInto', { collection }), 'success', { title: t('toast.insertedTitle') });
       return;
@@ -4133,7 +4177,7 @@ function Workspace() {
         ? (pipelineYieldsWholeDocuments(tab.lastAggregate) ? '{}' : null)
         : (tab.lastQuery?.projection ?? '{}'),
     });
-    closeDocumentEdit(tab.id);
+    closeDocumentEdit(tab.id, edit.id);
     await refreshTabResults(tab);
     toast(t('toast.documentSavedIn', { collection }), 'success', { title: t('toast.savedTitle') });
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3736,39 +3736,39 @@ function Workspace() {
     };
     setTabs(prev => prev.map(t => (t.id === tab.id ? { ...t, documentEdit: opened } : t)));
   };
-  /** Ends the tab's edit. With `editId`, only if that is still the edit open.
+  /** Ends whatever edit this tab has open — the user's own Cancel, where what
+   *  is on screen is exactly what they meant to close. A save that finished
+   *  uses `closeEditById` instead, since by then the edit may have moved on. */
+  const closeDocumentEdit = (tabId: string) =>
+    setTabs(prev => prev.map(t => (t.id === tabId ? { ...t, documentEdit: undefined } : t)));
+  /** Updates one edit, found by its own id — wherever its tab has got to.
    *
-   *  A save closes the dialog when it succeeds, and by then the user may have
-   *  started a different one on the same tab — closing that would throw away a
-   *  draft nobody finished with. The user's own Cancel passes no id: whatever
-   *  is on screen is what they meant to close. */
-  const closeDocumentEdit = (tabId: string, editId?: string) =>
-    setTabs(prev =>
-      prev.map(t => {
-        if (t.id !== tabId || !t.documentEdit) return t;
-        if (editId !== undefined && t.documentEdit.id !== editId) return t;
-        return { ...t, documentEdit: undefined };
-      })
-    );
-  /** Updates one edit, named by its own id — never merely "this tab's edit".
+   *  Matching on the tab was not enough twice over. The dialog is non-modal, so
+   *  the user can drag it aside and start another edit on the same tab while
+   *  the first save is in flight — and those controls include renaming the
+   *  collection, which preserves the edit but replaces the tab id. A completion
+   *  that named a tab therefore either landed on the wrong edit or on nothing
+   *  at all, leaving the renamed tab's dialog disabled for good with its
+   *  failure never shown (#326 review).
    *
-   *  Matching on the tab alone was not enough. The dialog is non-modal, so the
-   *  user can drag it aside and start another edit on the same tab while the
-   *  first save is in flight; the first result would then land on the second
-   *  edit, clearing a `saving` it never set or reporting a failure that was not
-   *  its own (#326 review). A result for an edit that is over lands nowhere. */
-  const patchDocumentEdit = (tabId: string, editId: string, patch: Partial<DocumentEdit>) =>
+   *  The edit's id survives both, so completions use it alone: they find the
+   *  edit that asked, or nothing, and never something else. */
+  const patchDocumentEdit = (editId: string, patch: Partial<DocumentEdit>) =>
     setTabs(prev =>
       prev.map(t =>
-        t.id === tabId && t.documentEdit?.id === editId
-          ? { ...t, documentEdit: { ...t.documentEdit, ...patch } }
-          : t
+        t.documentEdit?.id === editId ? { ...t, documentEdit: { ...t.documentEdit, ...patch } } : t
       )
+    );
+  /** Ends the edit with this id, wherever it is. Used by a save that finished;
+   *  the user's own Cancel closes what is on screen instead. */
+  const closeEditById = (editId: string) =>
+    setTabs(prev =>
+      prev.map(t => (t.documentEdit?.id === editId ? { ...t, documentEdit: undefined } : t))
     );
   const setDocumentDraft = (tabId: string, draft: string) => {
     const edit = tabs.find(t => t.id === tabId)?.documentEdit;
     if (!edit) return;
-    patchDocumentEdit(tabId, edit.id, { draft });
+    patchDocumentEdit(edit.id, { draft });
   };
 
   // The backend's copy of each tab's edit, kept level with state from one place
@@ -3801,6 +3801,13 @@ function Workspace() {
     for (const tabId of [...mirroredEditsRef.current.keys()]) {
       if (open.has(tabId)) continue;
       mirroredEditsRef.current.delete(tabId);
+      // Only a tab still open HERE gets the clear. A tab that has left this
+      // window's `tabs` needs none either way, and sending one is wrong: if it
+      // was closed, the backend dropped the whole model with it, and if it
+      // merely moved, the model is alive in another window and this would race
+      // the destination's own write to erase a draft that is still open
+      // (#326 review). Absence says the tab left, never that the edit ended.
+      if (!tabs.some(t => t.id === tabId)) continue;
       // Explicitly null, not absent: absent means "untouched" and would leave a
       // finished draft on the model for the next move to carry.
       mirrorUpdateTabState(tabId, activeConnectionsRef.current, { documentEdit: null });
@@ -4175,13 +4182,13 @@ function Workspace() {
     // so a result arriving after the user has moved on — to another tab, or to
     // a different edit on this one — reaches that edit or nothing at all.
     const editId = edit.id;
-    patchDocumentEdit(tab.id, editId, { saving: true, error: null });
+    patchDocumentEdit(editId, { saving: true, error: null });
     try {
       await saveDocument(tab, edit, json);
     } catch (err: any) {
-      patchDocumentEdit(tab.id, editId, { error: String(err?.message || err) });
+      patchDocumentEdit(editId, { error: String(err?.message || err) });
     } finally {
-      patchDocumentEdit(tab.id, editId, { saving: false });
+      patchDocumentEdit(editId, { saving: false });
     }
   };
 
@@ -4194,7 +4201,7 @@ function Workspace() {
         collection,
         document: json,
       });
-      closeDocumentEdit(tab.id, edit.id);
+      closeEditById(edit.id);
       await refreshTabResults(tab);
       toast(t('toast.documentInsertedInto', { collection }), 'success', { title: t('toast.insertedTitle') });
       return;
@@ -4238,7 +4245,7 @@ function Workspace() {
         ? (pipelineYieldsWholeDocuments(tab.lastAggregate) ? '{}' : null)
         : (tab.lastQuery?.projection ?? '{}'),
     });
-    closeDocumentEdit(tab.id, edit.id);
+    closeEditById(edit.id);
     await refreshTabResults(tab);
     toast(t('toast.documentSavedIn', { collection }), 'success', { title: t('toast.savedTitle') });
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4693,6 +4693,7 @@ function Workspace() {
             mode={activeTab?.documentEdit?.mode || 'insert'}
             initialJson={activeTab?.documentEdit?.initialJson || '{}'}
             json={activeTab?.documentEdit?.draft ?? ''}
+            editKey={activeTab?.id}
             onJsonChange={(draft) => activeTab && setDocumentDraft(activeTab.id, draft)}
             onClose={() => activeTab && closeDocumentEdit(activeTab.id)}
             onSave={handleSaveDocument}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,7 @@ import {
   flushTabState,
   cancelTabState,
   applyTabOp,
+  renameTabState,
   hasPendingDocumentEdit,
   type WorkspaceChangedPayload,
   type ConnectionsChangedPayload,
@@ -2745,6 +2746,12 @@ function Workspace() {
       // a no-op, and the rename then carries only the older draft — text lost
       // with nothing left pending to say so (#326 review).
       case 'rename_tab':
+        // The queued patch follows the tab, whether or not the rename itself is
+        // mirrored — an unmirrored tab can still have left one behind.
+        renameTabState(
+          toProfileSpaceId(action.oldId, activeConnections),
+          toProfileSpaceId(action.newId, activeConnections)
+        );
         if (unmirroredTabIdsRef.current.has(action.oldId)) {
           unmirroredTabIdsRef.current.delete(action.oldId);
           unmirroredTabIdsRef.current.add(action.newId);
@@ -3835,6 +3842,11 @@ function Workspace() {
     tab: QueryTab,
     edit: Omit<DocumentEdit, 'id' | 'draft' | 'error' | 'saving'>
   ) => {
+    // Frozen tabs take no new edit either. The dialog being non-modal is what
+    // makes this reachable — drag it aside and Insert again — and a replacement
+    // started now is mirrored after the move may already have taken its
+    // snapshot, so it goes nowhere and dies with the source tab (#326 review).
+    if (movingTabIds.has(tab.id)) return;
     const opened: DocumentEdit = {
       ...edit,
       id: newEditId(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,6 +127,15 @@ import { FolderCode, KeyRound, Radio, X, ChevronsRight, XSquare, Play, Settings,
 import logoMark from './assets/logo-mark.svg';
 import { loadTabColors, saveTabColor, TAB_COLORS, tabColorCss, type TabColorId } from './lib/tabColors';
 
+/** An edit or insert in progress, with the text the user has typed so far. */
+interface DocumentEdit {
+  mode: 'insert' | 'edit';
+  initialJson: string;
+  targetDoc: Record<string, any> | null;
+  /** Live text. Kept here so it outlives the dialog unmounting on a tab switch. */
+  draft: string;
+}
+
 export interface QueryTab {
   id: string;
   type: 'collection' | 'index' | 'shell' | 'settings' | 'quickstart' | 'export' | 'import' | 'tasks' | 'activity' | 'schema' | 'create-view' | 'gridfs' | 'monitoring' | 'users' | 'dump' | 'restore' | 'validation' | 'generate' | 'watch';
@@ -150,6 +159,9 @@ export interface QueryTab {
   // Which results tab is showing, kept on the tab for the same reason as
   // viewMode: the grid remounts on every run (#281).
   resultsTab?: ResultsTab;
+  // An in-progress document edit belongs to the tab it was opened from, so it
+  // survives a look at another tab and dies with this one (#277).
+  documentEdit?: DocumentEdit;
   // What the results pager last asked for. The values travel with the revision
   // so the builder can never observe a new revision beside a stale page size —
   // see DocumentViewer's pagerRequest prop.
@@ -3630,12 +3642,19 @@ function Workspace() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [exportTasks]);
 
-  const [documentModal, setDocumentModal] = useState<
-    { mode: 'insert' | 'edit'; initialJson: string; targetDoc: Record<string, any> | null; tabId: string } | null
-  >(null);
+  // Only the active tab's edit is rendered, so opening one no longer replaces
+  // another tab's work — each tab keeps its own until it is saved or closed.
+  const openDocumentEdit = (tab: QueryTab, edit: Omit<DocumentEdit, 'draft'>) =>
+    setTabs(prev => prev.map(t => (t.id === tab.id ? { ...t, documentEdit: { ...edit, draft: edit.initialJson } } : t)));
+  const closeDocumentEdit = (tabId: string) =>
+    setTabs(prev => prev.map(t => (t.id === tabId ? { ...t, documentEdit: undefined } : t)));
+  const setDocumentDraft = (tabId: string, draft: string) =>
+    setTabs(prev =>
+      prev.map(t => (t.id === tabId && t.documentEdit ? { ...t, documentEdit: { ...t.documentEdit, draft } } : t))
+    );
 
   const handleInsertDocument = (tab: QueryTab) => {
-    setDocumentModal({ mode: 'insert', initialJson: '{\n  \n}', targetDoc: null, tabId: tab.id });
+    openDocumentEdit(tab, { mode: 'insert', initialJson: "{\n  \n}", targetDoc: null });
   };
 
   const handleExportForTab = async (
@@ -3803,13 +3822,13 @@ function Workspace() {
   };
 
   const handleEditDocument = (tab: QueryTab, doc: Record<string, any>) => {
-    setDocumentModal({ mode: 'edit', initialJson: docToShell(doc), targetDoc: doc, tabId: tab.id });
+    openDocumentEdit(tab, { mode: 'edit', initialJson: docToShell(doc), targetDoc: doc });
   };
 
   // Duplicate: open the insert modal pre-filled with the document minus its _id.
   const handleDuplicateDocument = (tab: QueryTab, doc: Record<string, any>) => {
     const { _id, ...rest } = doc;
-    setDocumentModal({ mode: 'insert', initialJson: docToShell(rest), targetDoc: null, tabId: tab.id });
+    openDocumentEdit(tab, { mode: 'insert', initialJson: docToShell(rest), targetDoc: null });
   };
 
   const handleDeleteDocument = async (tab: QueryTab, doc: Record<string, any>) => {
@@ -3988,24 +4007,24 @@ function Workspace() {
   };
 
   const handleSaveDocument = async (json: string) => {
-    if (!documentModal) return;
-    const tab = tabs.find(t => t.id === documentModal.tabId);
-    if (!tab) return;
+    const tab = activeTab;
+    const edit = tab?.documentEdit;
+    if (!tab || !edit) return;
     const collection = tab.collection;
-    if (documentModal.mode === 'insert') {
+    if (edit.mode === 'insert') {
       await invoke('insert_document', {
         id: tab.connectionId,
         database: tab.db,
         collection,
         document: json,
       });
-      setDocumentModal(null);
+      closeDocumentEdit(tab.id);
       await refreshTabResults(tab);
       toast(t('toast.documentInsertedInto', { collection }), 'success', { title: t('toast.insertedTitle') });
       return;
     }
 
-    const target = documentModal.targetDoc;
+    const target = edit.targetDoc;
     if (!target || target._id === undefined) {
       // DocumentEditModal catches this and renders `err.message` straight into
       // its error banner, so the text is user-facing copy, not a dev invariant.
@@ -4042,7 +4061,7 @@ function Workspace() {
         ? (pipelineYieldsWholeDocuments(tab.lastAggregate) ? '{}' : null)
         : (tab.lastQuery?.projection ?? '{}'),
     });
-    setDocumentModal(null);
+    closeDocumentEdit(tab.id);
     await refreshTabResults(tab);
     toast(t('toast.documentSavedIn', { collection }), 'success', { title: t('toast.savedTitle') });
   };
@@ -4666,11 +4685,16 @@ function Workspace() {
             prefill={indexModalTarget?.prefill}
           />
 
+          {/* Driven by the ACTIVE tab: switching away hides the edit and
+              switching back restores it, because the text lives on the tab
+              rather than in the dialog (#277). */}
           <DocumentEditModal
-            isOpen={documentModal !== null}
-            mode={documentModal?.mode || 'insert'}
-            initialJson={documentModal?.initialJson || '{}'}
-            onClose={() => setDocumentModal(null)}
+            isOpen={activeTab?.documentEdit !== undefined}
+            mode={activeTab?.documentEdit?.mode || 'insert'}
+            initialJson={activeTab?.documentEdit?.initialJson || '{}'}
+            json={activeTab?.documentEdit?.draft ?? ''}
+            onJsonChange={(draft) => activeTab && setDocumentDraft(activeTab.id, draft)}
+            onClose={() => activeTab && closeDocumentEdit(activeTab.id)}
             onSave={handleSaveDocument}
           />
 

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -74,12 +74,29 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
     setUncontrolledJson(next);
     onJsonChange?.(next);
   };
-  const [error, setError] = useState<string | null>(null);
-  // Which edits have a save in flight, keyed the same way the reset is. Held
-  // per edit so returning to a tab mid-save still shows it as saving, and so a
-  // pending request cannot be forgotten by looking at a different tab.
+  // Everything transient is keyed by edit, not held for whichever edit happens
+  // to be on screen.
+  //
+  // Scoping these one at a time is what kept going wrong: the component-wide
+  // flag re-enabled Save mid-request, and the component-wide error then showed
+  // one tab's failure on another and lost it on the way back (#326 review). An
+  // edit's error and its in-flight save are facts about that edit, and they
+  // outlive the dialog looking elsewhere, so they are stored the same way the
+  // draft already is.
+  const [errors, setErrors] = useState<ReadonlyMap<string, string>>(() => new Map());
   const [savingKeys, setSavingKeys] = useState<ReadonlySet<string>>(() => new Set());
-  const saving = savingKeys.has(editKey ?? '');
+  const currentKey = editKey ?? '';
+  const error = errors.get(currentKey) ?? null;
+  const saving = savingKeys.has(currentKey);
+  /** Records against the key the request captured, not against whatever is showing now. */
+  const setErrorFor = (key: string, message: string | null) =>
+    setErrors(prev => {
+      if (message === null && !prev.has(key)) return prev;
+      const next = new Map(prev);
+      if (message === null) next.delete(key);
+      else next.set(key, message);
+      return next;
+    });
   const validationError = useMemo(() => validateDocument(json, t), [json, t]);
   const theme = useMonacoTheme();
   const monacoRef = useRef<Parameters<
@@ -102,28 +119,34 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
     // it — resetting here would wipe the edit every time the dialog reappeared,
     // which is precisely what returning to a tab does.
     if (controlledJson === undefined) setUncontrolledJson(initialJson);
-    setError(null);
-    // Deliberately does NOT touch what is in flight. Clearing it here re-enabled
-    // Save while the original request was still running, so a second click sent
-    // a second insert and could write the document twice (#326 review).
-    // `controlledJson` is deliberately not a dependency: this runs when the
-    // dialog opens, not on every keystroke.
+    // Clears only THIS edit's error, and only when this edit is starting: the
+    // dialog opening, or a different document being opened in the same tab.
+    //
+    // `editKey` is deliberately not a dependency any more. Resetting on it was
+    // what cleared a save that was still running, and now that both fields are
+    // per edit there is nothing to reset when the user merely looks elsewhere —
+    // each edit already shows its own state.
+    setErrorFor(currentKey, null);
+    // `controlledJson` is likewise not a dependency: this runs when the dialog
+    // opens, not on every keystroke.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, initialJson, editKey]);
+  }, [isOpen, initialJson]);
 
   const handleSave = async () => {
+    // Captured now, so a result arriving after the user has moved on is still
+    // filed against the edit that asked for it.
+    const key = currentKey;
     if (validationError) {
-      setError(validationError);
+      setErrorFor(key, validationError);
       return;
     }
     const ejson = shellToEjson(json);
-    const key = editKey ?? '';
-    setError(null);
+    setErrorFor(key, null);
     setSavingKeys(prev => new Set(prev).add(key));
     try {
       await onSave(ejson);
     } catch (err: any) {
-      setError(String(err?.message || err));
+      setErrorFor(key, String(err?.message || err));
     } finally {
       // Retire the key this request claimed, and only that one. A set rather
       // than a flag because "is a save running" is a fact about an edit, not

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -58,6 +58,15 @@ interface DocumentEditModalProps {
    *  difference, so the caller keeps them. */
   error?: string | null;
   saving?: boolean;
+  /** The edit is on its way to another window: show it, change nothing.
+   *
+   *  Between dispatching a move and the reconciliation that takes the tab away,
+   *  this window still shows the editor while the backend may already have
+   *  handed the tab over. Anything typed here would be mirrored under an id the
+   *  destination no longer reconciles, and a save started here would not travel
+   *  with it (#326 review). Read-only says so, rather than quietly dropping the
+   *  keystrokes. */
+  frozen?: boolean;
 }
 
 export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
@@ -70,6 +79,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   onJsonChange,
   error = null,
   saving = false,
+  frozen = false,
 }) => {
   const { t } = useTranslation('documents');
   const [uncontrolledJson, setUncontrolledJson] = useState(initialJson);
@@ -192,6 +202,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
                 wordBasedSuggestions: 'off',
                 parameterHints: { enabled: false },
                 hover: { enabled: false },
+                readOnly: frozen,
               }}
             />
           </div>
@@ -218,7 +229,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
           <Button
             type="button"
             onClick={handleSave}
-            disabled={saving || !!validationError}
+            disabled={saving || frozen || !!validationError}
             data-testid="document-save-btn"
           >
             {mode === 'insert' ? t('editModal.actions.insert') : t('editModal.actions.saveChanges')}

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -39,6 +39,14 @@ interface DocumentEditModalProps {
   initialJson: string;
   onClose: () => void;
   onSave: (json: string) => void | Promise<void>;
+  /** The draft text, when the caller wants to own it.
+   *
+   *  Held here, an edit dies whenever this dialog unmounts — which is exactly
+   *  what happens when the user looks at another tab. Lifting it lets the edit
+   *  belong to the tab it was opened from, so switching away and back returns
+   *  to the text as it was (#277). Omit both to keep the text locally. */
+  json?: string;
+  onJsonChange?: (json: string) => void;
 }
 
 export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
@@ -47,9 +55,16 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   initialJson,
   onClose,
   onSave,
+  json: controlledJson,
+  onJsonChange,
 }) => {
   const { t } = useTranslation('documents');
-  const [json, setJson] = useState(initialJson);
+  const [uncontrolledJson, setUncontrolledJson] = useState(initialJson);
+  const json = controlledJson ?? uncontrolledJson;
+  const setJson = (next: string) => {
+    setUncontrolledJson(next);
+    onJsonChange?.(next);
+  };
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const validationError = useMemo(() => validateDocument(json, t), [json, t]);
@@ -69,11 +84,16 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   useEscapeClose(isOpen, onClose);
 
   useEffect(() => {
-    if (isOpen) {
-      setJson(initialJson);
-      setError(null);
-      setSaving(false);
-    }
+    if (!isOpen) return;
+    // Only reset the text we own. A controlled draft is reset by whoever holds
+    // it — resetting here would wipe the edit every time the dialog reappeared,
+    // which is precisely what returning to a tab does.
+    if (controlledJson === undefined) setUncontrolledJson(initialJson);
+    setError(null);
+    setSaving(false);
+    // `controlledJson` is deliberately not a dependency: this runs when the
+    // dialog opens, not on every keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, initialJson]);
 
   const handleSave = async () => {
@@ -93,7 +113,13 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+    // `modal={false}`: editing a document is exactly when
+    // you want to glance at another tab — to compare a field or copy an id —
+    // and a modal made that cost you the edit (#277). Without the focus trap
+    // and the scrim the rest of the app stays usable while this is open. Radix
+    // omits the overlay altogether outside modal mode, so there is no scrim to
+    // hide — the dialog simply floats above the app.
+    <Dialog modal={false} open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
       <DraggableDialogContent
         defaultWidth={820}
         defaultHeight={560}

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -75,7 +75,11 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
     onJsonChange?.(next);
   };
   const [error, setError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
+  // Which edits have a save in flight, keyed the same way the reset is. Held
+  // per edit so returning to a tab mid-save still shows it as saving, and so a
+  // pending request cannot be forgotten by looking at a different tab.
+  const [savingKeys, setSavingKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const saving = savingKeys.has(editKey ?? '');
   const validationError = useMemo(() => validateDocument(json, t), [json, t]);
   const theme = useMonacoTheme();
   const monacoRef = useRef<Parameters<
@@ -99,7 +103,9 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
     // which is precisely what returning to a tab does.
     if (controlledJson === undefined) setUncontrolledJson(initialJson);
     setError(null);
-    setSaving(false);
+    // Deliberately does NOT touch what is in flight. Clearing it here re-enabled
+    // Save while the original request was still running, so a second click sent
+    // a second insert and could write the document twice (#326 review).
     // `controlledJson` is deliberately not a dependency: this runs when the
     // dialog opens, not on every keystroke.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -111,18 +117,24 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
       return;
     }
     const ejson = shellToEjson(json);
+    const key = editKey ?? '';
     setError(null);
-    setSaving(true);
+    setSavingKeys(prev => new Set(prev).add(key));
     try {
       await onSave(ejson);
     } catch (err: any) {
       setError(String(err?.message || err));
     } finally {
-      // Cleared on success too. It used to be left set, which was invisible
-      // only because a save closed the dialog and the next one was a fresh
-      // mount — no longer true now that another tab's edit can keep this
-      // component alive (#326 review).
-      setSaving(false);
+      // Retire the key this request claimed, and only that one. A set rather
+      // than a flag because "is a save running" is a fact about an edit, not
+      // about this component: two tabs can each have one in flight, and looking
+      // at one must not report on the other.
+      setSavingKeys(prev => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
     }
   };
 

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -47,6 +47,14 @@ interface DocumentEditModalProps {
    *  to the text as it was (#277). Omit both to keep the text locally. */
   json?: string;
   onJsonChange?: (json: string) => void;
+  /** Identifies WHICH edit this is, so transient state does not follow the user
+   *  from one to another.
+   *
+   *  `isOpen` and `initialJson` cannot tell two edits apart: switch between two
+   *  tabs that both have an insert open and both stay the same, so an error or
+   *  an in-flight save from one would still be on screen for the other (#326
+   *  review). Pass the owning tab's id. */
+  editKey?: string;
 }
 
 export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
@@ -57,6 +65,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   onSave,
   json: controlledJson,
   onJsonChange,
+  editKey,
 }) => {
   const { t } = useTranslation('documents');
   const [uncontrolledJson, setUncontrolledJson] = useState(initialJson);
@@ -94,7 +103,7 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
     // `controlledJson` is deliberately not a dependency: this runs when the
     // dialog opens, not on every keystroke.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, initialJson]);
+  }, [isOpen, initialJson, editKey]);
 
   const handleSave = async () => {
     if (validationError) {
@@ -108,6 +117,11 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
       await onSave(ejson);
     } catch (err: any) {
       setError(String(err?.message || err));
+    } finally {
+      // Cleared on success too. It used to be left set, which was invisible
+      // only because a save closed the dialog and the next one was a fresh
+      // mount — no longer true now that another tab's edit can keep this
+      // component alive (#326 review).
       setSaving(false);
     }
   };

--- a/src/components/DocumentEditModal.tsx
+++ b/src/components/DocumentEditModal.tsx
@@ -47,14 +47,17 @@ interface DocumentEditModalProps {
    *  to the text as it was (#277). Omit both to keep the text locally. */
   json?: string;
   onJsonChange?: (json: string) => void;
-  /** Identifies WHICH edit this is, so transient state does not follow the user
-   *  from one to another.
+  /** A save of the current edit that failed, and whether one is in flight.
    *
-   *  `isOpen` and `initialJson` cannot tell two edits apart: switch between two
-   *  tabs that both have an insert open and both stay the same, so an error or
-   *  an in-flight save from one would still be on screen for the other (#326
-   *  review). Pass the owning tab's id. */
-  editKey?: string;
+   *  Owned by the caller for the same reason the draft is: they belong to the
+   *  edit, not to this dialog, and this dialog comes and goes with the active
+   *  tab. Held here they were repeatedly shown against the wrong edit or lost
+   *  on the way back to the right one — a keyed map fixed the first and still
+   *  could not tell "a new edit began" from "the old one is visible again",
+   *  because both look alike from in here (#326 review). The caller knows the
+   *  difference, so the caller keeps them. */
+  error?: string | null;
+  saving?: boolean;
 }
 
 export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
@@ -65,7 +68,8 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
   onSave,
   json: controlledJson,
   onJsonChange,
-  editKey,
+  error = null,
+  saving = false,
 }) => {
   const { t } = useTranslation('documents');
   const [uncontrolledJson, setUncontrolledJson] = useState(initialJson);
@@ -74,29 +78,8 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
     setUncontrolledJson(next);
     onJsonChange?.(next);
   };
-  // Everything transient is keyed by edit, not held for whichever edit happens
-  // to be on screen.
-  //
-  // Scoping these one at a time is what kept going wrong: the component-wide
-  // flag re-enabled Save mid-request, and the component-wide error then showed
-  // one tab's failure on another and lost it on the way back (#326 review). An
-  // edit's error and its in-flight save are facts about that edit, and they
-  // outlive the dialog looking elsewhere, so they are stored the same way the
-  // draft already is.
-  const [errors, setErrors] = useState<ReadonlyMap<string, string>>(() => new Map());
-  const [savingKeys, setSavingKeys] = useState<ReadonlySet<string>>(() => new Set());
-  const currentKey = editKey ?? '';
-  const error = errors.get(currentKey) ?? null;
-  const saving = savingKeys.has(currentKey);
-  /** Records against the key the request captured, not against whatever is showing now. */
-  const setErrorFor = (key: string, message: string | null) =>
-    setErrors(prev => {
-      if (message === null && !prev.has(key)) return prev;
-      const next = new Map(prev);
-      if (message === null) next.delete(key);
-      else next.set(key, message);
-      return next;
-    });
+  // Derived from the text on screen, so it needs no owner and no lifetime: it
+  // is recomputed rather than remembered, and cannot outlive what it describes.
   const validationError = useMemo(() => validateDocument(json, t), [json, t]);
   const theme = useMonacoTheme();
   const monacoRef = useRef<Parameters<
@@ -117,48 +100,22 @@ export const DocumentEditModal: React.FC<DocumentEditModalProps> = ({
     if (!isOpen) return;
     // Only reset the text we own. A controlled draft is reset by whoever holds
     // it — resetting here would wipe the edit every time the dialog reappeared,
-    // which is precisely what returning to a tab does.
+    // which is precisely what returning to a tab does. Nothing else is reset
+    // here: this effect cannot tell a new edit from an old one coming back into
+    // view, and everything that turns on that distinction now lives with the
+    // caller, who can (#326 review).
     if (controlledJson === undefined) setUncontrolledJson(initialJson);
-    // Clears only THIS edit's error, and only when this edit is starting: the
-    // dialog opening, or a different document being opened in the same tab.
-    //
-    // `editKey` is deliberately not a dependency any more. Resetting on it was
-    // what cleared a save that was still running, and now that both fields are
-    // per edit there is nothing to reset when the user merely looks elsewhere —
-    // each edit already shows its own state.
-    setErrorFor(currentKey, null);
-    // `controlledJson` is likewise not a dependency: this runs when the dialog
-    // opens, not on every keystroke.
+    // `controlledJson` is deliberately not a dependency: this runs when the
+    // dialog opens, not on every keystroke.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, initialJson]);
 
-  const handleSave = async () => {
-    // Captured now, so a result arriving after the user has moved on is still
-    // filed against the edit that asked for it.
-    const key = currentKey;
-    if (validationError) {
-      setErrorFor(key, validationError);
-      return;
-    }
-    const ejson = shellToEjson(json);
-    setErrorFor(key, null);
-    setSavingKeys(prev => new Set(prev).add(key));
-    try {
-      await onSave(ejson);
-    } catch (err: any) {
-      setErrorFor(key, String(err?.message || err));
-    } finally {
-      // Retire the key this request claimed, and only that one. A set rather
-      // than a flag because "is a save running" is a fact about an edit, not
-      // about this component: two tabs can each have one in flight, and looking
-      // at one must not report on the other.
-      setSavingKeys(prev => {
-        if (!prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.delete(key);
-        return next;
-      });
-    }
+  // Save is disabled while `validationError` is set, so reaching here means the
+  // text parses. The caller runs the request and reports back through `saving`
+  // and `error`.
+  const handleSave = () => {
+    if (validationError) return;
+    onSave(shellToEjson(json));
   };
 
   return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { useDialogs } from './dialogs/DialogProvider';
-import { isNamespaceBusy, type SavingTab } from '../lib/namespaceBusy';
+import { isNamespaceBusy, type PendingSave } from '../lib/namespaceBusy';
 import { confirmByTypedName } from '../lib/typedNameConfirm';
 import { fuzzyMatch } from '../lib/fuzzyMatch';
 import { type CollectionSelection, emptySelection, toggleCollection, selectionScope } from '@/lib/collectionSelection';
@@ -202,9 +202,10 @@ interface SidebarProps {
   onDatabaseDropped?: (connectionId: string, dbName: string) => void;
   onDatabaseRenamed?: (connectionId: string, oldName: string, newName: string) => void;
   onNamespaceMutated?: (connectionId?: string) => void;
-  /** The workspace tabs, so a rename can refuse while one of them is mid-save.
-   *  Only the namespace and the save flag are read — see . */
-  openTabs?: readonly SavingTab[];
+  /** Document writes this window has sent and not yet seen answered, so a
+   *  rename or a drop can refuse before it starts. Advisory: the backend makes
+   *  the same check across every window and is the one that decides. */
+  pendingSaves?: readonly PendingSave[];
   onFilterQueryChange?: (query: string) => void;
   indexMutationTrigger?: number;
   collectionMutationTrigger?: number;
@@ -332,7 +333,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onDatabaseDropped,
   onDatabaseRenamed,
   onNamespaceMutated,
-  openTabs,
+  pendingSaves,
   onFilterQueryChange,
   indexMutationTrigger,
   collectionMutationTrigger,
@@ -983,6 +984,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const handleDropCollection = async (connectionId: string, dbName: string, collName: string) => {
+    // The same race as a rename, and worse: a drop that lands before a pending
+    // insert has the server recreate the collection for it, so the drop comes
+    // undone with one document sitting in it (#326 review). The backend refuses
+    // this too and its answer is the true one — it sees every window; this is
+    // here to refuse before the confirm dialog rather than after it.
+    if (isNamespaceBusy(pendingSaves ?? [], connectionId, dbName, collName)) {
+      toast(t('toasts.namespaceBusyWithSave'), 'error');
+      return;
+    }
     const conn = activeConnections.find((c) => c.id === connectionId);
     // #188 security review Fix 5: block read-only BEFORE the confirm dialog
     // and, critically, before the `isMock` branch below — which mutates the
@@ -1059,7 +1069,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     // the old name and write into it, while the tab reports success against the
     // new one (#326 review). The wait is brief; splitting a write across two
     // collections is not recoverable.
-    if (isNamespaceBusy(openTabs ?? [], connectionId, dbName, collName)) {
+    if (isNamespaceBusy(pendingSaves ?? [], connectionId, dbName, collName)) {
       toast(t('toasts.namespaceBusyWithSave'), 'error');
       return;
     }
@@ -1148,6 +1158,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const handleDropDatabase = async (connectionId: string, dbName: string) => {
+    // Every collection under it goes, so any write below the database blocks.
+    if (isNamespaceBusy(pendingSaves ?? [], connectionId, dbName)) {
+      toast(t('toasts.namespaceBusyWithSave'), 'error');
+      return;
+    }
     const conn = activeConnections.find((c) => c.id === connectionId);
     // #188 security review Fix 5: see handleDropCollection's comment on this
     // same pattern — blocks the `isMock` branch below from dropping a
@@ -1244,7 +1259,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const handleRenameDatabase = async (connectionId: string, dbName: string) => {
     // Same race, one level up: every collection under this database moves, so
     // a save running against any of them is enough to refuse (#326 review).
-    if (isNamespaceBusy(openTabs ?? [], connectionId, dbName)) {
+    if (isNamespaceBusy(pendingSaves ?? [], connectionId, dbName)) {
       toast(t('toasts.namespaceBusyWithSave'), 'error');
       return;
     }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { useDialogs } from './dialogs/DialogProvider';
+import { isNamespaceBusy, type SavingTab } from '../lib/namespaceBusy';
 import { confirmByTypedName } from '../lib/typedNameConfirm';
 import { fuzzyMatch } from '../lib/fuzzyMatch';
 import { type CollectionSelection, emptySelection, toggleCollection, selectionScope } from '@/lib/collectionSelection';
@@ -201,6 +202,9 @@ interface SidebarProps {
   onDatabaseDropped?: (connectionId: string, dbName: string) => void;
   onDatabaseRenamed?: (connectionId: string, oldName: string, newName: string) => void;
   onNamespaceMutated?: (connectionId?: string) => void;
+  /** The workspace tabs, so a rename can refuse while one of them is mid-save.
+   *  Only the namespace and the save flag are read — see . */
+  openTabs?: readonly SavingTab[];
   onFilterQueryChange?: (query: string) => void;
   indexMutationTrigger?: number;
   collectionMutationTrigger?: number;
@@ -328,6 +332,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onDatabaseDropped,
   onDatabaseRenamed,
   onNamespaceMutated,
+  openTabs,
   onFilterQueryChange,
   indexMutationTrigger,
   collectionMutationTrigger,
@@ -1049,6 +1054,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const handleRenameCollection = async (connectionId: string, dbName: string, collName: string) => {
+    // A document save already sent names this namespace. Renaming it now is a
+    // race MongoDB settles: if the rename lands first, the insert can recreate
+    // the old name and write into it, while the tab reports success against the
+    // new one (#326 review). The wait is brief; splitting a write across two
+    // collections is not recoverable.
+    if (isNamespaceBusy(openTabs ?? [], connectionId, dbName, collName)) {
+      toast(t('toasts.namespaceBusyWithSave'), 'error');
+      return;
+    }
     const conn = activeConnections.find((c) => c.id === connectionId);
     // #188 Task 3: on a confirm_destructive connection, typing the current
     // collection name (the "already a prompt" precedent kept as-is below for
@@ -1228,6 +1242,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const handleRenameDatabase = async (connectionId: string, dbName: string) => {
+    // Same race, one level up: every collection under this database moves, so
+    // a save running against any of them is enough to refuse (#326 review).
+    if (isNamespaceBusy(openTabs ?? [], connectionId, dbName)) {
+      toast(t('toasts.namespaceBusyWithSave'), 'error');
+      return;
+    }
     const newName = await prompt({
       title: t('dialogs.renameDatabase.promptTitle'),
       message: t('dialogs.enterNewDatabaseName'),

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -4347,6 +4347,46 @@ describe('App Component', () => {
       expect(calls.some((c) => c.cmd === 'workspace_apply')).toBe(false);
     });
 
+    it('refuses to detach a tab whose document save is still running (#326 review)', async () => {
+      // The request belongs to this window and settles here, so it cannot
+      // travel — and `carriedDocumentEdit` drops `saving` for exactly that
+      // reason. That would leave the destination's Save enabled over a
+      // document already being written, with the success clear arriving as a
+      // non-cross-window op it never reconciles: one more click, two documents.
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'execute_mql_query') {
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+        }
+        // Never settles: the insert is in flight for the whole test.
+        if (cmd === 'insert_document') return new Promise<string>(() => {});
+        return Promise.resolve([]);
+      });
+      const { fireEvent, within, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await screen.findByText(/"John Doe"/);
+      fireEvent.click(screen.getByTestId('insert-doc-btn'));
+      fireEvent.change(await screen.findByTestId('document-json-input'), {
+        target: { value: '{"name":"Ada"}' },
+      });
+      fireEvent.click(screen.getByTestId('document-save-btn'));
+      await waitFor(() => expect(screen.getByTestId('document-save-btn')).toBeDisabled());
+
+      const tabStrip = screen.getByTestId('workspace-tab-strip');
+      const customersTab = await within(tabStrip).findByText('customers');
+      calls.length = 0;
+      fireEvent.contextMenu(customersTab.closest('div')!);
+      fireEvent.click(await screen.findByText('Detach to New Window'));
+
+      expect(calls.filter((c) => c.cmd === 'workspace_detach_tab')).toHaveLength(0);
+      expect(await screen.findByText(/Wait for the document save to finish/)).toBeInTheDocument();
+    });
+
+
     it('moving to another window calls workspace_apply with move_tab_to_window and never touches this window\'s local layout', async () => {
       const calls: any[] = [];
       mockInvoke.mockImplementation((cmd: string, args: any) => {

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -957,6 +957,48 @@ describe('App Component', () => {
       expect(screen.getByTestId('document-json-input')).toHaveValue('{"name":"second"}');
     });
 
+    it('mirrors the draft, and clears it on close', async () => {
+      // #326 review: the clear used to be announced by `closeDocumentEdit`,
+      // which decided whether to send it before its own `setTabs` updater had
+      // run — so a close could send nothing, leaving an earlier debounced draft
+      // standing on the backend for the next move to revive.
+      const calls: any[] = [];
+      mockInvoke.mockImplementation((cmd: string, args: any) => {
+        calls.push({ cmd, args });
+        if (cmd === 'execute_mql_query') {
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+        }
+        return Promise.resolve([]);
+      });
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await screen.findByText(/"John Doe"/);
+      fireEvent.click(screen.getByTestId('insert-doc-btn'));
+      fireEvent.change(await screen.findByTestId('document-json-input'), {
+        target: { value: '{"name":"Ada"}' },
+      });
+
+      const edits = () =>
+        calls
+          .filter((c) => c.cmd === 'workspace_apply' && c.args?.op?.type === 'update_tab_state')
+          .filter((c) => 'document_edit' in c.args.op)
+          .map((c) => c.args.op.document_edit);
+
+      await waitFor(() => {
+        expect(edits().some((e) => e && e.draft === '{"name":"Ada"}')).toBe(true);
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      await waitFor(() => {
+        // Explicitly null, not merely absent — absent means "untouched".
+        expect(edits().at(-1)).toBeNull();
+      });
+    });
+
+
   });
 
 

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -882,6 +882,81 @@ describe('App Component', () => {
       await screen.findByTestId('document-json-input');
       expect(screen.getByTestId('document-save-btn')).toBeDisabled();
     });
+
+    it('leaves a replacement edit alone when the first one it replaced fails', async () => {
+      // The dialog is non-modal, so it can be dragged aside and a second insert
+      // started on the SAME tab while the first save is still running. Matched
+      // on the tab alone, the first result would land on the second edit
+      // (#326 review): clearing a `saving` it never set, or reporting a failure
+      // that was not its own.
+      const explode = pendingInsert();
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await screen.findByText(/"John Doe"/);
+      fireEvent.click(screen.getByTestId('insert-doc-btn'));
+      fireEvent.change(await screen.findByTestId('document-json-input'), {
+        target: { value: '{"name":"first"}' },
+      });
+      fireEvent.click(screen.getByTestId('document-save-btn'));
+      await waitFor(() => expect(screen.getByTestId('document-save-btn')).toBeDisabled());
+
+      // Same tab, a second insert — this replaces the edit that is still saving.
+      fireEvent.click(screen.getByTestId('insert-doc-btn'));
+      const second = await screen.findByTestId('document-json-input');
+      fireEvent.change(second, { target: { value: '{"name":"second"}' } });
+      // A fresh edit, so it is savable even though the first request is live.
+      expect(screen.getByTestId('document-save-btn')).not.toBeDisabled();
+
+      explode();
+
+      // The failure belonged to an edit that is over. It does not surface on the
+      // one that replaced it, and the draft here is untouched.
+      await waitFor(() =>
+        expect(screen.getByTestId('document-json-input')).toHaveValue('{"name":"second"}')
+      );
+      expect(screen.queryByTestId('document-edit-error')).toBeNull();
+      expect(screen.getByTestId('document-save-btn')).not.toBeDisabled();
+    });
+
+    it('does not close a replacement edit when the first one it replaced succeeds', async () => {
+      // The mirror image: a success closes the dialog, and closing the wrong
+      // edit would take a draft nobody had finished with.
+      let resolveInsert!: (v: string) => void;
+      mockInvoke.mockImplementation((cmd) => {
+        if (cmd === 'execute_mql_query') {
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+        }
+        if (cmd === 'insert_document') return new Promise<string>((r) => { resolveInsert = r; });
+        return Promise.resolve([]);
+      });
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await screen.findByText(/"John Doe"/);
+      fireEvent.click(screen.getByTestId('insert-doc-btn'));
+      fireEvent.change(await screen.findByTestId('document-json-input'), {
+        target: { value: '{"name":"first"}' },
+      });
+      fireEvent.click(screen.getByTestId('document-save-btn'));
+      await waitFor(() => expect(screen.getByTestId('document-save-btn')).toBeDisabled());
+
+      fireEvent.click(screen.getByTestId('insert-doc-btn'));
+      fireEvent.change(await screen.findByTestId('document-json-input'), {
+        target: { value: '{"name":"second"}' },
+      });
+
+      resolveInsert('"new-id"');
+
+      // The first insert landed — but the dialog still holds the second draft.
+      await screen.findByText(/Document inserted into customers/);
+      expect(screen.getByTestId('document-json-input')).toHaveValue('{"name":"second"}');
+    });
+
   });
 
 

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -998,6 +998,38 @@ describe('App Component', () => {
       });
     });
 
+    it('still reports a failure after the tab is renamed mid-save', async () => {
+      // #326 review: the dialog is non-modal, so renaming the database stays
+      // reachable while a save runs. The rename preserves the edit but replaces
+      // the tab id, and a completion that named the tab then reached nothing:
+      // the failure never appeared and `saving` was never cleared, leaving the
+      // renamed tab's editor disabled for good.
+      const explode = pendingInsert();
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await screen.findByText(/"John Doe"/);
+      fireEvent.click(screen.getByTestId('insert-doc-btn'));
+      fireEvent.change(await screen.findByTestId('document-json-input'), {
+        target: { value: '{"name":"Ada"}' },
+      });
+      fireEvent.click(screen.getByTestId('document-save-btn'));
+      await waitFor(() => expect(screen.getByTestId('document-save-btn')).toBeDisabled());
+
+      // The tab id changes under the running request; the edit survives it.
+      fireEvent.click(screen.getByTestId('rename-db-btn'));
+      await waitFor(() => expect(screen.getByTestId('document-json-input')).toHaveValue('{"name":"Ada"}'));
+
+      explode();
+
+      expect(await screen.findByTestId('document-edit-error')).toHaveTextContent('insert exploded');
+      // And Save is usable again, rather than stuck on a `saving` nobody cleared.
+      await waitFor(() => expect(screen.getByTestId('document-save-btn')).not.toBeDisabled());
+    });
+
+
 
   });
 

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -792,6 +792,99 @@ describe('App Component', () => {
     });
   });
 
+  // #326 review: an edit's failure and its pending save belong to the edit, not
+  // to the dialog — the dialog is a view of whichever tab is active, so it
+  // unmounts on the way to another tab and remounts on the way back. Kept in
+  // the dialog, a failure was reported against whichever edit happened to be on
+  // screen, and clearing it on the way back could not be told apart from
+  // clearing it for a genuinely new edit. Both now live on the tab beside the
+  // draft, so these are App's to guarantee.
+  describe('a save failure stays with the edit that caused it (#326 review)', () => {
+    /** An insert whose result this test releases by hand. */
+    const pendingInsert = () => {
+      let reject!: (e: Error) => void;
+      mockInvoke.mockImplementation((cmd) => {
+        if (cmd === 'execute_mql_query') {
+          return Promise.resolve([JSON.stringify({ _id: '1', name: 'John Doe' })]);
+        }
+        if (cmd === 'insert_document') return new Promise<string>((_, r) => { reject = r; });
+        return Promise.resolve([]);
+      });
+      return () => reject(new Error('insert exploded'));
+    };
+
+    it('reports it on its own tab, not on the one in view when it lands', async () => {
+      const explode = pendingInsert();
+      const { fireEvent } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      // customers: start an insert and submit it.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await screen.findByText(/"John Doe"/);
+      fireEvent.click(screen.getByTestId('insert-doc-btn'));
+      fireEvent.change(await screen.findByTestId('document-json-input'), {
+        target: { value: '{"name":"Ada"}' },
+      });
+      fireEvent.click(screen.getByTestId('document-save-btn'));
+
+      // orders: an EDIT, so the two dialogs differ in `initialJson` — the case a
+      // keyed error could not tell from a new edit beginning.
+      fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
+      await screen.findByText(/"John Doe"/);
+      fireEvent.click(screen.getAllByTestId('edit-doc-btn')[0]);
+      await screen.findByTestId('document-json-input');
+
+      // Only now does the customers insert fail, with its own dialog off screen.
+      explode();
+
+      // Back on customers the failure is waiting — which is also what proves it
+      // has landed, so the next assertion is about a state that exists.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findByTestId('document-edit-error')).toHaveTextContent('insert exploded');
+
+      // And it is nowhere near the orders edit, which did not fail.
+      fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
+      await screen.findByTestId('document-json-input');
+      expect(screen.queryByTestId('document-edit-error')).toBeNull();
+
+      // Returning to customers a second time still finds it: coming back into
+      // view is not the end of an edit (#326 review).
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      expect(await screen.findByTestId('document-edit-error')).toHaveTextContent('insert exploded');
+    });
+
+    it('disables Save on the edit that is saving, and only that one', async () => {
+      pendingInsert();
+      const { fireEvent, waitFor } = await import('@testing-library/react');
+      renderWithProviders(<App />);
+      await screen.findByTestId('mock-sidebar');
+
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await screen.findByText(/"John Doe"/);
+      fireEvent.click(screen.getByTestId('insert-doc-btn'));
+      fireEvent.change(await screen.findByTestId('document-json-input'), {
+        target: { value: '{"name":"Ada"}' },
+      });
+      fireEvent.click(screen.getByTestId('document-save-btn'));
+      await waitFor(() => expect(screen.getByTestId('document-save-btn')).toBeDisabled());
+
+      // A different tab's edit is savable while this one is still in flight.
+      fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
+      await screen.findByText(/"John Doe"/);
+      fireEvent.click(screen.getAllByTestId('edit-doc-btn')[0]);
+      await screen.findByTestId('document-json-input');
+      expect(screen.getByTestId('document-save-btn')).not.toBeDisabled();
+
+      // And the one that is saving still is, so a second click cannot write the
+      // document twice.
+      fireEvent.click(screen.getByTestId('select-collection-btn'));
+      await screen.findByTestId('document-json-input');
+      expect(screen.getByTestId('document-save-btn')).toBeDisabled();
+    });
+  });
+
+
   it('opens settings as a workspace tab', async () => {
     mockInvoke.mockImplementation((cmd) => {
       if (cmd === 'load_app_settings') {

--- a/src/components/__tests__/DocumentEditModal.test.tsx
+++ b/src/components/__tests__/DocumentEditModal.test.tsx
@@ -206,4 +206,35 @@ describe('DocumentEditModal — reports the save state it is given (#326 review)
     render(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' saving={false} />);
     expect(screen.getByTestId('document-save-btn')).not.toBeDisabled();
   });
+
+  it('freezes the edit once its tab is on the way to another window', () => {
+    // #326 review: the move is fire-and-forget, so the backend can have taken
+    // the tab's snapshot while this window still shows the editor. A keystroke
+    // here goes to an id the destination no longer reconciles, and a save
+    // started here does not travel with the edit.
+    const onSave = vi.fn();
+    const onJsonChange = vi.fn();
+    render(
+      <DocumentEditModal
+        {...base}
+        onSave={onSave}
+        onJsonChange={onJsonChange}
+        json='{"a":1}'
+        frozen
+      />
+    );
+    expect(screen.getByTestId('document-save-btn')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('is editable again when the freeze lifts', () => {
+    const onSave = vi.fn();
+    const { rerender } = render(
+      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' frozen />
+    );
+    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"a":1}' frozen={false} />);
+    expect(screen.getByTestId('document-save-btn')).not.toBeDisabled();
+  });
+
 });

--- a/src/components/__tests__/DocumentEditModal.test.tsx
+++ b/src/components/__tests__/DocumentEditModal.test.tsx
@@ -251,3 +251,49 @@ describe('DocumentEditModal — a pending save survives a look elsewhere (#326 r
     expect(screen.getByTestId('document-save-btn')).not.toBeDisabled();
   });
 });
+
+// #326 review: a rejection can settle after the user has moved on. Written to a
+// component-wide slot it appeared on whichever edit was showing, and the reset
+// then discarded it — so the failure was reported against the wrong edit and
+// lost by the one it belonged to.
+describe('DocumentEditModal — a failure stays with the edit that caused it (#326 review)', () => {
+  const base = {
+    isOpen: true as const,
+    mode: 'insert' as const,
+    initialJson: '{\n  \n}',
+    onClose: vi.fn(),
+    onJsonChange: vi.fn(),
+  };
+
+  it('does not show one edit\'s failure on another', async () => {
+    let reject!: (e: Error) => void;
+    const onSave = vi.fn(() => new Promise<void>((_, r) => { reject = r; }));
+    const { rerender } = render(
+      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />
+    );
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+
+    // Move to another tab's edit, THEN let tab A's request fail.
+    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' editKey="tab-b" />);
+    reject(new Error('tab-a exploded'));
+
+    await waitFor(() => expect(screen.getByTestId('document-save-btn')).not.toBeDisabled());
+    expect(screen.queryByTestId('document-edit-error')).toBeNull();
+  });
+
+  it('shows it again on the edit that owns it', async () => {
+    let reject!: (e: Error) => void;
+    const onSave = vi.fn(() => new Promise<void>((_, r) => { reject = r; }));
+    const { rerender } = render(
+      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />
+    );
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' editKey="tab-b" />);
+    reject(new Error('tab-a exploded'));
+    await waitFor(() => expect(screen.getByTestId('document-save-btn')).not.toBeDisabled());
+
+    // Back to A: its own failure is waiting, not discarded.
+    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />);
+    expect(screen.getByTestId('document-edit-error')).toHaveTextContent('tab-a exploded');
+  });
+});

--- a/src/components/__tests__/DocumentEditModal.test.tsx
+++ b/src/components/__tests__/DocumentEditModal.test.tsx
@@ -109,3 +109,57 @@ describe('DocumentEditModal', () => {
     expect(screen.queryByTestId('document-edit-modal')).not.toBeInTheDocument();
   });
 });
+
+// #277: the edit dialog was a modal held in one app-wide slot, so it blocked
+// the whole window and one edit existed at a time. Editing a document is
+// exactly when you want to glance at another tab — to compare a field or copy
+// an id — and doing so cost you what you had typed.
+describe('DocumentEditModal — an edit belongs to its tab (#277)', () => {
+  const props = {
+    isOpen: true,
+    mode: 'edit' as const,
+    initialJson: '{ "a": 1 }',
+    onClose: vi.fn(),
+    onSave: vi.fn(),
+  };
+
+  it('reports edits instead of keeping them, when the caller owns the text', () => {
+    const onJsonChange = vi.fn();
+    render(<DocumentEditModal {...props} json='{ "a": 1 }' onJsonChange={onJsonChange} />);
+    fireEvent.change(screen.getByTestId('document-json-input'), {
+      target: { value: '{ "a": 2 }' },
+    });
+    expect(onJsonChange).toHaveBeenCalledWith('{ "a": 2 }');
+  });
+
+  it('restores a draft rather than resetting it when it reappears', () => {
+    // Leaving the tab unmounts this; coming back mounts it again. If reopening
+    // reset the text to initialJson, the unsaved work would be gone — which is
+    // the whole point of the change.
+    const { rerender } = render(
+      <DocumentEditModal {...props} isOpen={false} json='{ "a": 2 }' onJsonChange={vi.fn()} />
+    );
+    rerender(<DocumentEditModal {...props} isOpen json='{ "a": 2 }' onJsonChange={vi.fn()} />);
+    expect(screen.getByTestId('document-json-input')).toHaveValue('{ "a": 2 }');
+  });
+
+  it('still resets its own text when nobody else owns it', () => {
+    // The uncontrolled contract is unchanged: reopening starts fresh.
+    const { rerender } = render(<DocumentEditModal {...props} isOpen={false} />);
+    rerender(<DocumentEditModal {...props} isOpen />);
+    expect(screen.getByTestId('document-json-input')).toHaveValue('{ "a": 1 }');
+  });
+
+  it('does not cover the app with a blocking scrim', () => {
+    // Non-modal is what lets another tab be used while this is open. The
+    // overlay is Radix's `bg-black/80` element; asserting it is *hidden* rather
+    // than merely absent keeps this honest — an empty query would pass whether
+    // or not the scrim were there.
+    const { baseElement } = render(<DocumentEditModal {...props} />);
+    // Radix omits the overlay entirely outside modal mode, so the assertion is
+    // that no scrim exists at all. It fails on the modal version, where the
+    // `bg-black/80` element is present and covering the app.
+    expect(baseElement.querySelector('.fixed.inset-0')).toBeNull();
+    expect(screen.getByTestId('document-edit-modal')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/DocumentEditModal.test.tsx
+++ b/src/components/__tests__/DocumentEditModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // The modal's JSON editor wraps @monaco-editor/react; mock it with a plain
 // <textarea> that exposes the test id via wrapperProps and round-trips value.
@@ -161,5 +161,46 @@ describe('DocumentEditModal — an edit belongs to its tab (#277)', () => {
     // `bg-black/80` element is present and covering the app.
     expect(baseElement.querySelector('.fixed.inset-0')).toBeNull();
     expect(screen.getByTestId('document-edit-modal')).toBeInTheDocument();
+  });
+});
+
+// #326 review: with two tabs each holding an edit, this component stays mounted
+// as the user moves between them. `isOpen` and `initialJson` cannot tell those
+// edits apart — two inserts share the same initial text — so transient state
+// followed the user from one edit to the other.
+describe('DocumentEditModal — transient state does not cross edits (#326 review)', () => {
+  const base = {
+    isOpen: true as const,
+    mode: 'insert' as const,
+    initialJson: '{\n  \n}',
+    onClose: vi.fn(),
+  };
+
+  it('clears the saving flag after a successful save', () => {
+    // It was only ever cleared on failure. Invisible while a save closed the
+    // dialog, and permanent once another tab's edit keeps it mounted: the Save
+    // button stayed disabled with no way back.
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' onJsonChange={vi.fn()} editKey="tab-a" />
+    );
+    const save = screen.getByTestId('document-save-btn');
+    fireEvent.click(save);
+    return waitFor(() => expect(save).not.toBeDisabled());
+  });
+
+  it('drops an error when the user moves to another tab\'s edit', () => {
+    const onSave = vi.fn().mockRejectedValue(new Error('boom'));
+    const { rerender } = render(
+      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' onJsonChange={vi.fn()} editKey="tab-a" />
+    );
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+    return waitFor(() => expect(screen.getByTestId('document-edit-error')).toBeInTheDocument()).then(() => {
+      // Same isOpen, same initialJson — only the owning tab differs.
+      rerender(
+        <DocumentEditModal {...base} onSave={onSave} json='{"b":2}' onJsonChange={vi.fn()} editKey="tab-b" />
+      );
+      expect(screen.queryByTestId('document-edit-error')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/__tests__/DocumentEditModal.test.tsx
+++ b/src/components/__tests__/DocumentEditModal.test.tsx
@@ -204,3 +204,50 @@ describe('DocumentEditModal — transient state does not cross edits (#326 revie
     });
   });
 });
+
+// #326 review (P1): a pending save is a fact about an edit, not about this
+// component. Clearing it when the user looked at another tab re-enabled Save
+// while the original insert was still running, so a second click could write
+// the document twice.
+describe('DocumentEditModal — a pending save survives a look elsewhere (#326 review)', () => {
+  const base = {
+    isOpen: true as const,
+    mode: 'insert' as const,
+    initialJson: '{\n  \n}',
+    onClose: vi.fn(),
+    onJsonChange: vi.fn(),
+  };
+
+  it('keeps Save disabled after switching away and back mid-save', async () => {
+    // Never resolves: the request is still in flight for the whole test.
+    const onSave = vi.fn(() => new Promise<void>(() => {}));
+    const { rerender } = render(
+      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />
+    );
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+    await waitFor(() => expect(screen.getByTestId('document-save-btn')).toBeDisabled());
+
+    // Away to another tab's edit...
+    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' editKey="tab-b" />);
+    // ...and back, with tab A's insert still running.
+    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />);
+
+    expect(screen.getByTestId('document-save-btn')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+    // One request, not two — a second would be a duplicate document.
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports saving per edit, not for whichever is on screen', async () => {
+    // Tab A is mid-save; tab B has done nothing and must still be savable.
+    const onSave = vi.fn(() => new Promise<void>(() => {}));
+    const { rerender } = render(
+      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />
+    );
+    fireEvent.click(screen.getByTestId('document-save-btn'));
+    await waitFor(() => expect(screen.getByTestId('document-save-btn')).toBeDisabled());
+
+    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' editKey="tab-b" />);
+    expect(screen.getByTestId('document-save-btn')).not.toBeDisabled();
+  });
+});

--- a/src/components/__tests__/DocumentEditModal.test.tsx
+++ b/src/components/__tests__/DocumentEditModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 // The modal's JSON editor wraps @monaco-editor/react; mock it with a plain
 // <textarea> that exposes the test id via wrapperProps and round-trips value.
@@ -164,52 +164,13 @@ describe('DocumentEditModal — an edit belongs to its tab (#277)', () => {
   });
 });
 
-// #326 review: with two tabs each holding an edit, this component stays mounted
-// as the user moves between them. `isOpen` and `initialJson` cannot tell those
-// edits apart — two inserts share the same initial text — so transient state
-// followed the user from one edit to the other.
-describe('DocumentEditModal — transient state does not cross edits (#326 review)', () => {
-  const base = {
-    isOpen: true as const,
-    mode: 'insert' as const,
-    initialJson: '{\n  \n}',
-    onClose: vi.fn(),
-  };
-
-  it('clears the saving flag after a successful save', () => {
-    // It was only ever cleared on failure. Invisible while a save closed the
-    // dialog, and permanent once another tab's edit keeps it mounted: the Save
-    // button stayed disabled with no way back.
-    const onSave = vi.fn().mockResolvedValue(undefined);
-    render(
-      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' onJsonChange={vi.fn()} editKey="tab-a" />
-    );
-    const save = screen.getByTestId('document-save-btn');
-    fireEvent.click(save);
-    return waitFor(() => expect(save).not.toBeDisabled());
-  });
-
-  it('drops an error when the user moves to another tab\'s edit', () => {
-    const onSave = vi.fn().mockRejectedValue(new Error('boom'));
-    const { rerender } = render(
-      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' onJsonChange={vi.fn()} editKey="tab-a" />
-    );
-    fireEvent.click(screen.getByTestId('document-save-btn'));
-    return waitFor(() => expect(screen.getByTestId('document-edit-error')).toBeInTheDocument()).then(() => {
-      // Same isOpen, same initialJson — only the owning tab differs.
-      rerender(
-        <DocumentEditModal {...base} onSave={onSave} json='{"b":2}' onJsonChange={vi.fn()} editKey="tab-b" />
-      );
-      expect(screen.queryByTestId('document-edit-error')).not.toBeInTheDocument();
-    });
-  });
-});
-
-// #326 review (P1): a pending save is a fact about an edit, not about this
-// component. Clearing it when the user looked at another tab re-enabled Save
-// while the original insert was still running, so a second click could write
-// the document twice.
-describe('DocumentEditModal — a pending save survives a look elsewhere (#326 review)', () => {
+// #326 review: the error and the pending save are the caller's now. This
+// dialog is a view of whichever tab is active — it unmounts when the user
+// looks elsewhere and remounts on the way back — so state that has to outlive
+// that cannot live here. Three attempts to keep it here each failed the same
+// way, the last because `isOpen` and `initialJson` cannot tell a new edit from
+// an old one returning to view. What this dialog still owes is showing them.
+describe('DocumentEditModal — reports the save state it is given (#326 review)', () => {
   const base = {
     isOpen: true as const,
     mode: 'insert' as const,
@@ -218,82 +179,31 @@ describe('DocumentEditModal — a pending save survives a look elsewhere (#326 r
     onJsonChange: vi.fn(),
   };
 
-  it('keeps Save disabled after switching away and back mid-save', async () => {
-    // Never resolves: the request is still in flight for the whole test.
-    const onSave = vi.fn(() => new Promise<void>(() => {}));
+  it('shows the failure it is handed, and drops it when the caller does', () => {
     const { rerender } = render(
-      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />
+      <DocumentEditModal {...base} onSave={vi.fn()} json='{"a":1}' error="boom" />
     );
-    fireEvent.click(screen.getByTestId('document-save-btn'));
-    await waitFor(() => expect(screen.getByTestId('document-save-btn')).toBeDisabled());
-
-    // Away to another tab's edit...
-    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' editKey="tab-b" />);
-    // ...and back, with tab A's insert still running.
-    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />);
-
-    expect(screen.getByTestId('document-save-btn')).toBeDisabled();
-    fireEvent.click(screen.getByTestId('document-save-btn'));
-    // One request, not two — a second would be a duplicate document.
-    expect(onSave).toHaveBeenCalledTimes(1);
-  });
-
-  it('reports saving per edit, not for whichever is on screen', async () => {
-    // Tab A is mid-save; tab B has done nothing and must still be savable.
-    const onSave = vi.fn(() => new Promise<void>(() => {}));
-    const { rerender } = render(
-      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />
-    );
-    fireEvent.click(screen.getByTestId('document-save-btn'));
-    await waitFor(() => expect(screen.getByTestId('document-save-btn')).toBeDisabled());
-
-    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' editKey="tab-b" />);
-    expect(screen.getByTestId('document-save-btn')).not.toBeDisabled();
-  });
-});
-
-// #326 review: a rejection can settle after the user has moved on. Written to a
-// component-wide slot it appeared on whichever edit was showing, and the reset
-// then discarded it — so the failure was reported against the wrong edit and
-// lost by the one it belonged to.
-describe('DocumentEditModal — a failure stays with the edit that caused it (#326 review)', () => {
-  const base = {
-    isOpen: true as const,
-    mode: 'insert' as const,
-    initialJson: '{\n  \n}',
-    onClose: vi.fn(),
-    onJsonChange: vi.fn(),
-  };
-
-  it('does not show one edit\'s failure on another', async () => {
-    let reject!: (e: Error) => void;
-    const onSave = vi.fn(() => new Promise<void>((_, r) => { reject = r; }));
-    const { rerender } = render(
-      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />
-    );
-    fireEvent.click(screen.getByTestId('document-save-btn'));
-
-    // Move to another tab's edit, THEN let tab A's request fail.
-    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' editKey="tab-b" />);
-    reject(new Error('tab-a exploded'));
-
-    await waitFor(() => expect(screen.getByTestId('document-save-btn')).not.toBeDisabled());
+    expect(screen.getByTestId('document-edit-error')).toHaveTextContent('boom');
+    rerender(<DocumentEditModal {...base} onSave={vi.fn()} json='{"a":1}' error={null} />);
     expect(screen.queryByTestId('document-edit-error')).toBeNull();
   });
 
-  it('shows it again on the edit that owns it', async () => {
-    let reject!: (e: Error) => void;
-    const onSave = vi.fn(() => new Promise<void>((_, r) => { reject = r; }));
-    const { rerender } = render(
-      <DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />
-    );
-    fireEvent.click(screen.getByTestId('document-save-btn'));
-    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' editKey="tab-b" />);
-    reject(new Error('tab-a exploded'));
-    await waitFor(() => expect(screen.getByTestId('document-save-btn')).not.toBeDisabled());
+  it('refuses a second submit while the caller reports one in flight', () => {
+    // Two inserts would write the document twice, so this is the guard that
+    // matters — and it holds however the user got here, because the answer
+    // comes from the edit rather than from anything this component remembers.
+    const onSave = vi.fn();
+    render(<DocumentEditModal {...base} onSave={onSave} json='{"a":1}' saving />);
+    const save = screen.getByTestId('document-save-btn');
+    expect(save).toBeDisabled();
+    fireEvent.click(save);
+    expect(onSave).not.toHaveBeenCalled();
+  });
 
-    // Back to A: its own failure is waiting, not discarded.
-    rerender(<DocumentEditModal {...base} onSave={onSave} json='{"a":1}' editKey="tab-a" />);
-    expect(screen.getByTestId('document-edit-error')).toHaveTextContent('tab-a exploded');
+  it('stays savable when the caller reports no save of its own', () => {
+    // The sibling case: one tab mid-save must not disable another tab's Save.
+    const onSave = vi.fn();
+    render(<DocumentEditModal {...base} onSave={onSave} json='{"b":2}' saving={false} />);
+    expect(screen.getByTestId('document-save-btn')).not.toBeDisabled();
   });
 });

--- a/src/lib/__tests__/namespaceBusy.test.ts
+++ b/src/lib/__tests__/namespaceBusy.test.ts
@@ -1,49 +1,42 @@
 import { describe, it, expect } from 'vitest';
-import { isNamespaceBusy, type SavingTab } from '../namespaceBusy';
+import { isNamespaceBusy, type PendingSave } from '../namespaceBusy';
 
-// #326 review: the dialog is non-modal, so the rename controls stay reachable
-// while a document save is in flight. The request is bound to the namespace it
-// was sent with — if the rename reaches MongoDB first, the insert can recreate
-// the old collection and write into it while the tab reports success against
-// the new name.
+// #326 review: the dialog is non-modal, so the rename and drop controls stay
+// reachable while a document save is in flight. The request is bound to the
+// namespace it was sent with — if the rename or drop reaches MongoDB first, the
+// server can recreate that namespace for the write, undoing the drop or
+// splitting the write across two collections.
 describe('isNamespaceBusy', () => {
-  const tab = (over: Partial<SavingTab> = {}): SavingTab => ({
+  const save = (over: Partial<PendingSave> = {}): PendingSave => ({
     connectionId: 'conn-1',
     db: 'sales_db',
     collection: 'customers',
-    documentEdit: { saving: true },
     ...over,
   });
 
   it('reports the collection a save is running against', () => {
-    expect(isNamespaceBusy([tab()], 'conn-1', 'sales_db', 'customers')).toBe(true);
+    expect(isNamespaceBusy([save()], 'conn-1', 'sales_db', 'customers')).toBe(true);
   });
 
-  it('reports its database too, since a database rename moves every collection', () => {
-    expect(isNamespaceBusy([tab()], 'conn-1', 'sales_db')).toBe(true);
+  it('reports its database too, since a database rename or drop takes every collection', () => {
+    expect(isNamespaceBusy([save()], 'conn-1', 'sales_db')).toBe(true);
   });
 
   it('leaves a different collection, database or connection alone', () => {
-    expect(isNamespaceBusy([tab()], 'conn-1', 'sales_db', 'orders')).toBe(false);
-    expect(isNamespaceBusy([tab()], 'conn-1', 'other_db')).toBe(false);
-    expect(isNamespaceBusy([tab()], 'conn-2', 'sales_db', 'customers')).toBe(false);
+    expect(isNamespaceBusy([save()], 'conn-1', 'sales_db', 'orders')).toBe(false);
+    expect(isNamespaceBusy([save()], 'conn-1', 'other_db')).toBe(false);
+    expect(isNamespaceBusy([save()], 'conn-2', 'sales_db', 'customers')).toBe(false);
   });
 
-  it('is about a save, not an open editor', () => {
-    // An edit sitting there unsaved binds nothing: the user can rename around it.
-    expect(isNamespaceBusy([tab({ documentEdit: { saving: false } })], 'conn-1', 'sales_db')).toBe(false);
-    expect(isNamespaceBusy([tab({ documentEdit: undefined })], 'conn-1', 'sales_db')).toBe(false);
-  });
-
-  it('finds the save on whichever tab is running it', () => {
-    // Two tabs can be open on one collection, and it is the collection being
-    // renamed — so the answer cannot depend on which tab is active.
-    const idle = tab({ documentEdit: undefined });
-    const saving = tab();
-    expect(isNamespaceBusy([idle, saving], 'conn-1', 'sales_db', 'customers')).toBe(true);
-  });
-
-  it('is false for no tabs at all', () => {
+  it('answers about requests, so an edit merely sitting open binds nothing', () => {
+    // The registry holds sent requests only. An unsaved editor is not one, and
+    // the user can rename around it.
     expect(isNamespaceBusy([], 'conn-1', 'sales_db', 'customers')).toBe(false);
+  });
+
+  it('still reports a save whose namespace differs from the others outstanding', () => {
+    const elsewhere = save({ db: 'other_db', collection: 'things' });
+    expect(isNamespaceBusy([elsewhere, save()], 'conn-1', 'sales_db', 'customers')).toBe(true);
+    expect(isNamespaceBusy([elsewhere, save()], 'conn-1', 'other_db', 'things')).toBe(true);
   });
 });

--- a/src/lib/__tests__/namespaceBusy.test.ts
+++ b/src/lib/__tests__/namespaceBusy.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { isNamespaceBusy, type SavingTab } from '../namespaceBusy';
+
+// #326 review: the dialog is non-modal, so the rename controls stay reachable
+// while a document save is in flight. The request is bound to the namespace it
+// was sent with — if the rename reaches MongoDB first, the insert can recreate
+// the old collection and write into it while the tab reports success against
+// the new name.
+describe('isNamespaceBusy', () => {
+  const tab = (over: Partial<SavingTab> = {}): SavingTab => ({
+    connectionId: 'conn-1',
+    db: 'sales_db',
+    collection: 'customers',
+    documentEdit: { saving: true },
+    ...over,
+  });
+
+  it('reports the collection a save is running against', () => {
+    expect(isNamespaceBusy([tab()], 'conn-1', 'sales_db', 'customers')).toBe(true);
+  });
+
+  it('reports its database too, since a database rename moves every collection', () => {
+    expect(isNamespaceBusy([tab()], 'conn-1', 'sales_db')).toBe(true);
+  });
+
+  it('leaves a different collection, database or connection alone', () => {
+    expect(isNamespaceBusy([tab()], 'conn-1', 'sales_db', 'orders')).toBe(false);
+    expect(isNamespaceBusy([tab()], 'conn-1', 'other_db')).toBe(false);
+    expect(isNamespaceBusy([tab()], 'conn-2', 'sales_db', 'customers')).toBe(false);
+  });
+
+  it('is about a save, not an open editor', () => {
+    // An edit sitting there unsaved binds nothing: the user can rename around it.
+    expect(isNamespaceBusy([tab({ documentEdit: { saving: false } })], 'conn-1', 'sales_db')).toBe(false);
+    expect(isNamespaceBusy([tab({ documentEdit: undefined })], 'conn-1', 'sales_db')).toBe(false);
+  });
+
+  it('finds the save on whichever tab is running it', () => {
+    // Two tabs can be open on one collection, and it is the collection being
+    // renamed — so the answer cannot depend on which tab is active.
+    const idle = tab({ documentEdit: undefined });
+    const saving = tab();
+    expect(isNamespaceBusy([idle, saving], 'conn-1', 'sales_db', 'customers')).toBe(true);
+  });
+
+  it('is false for no tabs at all', () => {
+    expect(isNamespaceBusy([], 'conn-1', 'sales_db', 'customers')).toBe(false);
+  });
+});

--- a/src/lib/namespaceBusy.ts
+++ b/src/lib/namespaceBusy.ts
@@ -1,0 +1,42 @@
+/**
+ * Whether a namespace has a document write in flight against it.
+ *
+ * A save is bound to the namespace it was sent with. Renaming or dropping that
+ * namespace while the request is out is a race the client cannot win: if the
+ * rename reaches MongoDB first, the insert can recreate the old collection and
+ * write into it, and the tab reports success against the new name (#326
+ * review). The dialog is non-modal, so those controls stay reachable for the
+ * whole request — this is what lets them refuse for its duration.
+ *
+ * Deliberately about the namespace rather than the tab: two tabs can be open on
+ * the same collection, and it is the collection being renamed.
+ */
+
+/** The parts of a tab this needs — a structural subset of App's `QueryTab`. */
+export interface SavingTab {
+  connectionId: string;
+  db: string;
+  collection: string;
+  documentEdit?: { saving: boolean } | undefined;
+}
+
+/**
+ * True when any tab has a document save running against this namespace.
+ *
+ * Omit `collection` to ask about a whole database, which is what a database
+ * rename needs: every collection under it moves.
+ */
+export function isNamespaceBusy(
+  tabs: readonly SavingTab[],
+  connectionId: string,
+  db: string,
+  collection?: string
+): boolean {
+  return tabs.some(
+    (tab) =>
+      tab.documentEdit?.saving === true &&
+      tab.connectionId === connectionId &&
+      tab.db === db &&
+      (collection === undefined || tab.collection === collection)
+  );
+}

--- a/src/lib/namespaceBusy.ts
+++ b/src/lib/namespaceBusy.ts
@@ -12,31 +12,42 @@
  * the same collection, and it is the collection being renamed.
  */
 
-/** The parts of a tab this needs — a structural subset of App's `QueryTab`. */
-export interface SavingTab {
+/**
+ * One document write that has been sent and not yet answered.
+ *
+ * Recorded per request rather than read off the edit that started it. An edit
+ * can be replaced while its save is still running — the non-modal dialog
+ * exists so a second one can be started on the same tab — and asking the
+ * current edit whether it is saving then answers about the wrong request, or
+ * about none at all (#326 review). A request outlives the edit; this is the
+ * record that outlives it too.
+ */
+export interface PendingSave {
   connectionId: string;
   db: string;
   collection: string;
-  documentEdit?: { saving: boolean } | undefined;
 }
 
 /**
- * True when any tab has a document save running against this namespace.
+ * True when a document write is outstanding against this namespace.
  *
  * Omit `collection` to ask about a whole database, which is what a database
- * rename needs: every collection under it moves.
+ * rename or drop needs: every collection under it moves or goes.
+ *
+ * This is the fast answer, for a control that can refuse before it starts. It
+ * only knows about this window; the authoritative check is the backend's, which
+ * sees every window's requests — see `namespace_guard.rs`.
  */
 export function isNamespaceBusy(
-  tabs: readonly SavingTab[],
+  saves: readonly PendingSave[],
   connectionId: string,
   db: string,
   collection?: string
 ): boolean {
-  return tabs.some(
-    (tab) =>
-      tab.documentEdit?.saving === true &&
-      tab.connectionId === connectionId &&
-      tab.db === db &&
-      (collection === undefined || tab.collection === collection)
+  return saves.some(
+    (save) =>
+      save.connectionId === connectionId &&
+      save.db === db &&
+      (collection === undefined || save.collection === collection)
   );
 }

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -57,6 +57,7 @@
     "deletedTitle": "Gelöscht",
     "documentDeletedFrom": "Dokument aus {{collection}} gelöscht",
     "documentInsertedInto": "Dokument in {{collection}} eingefügt",
+    "documentSaveInProgress": "Warte, bis das Dokument gespeichert ist, bevor du diesen Tab verschiebst.",
     "documentSavedIn": "Dokument in {{collection}} gespeichert",
     "downloadFailed": "Herunterladen fehlgeschlagen: {{detail}}",
     "dumpFailedToStart": "Dump konnte nicht gestartet werden: {{detail}}",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -57,6 +57,7 @@
     "deletedTitle": "Gelöscht",
     "documentDeletedFrom": "Dokument aus {{collection}} gelöscht",
     "documentInsertedInto": "Dokument in {{collection}} eingefügt",
+    "documentEditNotSynced": "Der Dokumententwurf dieses Tabs konnte nicht gespeichert werden. Der Tab wurde nicht verschoben.",
     "documentSaveInProgress": "Warte, bis das Dokument gespeichert ist, bevor du diesen Tab verschiebst.",
     "documentSavedIn": "Dokument in {{collection}} gespeichert",
     "downloadFailed": "Herunterladen fehlgeschlagen: {{detail}}",

--- a/src/locales/de/sidebar.json
+++ b/src/locales/de/sidebar.json
@@ -161,6 +161,7 @@
     "pinned": "An Seitenleiste angeheftet",
     "readOnlyBlocked": "Diese Verbindung ist schreibgeschützt (Produktionsschutz). Ändere den Verbindungsmodus im Verbindungsmanager, um Daten zu bearbeiten.",
     "removedFromFavorites": "Aus Favoriten entfernt",
+    "namespaceBusyWithSave": "Hier wird gerade ein Dokument gespeichert. Warte, bis das fertig ist, bevor du umbenennst.",
     "renameCollectionFailed": "Collection konnte nicht umbenannt werden: {{error}}",
     "renameDatabaseFailed": "Datenbank konnte nicht umbenannt werden: {{error}}",
     "savedQueryGone": "Gespeicherte Abfrage existiert nicht mehr",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -58,6 +58,7 @@
     "documentDeletedFrom": "Document deleted from {{collection}}",
     "documentInsertedInto": "Document inserted into {{collection}}",
     "documentSavedIn": "Document saved in {{collection}}",
+    "documentSaveInProgress": "Wait for the document save to finish before moving this tab.",
     "downloadFailed": "Download failed: {{detail}}",
     "dumpFailedToStart": "Dump failed to start: {{detail}}",
     "exportedDocuments_one": "Exported {{count}} document(s) to {{path}}",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -56,6 +56,7 @@
     "deletedTitle": "Deleted",
     "deleteFailed": "Delete failed: {{detail}}",
     "documentDeletedFrom": "Document deleted from {{collection}}",
+    "documentEditNotSynced": "Could not save this tab’s document draft. The tab was not moved.",
     "documentInsertedInto": "Document inserted into {{collection}}",
     "documentSavedIn": "Document saved in {{collection}}",
     "documentSaveInProgress": "Wait for the document save to finish before moving this tab.",

--- a/src/locales/en/sidebar.json
+++ b/src/locales/en/sidebar.json
@@ -157,6 +157,7 @@
     "createDatabaseFailed": "Failed to create database: {{error}}",
     "dropCollectionFailed": "Failed to drop collection: {{error}}",
     "dropDatabaseFailed": "Failed to drop database: {{error}}",
+    "namespaceBusyWithSave": "A document is being saved here. Wait for it to finish before renaming.",
     "noSavedConnection": "No saved connection \"{{name}}\". Add it in Connection Manager, then try again.",
     "pinned": "Pinned to sidebar",
     "readOnlyBlocked": "This connection is read-only (production safeguard). Change the connection mode in its settings to modify data.",

--- a/src/locales/zh-Hans/common.json
+++ b/src/locales/zh-Hans/common.json
@@ -54,6 +54,7 @@
     "deleteFailed": "删除失败：{{detail}}",
     "documentDeletedFrom": "已从 {{collection}} 中删除文档",
     "documentInsertedInto": "已向 {{collection}} 插入文档",
+    "documentEditNotSynced": "无法保存此标签页的文档草稿，标签页未被移动。",
     "documentSaveInProgress": "请等待文档保存完成后再移动此标签页。",
     "documentSavedIn": "已在 {{collection}} 中保存文档",
     "downloadFailed": "下载失败：{{detail}}",

--- a/src/locales/zh-Hans/common.json
+++ b/src/locales/zh-Hans/common.json
@@ -54,6 +54,7 @@
     "deleteFailed": "删除失败：{{detail}}",
     "documentDeletedFrom": "已从 {{collection}} 中删除文档",
     "documentInsertedInto": "已向 {{collection}} 插入文档",
+    "documentSaveInProgress": "请等待文档保存完成后再移动此标签页。",
     "documentSavedIn": "已在 {{collection}} 中保存文档",
     "downloadFailed": "下载失败：{{detail}}",
     "dumpFailedToStart": "备份导出启动失败：{{detail}}",

--- a/src/locales/zh-Hans/sidebar.json
+++ b/src/locales/zh-Hans/sidebar.json
@@ -161,6 +161,7 @@
     "pinned": "已固定到侧边栏",
     "readOnlyBlocked": "此连接为只读（生产保护）。如需修改数据，请在连接设置中更改连接模式。",
     "removedFromFavorites": "已从收藏中移除",
+    "namespaceBusyWithSave": "此处正在保存文档，请等待完成后再重命名。",
     "renameCollectionFailed": "重命名 Collection 失败：{{error}}",
     "renameDatabaseFailed": "重命名数据库失败：{{error}}",
     "savedQueryGone": "该已保存的查询已不存在",

--- a/src/workspace/__tests__/persistence.test.ts
+++ b/src/workspace/__tests__/persistence.test.ts
@@ -344,6 +344,7 @@ describe('materializeArrivingTab', () => {
 describe('an in-progress document edit travels with its tab (#326 review)', () => {
   const connections: PersistableConnection[] = [{ id: 'live-conn-1', profileId: 'p1', name: 'Profile 1' }];
   const edit = {
+    id: 'edit-1',
     mode: 'edit',
     initialJson: '{"_id":"1"}',
     targetDoc: { _id: '1' },
@@ -355,6 +356,7 @@ describe('an in-progress document edit travels with its tab (#326 review)', () =
   it('carries the text, and leaves the pending save and its failure behind', () => {
     const carried = carriedDocumentEdit(edit) as Record<string, unknown>;
     expect(carried).toEqual({
+      id: 'edit-1',
       mode: 'edit',
       initialJson: '{"_id":"1"}',
       targetDoc: { _id: '1' },

--- a/src/workspace/__tests__/persistence.test.ts
+++ b/src/workspace/__tests__/persistence.test.ts
@@ -6,6 +6,7 @@ import {
   toProfileSpaceId,
   toLiveSpaceId,
   materializeArrivingTab,
+  carriedDocumentEdit,
   type PersistableTab,
   type PersistableConnection,
   type PersistedTab,
@@ -333,6 +334,75 @@ describe('materializeArrivingTab', () => {
     expect(isLive).toBe(false);
     expect(tab.id).toBe('tasks');
     expect(tab.connectionId).toBe('');
+  });
+});
+
+
+// #326 review: a tab moved or detached to another window is rebuilt there from
+// the persisted model, so anything missing from the model the move discards.
+// Before this, that included the document the user was part-way through typing.
+describe('an in-progress document edit travels with its tab (#326 review)', () => {
+  const connections: PersistableConnection[] = [{ id: 'live-conn-1', profileId: 'p1', name: 'Profile 1' }];
+  const edit = {
+    mode: 'edit',
+    initialJson: '{"_id":"1"}',
+    targetDoc: { _id: '1' },
+    draft: '{"_id":"1","name":"half typed"}',
+    error: 'a failure from the window it left',
+    saving: true,
+  };
+
+  it('carries the text, and leaves the pending save and its failure behind', () => {
+    const carried = carriedDocumentEdit(edit) as Record<string, unknown>;
+    expect(carried).toEqual({
+      mode: 'edit',
+      initialJson: '{"_id":"1"}',
+      targetDoc: { _id: '1' },
+      draft: '{"_id":"1","name":"half typed"}',
+    });
+    // `saving` must not travel: the request belongs to the window that made it
+    // and settles there, so an arriving tab claiming one was in flight would
+    // disable Save with nothing left to finish it.
+    expect(carried.saving).toBeUndefined();
+    expect(carried.error).toBeUndefined();
+  });
+
+  it('has nothing to carry for a tab with no edit open', () => {
+    expect(carriedDocumentEdit(undefined)).toBeUndefined();
+    expect(carriedDocumentEdit(null)).toBeUndefined();
+  });
+
+  it('puts it on the persisted tab', () => {
+    const persisted = toPersistedTab(
+      {
+        id: 'live-conn-1.mydb.mycoll',
+        type: 'collection',
+        connectionId: 'live-conn-1',
+        db: 'mydb',
+        collection: 'mycoll',
+        documentEdit: edit,
+      },
+      { id: 'live-conn-1', profileId: 'p1', name: 'Profile 1' },
+      undefined
+    );
+    expect((persisted?.documentEdit as Record<string, unknown>).draft).toBe('{"_id":"1","name":"half typed"}');
+    expect((persisted?.documentEdit as Record<string, unknown>).saving).toBeUndefined();
+  });
+
+  it('hands it to the tab the destination window builds', () => {
+    const { tab } = materializeArrivingTab(
+      {
+        id: 'profile:p1.mydb.mycoll',
+        type: 'collection',
+        profileId: 'p1',
+        profileName: 'Profile 1',
+        db: 'mydb',
+        collection: 'mycoll',
+        documentEdit: carriedDocumentEdit(edit),
+      },
+      connections
+    );
+    expect((tab.documentEdit as Record<string, unknown>).draft).toBe('{"_id":"1","name":"half typed"}');
   });
 });
 

--- a/src/workspace/__tests__/persistence.test.ts
+++ b/src/workspace/__tests__/persistence.test.ts
@@ -408,6 +408,50 @@ describe('an in-progress document edit travels with its tab (#326 review)', () =
   });
 });
 
+
+// #326 review: three ways the transfer could still lose or duplicate work —
+// the boot path a detached window actually takes, the debounce racing an
+// immediate move, and a request that cannot travel with the tab that made it.
+describe('a document edit survives the whole transfer (#326 review)', () => {
+  const carried = {
+    id: 'edit-1',
+    mode: 'insert',
+    initialJson: '{}',
+    targetDoc: null,
+    draft: '{"name":"half typed"}',
+  };
+
+  it('reaches a window that boots into it, not only one already running', () => {
+    // "Detach to New Window" starts the destination renderer, which reads the
+    // workspace through this function rather than through
+    // `materializeArrivingTab` — so omitting the field here discarded the draft
+    // on exactly the path the transfer exists for.
+    const ws: PersistedWorkspace = {
+      revision: 1,
+      windows: [
+        {
+          id: 'win-2',
+          splitTree: { kind: 'pane', id: 'pane-1', tabIds: ['profile:p1.mydb.mycoll'], activeTabId: 'profile:p1.mydb.mycoll' },
+          focusedPaneId: 'pane-1',
+        },
+      ],
+      tabs: [
+        {
+          id: 'profile:p1.mydb.mycoll',
+          type: 'collection',
+          profileId: 'p1',
+          profileName: 'Profile 1',
+          db: 'mydb',
+          collection: 'mycoll',
+          documentEdit: carried,
+        },
+      ],
+    };
+    const { tabs } = toDisconnectedSnapshot(ws, 'win-2');
+    expect((tabs[0].documentEdit as Record<string, unknown>).draft).toBe('{"name":"half typed"}');
+  });
+});
+
 // CRITICAL regression coverage: before this fix, `dispatchWorkspace`'s
 // mirror sent op ids VERBATIM (live-connection space) while `toPersistedTab`
 // rewrote the nested `open_tab.tab` payload into profile-space — splitting

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
 
-import { updateTabState, flushTabState, cancelTabState, hasPendingDocumentEdit, applyTabOp, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
+import { updateTabState, flushTabState, cancelTabState, hasPendingDocumentEdit, applyTabOp, renameTabState, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
 import { toPersistedTab, toProfileSpaceId, type PersistableConnection } from '../persistence';
 import type { WorkspaceAction } from '../model';
 
@@ -142,6 +142,54 @@ describe('workspaceStore', () => {
     settleFirst(undefined);
     await closed;
     expect(order).toEqual(['start:update_tab_state', 'start:close_tab']);
+  });
+
+
+  it('renameTabState moves a queued patch onto the tab\'s new id', async () => {
+    // #326 review: a patch restored after a failed write is keyed by the id it
+    // was sent with. Rename the collection and that id is free again — reopen it
+    // later and the deterministic id returns with a renamed tab's draft still
+    // queued against it.
+    invokeMock.mockRejectedValueOnce(new Error('backend down'));
+    updateTabState('old-id', { documentEdit: { draft: 'half typed' } });
+    expect(await flushTabState('old-id')).toBe(false);
+    expect(hasPendingDocumentEdit('old-id')).toBe(true);
+
+    renameTabState('old-id', 'new-id');
+    expect(hasPendingDocumentEdit('old-id')).toBe(false);
+    expect(hasPendingDocumentEdit('new-id')).toBe(true);
+
+    invokeMock.mockClear();
+    vi.advanceTimersByTime(500);
+    expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
+      op: { type: 'update_tab_state', tab_id: 'new-id', document_edit: { draft: 'half typed' } },
+      origin: 'main',
+    });
+  });
+
+  it('renameTabState lets a value already queued under the new id win', () => {
+    updateTabState('old-id', { documentEdit: { draft: 'older' } });
+    updateTabState('new-id', { documentEdit: { draft: 'newer' } });
+    renameTabState('old-id', 'new-id');
+
+    invokeMock.mockClear();
+    vi.advanceTimersByTime(500);
+    const forNewId = invokeMock.mock.calls.filter(([, a]: any) => (a.op as any).tab_id === 'new-id');
+    expect(forNewId).toHaveLength(1);
+    expect((forNewId[0][1].op as any).document_edit).toEqual({ draft: 'newer' });
+  });
+
+  it('renameTabState disowns a write still out under the old id', async () => {
+    // It cannot be recalled, but its failure must not restore a patch under an
+    // id that is nobody's tab now.
+    let rejectWrite!: (e: Error) => void;
+    invokeMock.mockImplementationOnce(() => new Promise((_, r) => { rejectWrite = r; }));
+    updateTabState('old-id', { documentEdit: { draft: 'half typed' } });
+    vi.advanceTimersByTime(500);
+
+    renameTabState('old-id', 'new-id');
+    rejectWrite(new Error('backend down'));
+    await vi.waitFor(() => expect(hasPendingDocumentEdit('old-id')).toBe(false));
   });
 
 

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
 
-import { updateTabState, flushTabState, cancelTabState, hasPendingDocumentEdit, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
+import { updateTabState, flushTabState, cancelTabState, hasPendingDocumentEdit, applyTabOp, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
 import { toPersistedTab, toProfileSpaceId, type PersistableConnection } from '../persistence';
 import type { WorkspaceAction } from '../model';
 
@@ -96,6 +96,54 @@ describe('workspaceStore', () => {
     await flushed;
     expect(done).toBe(true);
   });
+
+  it('keeps counting a draft when a second write for the tab overlaps it', async () => {
+    // #326 review: tracking one write per tab meant the second erased the
+    // first's record. A query-state update starting while a draft was still in
+    // flight made `hasPendingDocumentEdit` report false, and a move could go.
+    let settleDraft!: (v: unknown) => void;
+    invokeMock.mockImplementationOnce(() => new Promise((r) => { settleDraft = r; }));
+    updateTabState('t1', { documentEdit: { draft: '{"name":"Ada"}' } });
+    vi.advanceTimersByTime(500);
+    expect(hasPendingDocumentEdit('t1')).toBe(true);
+
+    // A second, unrelated write for the same tab while the first is away.
+    updateTabState('t1', { lastQuery: { filter: '{}' } });
+    vi.advanceTimersByTime(500);
+    expect(hasPendingDocumentEdit('t1')).toBe(true);
+
+    settleDraft(undefined);
+    await vi.waitFor(() => expect(hasPendingDocumentEdit('t1')).toBe(false));
+  });
+
+  it('runs a tab\'s writes one at a time, in the order they were issued', async () => {
+    // The close of a tab must not overtake a draft still on its way, and the
+    // reopen that reuses the id must not overtake the close (#326 review).
+    const order: string[] = [];
+    let settleFirst!: (v: unknown) => void;
+    invokeMock.mockImplementationOnce((_cmd: string, args: any) => {
+      order.push(`start:${args.op.type}`);
+      return new Promise((r) => { settleFirst = r; });
+    });
+    invokeMock.mockImplementation((_cmd: string, args: any) => {
+      order.push(`start:${args.op.type}`);
+      return Promise.resolve();
+    });
+
+    updateTabState('t1', { documentEdit: { draft: 'half typed' } });
+    vi.advanceTimersByTime(500);
+    expect(order).toEqual(['start:update_tab_state']);
+
+    // Issued while the draft write is still out; must not start yet.
+    const closed = applyTabOp(['t1'], { type: 'close_tab', tab_id: 't1' });
+    await Promise.resolve();
+    expect(order).toEqual(['start:update_tab_state']);
+
+    settleFirst(undefined);
+    await closed;
+    expect(order).toEqual(['start:update_tab_state', 'start:close_tab']);
+  });
+
 
   it('cancelTabState drops a pending patch instead of sending it late', () => {
     // Tab ids are deterministic: close a tab mid-debounce and reopen the same

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
 
-import { updateTabState, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
+import { updateTabState, flushTabState, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
 import { toPersistedTab, toProfileSpaceId, type PersistableConnection } from '../persistence';
 import type { WorkspaceAction } from '../model';
 
@@ -53,6 +53,32 @@ describe('workspaceStore', () => {
       origin: 'main',
     });
   });
+
+  it('flushTabState sends a pending patch immediately, and only once', () => {
+    // #326 review: a cross-window move is issued immediately and is
+    // backend-authoritative, so the destination reads the tab as the backend
+    // has it right then. A draft still sitting in the debounce would not be
+    // there — and the flush that followed is not a cross-window op, so the
+    // destination would never reconcile it.
+    updateTabState('t1', { documentEdit: { draft: '{"name":"half typed"}' } });
+    expect(invokeMock).not.toHaveBeenCalled();
+
+    flushTabState('t1');
+    expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
+      op: { type: 'update_tab_state', tab_id: 't1', document_edit: { draft: '{"name":"half typed"}' } },
+      origin: 'main',
+    });
+
+    // The timer it pre-empted must not fire a second write.
+    vi.advanceTimersByTime(500);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushTabState is a no-op for a tab with nothing pending', () => {
+    flushTabState('t-nothing');
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
 
   it('omits fields never passed to updateTabState (no key at all, not undefined)', () => {
     updateTabState('t1', { lastQuery: { filter: '{}' } });

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -132,6 +132,41 @@ describe('workspaceStore', () => {
     expect(hasPendingDocumentEdit('t2')).toBe(false);
   });
 
+  it('keeps a patch pending when its write fails, so a retry still has it', async () => {
+    // #326 review: a move aborts on a failed flush — but if the patch were
+    // spent, the next attempt would find nothing queued, report success without
+    // writing, and move against the same stale model the first attempt refused.
+    invokeMock.mockRejectedValueOnce(new Error('backend down'));
+    updateTabState('t1', { documentEdit: { draft: '{"name":"Ada"}' } });
+
+    expect(await flushTabState('t1')).toBe(false);
+    expect(hasPendingDocumentEdit('t1')).toBe(true);
+
+    // The retry writes it, and this time it lands.
+    invokeMock.mockClear();
+    expect(await flushTabState('t1')).toBe(true);
+    expect(invokeMock).toHaveBeenCalledWith('workspace_apply', {
+      op: { type: 'update_tab_state', tab_id: 't1', document_edit: { draft: '{"name":"Ada"}' } },
+      origin: 'main',
+    });
+    expect(hasPendingDocumentEdit('t1')).toBe(false);
+  });
+
+  it('lets a newer value win over one whose write failed', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('backend down'));
+    updateTabState('t1', { documentEdit: { draft: 'first' } });
+    const failing = flushTabState('t1');
+    // Typed while that request was in flight.
+    updateTabState('t1', { documentEdit: { draft: 'second' } });
+    expect(await failing).toBe(false);
+
+    invokeMock.mockClear();
+    await flushTabState('t1');
+    const [, { op }] = invokeMock.mock.calls[0];
+    expect((op as any).document_edit).toEqual({ draft: 'second' });
+  });
+
+
 
 
 

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
 
-import { updateTabState, flushTabState, cancelTabState, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
+import { updateTabState, flushTabState, cancelTabState, hasPendingDocumentEdit, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
 import { toPersistedTab, toProfileSpaceId, type PersistableConnection } from '../persistence';
 import type { WorkspaceAction } from '../model';
 
@@ -113,6 +113,25 @@ describe('workspaceStore', () => {
     vi.advanceTimersByTime(500);
     expect(invokeMock).not.toHaveBeenCalled();
   });
+
+  it('hasPendingDocumentEdit reports a queued clear, not just a queued draft', () => {
+    // #326 review: cancelling an edit removes it from the tab at once while its
+    // `document_edit: null` is still in the debounce. At that moment the tab has
+    // no edit and the backend still holds the draft — so "does this tab have an
+    // edit" is the wrong question to gate a move on.
+    expect(hasPendingDocumentEdit('t1')).toBe(false);
+
+    updateTabState('t1', { documentEdit: null });
+    expect(hasPendingDocumentEdit('t1')).toBe(true);
+
+    vi.advanceTimersByTime(500);
+    expect(hasPendingDocumentEdit('t1')).toBe(false);
+
+    // A patch about something else is not a reason to hold up a move.
+    updateTabState('t2', { lastQuery: { filter: '{}' } });
+    expect(hasPendingDocumentEdit('t2')).toBe(false);
+  });
+
 
 
 

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
 
-import { updateTabState, flushTabState, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
+import { updateTabState, flushTabState, cancelTabState, resetUpdateTabStateDebounce, workspaceApply, workspaceGet, actionToOp } from '../workspaceStore';
 import { toPersistedTab, toProfileSpaceId, type PersistableConnection } from '../persistence';
 import type { WorkspaceAction } from '../model';
 
@@ -78,6 +78,42 @@ describe('workspaceStore', () => {
     flushTabState('t-nothing');
     expect(invokeMock).not.toHaveBeenCalled();
   });
+
+  it('flushTabState resolves only once the backend write settles', async () => {
+    // #326 review: a move is a separate backend command, so starting the flush
+    // first buys no ordering — the move could take the store first and snapshot
+    // the older draft. Callers await this, so it has to mean something.
+    let settle!: () => void;
+    invokeMock.mockImplementationOnce(() => new Promise<void>((r) => { settle = r; }));
+    updateTabState('t1', { documentEdit: { draft: '{"name":"Ada"}' } });
+
+    let done = false;
+    const flushed = flushTabState('t1').then(() => { done = true; });
+    await Promise.resolve();
+    expect(done).toBe(false);
+
+    settle();
+    await flushed;
+    expect(done).toBe(true);
+  });
+
+  it('cancelTabState drops a pending patch instead of sending it late', () => {
+    // Tab ids are deterministic: close a tab mid-debounce and reopen the same
+    // collection, and the queued draft would land on the new model — an editor
+    // the user closed, attached to a tab that never had one.
+    updateTabState('t1', { documentEdit: { draft: '{"name":"Ada"}' } });
+    cancelTabState('t1');
+    vi.advanceTimersByTime(500);
+    expect(invokeMock).not.toHaveBeenCalled();
+
+    // And the batch form, for close_many.
+    updateTabState('t2', { documentEdit: { draft: 'x' } });
+    updateTabState('t3', { documentEdit: { draft: 'y' } });
+    cancelTabState(['t2', 't3']);
+    vi.advanceTimersByTime(500);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
 
 
   it('omits fields never passed to updateTabState (no key at all, not undefined)', () => {

--- a/src/workspace/__tests__/workspaceStore.test.ts
+++ b/src/workspace/__tests__/workspaceStore.test.ts
@@ -114,7 +114,7 @@ describe('workspaceStore', () => {
     expect(invokeMock).not.toHaveBeenCalled();
   });
 
-  it('hasPendingDocumentEdit reports a queued clear, not just a queued draft', () => {
+  it('hasPendingDocumentEdit reports a queued clear, not just a queued draft', async () => {
     // #326 review: cancelling an edit removes it from the tab at once while its
     // `document_edit: null` is still in the debounce. At that moment the tab has
     // no edit and the backend still holds the draft — so "does this tab have an
@@ -124,13 +124,41 @@ describe('workspaceStore', () => {
     updateTabState('t1', { documentEdit: null });
     expect(hasPendingDocumentEdit('t1')).toBe(true);
 
+    // Still pending once the timer fires: it has left the queue but the backend
+    // has not answered yet, and that interval is the one a move must not slip
+    // through. Only settling clears it.
     vi.advanceTimersByTime(500);
-    expect(hasPendingDocumentEdit('t1')).toBe(false);
+    expect(hasPendingDocumentEdit('t1')).toBe(true);
+    await vi.waitFor(() => expect(hasPendingDocumentEdit('t1')).toBe(false));
 
     // A patch about something else is not a reason to hold up a move.
     updateTabState('t2', { lastQuery: { filter: '{}' } });
     expect(hasPendingDocumentEdit('t2')).toBe(false);
   });
+
+  it('counts a write that has left the queue but not landed', async () => {
+    // #326 review: between the debounce firing and the backend answering, the
+    // tab looked synchronized — nothing queued — so a move could start and
+    // overtake the write it was supposed to follow.
+    let settle!: (v: unknown) => void;
+    invokeMock.mockImplementationOnce(() => new Promise((r) => { settle = r; }));
+    updateTabState('t1', { documentEdit: { draft: '{"name":"Ada"}' } });
+    vi.advanceTimersByTime(500);
+
+    // Queue is empty, but the backend does not have it yet.
+    expect(hasPendingDocumentEdit('t1')).toBe(true);
+
+    let moved = false;
+    const ready = flushTabState('t1').then((ok) => { moved = ok; });
+    await Promise.resolve();
+    expect(moved).toBe(false);
+
+    settle(undefined);
+    await ready;
+    expect(moved).toBe(true);
+    expect(hasPendingDocumentEdit('t1')).toBe(false);
+  });
+
 
   it('keeps a patch pending when its write fails, so a retry still has it', async () => {
     // #326 review: a move aborts on a failed flush — but if the patch were

--- a/src/workspace/persistence.ts
+++ b/src/workspace/persistence.ts
@@ -110,8 +110,10 @@ export interface PersistableTab {
  */
 export function carriedDocumentEdit(edit: unknown): unknown {
   if (!edit || typeof edit !== 'object') return undefined;
-  const { mode, initialJson, targetDoc, draft } = edit as Record<string, unknown>;
-  return { mode, initialJson, targetDoc: targetDoc ?? null, draft };
+  const { id, mode, initialJson, targetDoc, draft } = edit as Record<string, unknown>;
+  // `id` travels so the arriving edit keeps the identity its completions are
+  // matched against; the rest is the text itself.
+  return { id, mode, initialJson, targetDoc: targetDoc ?? null, draft };
 }
 
 export interface PersistableConnection {

--- a/src/workspace/persistence.ts
+++ b/src/workspace/persistence.ts
@@ -284,6 +284,11 @@ export function toDisconnectedSnapshot(
     explainResult: null,
     lastQuery: t.lastQuery,
     lastAggregate: t.lastAggregate,
+    // The other way a tab reaches a new window. "Detach to New Window" boots
+    // the destination renderer through `workspace_get` and this function, not
+    // through `materializeArrivingTab` — so leaving it out here discarded the
+    // draft on exactly the path the transfer was added for (#326 review).
+    documentEdit: t.documentEdit,
   }));
 
   const builderStates = new Map<string, unknown>();

--- a/src/workspace/persistence.ts
+++ b/src/workspace/persistence.ts
@@ -65,6 +65,7 @@ export interface PersistedTab {
   lastQuery?: unknown;
   lastAggregate?: unknown;
   builderState?: unknown;
+  documentEdit?: unknown;
 }
 
 export interface PersistedWindow {
@@ -92,6 +93,25 @@ export interface PersistableTab {
   indexName?: string;
   lastQuery?: unknown;
   lastAggregate?: unknown;
+  documentEdit?: unknown;
+}
+
+/** The part of an in-progress document edit that travels with its tab.
+ *
+ *  A tab moved to another window is rebuilt there from the persisted model, so
+ *  an edit that is not in the model is an edit the move throws away — the text
+ *  the user had typed and not yet saved (#326 review).
+ *
+ *  What is left behind is deliberate. `saving` belongs to the window that made
+ *  the request: it will settle there, and an arriving tab that claimed a save
+ *  was in flight would disable Save with nothing left to finish it. `error` is
+ *  the outcome of a request the destination never made, and stale by the time
+ *  it lands. The text is the part worth keeping.
+ */
+export function carriedDocumentEdit(edit: unknown): unknown {
+  if (!edit || typeof edit !== 'object') return undefined;
+  const { mode, initialJson, targetDoc, draft } = edit as Record<string, unknown>;
+  return { mode, initialJson, targetDoc: targetDoc ?? null, draft };
 }
 
 export interface PersistableConnection {
@@ -116,6 +136,7 @@ export interface RestoredTab {
   explainResult: string | null;
   lastQuery?: unknown;
   lastAggregate?: unknown;
+  documentEdit?: unknown;
 }
 
 // export/import tabs reference in-flight task state that no longer exists
@@ -190,6 +211,7 @@ export function toPersistedTab(
       lastQuery: tab.lastQuery,
       lastAggregate: tab.lastAggregate,
       builderState,
+      documentEdit: carriedDocumentEdit(tab.documentEdit),
     };
   }
 
@@ -207,6 +229,7 @@ export function toPersistedTab(
     lastQuery: tab.lastQuery,
     lastAggregate: tab.lastAggregate,
     builderState,
+    documentEdit: carriedDocumentEdit(tab.documentEdit),
   };
 }
 
@@ -315,6 +338,9 @@ export function materializeArrivingTab(
       explainResult: null,
       lastQuery: tab.lastQuery,
       lastAggregate: tab.lastAggregate,
+      // Carried through so a moved tab arrives with the text the user was
+      // typing rather than an empty dialog (#326 review).
+      documentEdit: tab.documentEdit,
     },
   };
 }

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -43,16 +43,19 @@ export async function workspaceGet(): Promise<PersistedWorkspace | null> {
  * `workspace-changed` listener recognize and ignore its own echo — see
  * App.tsx's foreign-event reconciliation effect.
  */
-export function workspaceApply(op: Record<string, unknown>): Promise<void> {
-  // Returns the promise so a caller that must not race it can wait — a
-  // cross-window move reads the backend store as it stands, so the draft it
-  // carries has to have landed first (#326 review). Callers with no ordering
-  // requirement ignore it exactly as before; the rejection is still handled
-  // here, so an ignored promise never surfaces as an unhandled one.
+export function workspaceApply(op: Record<string, unknown>): Promise<boolean> {
+  // Resolves to whether the write landed, rather than rejecting. Most callers
+  // are fire-and-forget and ignore the result, so a rejection here would be an
+  // unhandled one — but a caller that must not race the write needs to know it
+  // happened at all: a cross-window move that proceeds on a failed flush reads
+  // a stale model, which either drops the newest draft or brings back an editor
+  // whose insert already succeeded, ready to write the document twice
+  // (#326 review). Reporting it as a value keeps both callers honest.
   return invoke('workspace_apply', { op, origin: windowLabel() })
-    .then(() => undefined)
+    .then(() => true)
     .catch((err) => {
       console.warn('workspace_apply failed', err);
+      return false;
     });
 }
 
@@ -353,11 +356,11 @@ const DEBOUNCE_MS = 500;
 const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const pendingPatches = new Map<string, UpdateTabStatePatch>();
 
-function flushUpdateTabState(tabId: string): Promise<void> {
+function flushUpdateTabState(tabId: string): Promise<boolean> {
   debounceTimers.delete(tabId);
   const patch = pendingPatches.get(tabId);
   pendingPatches.delete(tabId);
-  if (!patch) return Promise.resolve();
+  if (!patch) return Promise.resolve(true);
 
   const op: Record<string, unknown> = { type: 'update_tab_state', tab_id: tabId };
   if ('lastQuery' in patch) op.last_query = patch.lastQuery;
@@ -398,7 +401,7 @@ export function updateTabState(tabId: string, patch: UpdateTabStatePatch): void 
  * the destination never reconciles it (#326 review). Callers about to issue a
  * move or a detach flush first, so what travels is what is on screen.
  */
-export function flushTabState(tabId: string): Promise<void> {
+export function flushTabState(tabId: string): Promise<boolean> {
   const timer = debounceTimers.get(tabId);
   if (timer !== undefined) clearTimeout(timer);
   return flushUpdateTabState(tabId);

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -333,6 +333,13 @@ export interface UpdateTabStatePatch {
   lastQuery?: unknown;
   lastAggregate?: unknown;
   builderState?: unknown;
+  /** The tab's unsaved document edit, or `null` once it is over.
+   *
+   *  Mirrored because a tab moved to another window is materialized from the
+   *  backend's copy — so an edit that never reached it is an edit the move
+   *  discards (#326 review). `null` rather than omitted on close: absent means
+   *  "untouched", which would leave a finished draft on the model. */
+  documentEdit?: unknown;
 }
 
 const DEBOUNCE_MS = 500;
@@ -349,6 +356,7 @@ function flushUpdateTabState(tabId: string): void {
   if ('lastQuery' in patch) op.last_query = patch.lastQuery;
   if ('lastAggregate' in patch) op.last_aggregate = patch.lastAggregate;
   if ('builderState' in patch) op.builder_state = patch.builderState;
+  if ('documentEdit' in patch) op.document_edit = patch.documentEdit;
   workspaceApply(op);
 }
 

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -43,10 +43,17 @@ export async function workspaceGet(): Promise<PersistedWorkspace | null> {
  * `workspace-changed` listener recognize and ignore its own echo — see
  * App.tsx's foreign-event reconciliation effect.
  */
-export function workspaceApply(op: Record<string, unknown>): void {
-  invoke('workspace_apply', { op, origin: windowLabel() }).catch((err) => {
-    console.warn('workspace_apply failed', err);
-  });
+export function workspaceApply(op: Record<string, unknown>): Promise<void> {
+  // Returns the promise so a caller that must not race it can wait — a
+  // cross-window move reads the backend store as it stands, so the draft it
+  // carries has to have landed first (#326 review). Callers with no ordering
+  // requirement ignore it exactly as before; the rejection is still handled
+  // here, so an ignored promise never surfaces as an unhandled one.
+  return invoke('workspace_apply', { op, origin: windowLabel() })
+    .then(() => undefined)
+    .catch((err) => {
+      console.warn('workspace_apply failed', err);
+    });
 }
 
 /**
@@ -346,18 +353,18 @@ const DEBOUNCE_MS = 500;
 const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const pendingPatches = new Map<string, UpdateTabStatePatch>();
 
-function flushUpdateTabState(tabId: string): void {
+function flushUpdateTabState(tabId: string): Promise<void> {
   debounceTimers.delete(tabId);
   const patch = pendingPatches.get(tabId);
   pendingPatches.delete(tabId);
-  if (!patch) return;
+  if (!patch) return Promise.resolve();
 
   const op: Record<string, unknown> = { type: 'update_tab_state', tab_id: tabId };
   if ('lastQuery' in patch) op.last_query = patch.lastQuery;
   if ('lastAggregate' in patch) op.last_aggregate = patch.lastAggregate;
   if ('builderState' in patch) op.builder_state = patch.builderState;
   if ('documentEdit' in patch) op.document_edit = patch.documentEdit;
-  workspaceApply(op);
+  return workspaceApply(op);
 }
 
 /**
@@ -391,10 +398,29 @@ export function updateTabState(tabId: string, patch: UpdateTabStatePatch): void 
  * the destination never reconciles it (#326 review). Callers about to issue a
  * move or a detach flush first, so what travels is what is on screen.
  */
-export function flushTabState(tabId: string): void {
+export function flushTabState(tabId: string): Promise<void> {
   const timer = debounceTimers.get(tabId);
   if (timer !== undefined) clearTimeout(timer);
-  flushUpdateTabState(tabId);
+  return flushUpdateTabState(tabId);
+}
+
+/**
+ * Drop `tabId`'s pending patch without sending it.
+ *
+ * Tab ids are deterministic, so closing a tab and reopening the same
+ * collection produces the same id. A draft still inside the debounce would
+ * then land on the newly created model — an editor the user closed,
+ * reattached to a tab that never had one, waiting for the next restart or
+ * move to bring it back (#326 review). A patch for a tab that is gone
+ * describes nothing, so it goes with it.
+ */
+export function cancelTabState(tabIds: string | string[]): void {
+  for (const tabId of Array.isArray(tabIds) ? tabIds : [tabIds]) {
+    const timer = debounceTimers.get(tabId);
+    if (timer !== undefined) clearTimeout(timer);
+    debounceTimers.delete(tabId);
+    pendingPatches.delete(tabId);
+  }
 }
 
 /** Test-only: flush and clear all pending debounced updateTabState timers. */

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -355,43 +355,120 @@ export interface UpdateTabStatePatch {
 const DEBOUNCE_MS = 500;
 const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const pendingPatches = new Map<string, UpdateTabStatePatch>();
-/** Writes that have left the queue but not yet landed.
+/**
+ * What is still owed to the backend for one tab.
  *
- *  A patch is queued, then in flight, then done, and only the first of those
- *  was visible. Between the debounce firing and the backend answering, a tab
- *  looked synchronized: a move could start, reach the store first, and carry
- *  the older draft — or the editor a cancel or a completed insert had just
- *  cleared, offering it for a second write (#326 review). */
-const inFlightWrites = new Map<string, { done: Promise<boolean>; documentEdit: boolean }>();
+ * Every write naming a tab goes through here, and they run one at a time in
+ * the order they were issued. That ordering is the point. A tab's writes reach
+ * a store that also serves other windows, and the interesting ops — a move, a
+ * detach, a close — read it as it stands the moment they arrive, so two writes
+ * for the same tab overtaking each other is the difference between carrying a
+ * draft and carrying the one before it.
+ *
+ * Tracking a single outstanding write was not enough twice over: a second one
+ * replaced the first's record, and a close could not see either (#326 review).
+ * A chain has no such gaps — `tail` is everything outstanding, and
+ * `documentEdits` counts how many of those carry a draft, which is what
+ * decides whether a move may go now.
+ */
+interface TabWrites {
+  tail: Promise<boolean>;
+  documentEdits: number;
+}
+const tabWrites = new Map<string, TabWrites>();
+/** Bumped when a tab closes, so a write issued before it cannot re-queue after. */
+const tabGenerations = new Map<string, number>();
+
+const generationOf = (tabId: string) => tabGenerations.get(tabId) ?? 0;
+
+/**
+ * Run `send` once every write already issued for these tabs has settled, and
+ * count it as outstanding until it settles itself.
+ *
+ * `tabIds` is a list because a `close_many` names several at once: it has to
+ * follow each of their queues, and each of them has to follow it.
+ */
+function chainTabWrites(
+  tabIds: string[],
+  send: () => Promise<boolean>,
+  carriesDocumentEdit = false
+): Promise<boolean> {
+  const settle = (landed: boolean) => {
+    for (const id of tabIds) {
+      const entry = tabWrites.get(id);
+      if (!entry) continue;
+      if (carriesDocumentEdit) entry.documentEdits -= 1;
+      // Only the last write out clears the tab: an earlier one settling says
+      // nothing about the ones still behind it.
+      if (entry.tail === done) tabWrites.delete(id);
+    }
+    return landed;
+  };
+  const priors = tabIds
+    .map((id) => tabWrites.get(id)?.tail)
+    .filter((tail): tail is Promise<boolean> => tail !== undefined);
+  // Nothing outstanding means nothing to order behind, so the write goes now.
+  // Waiting on an already-resolved promise would still cost a turn of the
+  // microtask queue, which is a behaviour change for every write in the app to
+  // buy ordering only some of them need.
+  const done: Promise<boolean> =
+    priors.length === 0 ? send().then(settle) : Promise.all(priors).then(send).then(settle);
+  for (const id of tabIds) {
+    const entry = tabWrites.get(id);
+    tabWrites.set(id, {
+      tail: done,
+      documentEdits: (entry?.documentEdits ?? 0) + (carriesDocumentEdit ? 1 : 0),
+    });
+  }
+  return done;
+}
+
+/**
+ * Mirror one op that names tabs, ordered against everything else for them.
+ *
+ * Used for the ops that create and destroy tab models — a close must not
+ * overtake a draft still on its way, and the reopen that follows must not
+ * overtake the close (#326 review). Ordering only within a tab; ops for
+ * different tabs still run concurrently.
+ */
+export function applyTabOp(tabIds: string[], op: Record<string, unknown>): Promise<boolean> {
+  return chainTabWrites(tabIds, () => workspaceApply(op));
+}
 
 function flushUpdateTabState(tabId: string): Promise<boolean> {
   debounceTimers.delete(tabId);
   const patch = pendingPatches.get(tabId);
   pendingPatches.delete(tabId);
-  if (!patch) return Promise.resolve(true);
+  if (!patch) return tabWrites.get(tabId)?.tail ?? Promise.resolve(true);
 
   const op: Record<string, unknown> = { type: 'update_tab_state', tab_id: tabId };
   if ('lastQuery' in patch) op.last_query = patch.lastQuery;
   if ('lastAggregate' in patch) op.last_aggregate = patch.lastAggregate;
   if ('builderState' in patch) op.builder_state = patch.builderState;
   if ('documentEdit' in patch) op.document_edit = patch.documentEdit;
-  const done = workspaceApply(op).then((landed) => {
-    // A failed write leaves the patch pending, not spent. Dropping it made the
-    // next attempt look clean: nothing queued, so a flush would report success
-    // without writing, and a move would go ahead on the same stale model the
-    // first attempt refused to move against (#326 review).
-    //
-    // Anything queued while this was in flight is newer and wins; the restored
-    // fields only fill what nobody has spoken for since.
-    if (!landed) pendingPatches.set(tabId, { ...patch, ...(pendingPatches.get(tabId) ?? {}) });
-    // Cleared here rather than in a `finally`, so it is gone before anyone
-    // waiting on `done` observes the result — and only if this is still the
-    // write being tracked, since a later one may have replaced it.
-    if (inFlightWrites.get(tabId)?.done === done) inFlightWrites.delete(tabId);
-    return landed;
-  });
-  inFlightWrites.set(tabId, { done, documentEdit: 'documentEdit' in patch });
-  return done;
+  const issuedAt = generationOf(tabId);
+  return chainTabWrites(
+    [tabId],
+    () =>
+      workspaceApply(op).then((landed) => {
+        // A failed write leaves the patch pending, not spent. Dropping it made
+        // the next attempt look clean: nothing queued, so a flush would report
+        // success without writing, and a move would go ahead on the same stale
+        // model the first attempt refused to move against (#326 review).
+        //
+        // Unless the tab closed while this was away — then the patch describes
+        // a model that no longer exists, and re-queueing it would leave a draft
+        // waiting to attach itself to the next tab given the same id.
+        //
+        // Anything queued since is newer and wins; the restored fields fill
+        // only what nobody has spoken for.
+        if (!landed && generationOf(tabId) === issuedAt) {
+          pendingPatches.set(tabId, { ...patch, ...(pendingPatches.get(tabId) ?? {}) });
+        }
+        return landed;
+      }),
+    'documentEdit' in patch
+  );
 }
 
 /**
@@ -426,13 +503,23 @@ export function updateTabState(tabId: string, patch: UpdateTabStatePatch): void 
  * move or a detach flush first, so what travels is what is on screen.
  */
 export async function flushTabState(tabId: string): Promise<boolean> {
-  const timer = debounceTimers.get(tabId);
-  if (timer !== undefined) clearTimeout(timer);
-  // A write already on its way is part of "what is on screen has landed" —
-  // waiting only for the queue would let a move overtake it.
-  const running = inFlightWrites.get(tabId);
-  const ranBefore = running ? await running.done : true;
-  return (await flushUpdateTabState(tabId)) && ranBefore;
+  // Repeats because the wait is a gap: a keystroke during it queues a patch
+  // behind the one being sent. Each pass sends what is queued and waits for
+  // everything outstanding; it returns when a pass finds neither.
+  for (let pass = 0; pass < 8; pass++) {
+    const timer = debounceTimers.get(tabId);
+    if (timer !== undefined) clearTimeout(timer);
+    // A write that did not land ends this: the patch stays pending, and
+    // whether to try again is the caller's call, not a loop's.
+    if (!(await flushUpdateTabState(tabId))) return false;
+    const outstanding = tabWrites.get(tabId);
+    if (outstanding && !(await outstanding.tail)) return false;
+    if (!pendingPatches.has(tabId) && !tabWrites.has(tabId)) return true;
+  }
+  // Still not settled after eight rounds. Reporting failure is the honest
+  // answer: the caller's whole reason for asking is that it must not act on a
+  // model it cannot vouch for.
+  return false;
 }
 
 /**
@@ -459,9 +546,11 @@ export async function flushTabState(tabId: string): Promise<boolean> {
 export function hasPendingDocumentEdit(tabId: string): boolean {
   const patch = pendingPatches.get(tabId);
   if (patch && 'documentEdit' in patch) return true;
-  // In flight counts as pending: it has left the queue but the backend does not
-  // have it yet, which is exactly the interval a move must not slip through.
-  return inFlightWrites.get(tabId)?.documentEdit ?? false;
+  // Outstanding counts as pending: a write has left the queue but the backend
+  // does not have it yet, which is exactly the interval a move must not slip
+  // through. Counted rather than flagged, because several can overlap and the
+  // last to settle is not necessarily the one carrying a draft (#326 review).
+  return (tabWrites.get(tabId)?.documentEdits ?? 0) > 0;
 }
 
 export function cancelTabState(tabIds: string | string[]): void {
@@ -470,6 +559,12 @@ export function cancelTabState(tabIds: string | string[]): void {
     if (timer !== undefined) clearTimeout(timer);
     debounceTimers.delete(tabId);
     pendingPatches.delete(tabId);
+    // A write already on its way cannot be recalled, but it can be disowned:
+    // past this generation its failure does not re-queue it, so it cannot come
+    // back to attach a dead tab's draft to the next tab given the same id. The
+    // close op itself is chained behind it, so the model it may land on is
+    // removed immediately afterwards (#326 review).
+    tabGenerations.set(tabId, generationOf(tabId) + 1);
   }
 }
 
@@ -478,5 +573,6 @@ export function resetUpdateTabStateDebounce(): void {
   for (const timer of debounceTimers.values()) clearTimeout(timer);
   debounceTimers.clear();
   pendingPatches.clear();
-  inFlightWrites.clear();
+  tabWrites.clear();
+  tabGenerations.clear();
 }

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -367,7 +367,17 @@ function flushUpdateTabState(tabId: string): Promise<boolean> {
   if ('lastAggregate' in patch) op.last_aggregate = patch.lastAggregate;
   if ('builderState' in patch) op.builder_state = patch.builderState;
   if ('documentEdit' in patch) op.document_edit = patch.documentEdit;
-  return workspaceApply(op);
+  return workspaceApply(op).then((landed) => {
+    // A failed write leaves the patch pending, not spent. Dropping it made the
+    // next attempt look clean: nothing queued, so a flush would report success
+    // without writing, and a move would go ahead on the same stale model the
+    // first attempt refused to move against (#326 review).
+    //
+    // Anything queued while this was in flight is newer and wins; the restored
+    // fields only fill what nobody has spoken for since.
+    if (!landed) pendingPatches.set(tabId, { ...patch, ...(pendingPatches.get(tabId) ?? {}) });
+    return landed;
+  });
 }
 
 /**

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -355,6 +355,14 @@ export interface UpdateTabStatePatch {
 const DEBOUNCE_MS = 500;
 const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const pendingPatches = new Map<string, UpdateTabStatePatch>();
+/** Writes that have left the queue but not yet landed.
+ *
+ *  A patch is queued, then in flight, then done, and only the first of those
+ *  was visible. Between the debounce firing and the backend answering, a tab
+ *  looked synchronized: a move could start, reach the store first, and carry
+ *  the older draft — or the editor a cancel or a completed insert had just
+ *  cleared, offering it for a second write (#326 review). */
+const inFlightWrites = new Map<string, { done: Promise<boolean>; documentEdit: boolean }>();
 
 function flushUpdateTabState(tabId: string): Promise<boolean> {
   debounceTimers.delete(tabId);
@@ -367,7 +375,7 @@ function flushUpdateTabState(tabId: string): Promise<boolean> {
   if ('lastAggregate' in patch) op.last_aggregate = patch.lastAggregate;
   if ('builderState' in patch) op.builder_state = patch.builderState;
   if ('documentEdit' in patch) op.document_edit = patch.documentEdit;
-  return workspaceApply(op).then((landed) => {
+  const done = workspaceApply(op).then((landed) => {
     // A failed write leaves the patch pending, not spent. Dropping it made the
     // next attempt look clean: nothing queued, so a flush would report success
     // without writing, and a move would go ahead on the same stale model the
@@ -376,8 +384,14 @@ function flushUpdateTabState(tabId: string): Promise<boolean> {
     // Anything queued while this was in flight is newer and wins; the restored
     // fields only fill what nobody has spoken for since.
     if (!landed) pendingPatches.set(tabId, { ...patch, ...(pendingPatches.get(tabId) ?? {}) });
+    // Cleared here rather than in a `finally`, so it is gone before anyone
+    // waiting on `done` observes the result — and only if this is still the
+    // write being tracked, since a later one may have replaced it.
+    if (inFlightWrites.get(tabId)?.done === done) inFlightWrites.delete(tabId);
     return landed;
   });
+  inFlightWrites.set(tabId, { done, documentEdit: 'documentEdit' in patch });
+  return done;
 }
 
 /**
@@ -411,10 +425,14 @@ export function updateTabState(tabId: string, patch: UpdateTabStatePatch): void 
  * the destination never reconciles it (#326 review). Callers about to issue a
  * move or a detach flush first, so what travels is what is on screen.
  */
-export function flushTabState(tabId: string): Promise<boolean> {
+export async function flushTabState(tabId: string): Promise<boolean> {
   const timer = debounceTimers.get(tabId);
   if (timer !== undefined) clearTimeout(timer);
-  return flushUpdateTabState(tabId);
+  // A write already on its way is part of "what is on screen has landed" —
+  // waiting only for the queue would let a move overtake it.
+  const running = inFlightWrites.get(tabId);
+  const ranBefore = running ? await running.done : true;
+  return (await flushUpdateTabState(tabId)) && ranBefore;
 }
 
 /**
@@ -440,7 +458,10 @@ export function flushTabState(tabId: string): Promise<boolean> {
  */
 export function hasPendingDocumentEdit(tabId: string): boolean {
   const patch = pendingPatches.get(tabId);
-  return !!patch && 'documentEdit' in patch;
+  if (patch && 'documentEdit' in patch) return true;
+  // In flight counts as pending: it has left the queue but the backend does not
+  // have it yet, which is exactly the interval a move must not slip through.
+  return inFlightWrites.get(tabId)?.documentEdit ?? false;
 }
 
 export function cancelTabState(tabIds: string | string[]): void {
@@ -457,4 +478,5 @@ export function resetUpdateTabStateDebounce(): void {
   for (const timer of debounceTimers.values()) clearTimeout(timer);
   debounceTimers.clear();
   pendingPatches.clear();
+  inFlightWrites.clear();
 }

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -380,6 +380,23 @@ export function updateTabState(tabId: string, patch: UpdateTabStatePatch): void 
   );
 }
 
+/**
+ * Send `tabId`'s pending patch now instead of when its timer fires.
+ *
+ * The debounce assumes nothing is racing it. A cross-window move is: it is
+ * backend-authoritative and issued immediately, so the destination reads the
+ * tab as the backend has it at that instant. Detach right after opening an
+ * editor, or move right after typing, and the snapshot the destination sees
+ * predates the draft — and the flush that follows is not a cross-window op, so
+ * the destination never reconciles it (#326 review). Callers about to issue a
+ * move or a detach flush first, so what travels is what is on screen.
+ */
+export function flushTabState(tabId: string): void {
+  const timer = debounceTimers.get(tabId);
+  if (timer !== undefined) clearTimeout(timer);
+  flushUpdateTabState(tabId);
+}
+
 /** Test-only: flush and clear all pending debounced updateTabState timers. */
 export function resetUpdateTabStateDebounce(): void {
   for (const timer of debounceTimers.values()) clearTimeout(timer);

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -553,6 +553,36 @@ export function hasPendingDocumentEdit(tabId: string): boolean {
   return (tabWrites.get(tabId)?.documentEdits ?? 0) > 0;
 }
 
+/**
+ * Move `oldId`'s queued patch onto `newId`, because its tab just became that.
+ *
+ * A patch restored after a failed write is keyed by the id it was sent with.
+ * Rename the collection and that id is free again — recreate the namespace,
+ * reopen the tab, and the deterministic id comes back with a stale draft still
+ * queued against it, waiting for the next flush to put a renamed tab's text on
+ * a model that never had it (#326 review). The patch belongs to the tab, so it
+ * follows the tab.
+ *
+ * The old id's generation is bumped as well: a write still out under it must
+ * not restore itself there on failure, now that nothing is that tab any more.
+ */
+export function renameTabState(oldId: string, newId: string): void {
+  const timer = debounceTimers.get(oldId);
+  if (timer !== undefined) clearTimeout(timer);
+  debounceTimers.delete(oldId);
+
+  const patch = pendingPatches.get(oldId);
+  pendingPatches.delete(oldId);
+  tabGenerations.set(oldId, generationOf(oldId) + 1);
+  if (!patch) return;
+
+  // Anything already queued under the new id is newer and wins.
+  pendingPatches.set(newId, { ...patch, ...(pendingPatches.get(newId) ?? {}) });
+  if (!debounceTimers.has(newId)) {
+    debounceTimers.set(newId, setTimeout(() => flushUpdateTabState(newId), DEBOUNCE_MS));
+  }
+}
+
 export function cancelTabState(tabIds: string | string[]): void {
   for (const tabId of Array.isArray(tabIds) ? tabIds : [tabIds]) {
     const timer = debounceTimers.get(tabId);

--- a/src/workspace/workspaceStore.ts
+++ b/src/workspace/workspaceStore.ts
@@ -414,6 +414,22 @@ export function flushTabState(tabId: string): Promise<void> {
  * move to bring it back (#326 review). A patch for a tab that is gone
  * describes nothing, so it goes with it.
  */
+/**
+ * Whether `tabId` has a document-edit change still waiting in the debounce.
+ *
+ * Asked before a cross-window move, which must not overtake it. A cancelled
+ * edit queues `document_edit: null` and is gone from the tab immediately, so
+ * "does this tab have an edit" is the wrong question at that moment — the tab
+ * has none while the backend still holds the draft the move would carry
+ * (#326 review). Only this field is asked about: the others have no ordering
+ * requirement against a move, and flushing them would put a write in front of
+ * every move that never used to be there.
+ */
+export function hasPendingDocumentEdit(tabId: string): boolean {
+  const patch = pendingPatches.get(tabId);
+  return !!patch && 'documentEdit' in patch;
+}
+
 export function cancelTabState(tabIds: string | string[]): void {
   for (const tabId of Array.isArray(tabIds) ? tabIds : [tabIds]) {
     const timer = debounceTimers.get(tabId);


### PR DESCRIPTION
## Summary

The edit dialog was a modal held in one app-wide slot, so it blocked the whole window and only one edit could exist at a time. Editing a document is exactly when you want to glance at another tab — compare a field, check a related document, copy an id — and doing so meant cancelling and losing what you had typed.

An edit now belongs to the tab it was opened from.

| Expectation from the issue | How |
|---|---|
| Opening an edit does not block the app | `modal={false}` — no focus trap, no scrim |
| Switching away hides it | only the active tab's edit is rendered |
| Switching back restores the unsaved text | the draft lives on the tab, not in the dialog |
| Two tabs can each have one | state is per-tab, not a single slot |
| Closing the tab discards its editor | the edit dies with the tab's state |

## Which of the two shapes

The issue offered either re-housing the dialog inside the tab's pane, or keeping it floating but non-modal and mounted for the active tab. **I took the second**, as the smaller change: the dialog stays floating, draggable and resizable exactly as it is today, and the diff is state plumbing rather than a visual redesign. Happy to move it into the pane instead if you'd rather — that's a design call, not a technical constraint.

## Notes on the implementation

**The draft is lifted rather than kept in the dialog.** The dialog unmounts on a tab switch, so text held inside it would die with it — the same reason `viewMode` and (in #325) the results tab already live on the tab. The dialog stays uncontrolled when no `json`/`onJsonChange` is passed, so its existing contract — reopening starts fresh from `initialJson` — is unchanged and still covered by a test.

**There is no hidden overlay.** I first passed `overlayClassName="hidden"`, then found Radix omits the overlay entirely outside modal mode — so the prop was doing nothing. Removed rather than left in place implying it mattered.

`handleSaveDocument` now reads the active tab, which is the only one whose edit is rendered, rather than a `tabId` carried on the app-wide slot.

## Related issue

Closes #277. Came out of #275, as noted there.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Website

## How was this tested?

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (Vitest) passes
- [x] `npm run i18n:check` passes
- [ ] `cargo test` — no backend change
- [ ] Manually verified in the running app (`npm run tauri dev`)

Four tests: edits reported to the owner rather than kept, a draft restored rather than reset when the dialog reappears, the uncontrolled path still resetting, and no blocking scrim. Three fail on `dev`; the fourth is a deliberate no-regression guard on the unchanged path.

Full suite: **1716 passed, 5 failed** — the same 5 that fail on a clean `dev`. Unrelated, left alone.

**Not manually verified, and this one earns the caveat more than most** — it changes modality and focus behaviour, which tests exercise poorly. Worth walking: open an edit, switch tabs, come back; open edits in two tabs at once; close a tab with an edit open; check Escape and click-outside still behave.

## Checklist

- [x] This PR targets `dev` (not `main`)
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …)
- [x] No telemetry, secrets, or real connection strings added
- [ ] Docs / README / website updated if behavior changed
