### PR TITLE
fix(results): keep table column widths across a query run

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -194,6 +194,12 @@ export interface QueryTab {
   // Which results tab is showing, kept on the tab for the same reason as
   // viewMode: the grid remounts on every run (#281).
   resultsTab?: ResultsTab;
+  // Table column widths the user dragged, kept on the tab for the same reason
+  // again: re-running a query threw them away and every column snapped back to
+  // its default, so widening a column to read a field had to be redone after
+  // every run (#268). Keyed by column name, which is why this belongs to a tab
+  // — a tab is one collection, and its columns are that collection's.
+  columnWidths?: Record<string, number>;
   // An in-progress document edit belongs to the tab it was opened from, so it
   // survives a look at another tab and dies with this one (#277).
   documentEdit?: DocumentEdit;
@@ -265,6 +271,8 @@ function rowsAreStoredDocuments(tab: {
   if (tab.lastAggregate) return pipelineYieldsWholeDocuments(tab.lastAggregate);
   return !projectionComputesId(tab.lastQuery?.projection);
 }
+
+const EMPTY_COLUMN_WIDTHS: Record<string, number> = {};
 
 const DEFAULT_QUERY = { filter: '{}', sort: '{}', projection: '{}', limit: 50, skip: 0 };
 
@@ -760,6 +768,12 @@ function Workspace() {
   const handleResultsTabChange = useCallback((tabId: string, resultsTab: ResultsTab) => {
     setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, resultsTab } : t)));
   }, []);
