### PR TITLE
fix(results): make select-all a selection the page can actually see

### DIFF
--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -13,7 +13,11 @@ import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
 import { EJSON } from 'bson';
 import { copyValueToText } from '../lib/copyValue';
 import { ResultsFindBar } from './ResultsFindBar';
-import { activeResultsPaneElement, registerResultsFindTarget } from '../lib/resultsFindShortcut';
+import {
+  activeResultsPaneElement,
+  eventBelongsToAnEditor,
+  registerResultsFindTarget,
+} from '../lib/resultsFindShortcut';
 import { findMatches, isMatchAt, stepMatch, type FindCell } from '../lib/resultsFind';
 import {
   bsonCallOf,
@@ -1368,6 +1372,47 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // including the ones inside the view, which bubble here just the same. What
   // it costs is the containment the React tree used to grant for free, so
   // `handleJsonCopy` establishes that itself before it writes anything.
+  // Make the select-all a selection the page can actually see (#328).
+  //
+  // The app sets `user-select: none` on `body` so its chrome does not select
+  // like a web page. Under that, Chromium *paints* a select-all across the
+  // rows — every one of them highlights — while reporting the selection to
+  // script as collapsed and empty: `isCollapsed` true, `toString()` ''. So the
+  // browser had nothing to copy and neither did we, and the clipboard was left
+  // untouched. Not truncated: untouched, because there was nothing to truncate.
+  //
+  // Claiming the key and setting the range explicitly gives a real selection
+  // that both the native copy and the rebuild below can read. It is the better
+  // meaning of the shortcut too: in a results pane, select-all is about the
+  // results, not about the whole application around them.
+  useEffect(() => {
+    if (viewMode !== 'json') return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.key !== 'a' && e.key !== 'A') return;
+      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
+      // A query editor or a text field owns this key for its own content.
+      if (eventBelongsToAnEditor(e.target)) return;
+      const container = jsonViewRef.current;
+      if (!container) return;
+      // Same ownership question the copy asks, and the same answer: in a split,
+      // the pane the user is working in is the one that responds.
+      const active = activeResultsPaneElement();
+      if (active && paneRootRef.current && active !== paneRootRef.current) return;
+      const selection = document.getSelection();
+      if (!selection) return;
+      const range = document.createRange();
+      range.selectNodeContents(container);
+      selection.removeAllRanges();
+      selection.addRange(range);
+      e.preventDefault();
+    };
+    // Capture, for the same reason the find shortcut uses it: to be ahead of
+    // any window-level handler that would otherwise claim the key first.
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [viewMode]);
+
   const jsonCopyRef = React.useRef(handleJsonCopy);
   useEffect(() => {
     jsonCopyRef.current = handleJsonCopy;

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -14,9 +14,9 @@ import { EJSON } from 'bson';
 import { copyValueToText } from '../lib/copyValue';
 import { ResultsFindBar } from './ResultsFindBar';
 import {
-  activeResultsPaneElement,
-  eventBelongsToAnEditor,
+  isTextEntryContext,
   registerResultsFindTarget,
+  resultsPaneElementForEvent,
 } from '../lib/resultsFindShortcut';
 import { findMatches, isMatchAt, stepMatch, type FindCell } from '../lib/resultsFind';
 import {
@@ -1301,7 +1301,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
     // one place: the pane holding focus, else the one last pointed at, else the
     // only one. With several panes and no signal it returns null, and the
     // `defaultPrevented` guard above makes the first view to arrive answer.
-    const activePane = activeResultsPaneElement();
+    const activePane = resultsPaneElementForEvent(e.target);
     const paneRoot = paneRootRef.current;
     if (!endpointsHere && activePane && paneRoot && activePane !== paneRoot) return;
     const tracked = jsonRangeOf(jsonSelectionRef.current);
@@ -1392,13 +1392,16 @@ export const DataGrid: React.FC<DataGridProps> = ({
       if (e.key !== 'a' && e.key !== 'A') return;
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       // A query editor or a text field owns this key for its own content.
-      if (eventBelongsToAnEditor(e.target)) return;
+      if (isTextEntryContext(e.target)) return;
       const container = jsonViewRef.current;
       if (!container) return;
       // Same ownership question the copy asks, and the same answer: in a split,
       // the pane the user is working in is the one that responds.
-      const active = activeResultsPaneElement();
-      if (active && paneRootRef.current && active !== paneRootRef.current) return;
+      // Target-aware: an event from another region belongs to that region, and
+      // only one from nothing in particular falls back to the pane last pointed
+      // at. Reading focus alone let this pane answer for the whole app.
+      const active = resultsPaneElementForEvent(e.target);
+      if (active !== paneRootRef.current) return;
       const selection = document.getSelection();
       if (!selection) return;
       const range = document.createRange();

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1636,6 +1636,43 @@ describe('DataGrid — select-all copies every row (#320)', () => {
       expect(pressSelectAll(inner).defaultPrevented).toBe(false);
     });
 
+    it('leaves the key to the results find bar, which is a text field like any other', () => {
+      // The find shortcut deliberately treats its own input as NOT an editor, so
+      // Ctrl+F with the caret already in it means 'search here again'. That
+      // exception is find's alone: select-all in that input means select the
+      // search text, and taking it would leave the user unable to (#328 review).
+      //
+      // The bar is mounted INSIDE the pane, where it really lives. Outside it the
+      // pane declines on ownership instead, and the test would pass without ever
+      // reaching the predicate it is about.
+      const container = document.body.appendChild(document.createElement('div'));
+      render(<DataGrid documents={manyDocs} />, { container });
+      fireEvent.click(within(container).getByRole('button', { name: /json/i }));
+      const bar = container.firstElementChild!.appendChild(document.createElement('div'));
+      bar.setAttribute('data-results-find-input', '');
+      const input = bar.appendChild(document.createElement('input'));
+
+      expect(pressSelectAll(input).defaultPrevented).toBe(false);
+    });
+
+    it('leaves the key to a non-editor element in another part of the app', () => {
+      // A focused control elsewhere — a sidebar row, a button — is not nothing in
+      // particular, so the pane must not answer for it just because it was the
+      // last one pointed at. Reading focus alone let a single pane claim
+      // Ctrl/Cmd+A for the whole window (#328 review).
+      const view = openJsonView();
+      selectPane(view.closest('div')!.parentElement ?? view);
+      const elsewhere = document.body.appendChild(document.createElement('div'));
+      elsewhere.tabIndex = 0;
+      document.getSelection()?.removeAllRanges();
+
+      const event = pressSelectAll(elsewhere);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(document.getSelection()?.rangeCount ?? 0).toBe(0);
+    });
+
+
     it('leaves the key to whichever pane the user is working in', () => {
       const mount = (docs: unknown[]) => {
         const container = document.body.appendChild(document.createElement('div'));

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1571,6 +1571,95 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     } as unknown as Selection;
   };
 
+  // #328 root cause: the app sets `user-select: none` on `body`, and under that
+  // Chromium paints a select-all across the rows while reporting the selection
+  // to script as collapsed and empty. The browser had nothing to copy and
+  // neither did the rebuild, so the clipboard was left untouched.
+  //
+  // These use the real Selection API rather than a mocked one. That is the
+  // point: every earlier test mocked `getSelection()` to return a non-collapsed
+  // range over `document.body` — precisely the state the browser does not
+  // produce — so they passed while the app did nothing at all.
+  describe('the select-all shortcut makes a selection the page can see (#328)', () => {
+    const pressSelectAll = (target: EventTarget) => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'a',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      target.dispatchEvent(event);
+      return event;
+    };
+
+    it('claims the key and selects the view, leaving a real range behind', () => {
+      const view = openJsonView();
+      document.getSelection()?.removeAllRanges();
+
+      const event = pressSelectAll(view);
+
+      expect(event.defaultPrevented).toBe(true);
+      const selection = document.getSelection()!;
+      expect(selection.rangeCount).toBe(1);
+      expect(selection.isCollapsed).toBe(false);
+      expect(view.contains(selection.anchorNode)).toBe(true);
+      expect(view.contains(selection.focusNode)).toBe(true);
+    });
+
+    it('rebuilds every row from that selection, including unmounted ones', () => {
+      const view = openJsonView();
+      const mounted = view.querySelectorAll('[data-json-line]').length;
+      document.getSelection()?.removeAllRanges();
+
+      pressSelectAll(view);
+      document.dispatchEvent(new Event('selectionchange'));
+
+      const setData = vi.fn();
+      fireEvent.copy(document.body, { clipboardData: { setData, getData: () => '' } });
+
+      expect(setData).toHaveBeenCalledTimes(1);
+      const lines = setData.mock.calls[0][1].split('\n');
+      expect(lines.length).toBeGreaterThan(mounted);
+      expect(lines[0]).toBe('{');
+    });
+
+    it('leaves the key to a text field or an editor', () => {
+      // Cmd/Ctrl+A in a query editor means "select this query". A pane that
+      // took it would be answering for something it does not own.
+      openJsonView();
+      const input = document.body.appendChild(document.createElement('input'));
+      expect(pressSelectAll(input).defaultPrevented).toBe(false);
+
+      const editor = document.body.appendChild(document.createElement('div'));
+      editor.className = 'monaco-editor';
+      const inner = editor.appendChild(document.createElement('span'));
+      expect(pressSelectAll(inner).defaultPrevented).toBe(false);
+    });
+
+    it('leaves the key to whichever pane the user is working in', () => {
+      const mount = (docs: unknown[]) => {
+        const container = document.body.appendChild(document.createElement('div'));
+        render(<DataGrid documents={docs as any} />, { container });
+        fireEvent.click(within(container).getByRole('button', { name: /json/i }));
+        return { container, view: within(container).getByTestId('json-view') };
+      };
+      const left = mount(manyDocs);
+      const right = mount(manyDocs);
+      // The user selects the right-hand pane.
+      selectPane(right.container);
+      document.getSelection()?.removeAllRanges();
+
+      // The key arrives at the document, not at either view.
+      pressSelectAll(document.body);
+
+      const selection = document.getSelection()!;
+      expect(selection.rangeCount).toBe(1);
+      expect(right.view.contains(selection.anchorNode)).toBe(true);
+      expect(left.view.contains(selection.anchorNode)).toBe(false);
+    });
+  });
+
+
   it('rebuilds every line, not just the mounted ones', () => {
     const view = openJsonView();
     const mounted = view.querySelectorAll('[data-json-line]').length;

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1673,6 +1673,32 @@ describe('DataGrid — select-all copies every row (#320)', () => {
     });
 
 
+    it('lets go of the key once the user clicks away from the pane', () => {
+      // The case the app showed and the test above missed. Most of the app is
+      // not focusable: clicking a sidebar row moves focus nowhere, so the next
+      // keypress targets <body> and reads as "from nothing in particular" —
+      // which the last-pointed fallback then answered with a pane the user had
+      // already left, selecting results they were not looking at (#328 review).
+      //
+      // The earlier test dispatched on a focusable element, so it took the
+      // target-is-in-another-region branch and never reached this one.
+      const container = document.body.appendChild(document.createElement('div'));
+      render(<DataGrid documents={manyDocs} />, { container });
+      fireEvent.click(within(container).getByRole('button', { name: /json/i }));
+      selectPane(container);
+
+      const elsewhere = document.body.appendChild(document.createElement('div'));
+      fireEvent.pointerDown(elsewhere);
+      document.getSelection()?.removeAllRanges();
+
+      // Focus went nowhere, so the key arrives at the body.
+      const event = pressSelectAll(document.body);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(document.getSelection()?.rangeCount ?? 0).toBe(0);
+    });
+
+
     it('leaves the key to whichever pane the user is working in', () => {
       const mount = (docs: unknown[]) => {
         const container = document.body.appendChild(document.createElement('div'));

--- a/src/lib/resultsFindShortcut.ts
+++ b/src/lib/resultsFindShortcut.ts
@@ -48,21 +48,34 @@ let lastPointedId: number | null = null;
 let listening = false;
 
 /**
- * Editors and text fields keep their own find/typing behaviour.
+ * Anywhere the user types: an editor, a text field, a contenteditable.
  *
- * Exported because every results-pane shortcut owes them the same deference,
- * not just find: Cmd/Ctrl+A inside a query editor means "select this query",
- * and a pane that took it would be answering for something it does not own.
+ * No exceptions — including the find bar's own input, which is a text field
+ * like any other. Every results-pane shortcut owes these the same deference,
+ * because inside one the key means something about its content: Cmd/Ctrl+A in
+ * a query editor means "select this query", and a pane that took it would be
+ * answering for something it does not own.
  */
-export function eventBelongsToAnEditor(target: EventTarget | null): boolean {
+export function isTextEntryContext(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
-  // The find bar's own input is a text field but is not somebody else's: the
-  // shortcut pressed inside it means "search here again", not "leave me alone".
-  if (target.closest(`[${RESULTS_FIND_INPUT_ATTR}]`)) return false;
   if (target.closest(".monaco-editor")) return true;
   const tag = target.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
   return target.closest('[contenteditable="true"]') !== null;
+}
+
+/**
+ * Text entry, as the FIND shortcut sees it — one exception to the above.
+ *
+ * The find bar's own input is a text field but is not somebody else's: Ctrl+F
+ * pressed with the caret already in it means "search here again", not "leave me
+ * alone". That exception belongs to find alone. Select-all in that input means
+ * "select the search text" like in any other field, so it uses the plain
+ * predicate instead (#328 review).
+ */
+function eventBelongsToAnEditor(target: EventTarget | null): boolean {
+  if (target instanceof Element && target.closest(`[${RESULTS_FIND_INPUT_ATTR}]`)) return false;
+  return isTextEntryContext(target);
 }
 
 /** The registered pane containing `node`, if any. */
@@ -94,8 +107,8 @@ function paneContaining(node: EventTarget | null): Pane | undefined {
  *
  * With several panes and no signal at all, nothing opens rather than all of them.
  */
-function targetPane(event: KeyboardEvent): Pane | undefined {
-  const fromTarget = paneContaining(event.target);
+function paneForEventTarget(target: EventTarget | null): Pane | undefined {
+  const fromTarget = paneContaining(target);
   if (fromTarget) return fromTarget;
 
   const fromFocus = paneContaining(document.activeElement);
@@ -103,10 +116,10 @@ function targetPane(event: KeyboardEvent): Pane | undefined {
 
   // Anything else focused belongs to another region, and the key is its business.
   const unfocused =
-    event.target === null ||
-    event.target === document.body ||
-    event.target === document ||
-    event.target === window;
+    target === null ||
+    target === document.body ||
+    target === document ||
+    target === window;
   if (!unfocused) return undefined;
 
   if (lastPointedId !== null) {
@@ -114,6 +127,10 @@ function targetPane(event: KeyboardEvent): Pane | undefined {
     if (pane?.element()) return pane;
   }
   return panes.size === 1 ? [...panes.values()][0] : undefined;
+}
+
+function targetPane(event: KeyboardEvent): Pane | undefined {
+  return paneForEventTarget(event.target);
 }
 
 function onKeyDown(event: KeyboardEvent): void {
@@ -175,27 +192,25 @@ export function registerResultsFindTarget(pane: Pane): () => void {
 }
 
 /**
- * The results pane the user is working in, by the same reckoning the shortcut
- * uses: the pane holding focus, else the one last pointed at, else the only one.
+ * The results pane an event is for, by exactly the reckoning the find shortcut
+ * uses — including its most important part, the event's own target.
  *
  * Exposed because "which pane is this for" is not a question about find. A copy
- * has to answer it too — several JSON views listen for the same select-all, and
- * one of them has to be the one that responds (#330 review). Keeping a second
- * notion of the active pane in the grid meant the two could disagree, and they
- * did: this one counts a click anywhere in the pane, its toolbar included, while
- * the grid's counted only clicks in the results body.
+ * has to answer it too, and so does select-all: several JSON views hear the same
+ * document-level event, and one of them has to be the one that responds (#330).
+ * Keeping a second notion of the active pane in the grid meant the two could
+ * disagree, and they did.
  *
- * `null` when nothing indicates a pane and there is more than one, which is the
- * honest answer — the caller decides what to do without a preference.
+ * Taking the target rather than only reading focus is what keeps a pane from
+ * answering for the rest of the app. An event from somewhere else that happens
+ * to be focused belongs to that somewhere else; only an event from nothing in
+ * particular falls back to the pane last pointed at (#328 review).
+ *
+ * `null` when nothing indicates a pane, which is the honest answer — the caller
+ * decides what to do without a preference.
  */
-export function activeResultsPaneElement(): HTMLElement | null {
-  const fromFocus = paneContaining(document.activeElement);
-  if (fromFocus) return fromFocus.element();
-  if (lastPointedId !== null) {
-    const el = panes.get(lastPointedId)?.element();
-    if (el) return el;
-  }
-  return panes.size === 1 ? [...panes.values()][0].element() : null;
+export function resultsPaneElementForEvent(target: EventTarget | null): HTMLElement | null {
+  return paneForEventTarget(target)?.element() ?? null;
 }
 
 /** Reset module state between tests. */

--- a/src/lib/resultsFindShortcut.ts
+++ b/src/lib/resultsFindShortcut.ts
@@ -47,8 +47,14 @@ let nextId = 1;
 let lastPointedId: number | null = null;
 let listening = false;
 
-/** Editors and text fields keep their own find/typing behaviour. */
-function eventBelongsToAnEditor(target: EventTarget | null): boolean {
+/**
+ * Editors and text fields keep their own find/typing behaviour.
+ *
+ * Exported because every results-pane shortcut owes them the same deference,
+ * not just find: Cmd/Ctrl+A inside a query editor means "select this query",
+ * and a pane that took it would be answering for something it does not own.
+ */
+export function eventBelongsToAnEditor(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   // The find bar's own input is a text field but is not somebody else's: the
   // shortcut pressed inside it means "search here again", not "leave me alone".

--- a/src/lib/resultsFindShortcut.ts
+++ b/src/lib/resultsFindShortcut.ts
@@ -126,11 +126,28 @@ function paneForEventTarget(target: EventTarget | null): Pane | undefined {
     const pane = panes.get(lastPointedId);
     if (pane?.element()) return pane;
   }
-  return panes.size === 1 ? [...panes.values()][0] : undefined;
+  return undefined;
 }
 
+/**
+ * Find is more generous than that: with a single pane on screen and nothing
+ * else indicating one, Cmd/Ctrl+F opens it.
+ *
+ * That generosity suits opening a find bar, which is harmless and obviously
+ * what the user meant. It does not suit a key that replaces the selection:
+ * pressing Cmd/Ctrl+A while working in the sidebar would select results the
+ * user was not looking at. So it stays here, with find, rather than in the
+ * shared resolver (#328 review).
+ */
 function targetPane(event: KeyboardEvent): Pane | undefined {
-  return paneForEventTarget(event.target);
+  const pane = paneForEventTarget(event.target);
+  if (pane) return pane;
+  const unfocused =
+    event.target === null ||
+    event.target === document.body ||
+    event.target === document ||
+    event.target === window;
+  return unfocused && panes.size === 1 ? [...panes.values()][0] : undefined;
 }
 
 function onKeyDown(event: KeyboardEvent): void {
@@ -160,6 +177,14 @@ function onPointerDown(event: Event): void {
       return;
     }
   }
+  // Pointing somewhere else means the user has left: a pane the user pointed at
+  // ten minutes ago is not where they are now.
+  //
+  // This matters because most of the app is not focusable. Clicking a sidebar
+  // row moves focus nowhere, so the next keypress targets <body> and reads as
+  // "from nothing in particular" — and a remembered pane would answer for it,
+  // selecting results the user had already navigated away from (#328 review).
+  lastPointedId = null;
 }
 
 /**


### PR DESCRIPTION
Closes #328 — properly this time. #330 fixed real problems around this, but all of them were downstream of a handler that never had a selection to work from.

## The cause

`body { user-select: none }` (`src/styles/globals.css:176`), which stops the app's chrome selecting like a web page.

Under it, Chromium **paints** a select-all across the rows — every one highlights — while reporting the selection to script as collapsed and empty. Instrumented from inside the running app, at the moment the `copy` event fires:

```
COPY fired | prevented=false | views=1 | anchor=#text focus=#text
          | collapsed=true | selLen=0 | encl=S> E<
HANDLER   here=1 own=me tracked=NULL live=NULL
```

Two consequences, which together are the entire bug:

1. The browser's own copy has nothing to copy, so the clipboard is left alone.
2. `selectedJsonEnds()` returns `null` on its `selection.isCollapsed` check, so nothing is recorded, `tracked` is `NULL`, and the rebuild never runs.

The clipboard was never truncated — it was untouched, because there was nothing to truncate. That distinction is what took so long to see: it looks like a copy that did nothing rather than a copy that copied the wrong thing.

## The fix

Claim Ctrl/Cmd+A while the JSON view is the active results pane and set the range explicitly with `selectNodeContents`. That leaves a real selection behind, which both the native copy and the rebuild can read.

It is also the better meaning of the shortcut: in a results pane, select-all is about the results, not the whole application around them. It defers to text fields and Monaco editors, where the key belongs to their content, and to whichever pane the user is working in — the same ownership question the copy already asks, answered from the same place.

## Verified in the app

This was only ever visible in a running app, so that is where it was checked, against live MongoDB:

| Result set | Copied |
|---|---|
| 1 document | 160 chars, 6 lines, whole document |
| 50 documents (~36 lines mounted) | 8172 chars, **297 lines, all 50 documents**, 0 blank lines |

The second is the one that matters: it reaches rows the DOM never held, and the #329 blank-line fix still holds alongside it.

## About the tests

Every existing select-all test mocks `getSelection()` to return a non-collapsed range over `document.body` — exactly the state the browser does **not** produce here. They asserted against a selection that never happens, so they passed while the app did nothing. The mock was the bug.

The new tests use the real Selection API and assert what the browser actually leaves behind. I disabled the fix and re-ran to confirm they are not passing for free: three of the four fail without it.

Full suite: 5 failures, all pre-existing and identical on clean `dev` (locale number formatting, and a `spawn npx ENOENT` in the bundle test).
