### PR TITLE
fix(sidebar): list collections from servers that answer with less detail

### DIFF
--- a/src-tauri/src/db/copy.rs
+++ b/src-tauri/src/db/copy.rs
@@ -144,6 +144,19 @@ pub struct PreflightResult {
     pub self_overwrite: bool,
 }
 
+/// The collections whose kind the server would not report.
+///
+/// Separated out so the rule can be tested for what it is: only an unreported
+/// kind counts, and an ordinary collection is never mistaken for one (#327
+/// review).
+fn unidentified_collections(chosen: &[crate::CollectionInfo]) -> Vec<&str> {
+    chosen
+        .iter()
+        .filter(|c| c.collection_type == crate::db::metadata::UNKNOWN_COLLECTION_TYPE)
+        .map(|c| c.name.as_str())
+        .collect()
+}
+
 /// Does `collection` exist in `db` on connection `id`? Works for mock + real.
 async fn collection_exists(state: &AppState, id: &str, db: &str, collection: &str) -> Result<bool, String> {
     let names = crate::list_collections_impl(state, id, db).await?;
@@ -651,6 +664,27 @@ async fn start_database_copy_inner(
         None => all,
     };
 
+    // A copy decides what to do with each collection by its type: views are
+    // skipped unless asked for, time-series are always skipped, and everything
+    // else is read and written document by document. So a type this server
+    // would not tell us is not something to assume our way past — treating an
+    // unidentified view as an ordinary collection would materialize it into the
+    // target, silently turning a view into a table of its own (#327 review).
+    //
+    // Refusing outright rather than skipping them: a copy that quietly leaves
+    // collections out looks like a copy that worked. This is also no loss of
+    // function, since a server that cannot describe its collections could not
+    // be copied from at all before — the listing itself failed.
+    let unidentified = unidentified_collections(&chosen);
+    if !unidentified.is_empty() {
+        return Err(format!(
+            "This server did not report what kind of collection these are, so they cannot be \
+             copied safely: {}. A view copied as a collection would be materialized into the \
+             target, which is not what a copy means.",
+            unidentified.join(", ")
+        ));
+    }
+
     let task_id = Uuid::new_v4().to_string();
     let task = TaskInfo {
         id: task_id.clone(),
@@ -793,6 +827,46 @@ async fn start_database_copy_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+
+    #[test]
+    fn only_an_unreported_kind_counts_as_unidentified() {
+        // #327 review: the fallback listing cannot tell a view from a collection,
+        // and a copy decides what to do from exactly that field. An unidentified
+        // view copied as an ordinary collection would be materialized into the
+        // target — a view silently turned into a table of its own.
+        let of = |name: &str, kind: &str| crate::CollectionInfo {
+            name: name.to_string(),
+            collection_type: kind.to_string(),
+        };
+        let chosen = vec![
+            of("customers", "collection"),
+            of("active_users", "view"),
+            of("readings", "timeseries"),
+            of("mystery", crate::db::metadata::UNKNOWN_COLLECTION_TYPE),
+        ];
+
+        assert_eq!(unidentified_collections(&chosen), vec!["mystery"]);
+    }
+
+    #[test]
+    fn a_fully_described_listing_is_never_refused() {
+        let of = |name: &str, kind: &str| crate::CollectionInfo {
+            name: name.to_string(),
+            collection_type: kind.to_string(),
+        };
+        let chosen = vec![of("customers", "collection"), of("active_users", "view")];
+        assert!(unidentified_collections(&chosen).is_empty());
+    }
+
+    #[test]
+    fn the_unknown_kind_is_not_one_the_copy_acts_on() {
+        // The whole point of a separate value: were it "collection", the copy
+        // would read it as a confirmed ordinary collection and proceed.
+        for known in ["collection", "view", "timeseries"] {
+            assert_ne!(crate::db::metadata::UNKNOWN_COLLECTION_TYPE, known);
+        }
+    }
 
     #[test]
     fn conflict_mode_parses_known_values_and_rejects_others() {

--- a/src-tauri/src/db/metadata.rs
+++ b/src-tauri/src/db/metadata.rs
@@ -452,3 +452,92 @@ async fn delete_index_inner(
         .map(|_| ())
         .map_err(|e| format!("Failed to delete index: {}", e))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reply a server like Azure Cosmos DB gives to `listCollections`: the
+    /// name, and not much else.
+    fn sparse_listing_entry() -> mongodb::bson::Document {
+        mongodb::bson::doc! { "name": "customers" }
+    }
+
+    /// #327: the driver's own type is what fails, before any of our code runs.
+    ///
+    /// `CollectionSpecification` requires `type`, `options` and `info`, and
+    /// `info.readOnly` as a bare bool, with a default on none of them. A server
+    /// that answers with less cannot be deserialized into it at all, so the
+    /// cursor yields an error, the listing returns `Err`, and the sidebar shows
+    /// an empty database — while `dbStats` beside it reports the real count.
+    ///
+    /// A Cosmos instance is the one thing this cannot be run against here: both
+    /// MongoDB-API emulator images are builds whose evaluation period expired,
+    /// and the current Linux emulator serves the NoSQL API only. So this pins
+    /// the mechanism at the point where it actually breaks — the shape the
+    /// driver will not accept — which is checkable without any server at all.
+    #[test]
+    fn the_driver_cannot_read_a_listing_that_omits_type_options_and_info() {
+        let missing_field = |d: mongodb::bson::Document| {
+            mongodb::bson::from_document::<mongodb::results::CollectionSpecification>(d)
+                .err()
+                .expect(
+                    "if the driver ever accepts a partial listing, the fallback is dead code \
+                     and should be deleted along with this test",
+                )
+                .to_string()
+        };
+
+        // One required field at a time, each refused in turn. Naming them keeps
+        // this honest: the listing fails for the reason claimed, not because the
+        // document was malformed in some other way.
+        assert!(missing_field(sparse_listing_entry()).contains("missing field `type`"));
+        assert!(missing_field(mongodb::bson::doc! {
+            "name": "customers", "type": "collection"
+        })
+        .contains("missing field `options`"));
+        assert!(missing_field(mongodb::bson::doc! {
+            "name": "customers", "type": "collection", "options": {}
+        })
+        .contains("missing field `info`"));
+        // And `info.readOnly` is a bare bool with no default of its own, so even
+        // an `info` that is present but empty is not enough.
+        assert!(missing_field(mongodb::bson::doc! {
+            "name": "customers", "type": "collection", "options": {}, "info": {}
+        })
+        .contains("missing field `readOnly`"));
+    }
+
+    /// The counterpart: what a real MongoDB sends does deserialize, so the
+    /// fallback is reached only by servers that answer with less.
+    #[test]
+    fn a_full_mongodb_listing_still_reads_normally() {
+        let spec = mongodb::bson::from_document::<mongodb::results::CollectionSpecification>(
+            mongodb::bson::doc! {
+                "name": "customers",
+                "type": "collection",
+                "options": {},
+                "info": { "readOnly": false },
+            },
+        )
+        .expect("a complete listing entry must still deserialize");
+        assert_eq!(spec.name, "customers");
+    }
+
+    /// The other half: what the server *will* answer is enough for names alone,
+    /// which is what the fallback asks for.
+    #[test]
+    fn a_sparse_entry_still_yields_its_name() {
+        let name = sparse_listing_entry().get_str("name").unwrap().to_string();
+        assert_eq!(name, "customers");
+    }
+
+    /// The fallback's type must stay distinguishable from a confirmed one — a
+    /// database copy refuses on it rather than materializing what may be a view.
+    #[test]
+    fn the_unknown_type_is_not_a_claim_about_the_collection() {
+        assert_ne!(UNKNOWN_COLLECTION_TYPE, "collection");
+        assert_ne!(UNKNOWN_COLLECTION_TYPE, "view");
+        assert_ne!(UNKNOWN_COLLECTION_TYPE, "timeseries");
+    }
+}

--- a/src-tauri/src/db/metadata.rs
+++ b/src-tauri/src/db/metadata.rs
@@ -111,8 +111,47 @@ async fn list_collections_impl_inner(
     };
 
     let database = client.database(db);
-    // Use list_collections (not list_collection_names) so we can read each
-    // collection's type and let the UI separate Collections / Views / etc.
+    match full_collection_specs(&database).await {
+        Ok(collections) => Ok(collections),
+        // Not every MongoDB-compatible service answers `listCollections` with
+        // everything the driver's `CollectionSpecification` insists on. It
+        // requires `type`, `options` and `info` — and `info.readOnly` as a bare
+        // `bool`, with no default anywhere — while Azure Cosmos DB replies with
+        // little more than the name. One missing field fails the whole listing,
+        // so the tree came up empty while the database's own popover, which
+        // asks `dbStats` instead, cheerfully reported the right count (#327).
+        //
+        // Names alone go out as `nameOnly: true`, which such a service can
+        // satisfy, and the driver then reads back only the name. Collections
+        // without their type are worth far more than no collections: everything
+        // shows as a plain collection, so a view is mislabelled rather than
+        // missing.
+        Err(spec_error) => {
+            let names = database.list_collection_names().await.map_err(|names_error| {
+                // Both failures, because the first one is the interesting one:
+                // it says what the server would not give, and the second only
+                // confirms the fallback did not help either.
+                format!("Failed to list collections: {spec_error}; names only: {names_error}")
+            })?;
+            Ok(names
+                .into_iter()
+                .map(|name| CollectionInfo {
+                    name,
+                    collection_type: "collection".to_string(),
+                })
+                .collect())
+        }
+    }
+}
+
+/// Every collection with its type, as `listCollections` reports it.
+///
+/// Preferred because the type is what lets the UI separate Collections from
+/// Views and time-series; see the fallback above for when a server cannot
+/// answer in that much detail.
+async fn full_collection_specs(
+    database: &mongodb::Database,
+) -> Result<Vec<CollectionInfo>, String> {
     let mut cursor = database
         .list_collections()
         .await

--- a/src-tauri/src/db/metadata.rs
+++ b/src-tauri/src/db/metadata.rs
@@ -80,6 +80,15 @@ pub async fn list_collections_impl(
     result
 }
 
+/// The type of a collection the server would not describe.
+///
+/// Deliberately not "collection". Callers decide things from this field, and
+/// the two are not the same claim: one says "this is an ordinary collection",
+/// the other says "this server did not say". A copy reads it to refuse rather
+/// than materialize what might be a view; the sidebar reads it as nothing in
+/// particular and draws the generic icon, which is exactly right (#327 review).
+pub const UNKNOWN_COLLECTION_TYPE: &str = "unknown";
+
 async fn list_collections_impl_inner(
     state: &AppState,
     id: &str,
@@ -137,7 +146,7 @@ async fn list_collections_impl_inner(
                 .into_iter()
                 .map(|name| CollectionInfo {
                     name,
-                    collection_type: "collection".to_string(),
+                    collection_type: UNKNOWN_COLLECTION_TYPE.to_string(),
                 })
                 .collect())
         }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -645,17 +645,31 @@ export const Sidebar: React.FC<SidebarProps> = ({
     setExpandedConnections((prev) => ({ ...prev, [connId]: true }));
   };
 
+  /**
+   * Load a database's collections into the tree, and say so when it cannot.
+   *
+   * The silence was half of #327. A server whose `listCollections` reply the
+   * driver could not read left the tree empty with nothing but a console line —
+   * indistinguishable from a database that genuinely has no collections, and
+   * flatly contradicted by the database's own popover, which asks `dbStats` and
+   * reported the real count. An empty tree should never be how the app says
+   * something failed.
+   */
+  const loadCollectionsInto = async (connectionId: string, dbName: string) => {
+    const key = `${connectionId}/${dbName}`;
+    try {
+      const colls = await invoke<CollectionInfo[]>('list_collections', { id: connectionId, db: dbName });
+      setCollections((prev) => ({ ...prev, [key]: colls }));
+    } catch (err) {
+      console.error(`Failed to load collections for database ${dbName}`, err);
+      toast(t('toasts.loadCollectionsFailed', { db: dbName, error: `${err}` }), 'error');
+    }
+  };
+
   const ensureDbExpanded = async (connId: string, dbName: string) => {
     const key = `${connId}/${dbName}`;
     setExpandedDbs((prev) => ({ ...prev, [key]: true }));
-    if (!collections[key]) {
-      try {
-        const colls = await invoke<CollectionInfo[]>('list_collections', { id: connId, db: dbName });
-        setCollections((prev) => ({ ...prev, [key]: colls }));
-      } catch (err) {
-        console.error(`Failed to load collections for database ${dbName}`, err);
-      }
-    }
+    if (!collections[key]) await loadCollectionsInto(connId, dbName);
   };
 
   const navigateToPinned = async (item: PinnedItem) => {
@@ -844,14 +858,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     const isExpanding = !expandedDbs[key];
     setExpandedDbs((prev) => ({ ...prev, [key]: !prev[key] }));
 
-    if (isExpanding && !collections[key]) {
-      try {
-        const colls = await invoke<CollectionInfo[]>('list_collections', { id: connectionId, db: dbName });
-        setCollections((prev) => ({ ...prev, [key]: colls }));
-      } catch (err) {
-        console.error(`Failed to load collections for database ${dbName}`, err);
-      }
-    }
+    if (isExpanding && !collections[key]) await loadCollectionsInto(connectionId, dbName);
   };
 
   const toggleCollectionsFolder = async (connectionId: string, dbName: string) => {
@@ -861,12 +868,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
     const collsKey = `${connectionId}/${dbName}`;
     if (!isCurrentlyExpanded && !collections[collsKey]) {
-      try {
-        const colls = await invoke<CollectionInfo[]>('list_collections', { id: connectionId, db: dbName });
-        setCollections((prev) => ({ ...prev, [collsKey]: colls }));
-      } catch (err) {
-        console.error(`Failed to load collections for database ${dbName}`, err);
-      }
+      await loadCollectionsInto(connectionId, dbName);
     }
   };
 
@@ -894,13 +896,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const handleRefreshDb = async (connectionId: string, dbName: string) => {
-    const key = `${connectionId}/${dbName}`;
-    try {
-      const colls = await invoke<CollectionInfo[]>('list_collections', { id: connectionId, db: dbName });
-      setCollections((prev) => ({ ...prev, [key]: colls }));
-    } catch (err) {
-      console.error(err);
-    }
+    // Refresh especially: the user asked for this one, so a failure they cannot
+    // see is a refresh that looks like it emptied the database.
+    await loadCollectionsInto(connectionId, dbName);
   };
 
   const handleAddDatabase = async (connectionId: string) => {

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -1576,6 +1576,40 @@ describe('Sidebar Component', () => {
     expect(await screen.findByText('orders')).toBeInTheDocument();
   });
 
+  it('says so when a database cannot list its collections (#327)', async () => {
+    // The silence was half the bug. A server whose `listCollections` reply the
+    // driver cannot read left the tree empty with only a console line — which
+    // reads as "this database has no collections", and is flatly contradicted
+    // by the database's own popover reporting the real count from `dbStats`.
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'list_databases') return Promise.resolve(['sales_db']);
+      if (cmd === 'list_collections') {
+        return Promise.reject(new Error('Failed to list collections: missing field `readOnly`'));
+      }
+      return Promise.resolve([]);
+    });
+
+    render(
+      <Sidebar
+        onSelectCollection={() => {}}
+        onSelectIndex={() => {}}
+        activeCollection={null}
+        activeConnections={[{ id: 'conn-1', name: 'Local', uri: 'mongodb://localhost' }]}
+        onOpenConnectionManager={() => {}}
+        onDisconnect={() => {}}
+        onOpenSettings={() => {}}
+      />,
+    );
+
+    fireEvent.click(await screen.findByText('sales_db'));
+
+    // The database is named, so the user knows which one, and the server's own
+    // words are kept — they are what makes this diagnosable at all.
+    const toast = await screen.findByText(/Could not list collections in sales_db/);
+    expect(toast).toHaveTextContent('missing field `readOnly`');
+  });
+
+
   it('pins a connection from the context menu and shows a toast', async () => {
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === 'list_databases') return Promise.resolve(['sales_db']);

--- a/src/locales/de/sidebar.json
+++ b/src/locales/de/sidebar.json
@@ -162,6 +162,7 @@
     "readOnlyBlocked": "Diese Verbindung ist schreibgeschützt (Produktionsschutz). Ändere den Verbindungsmodus im Verbindungsmanager, um Daten zu bearbeiten.",
     "removedFromFavorites": "Aus Favoriten entfernt",
     "namespaceBusyWithSave": "Hier wird gerade ein Dokument gespeichert. Warte, bis das fertig ist, bevor du umbenennst.",
+    "loadCollectionsFailed": "Sammlungen in {{db}} konnten nicht aufgelistet werden: {{error}}",
     "renameCollectionFailed": "Collection konnte nicht umbenannt werden: {{error}}",
     "renameDatabaseFailed": "Datenbank konnte nicht umbenannt werden: {{error}}",
     "savedQueryGone": "Gespeicherte Abfrage existiert nicht mehr",

--- a/src/locales/en/sidebar.json
+++ b/src/locales/en/sidebar.json
@@ -157,6 +157,7 @@
     "createDatabaseFailed": "Failed to create database: {{error}}",
     "dropCollectionFailed": "Failed to drop collection: {{error}}",
     "dropDatabaseFailed": "Failed to drop database: {{error}}",
+    "loadCollectionsFailed": "Could not list collections in {{db}}: {{error}}",
     "namespaceBusyWithSave": "A document is being saved here. Wait for it to finish before renaming.",
     "noSavedConnection": "No saved connection \"{{name}}\". Add it in Connection Manager, then try again.",
     "pinned": "Pinned to sidebar",

--- a/src/locales/zh-Hans/sidebar.json
+++ b/src/locales/zh-Hans/sidebar.json
@@ -162,6 +162,7 @@
     "readOnlyBlocked": "此连接为只读（生产保护）。如需修改数据，请在连接设置中更改连接模式。",
     "removedFromFavorites": "已从收藏中移除",
     "namespaceBusyWithSave": "此处正在保存文档，请等待完成后再重命名。",
+    "loadCollectionsFailed": "无法列出 {{db}} 中的集合：{{error}}",
     "renameCollectionFailed": "重命名 Collection 失败：{{error}}",
     "renameDatabaseFailed": "重命名数据库失败：{{error}}",
     "savedQueryGone": "该已保存的查询已不存在",


### PR DESCRIPTION
Closes #327.

## What is happening

The reporter's own detail is the diagnosis: the count is right and the list is empty, which means two different commands.

- **The popover count** comes from `DbStatsCard` → `get_db_stats` → `dbStats`. Cosmos answers it fine, so the number is correct.
- **The tree** comes from `list_collections` → `listCollections`, deserialized into the driver's full `CollectionSpecification`.

That struct requires more than Cosmos returns, and nothing in it has a default:

```rust
pub name: String,
#[serde(rename = "type")] pub collection_type: CollectionType,  // required
pub options: CreateCollectionOptions,                            // required
pub info: CollectionSpecificationInfo,                           // required
// ...and inside info:
pub read_only: bool,                                             // required, bare bool
```

Azure Cosmos DB's Mongo API replies with little more than the name. One missing field and the cursor yields a deserialization error, `list_collections_impl_inner` turns it into `Err`, and the tree is empty.

## Why it looked like "no collections" rather than "failed"

Every sidebar path did this:

```ts
} catch (err) { console.error(err); }
```

So the failure only existed in devtools. An empty tree became the app's way of saying "that did not work" — indistinguishable from a database that genuinely has none, and contradicted by the popover right beside it.

## The fix

**Fall back to names.** When the detailed listing fails, ask again with `list_collection_names()`, which goes out as `nameOnly: true` and reads back only the name. A server that cannot produce a full specification can still answer that. Collections lose their type on this path, so a view shows as a plain collection — mislabelled rather than missing, which is much the better failure. The first error is kept in the message, since it is the one that says what the server would not give.

**Stop swallowing it.** One loader now serves all four sidebar paths — expand, toggle, folder toggle and refresh — and reports what happened with the database named and the server's own words kept. Refresh especially: the user asked for that one, so a silent failure there looks like the refresh emptied the database.

## What is verified, and what is not

The error surfacing has a test, and I checked it fails when the toast is removed — with it swallowed, the assertion finds nothing, which is exactly the old behaviour.

The fallback itself is **not verified against Cosmos**, because reproducing it needs a Cosmos instance. The chain is drawn from the driver's own source and matches every detail of the report, but it is inference. The fallback is worth having either way — it costs nothing on a server that answers in full, and it is the difference between a usable tree and an empty one on a server that does not.

If @ericschmar can open devtools and share the `Failed to load collections for database …` line, that would confirm it outright — and after this change the app will show that text itself.