+  const handleColumnWidthsChange = useCallback(
+    (tabId: string, columnWidths: Record<string, number>) => {
+      setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, columnWidths } : t)));
+    },
+    []
+  );
   const handleChatMessagesChange = useCallback((tabId: string, messages: ChatMessage[]) => {
     const prev = tabChatCache.current.get(tabId);
     tabChatCache.current.set(tabId, { ...prev, messages, isOpen: prev?.isOpen ?? false });
@@ -4577,6 +4591,8 @@ function Workspace() {
                     onViewModeChange={(mode) => handleViewModeChange(tab.id, mode)}
                     activeTab={tab.resultsTab ?? 'results'}
                     onActiveTabChange={(t) => handleResultsTabChange(tab.id, t)}
+                    columnWidths={tab.columnWidths ?? EMPTY_COLUMN_WIDTHS}
+                    onColumnWidthsChange={(w) => handleColumnWidthsChange(tab.id, w)}
                     onCreateSuggestedIndex={s => handleCreateSuggestedIndex(tab, s)}
                     {...(!tab.lastAggregate ? {
                       onPageChange: (newSkip: number) => handlePageChange(tab, newSkip),

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -69,6 +69,12 @@ interface DataGridProps {
    *  choice the user loses (#281). Omit both to self-manage. */
   activeTab?: ResultsTab;
   onActiveTabChange?: (tab: ResultsTab) => void;
+  /** Table column widths, owned by the caller for the same reason as the two
+   *  above: the grid remounts on every run, so widths kept here are widths the
+   *  user re-drags after every query (#268). Keyed by column name. Omit both to
+   *  self-manage. */
+  columnWidths?: Record<string, number>;
+  onColumnWidthsChange?: (widths: Record<string, number>) => void;
   /**
    * Drop the control bar — the Results/Explain tabs, the view-mode switcher and
    * the row actions — and render the documents alone.
@@ -574,6 +580,8 @@ export const DataGrid: React.FC<DataGridProps> = ({
   viewMode: controlledViewMode,
   activeTab: controlledActiveTab,
   onActiveTabChange,
+  columnWidths: controlledColWidths,
+  onColumnWidthsChange,
   onViewModeChange,
   onCreateSuggestedIndex,
   connectionMode,
@@ -692,9 +700,19 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // Chromeless callers have no tabs to switch and no explain plan to show.
   const effectiveTab = chromeless ? 'results' : activeTab;
 
-  // Column resize: table view keeps per-column widths (session-scoped — the
-  // column set changes per collection); the tree view's key column persists.
-  const [colWidths, setColWidths] = useState<Record<string, number>>({});
+  // Column resize: table view keeps per-column widths, owned by the caller for
+  // the same reason `viewMode` and `activeTab` are. Held here they died with
+  // every run — the grid remounts, the widths came back as {}, and a column
+  // widened to read a field snapped back to 180px (#268).
+  const [uncontrolledColWidths, setUncontrolledColWidths] = useState<Record<string, number>>({});
+  const colWidths = controlledColWidths ?? uncontrolledColWidths;
+  const setColWidths = (update: (prev: Record<string, number>) => Record<string, number>) => {
+    setUncontrolledColWidths(update);
+    // Computed from the widths on screen rather than from the uncontrolled copy,
+    // which a controlled caller never updates and which would otherwise send
+    // every drag as though it were the first.
+    onColumnWidthsChange?.(update(colWidths));
+  };
   const colWidth = (col: string) => colWidths[col] ?? 180;
   // The table header and the virtualized body are separate boxes: only the body
   // scrolls. Once resized columns overflow the viewport the header would stay

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react';
 
 // Monaco renders the Query Code panel; mock it as a plain textarea (same shape
 // as the other component tests) so assertions can read the generated code.
@@ -611,6 +611,98 @@ describe('DataGrid — Compare documents', () => {
     openMenuForRow('Bob');
     expect(screen.getByText('Compare with…')).toBeInTheDocument();
     expect(screen.queryByText('Compare with selected')).not.toBeInTheDocument();
+  });
+});
+
+
+// #268: re-running a query threw away every column width. The results pane
+// renders `{loading ? <spinner/> : <DataGrid/>}`, so the grid unmounts on every
+// run and its widths came back as {} — a column widened to read a field snapped
+// straight back to its default, after every single run.
+describe('DataGrid — column widths survive a run (#268)', () => {
+  const widen = (label: RegExp) => {
+    const handle = screen.getByRole('separator', { name: label });
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    return handle;
+  };
+
+  it('reports a resize to the caller that owns the widths', () => {
+    const onColumnWidthsChange = vi.fn();
+    render(
+      <DataGrid documents={mockDocuments} columnWidths={{}} onColumnWidthsChange={onColumnWidthsChange} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    widen(/resize name column/i);
+
+    expect(onColumnWidthsChange).toHaveBeenCalledTimes(1);
+    // 180 default + one 16px step.
+    expect(onColumnWidthsChange.mock.calls[0][0]).toMatchObject({ name: 196 });
+  });
+
+  it('renders the width the caller gives it, so a remount keeps it', () => {
+    // The remount is the bug: this is what the grid comes back as after a run.
+    const { unmount } = render(<DataGrid documents={mockDocuments} columnWidths={{ name: 320 }} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    expect(screen.getByTestId('table-header').textContent).toContain('name');
+    unmount();
+
+    render(<DataGrid documents={mockDocuments} columnWidths={{ name: 320 }} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+
+    // Widened again from 320, not from the 180 default — which is only true if
+    // the width came from the caller rather than from remounted local state.
+    const onColumnWidthsChange = vi.fn();
+    cleanup();
+    render(
+      <DataGrid
+        documents={mockDocuments}
+        columnWidths={{ name: 320 }}
+        onColumnWidthsChange={onColumnWidthsChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    widen(/resize name column/i);
+    expect(onColumnWidthsChange.mock.calls[0][0]).toMatchObject({ name: 336 });
+  });
+
+  it('measures a resize made after a run from the width the run kept', () => {
+    // The whole scenario, in order: widen a column, run the query — which
+    // unmounts the grid — then widen again. The second drag has to start from
+    // the kept width, which is only true if the grid reads the caller's copy
+    // rather than the local one the remount just emptied.
+    const widths: Record<string, number> = {};
+    const onColumnWidthsChange = vi.fn((next: Record<string, number>) => {
+      Object.assign(widths, next);
+    });
+    const grid = () => (
+      <DataGrid
+        documents={mockDocuments}
+        columnWidths={{ ...widths }}
+        onColumnWidthsChange={onColumnWidthsChange}
+      />
+    );
+
+    render(grid());
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    widen(/resize name column/i);
+    expect(widths.name).toBe(196); // 180 + 16
+
+    // The run: spinner replaces the grid, then the grid comes back.
+    cleanup();
+    render(grid());
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    widen(/resize name column/i);
+
+    expect(widths.name).toBe(212); // 196 + 16, not 196 again
+  });
+
+  it('still manages its own widths when nobody owns them', () => {
+    // MongoShell renders the grid with nothing to persist to; it must keep
+    // working exactly as before.
+    render(<DataGrid documents={mockDocuments} />);
+    fireEvent.click(screen.getByRole('button', { name: /table/i }));
+    expect(() => widen(/resize name column/i)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
Closes #268.

## Cause

The results pane renders the grid conditionally:

```tsx
{tab.loading ? <spinner/> : <DataGrid …/>}
```

So every run unmounts the grid and mounts a new one. Column widths lived in that grid's own `useState`, so they came back as `{}` and every column snapped to its 180px default.

This is the third time the same remount has taken something from the user. `viewMode` was lifted to the tab because of it, then `activeTab` after that, and both carry a comment saying so:

```ts
/** Results view mode, owned by the caller so it survives this grid being
 *  unmounted. … the grid remounts on EVERY run … */
```

Widths go the same way. They belong on the tab for an extra reason too: they are keyed by column name, and a tab is one collection, so its widths are that collection's.

## The subtle part

The width reported to the caller is computed from the widths **on screen**, not from the grid's local copy:

```ts
onColumnWidthsChange?.(update(colWidths));
```

A controlled caller never updates that local copy, so measuring from it would make the first drag after every run start from 180 again — the bug would look fixed while still losing most of each resize. There is a test for exactly this, which drags, remounts, and drags again.

Uncontrolled callers are unaffected: MongoShell renders the grid with nothing to persist to and keeps managing its own widths.

## Verified in the app

Against live MongoDB, reading the header's pixel positions:

| Step | EMAIL column starts at |
| --- | --- |
| Fresh grid, default widths | x≈418 |
| After widening NAME | x≈478 |
| **After re-running the query** | **x≈478 — unchanged** |

The reporter's exact steps, and the width now survives.

## Tests

Four, and I checked they are not passing for free — reverting the fix fails two of them:

- a resize is reported to the owner
- the caller's width is what renders, so a remount keeps it *(fails without the fix)*
- a resize made after a run is measured from the width the run kept *(fails without the fix)*
- a caller that owns nothing still gets the old self-managed behaviour

Full suite: 5 failures, all pre-existing and identical on clean `dev`.

## Not in scope

The issue also asks that "generally any UI adjustment" survive. Lifting state per-property fixes them one at a time; the root cure is to stop unmounting the grid at all — render the spinner as an overlay — which would preserve scroll position, collapsed folds and find state too, and would stop this recurring. That is a change to how loading looks, so it belongs in its own PR rather than riding along here. Happy to open an issue for it.
