### PR TITLE
fix(results): make copying the JSON view yield what was selected

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -465,6 +465,21 @@ interface JsonRowExtra {
 // re-render dropped the user's selection mid-copy. A stable identity lets
 // re-renders reconcile in place, so the selection survives. Per-render data is
 // passed through `rowProps` instead of closures.
+/**
+ * The JSON view the user last clicked in, across every grid on screen.
+ *
+ * A split workspace can show two JSON views at once, and each listens for
+ * `copy` on the document because that is where a select-all is dispatched. A
+ * select-all encloses both, so both would answer and the second would overwrite
+ * the first's clipboard — the copy silently coming from whichever grid mounted
+ * last rather than the one the user is working in (#330 review).
+ *
+ * A drag needs none of this: its endpoints resolve inside exactly one view, and
+ * that view owns it. This only decides the enclosing case, where no view owns
+ * the selection by its endpoints and one of them still has to answer.
+ */
+let lastTouchedJsonView: HTMLElement | null = null;
+
 const JsonRow = ({
   index,
   style,
@@ -1262,6 +1277,27 @@ export const DataGrid: React.FC<DataGridProps> = ({
   }, [viewMode, visibleJsonLines]);
 
   const handleJsonCopy = (e: ClipboardEvent) => {
+    // Another JSON view has already answered this event. Two can be on screen in
+    // a split, both listen on the document, and both would otherwise write to
+    // the clipboard — the second silently replacing the first (#330 review).
+    if (e.defaultPrevented) return;
+    const container = jsonViewRef.current;
+    if (!container) return;
+    // Whose copy is this? A drag settles it by itself: its endpoints are inside
+    // one view, and that view answers. A select-all leaves them on <body>,
+    // enclosing every view equally, so the pane the user last clicked in
+    // answers for it. With no click yet — a select-all into a fresh window —
+    // nobody is preferred, and the guard above makes the first to arrive the
+    // one that answers rather than the last.
+    const selection = document.getSelection();
+    const endpointsHere =
+      !!selection &&
+      ((!!selection.anchorNode && container.contains(selection.anchorNode)) ||
+        (!!selection.focusNode && container.contains(selection.focusNode)));
+    // A view that has left the page owns nothing: it will never answer, and the
+    // one still on screen must not go on deferring to it.
+    const owner = lastTouchedJsonView?.isConnected ? lastTouchedJsonView : null;
+    if (!endpointsHere && owner && owner !== container) return;
     const tracked = jsonRangeOf(jsonSelectionRef.current);
     if (!tracked) return;
     // Stand aside only when the browser can be trusted to copy this exactly,
@@ -1284,10 +1320,8 @@ export const DataGrid: React.FC<DataGridProps> = ({
     // remembered range would answer for a copy from the query editor.
     if (!live) return;
     const spansAll = live.start.row <= tracked.start.row && live.end.row >= tracked.end.row;
-    const container = jsonViewRef.current;
     const wanted = tracked.end.row - tracked.start.row + 1;
     const allMounted =
-      !!container &&
       container.querySelectorAll('[data-json-line]').length >= wanted &&
       !!container.querySelector(`[data-json-line="${tracked.start.row}"]`) &&
       !!container.querySelector(`[data-json-line="${tracked.end.row}"]`);
@@ -1334,7 +1368,16 @@ export const DataGrid: React.FC<DataGridProps> = ({
     if (viewMode !== 'json') return;
     const onCopy = (e: ClipboardEvent) => jsonCopyRef.current(e);
     document.addEventListener('copy', onCopy);
-    return () => document.removeEventListener('copy', onCopy);
+    // Captured here rather than read in the cleanup: React detaches the ref
+    // before passive cleanups run, so by then there is nothing to compare.
+    const view = jsonViewRef.current;
+    return () => {
+      document.removeEventListener('copy', onCopy);
+      // Closing the pane the user last clicked in must not leave it holding
+      // ownership (#330 review). The copy handler double-checks with
+      // `isConnected`, since a view can also go without this ever running.
+      if (lastTouchedJsonView === view) lastTouchedJsonView = null;
+    };
   }, [viewMode]);
 
   const toggleFold = (id: number) => {
@@ -2044,6 +2087,11 @@ export const DataGrid: React.FC<DataGridProps> = ({
             // replacing it, so resetting there threw away the recorded range
             // just before the copy that needed it (#319 review).
             onMouseDown={(e) => {
+              // Which pane the user is working in. A split workspace can show
+              // two JSON views at once, and a select-all encloses both — so
+              // neither owns it by its endpoints and something has to say which
+              // one answers (#330 review).
+              lastTouchedJsonView = jsonViewRef.current;
               if (e.button === 0) jsonSelectionRef.current = { anchor: null, focus: null };
             }}
             className="flex min-h-0 min-w-0 flex-1 flex-col bg-background font-mono text-xs leading-relaxed"

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -13,7 +13,7 @@ import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
 import { EJSON } from 'bson';
 import { copyValueToText } from '../lib/copyValue';
 import { ResultsFindBar } from './ResultsFindBar';
-import { registerResultsFindTarget } from '../lib/resultsFindShortcut';
+import { activeResultsPaneElement, registerResultsFindTarget } from '../lib/resultsFindShortcut';
 import { findMatches, isMatchAt, stepMatch, type FindCell } from '../lib/resultsFind';
 import {
   bsonCallOf,
@@ -465,21 +465,6 @@ interface JsonRowExtra {
 // re-render dropped the user's selection mid-copy. A stable identity lets
 // re-renders reconcile in place, so the selection survives. Per-render data is
 // passed through `rowProps` instead of closures.
-/**
- * The JSON view the user last clicked in, across every grid on screen.
- *
- * A split workspace can show two JSON views at once, and each listens for
- * `copy` on the document because that is where a select-all is dispatched. A
- * select-all encloses both, so both would answer and the second would overwrite
- * the first's clipboard — the copy silently coming from whichever grid mounted
- * last rather than the one the user is working in (#330 review).
- *
- * A drag needs none of this: its endpoints resolve inside exactly one view, and
- * that view owns it. This only decides the enclosing case, where no view owns
- * the selection by its endpoints and one of them still has to answer.
- */
-let lastTouchedJsonView: HTMLElement | null = null;
-
 const JsonRow = ({
   index,
   style,
@@ -1294,10 +1279,16 @@ export const DataGrid: React.FC<DataGridProps> = ({
       !!selection &&
       ((!!selection.anchorNode && container.contains(selection.anchorNode)) ||
         (!!selection.focusNode && container.contains(selection.focusNode)));
-    // A view that has left the page owns nothing: it will never answer, and the
-    // one still on screen must not go on deferring to it.
-    const owner = lastTouchedJsonView?.isConnected ? lastTouchedJsonView : null;
-    if (!endpointsHere && owner && owner !== container) return;
+    // Asked of the pane, not of this view. Selecting a pane includes clicking
+    // its toolbar — switching to JSON is itself such a click — and a notion of
+    // "active" that only counted clicks in the results body disagreed with the
+    // one the app already uses for shortcut routing (#330 review). One answer,
+    // one place: the pane holding focus, else the one last pointed at, else the
+    // only one. With several panes and no signal it returns null, and the
+    // `defaultPrevented` guard above makes the first view to arrive answer.
+    const activePane = activeResultsPaneElement();
+    const paneRoot = paneRootRef.current;
+    if (!endpointsHere && activePane && paneRoot && activePane !== paneRoot) return;
     const tracked = jsonRangeOf(jsonSelectionRef.current);
     if (!tracked) return;
     // Stand aside only when the browser can be trusted to copy this exactly,
@@ -1374,16 +1365,9 @@ export const DataGrid: React.FC<DataGridProps> = ({
     if (viewMode !== 'json') return;
     const onCopy = (e: ClipboardEvent) => jsonCopyRef.current(e);
     document.addEventListener('copy', onCopy);
-    // Captured here rather than read in the cleanup: React detaches the ref
-    // before passive cleanups run, so by then there is nothing to compare.
-    const view = jsonViewRef.current;
-    return () => {
-      document.removeEventListener('copy', onCopy);
-      // Closing the pane the user last clicked in must not leave it holding
-      // ownership (#330 review). The copy handler double-checks with
-      // `isConnected`, since a view can also go without this ever running.
-      if (lastTouchedJsonView === view) lastTouchedJsonView = null;
-    };
+    // Nothing to unwind: ownership is the pane registry's, and a pane
+    // unregisters itself there when it goes.
+    return () => document.removeEventListener('copy', onCopy);
   }, [viewMode]);
 
   const toggleFold = (id: number) => {
@@ -2093,11 +2077,6 @@ export const DataGrid: React.FC<DataGridProps> = ({
             // replacing it, so resetting there threw away the recorded range
             // just before the copy that needed it (#319 review).
             onMouseDown={(e) => {
-              // Which pane the user is working in. A split workspace can show
-              // two JSON views at once, and a select-all encloses both — so
-              // neither owns it by its endpoints and something has to say which
-              // one answers (#330 review).
-              lastTouchedJsonView = jsonViewRef.current;
               if (e.button === 0) jsonSelectionRef.current = { anchor: null, focus: null };
             }}
             className="flex min-h-0 min-w-0 flex-1 flex-col bg-background font-mono text-xs leading-relaxed"

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -515,8 +515,14 @@ const JsonRow = ({
           </button>
         )}
       </span>
+      {/* `select-text` re-enables selection against the app-wide
+          `body { user-select: none }`, and everything inside inherits it —
+          which is why the blanket `[&_*]:select-text` that used to sit here is
+          gone. It was not adding reach, it was overriding the row actions'
+          `select-none` below and dragging three empty buttons into every copy
+          (#329). */}
       <span
-        className="flex-1 whitespace-pre pr-4 text-foreground select-text [&_*]:select-text"
+        className="flex-1 whitespace-pre pr-4 text-foreground select-text"
         style={{ paddingLeft: line.depth * 18 }}
       >
         {renderContent(line)}
@@ -527,8 +533,13 @@ const JsonRow = ({
             {line.hasComma ? ',' : ''}
           </span>
         )}
+        {/* Controls, not content. They live inside the text span so they sit
+            next to the document they act on, but a selection that runs over
+            them must not pick them up: they carry no text, so the browser
+            serialised each button as its own empty block and a copied document
+            arrived with three blank lines under its opening brace (#329). */}
         {line.isDocRoot && hasRowActions && line.doc && (
-          <span className="ml-2.5 inline-flex align-middle opacity-0 group-hover:opacity-100 [.flex:hover>&]:opacity-100">
+          <span className="ml-2.5 inline-flex select-none align-middle opacity-0 group-hover:opacity-100 [.flex:hover>&]:opacity-100">
             <RowActions doc={line.doc} />
           </span>
         )}

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -801,16 +801,27 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // Registered only while the results are actually showing: the find bar lives
   // in the results tab, so claiming the key from the explain or code tab would
   // swallow it and open a bar the user cannot see.
+  // Registered for the pane's whole life, not only while its results are
+  // showing. Being registered is what makes a click in this pane count as
+  // selecting it, and that is true on every tab: a pane on the explain tab used
+  // to vanish from the registry, so clicking it selected nothing and the copy
+  // it was about went to whichever pane was still registered (#330 review).
+  // Whether the find bar can open is asked separately, at the moment the key
+  // is pressed.
+  const effectiveTabRef = React.useRef(effectiveTab);
+  effectiveTabRef.current = effectiveTab;
   useEffect(() => {
-    if (effectiveTab !== 'results') return;
     return registerResultsFindTarget({
       element: () => paneRootRef.current,
+      canOpenFind: () => effectiveTabRef.current === 'results',
       open: () => {
         setFindOpen(true);
         setFindFocusToken((token) => token + 1);
       },
     });
-  }, [effectiveTab]);
+    // Registered once: re-registering on every tab change would mint a new id
+    // and drop the record of this pane having been pointed at.
+  }, []);
 
   const closeFind = React.useCallback(() => {
     setFindOpen(false);

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1255,9 +1255,13 @@ export const DataGrid: React.FC<DataGridProps> = ({
     };
     document.addEventListener('selectionchange', onSelectionChange);
     return () => document.removeEventListener('selectionchange', onSelectionChange);
-  }, [viewMode]);
+    // The lines matter because a select-all is recorded as a row range, and its
+    // far end is the last line there is. The view no longer remounts between
+    // runs, so a listener left holding the previous result set would remember
+    // a select-all that stops short of the rows now on screen.
+  }, [viewMode, visibleJsonLines]);
 
-  const handleJsonCopy = (e: React.ClipboardEvent<HTMLDivElement>) => {
+  const handleJsonCopy = (e: ClipboardEvent) => {
     const tracked = jsonRangeOf(jsonSelectionRef.current);
     if (!tracked) return;
     // Stand aside only when the browser can be trusted to copy this exactly,
@@ -1273,7 +1277,13 @@ export const DataGrid: React.FC<DataGridProps> = ({
     // present too.
     const ends = selectedJsonEnds();
     const live = ends && jsonRangeOf(ends);
-    const spansAll = !!live && live.start.row <= tracked.start.row && live.end.row >= tracked.end.row;
+    // Listening on the document means every copy in the app arrives here, so
+    // this view has to say whether it owns one. A live range is exactly that
+    // claim: `selectedJsonEnds` resolves an endpoint only for a selection that
+    // touches these rows, or encloses the view outright. Without it the
+    // remembered range would answer for a copy from the query editor.
+    if (!live) return;
+    const spansAll = live.start.row <= tracked.start.row && live.end.row >= tracked.end.row;
     const container = jsonViewRef.current;
     const wanted = tracked.end.row - tracked.start.row + 1;
     const allMounted =
@@ -1301,9 +1311,32 @@ export const DataGrid: React.FC<DataGridProps> = ({
       })
       .join('\n');
     if (!text) return;
+    if (!e.clipboardData) return;
     e.clipboardData.setData('text/plain', text);
     e.preventDefault();
   };
+
+  // The browser, not us, decides where a copy event lands: it targets the
+  // element holding the selection's focus, and a select-all leaves that on
+  // <body>. That is an ancestor of the React root, so an `onCopy` on the view
+  // is never reached and the copy fell through to the browser — which holds
+  // only the mounted screenful, or in practice nothing at all (#328).
+  //
+  // Listening on the document puts the handler where every copy passes,
+  // including the ones inside the view, which bubble here just the same. What
+  // it costs is the containment the React tree used to grant for free, so
+  // `handleJsonCopy` establishes that itself before it writes anything.
+  const jsonCopyRef = React.useRef(handleJsonCopy);
+  useEffect(() => {
+    jsonCopyRef.current = handleJsonCopy;
+  });
+  useEffect(() => {
+    if (viewMode !== 'json') return;
+    const onCopy = (e: ClipboardEvent) => jsonCopyRef.current(e);
+    document.addEventListener('copy', onCopy);
+    return () => document.removeEventListener('copy', onCopy);
+  }, [viewMode]);
+
   const toggleFold = (id: number) => {
     setCollapsedFolds((prev) => {
       const next = new Set(prev);
@@ -2013,7 +2046,6 @@ export const DataGrid: React.FC<DataGridProps> = ({
             onMouseDown={(e) => {
               if (e.button === 0) jsonSelectionRef.current = { anchor: null, focus: null };
             }}
-            onCopy={handleJsonCopy}
             className="flex min-h-0 min-w-0 flex-1 flex-col bg-background font-mono text-xs leading-relaxed"
             data-testid="json-view"
           >

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1325,7 +1325,13 @@ export const DataGrid: React.FC<DataGridProps> = ({
       container.querySelectorAll('[data-json-line]').length >= wanted &&
       !!container.querySelector(`[data-json-line="${tracked.start.row}"]`) &&
       !!container.querySelector(`[data-json-line="${tracked.end.row}"]`);
-    if (spansAll && allMounted) return;
+    // Standing aside says "the browser will copy exactly what this view holds",
+    // and that is only knowable when the selection lives inside this view. An
+    // enclosing selection covers the whole page, so leaving it to the browser
+    // yields every other selectable thing on it — in a split with two small
+    // panes, both panes' text, when the user asked for the one they clicked
+    // (#330 review). Those are rebuilt however many rows are mounted.
+    if (endpointsHere && spansAll && allMounted) return;
     const text = visibleJsonLines
       .slice(tracked.start.row, tracked.end.row + 1)
       .map((line, i) => {

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1673,6 +1673,46 @@ describe('DataGrid — select-all copies every row (#320)', () => {
   });
 
 
+  it('leaves a copy alone when the user is in a pane showing explain', () => {
+    // #330 review: registration used to be scoped to the results tab, so a pane
+    // showing explain vanished from the registry. Clicking it selected no pane,
+    // the fallback handed ownership to the other, still-registered pane, and a
+    // select-all over the explain output came back as that pane's rows instead.
+    const mountJson = () => {
+      const container = document.body.appendChild(document.createElement('div'));
+      render(<DataGrid documents={manyDocs} />, { container });
+      fireEvent.click(within(container).getByRole('button', { name: /json/i }));
+      return container;
+    };
+    const mountExplain = () => {
+      const container = document.body.appendChild(document.createElement('div'));
+      render(
+        <DataGrid documents={[{ _id: 1 }]} explainResult='{"queryPlanner": {}}' />,
+        { container }
+      );
+      fireEvent.click(within(container).getByRole('button', { name: /explain/i }));
+      return container;
+    };
+    mountJson();
+    const explainPane = mountExplain();
+
+    // The user is working in the explain pane.
+    selectPane(explainPane);
+
+    const getSelection = vi.spyOn(document, 'getSelection');
+    getSelection.mockReturnValue(selectAll());
+    document.dispatchEvent(new Event('selectionchange'));
+
+    const setData = vi.fn();
+    fireEvent.copy(document.body, { clipboardData: { setData, getData: () => '' } });
+
+    // Nobody rewrites the clipboard: the browser copies the explain text the
+    // user actually selected.
+    expect(setData).not.toHaveBeenCalled();
+    getSelection.mockRestore();
+  });
+
+
   it('lets the surviving pane answer once the other one closes', () => {
     // The pane holding ownership can be closed. It will never answer again, and
     // the one still on screen must not go on deferring to it (#330 review).

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1607,6 +1607,32 @@ describe('DataGrid — select-all copies every row (#320)', () => {
   });
 });
 
+// #329: the row's copy/edit/delete buttons sit inside its selectable text so
+// they stay next to the document they act on. They hold no text, so a copy that
+// ran over them serialised each one as an empty block and every document
+// arrived with three blank lines under its opening brace. jsdom does not
+// serialise a selection, so what is pinned here is the arrangement that decides
+// it: the controls opt out of selection, and nothing forces them back in.
+describe('DataGrid — row actions stay out of copied text (#329)', () => {
+  it('marks the row actions unselectable and leaves the text selectable', () => {
+    render(<DataGrid documents={mockDocuments} onEditDocument={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /json/i }));
+
+    const actions = screen.getAllByTestId('edit-doc-btn')[0].closest('span');
+    expect(actions).not.toBeNull();
+    expect(actions!.className).toContain('select-none');
+
+    // The text they live in still selects — the fix must not cost the view the
+    // selection it exists to allow, since `body` sets `user-select: none` for
+    // the whole app and this span is what opts back in.
+    const text = actions!.parentElement!;
+    expect(text.className).toContain('select-text');
+    // And it must not re-enable selection for its descendants wholesale: that
+    // blanket rule outranked the controls' `select-none` and was the bug.
+    expect(text.className).not.toContain('[&_*]:select-text');
+  });
+});
+
 // #281: after one visit to Explain, every subsequent run reopened it — the
 // Results tab had to be clicked again each time. The grid remounts on every run
 // (the pane renders `{loading ? <spinner/> : <DataGrid/>}`), a plan is not

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1621,6 +1621,43 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     getSelection.mockRestore();
   });
 
+  it('rebuilds for the owning pane even when every row is mounted', () => {
+    // #330 review: with both panes small enough to be fully mounted, the owner
+    // took the "let the browser do it" path — and the browser serializes the
+    // whole enclosing selection, so the copy came back with both panes' text.
+    // Standing aside only makes sense when the selection lives inside the view;
+    // an enclosing one covers the page.
+    //
+    // The earlier split tests used 40 documents each, which forced the rebuild
+    // and stepped straight over this path.
+    const mount = (docs: unknown[]) => {
+      const container = document.body.appendChild(document.createElement('div'));
+      const result = render(<DataGrid documents={docs as any} />, { container });
+      fireEvent.click(within(container).getByRole('button', { name: /json/i }));
+      return { result, view: within(container).getByTestId('json-view') };
+    };
+    const left = mount([{ _id: 'left-doc' }]);
+    const right = mount([{ _id: 'right-doc' }]);
+    // Precondition: both panes really are fully mounted, or this proves nothing.
+    expect(left.view.querySelectorAll('[data-json-line]').length).toBeGreaterThan(0);
+    expect(right.view.querySelectorAll('[data-json-line]').length).toBeGreaterThan(0);
+
+    fireEvent.mouseDown(right.view);
+    const getSelection = vi.spyOn(document, 'getSelection');
+    getSelection.mockReturnValue(selectAll());
+    document.dispatchEvent(new Event('selectionchange'));
+
+    const setData = vi.fn();
+    fireEvent.copy(document.body, { clipboardData: { setData, getData: () => '' } });
+
+    expect(setData).toHaveBeenCalledTimes(1);
+    const copied = setData.mock.calls[0][1];
+    expect(copied).toContain('right-doc');
+    expect(copied).not.toContain('left-doc');
+    getSelection.mockRestore();
+  });
+
+
   it('lets the surviving pane answer once the other one closes', () => {
     // The pane holding ownership can be closed. It will never answer again, and
     // the one still on screen must not go on deferring to it (#330 review).

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1582,6 +1582,63 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     getSelection.mockRestore();
   });
 
+  /** Two DataGrids side by side, each in its own container, as a split shows them. */
+  const openTwoJsonPanes = () => {
+    const mount = (docs: unknown[]) => {
+      const container = document.body.appendChild(document.createElement('div'));
+      const result = render(<DataGrid documents={docs as any} />, { container });
+      fireEvent.click(within(container).getByRole('button', { name: /json/i }));
+      return { result, view: within(container).getByTestId('json-view') };
+    };
+    // Both panes hold more than a screenful, so both need the rebuild — with a
+    // pane small enough to be fully mounted, the grid rightly stands aside and
+    // lets the browser copy, which would prove nothing about ownership.
+    const rightDocs = Array.from({ length: 40 }, (_, i) => ({ _id: i, name: `only-in-right-${i}` }));
+    return { left: mount(manyDocs), right: mount(rightDocs) };
+  };
+
+  it('has exactly one of two open JSON panes answer a select-all', () => {
+    // #330 review: a split workspace shows two JSON views, each listening on the
+    // document because that is where a select-all is dispatched. Both saw the
+    // enclosing selection, both wrote to the clipboard, and the second silently
+    // replaced the first — so Cmd+C copied whichever grid mounted last rather
+    // than the pane the user was working in.
+    const { right } = openTwoJsonPanes();
+
+    // The user is working in the right-hand pane.
+    fireEvent.mouseDown(right.view);
+
+    const getSelection = vi.spyOn(document, 'getSelection');
+    getSelection.mockReturnValue(selectAll());
+    document.dispatchEvent(new Event('selectionchange'));
+
+    const setData = vi.fn();
+    fireEvent.copy(document.body, { clipboardData: { setData, getData: () => '' } });
+
+    // One writer, and it is the pane that was clicked — not the last to mount.
+    expect(setData).toHaveBeenCalledTimes(1);
+    expect(setData.mock.calls[0][1]).toContain('only-in-right-0');
+    getSelection.mockRestore();
+  });
+
+  it('lets the surviving pane answer once the other one closes', () => {
+    // The pane holding ownership can be closed. It will never answer again, and
+    // the one still on screen must not go on deferring to it (#330 review).
+    const { right } = openTwoJsonPanes();
+    fireEvent.mouseDown(right.view);
+    right.result.unmount();
+
+    const getSelection = vi.spyOn(document, 'getSelection');
+    getSelection.mockReturnValue(selectAll());
+    document.dispatchEvent(new Event('selectionchange'));
+
+    const setData = vi.fn();
+    fireEvent.copy(document.body, { clipboardData: { setData, getData: () => '' } });
+
+    expect(setData).toHaveBeenCalledTimes(1);
+    expect(setData.mock.calls[0][1]).not.toContain('only-in-right-0');
+    getSelection.mockRestore();
+  });
   it('ignores a selection that does not enclose the view', () => {
     // The trap in the obvious fix: treating any unresolvable endpoint as the
     // view's bounds would claim rows for selections living elsewhere in the UI.

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1564,8 +1564,14 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     getSelection.mockReturnValue(selectAll());
     document.dispatchEvent(new Event('selectionchange'));
 
+    // Dispatched on <body>, because that is where the browser dispatches it.
+    // A copy event targets the element holding the selection's focus, and this
+    // selection's focus is <body> — an ancestor of the React root, so a
+    // handler on the view is never reached and nothing was copied at all
+    // (#328). Aiming this at `view` instead is what let the bug ship: it
+    // proved the rebuild works while stepping over the delivery it depends on.
     const setData = vi.fn();
-    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    fireEvent.copy(document.body, { clipboardData: { setData, getData: () => '' } });
 
     expect(setData).toHaveBeenCalledTimes(1);
     const lines = setData.mock.calls[0][1].split('\n');
@@ -1579,7 +1585,12 @@ describe('DataGrid — select-all copies every row (#320)', () => {
   it('ignores a selection that does not enclose the view', () => {
     // The trap in the obvious fix: treating any unresolvable endpoint as the
     // view's bounds would claim rows for selections living elsewhere in the UI.
-    const view = openJsonView();
+    // Listening on the document makes this the load-bearing case rather than a
+    // hypothetical one — every copy in the app now reaches this handler, so a
+    // copy from the query editor has to leave with the text it selected.
+    // Rendered, and deliberately not referenced again: the point is that the
+    // view is listening and still declines this copy.
+    openJsonView();
     const elsewhere = document.createElement('div');
     elsewhere.textContent = 'unrelated';
     document.body.appendChild(elsewhere);
@@ -1599,7 +1610,7 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     document.dispatchEvent(new Event('selectionchange'));
 
     const setData = vi.fn();
-    fireEvent.copy(view, { clipboardData: { setData, getData: () => '' } });
+    fireEvent.copy(elsewhere, { clipboardData: { setData, getData: () => '' } });
     expect(setData).not.toHaveBeenCalled();
 
     elsewhere.remove();

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1533,6 +1533,21 @@ describe('DataGrid — element selection boundaries (#322 review)', () => {
 // which holds only the mounted rows. Same silent truncation as #311, on the
 // more natural way to copy a whole result set.
 describe('DataGrid — select-all copies every row (#320)', () => {
+  beforeEach(() => resetResultsFindShortcutForTests());
+
+  /**
+   * Select a pane the way a user does: a pointer press inside it.
+   *
+   * Deliberately on a toolbar control rather than on the rows, because that is
+   * the case the old code got wrong. Ownership was recorded from a `mousedown`
+   * on the JSON body alone, so clicking a pane's toolbar — switching it to JSON
+   * is itself such a click — selected that pane for every other purpose while a
+   * copy still went to the pane before it (#330 review).
+   */
+  const selectPane = (container: HTMLElement) => {
+    fireEvent.pointerDown(within(container).getAllByRole('button')[0]);
+  };
+
   const manyDocs = Array.from({ length: 40 }, (_, i) => ({ _id: i, name: `n${i}` }));
 
   const openJsonView = () => {
@@ -1588,7 +1603,7 @@ describe('DataGrid — select-all copies every row (#320)', () => {
       const container = document.body.appendChild(document.createElement('div'));
       const result = render(<DataGrid documents={docs as any} />, { container });
       fireEvent.click(within(container).getByRole('button', { name: /json/i }));
-      return { result, view: within(container).getByTestId('json-view') };
+      return { result, container, view: within(container).getByTestId('json-view') };
     };
     // Both panes hold more than a screenful, so both need the rebuild — with a
     // pane small enough to be fully mounted, the grid rightly stands aside and
@@ -1606,7 +1621,7 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     const { right } = openTwoJsonPanes();
 
     // The user is working in the right-hand pane.
-    fireEvent.mouseDown(right.view);
+    selectPane(right.container);
 
     const getSelection = vi.spyOn(document, 'getSelection');
     getSelection.mockReturnValue(selectAll());
@@ -1634,7 +1649,7 @@ describe('DataGrid — select-all copies every row (#320)', () => {
       const container = document.body.appendChild(document.createElement('div'));
       const result = render(<DataGrid documents={docs as any} />, { container });
       fireEvent.click(within(container).getByRole('button', { name: /json/i }));
-      return { result, view: within(container).getByTestId('json-view') };
+      return { result, container, view: within(container).getByTestId('json-view') };
     };
     const left = mount([{ _id: 'left-doc' }]);
     const right = mount([{ _id: 'right-doc' }]);
@@ -1642,7 +1657,7 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     expect(left.view.querySelectorAll('[data-json-line]').length).toBeGreaterThan(0);
     expect(right.view.querySelectorAll('[data-json-line]').length).toBeGreaterThan(0);
 
-    fireEvent.mouseDown(right.view);
+    selectPane(right.container);
     const getSelection = vi.spyOn(document, 'getSelection');
     getSelection.mockReturnValue(selectAll());
     document.dispatchEvent(new Event('selectionchange'));
@@ -1662,7 +1677,7 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     // The pane holding ownership can be closed. It will never answer again, and
     // the one still on screen must not go on deferring to it (#330 review).
     const { right } = openTwoJsonPanes();
-    fireEvent.mouseDown(right.view);
+    selectPane(right.container);
     right.result.unmount();
 
     const getSelection = vi.spyOn(document, 'getSelection');

--- a/src/lib/resultsFindShortcut.ts
+++ b/src/lib/resultsFindShortcut.ts
@@ -29,6 +29,17 @@ interface Pane {
   element: () => HTMLElement | null;
   /** Called when this pane should open its find bar. */
   open: () => void;
+  /**
+   * Whether the find bar is reachable in this pane right now.
+   *
+   * Separate from being registered, because the two questions are different:
+   * "which pane is the user in" is true of every pane always, while "can this
+   * one open a find bar" is only true while its results tab is showing. A pane
+   * that unregistered itself on the explain tab was invisible here, so the
+   * user's click landed on no pane and the next question — which pane owns a
+   * copy — was answered with somebody else's (#330 review).
+   */
+  canOpenFind?: () => boolean;
 }
 
 const panes = new Map<number, Pane>();
@@ -107,7 +118,9 @@ function onKeyDown(event: KeyboardEvent): void {
   if (eventBelongsToAnEditor(event.target)) return;
 
   const pane = targetPane(event);
-  if (!pane) return;
+  // A pane with no find bar to open leaves the key alone rather than claiming
+  // it and doing nothing — the browser's own find is the better fallback.
+  if (!pane || pane.canOpenFind?.() === false) return;
   // Only now: leaving the key to the browser — and to Sidebar's own Cmd/Ctrl+F,
   // which stands down on defaultPrevented — when no pane claims it.
   event.preventDefault();

--- a/src/lib/resultsFindShortcut.ts
+++ b/src/lib/resultsFindShortcut.ts
@@ -155,6 +155,30 @@ export function registerResultsFindTarget(pane: Pane): () => void {
   };
 }
 
+/**
+ * The results pane the user is working in, by the same reckoning the shortcut
+ * uses: the pane holding focus, else the one last pointed at, else the only one.
+ *
+ * Exposed because "which pane is this for" is not a question about find. A copy
+ * has to answer it too — several JSON views listen for the same select-all, and
+ * one of them has to be the one that responds (#330 review). Keeping a second
+ * notion of the active pane in the grid meant the two could disagree, and they
+ * did: this one counts a click anywhere in the pane, its toolbar included, while
+ * the grid's counted only clicks in the results body.
+ *
+ * `null` when nothing indicates a pane and there is more than one, which is the
+ * honest answer — the caller decides what to do without a preference.
+ */
+export function activeResultsPaneElement(): HTMLElement | null {
+  const fromFocus = paneContaining(document.activeElement);
+  if (fromFocus) return fromFocus.element();
+  if (lastPointedId !== null) {
+    const el = panes.get(lastPointedId)?.element();
+    if (el) return el;
+  }
+  return panes.size === 1 ? [...panes.values()][0].element() : null;
+}
+
 /** Reset module state between tests. */
 export function resetResultsFindShortcutForTests(): void {
   if (listening && typeof window !== "undefined") {


### PR DESCRIPTION
Two defects in what a copy from the JSON results view yields, both found by running the app rather than by the suite.

Closes #328. Closes #329.

## Select-all copied nothing (#328)

`Ctrl/Cmd+A` highlights every row, and `Ctrl/Cmd+C` then put **nothing** on the clipboard. Verified with a controlled A/B in the same view: a drag over the same rows copied 243 characters, a select-all copied nothing at all.

The rebuild added in #320/#323 was correct and simply never ran. A select-all leaves the selection's endpoints on `<body>`, so that is where the browser dispatches the copy event — an ancestor of the React root, which an `onCopy` on the view never sees.

The handler now listens on the document, where every copy passes. That gives up the containment the React tree granted for free, so the handler establishes it itself: a live range means the selection resolves against these rows or encloses the view, and without one the remembered range would answer for a copy made in the query editor. The existing "ignores a selection that does not enclose the view" case becomes load-bearing rather than hypothetical, and still holds.

The selection-tracking listener also gained `visibleJsonLines` as a dependency: a select-all is recorded as a row range whose far end is the last line there is, and the view no longer remounts between runs, so a listener holding the previous result set would remember a range stopping short of the rows now on screen.

**On the test that was meant to guard this:** it dispatched with `fireEvent.copy(view, …)` — on the view itself, the one place a select-all does not go. It proved the rebuild and stepped over the delivery. It now dispatches on `document.body`, and fails against the previous listener with 0 calls to `setData`.

## Row buttons leaked blank lines into copied text (#329)

Every copied document arrived with three blank lines under its opening brace — a 22-row selection came back as 31 lines, exactly three per document-root row.

The copy/edit/delete buttons sit inside the row's selectable text so they stay beside the document they act on, and they carry no text of their own, so the browser serialised each as its own empty block. They are controls, not content, and now say so with `select-none`.

The blanket `[&_*]:select-text` beside them goes with it: descendants already inherit selection from the span, so it was adding no reach — only outranking the `select-none` this needs.

## Checks

- 97/97 in `DataGrid.test.tsx`, typecheck clean.
- The #328 test fails against the pre-fix listener; confirmed, not assumed.
- Full suite: 5 failures, all pre-existing and identical on clean `dev` (locale number formatting, and a `spawn npx ENOENT` in the bundle test).

Not yet exercised in a running app — the dev window here stopped taking synthetic input. The two checks worth a manual pass: select-all then copy pastes the whole result set, and a drag across documents copies with no blank lines under each `{`.
