### PR TITLE
feat(workspace): keep recently used tabs mounted, budgeted per kind

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5148,6 +5148,7 @@ function Workspace() {
                 return color ? tabColorCss(color) : undefined;
               })(),
               icon: tabIconFor(tab, tab.id === pane.activeTabId),
+              kind: tab.type,
             }))
         }
         renderTabContent={renderTabContent}

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '@/lib/utils';
+import { useTabVisible } from '@/workspace/tabVisibility';
 
 export interface ContextMenuItem {
   label: string;
@@ -27,6 +28,15 @@ interface ContextMenuProps {
 export const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, items, onClose }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState({ left: x, top: y });
+
+  // Rendered through a portal, so the wrapper that hides a kept-alive tab
+  // (#240) cannot hide this. Switching tabs by keyboard with a menu open
+  // would leave it over the new tab, its actions — deletes included — still
+  // wired to the hidden one. It closes instead.
+  const tabVisible = useTabVisible();
+  useEffect(() => {
+    if (!tabVisible) onClose();
+  }, [tabVisible, onClose]);
 
   // Keep the menu fully on screen.
   useLayoutEffect(() => {
@@ -60,6 +70,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, items, onClose }
     };
   }, [onClose]);
 
+  if (!tabVisible) return null;
   return createPortal(
     <div
       ref={ref}

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -34,6 +34,7 @@ import { Badge } from '@/components/ui/badge';
 import { useThemeOptional } from '@/hooks/use-theme';
 import { getScaledRowHeight } from '@/lib/themes/ui-scale';
 import { cn } from '@/lib/utils';
+import { useTabVisible } from '@/workspace/tabVisibility';
 import type { SpacingDensity } from '@/lib/themes/schema';
 
 interface DataGridProps {
@@ -1160,6 +1161,13 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // still mounted, and the copy is rebuilt from the line data rather than from
   // the DOM.
   const jsonViewRef = React.useRef<HTMLDivElement | null>(null);
+  // These grids listen on `document` for copy and select-all, and answer for a
+  // selection whose endpoints are inside their own container — which bypasses
+  // the active-pane check on purpose (#330). A kept-alive tab (#240) stays
+  // mounted with its selection intact, so a hidden grid would go on answering
+  // Ctrl+C in the tab the user switched to, copying data they cannot see. Only
+  // the grid on screen listens.
+  const tabVisible = useTabVisible();
   // The two ends of the selection, each remembered independently at the last
   // row it was seen on. Modelling the ends rather than a min/max span is what
   // lets the range CONTRACT: during a drag the anchor is fixed and only the
@@ -1404,7 +1412,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // meaning of the shortcut too: in a results pane, select-all is about the
   // results, not about the whole application around them.
   useEffect(() => {
-    if (viewMode !== 'json') return;
+    if (viewMode !== 'json' || !tabVisible) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.defaultPrevented) return;
       if (e.key !== 'a' && e.key !== 'A') return;
@@ -1432,20 +1440,20 @@ export const DataGrid: React.FC<DataGridProps> = ({
     // any window-level handler that would otherwise claim the key first.
     document.addEventListener('keydown', onKeyDown, true);
     return () => document.removeEventListener('keydown', onKeyDown, true);
-  }, [viewMode]);
+  }, [viewMode, tabVisible]);
 
   const jsonCopyRef = React.useRef(handleJsonCopy);
   useEffect(() => {
     jsonCopyRef.current = handleJsonCopy;
   });
   useEffect(() => {
-    if (viewMode !== 'json') return;
+    if (viewMode !== 'json' || !tabVisible) return;
     const onCopy = (e: ClipboardEvent) => jsonCopyRef.current(e);
     document.addEventListener('copy', onCopy);
     // Nothing to unwind: ownership is the pane registry's, and a pane
     // unregisters itself there when it goes.
     return () => document.removeEventListener('copy', onCopy);
-  }, [viewMode]);
+  }, [viewMode, tabVisible]);
 
   const toggleFold = (id: number) => {
     setCollapsedFolds((prev) => {

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -23,6 +23,7 @@ import { useMonacoTheme, useMonacoFontSize } from '../lib/useMonacoTheme';
 import { attachMonaco } from '../lib/monacoAppTheme';
 import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 import { windowLabel } from '../workspace/workspaceStore';
+import { useTabVisible } from '../workspace/tabVisibility';
 
 type ShellTab = 'console' | 'viewer';
 
@@ -688,10 +689,17 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connectionId, connectionUri, mongoshPath, retryNonce, sessionKey, hydrated]);
 
+  // Pinned to the newest output. Not while the tab is hidden: a kept-alive
+  // tab (#240) is `display: none`, where scrollHeight is 0 and the assignment
+  // would reset the position — and nothing would scroll again on reveal. So
+  // the scroll waits for the tab to be shown, which is what brings a command
+  // that finished while the user was elsewhere into view.
+  const tabVisible = useTabVisible();
   useEffect(() => {
+    if (!tabVisible) return;
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [entries, tab]);
+  }, [entries, tab, tabVisible]);
 
   // When the session failed to attach, probe for a usable mongosh (managed
   // install, PATH, well-known locations) so the gate can offer a one-click
@@ -1245,7 +1253,11 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         </div>
 
         {tab === 'console' ? (
-          <div className="min-h-0 flex-1 overflow-y-auto p-2 font-mono text-xs" ref={scrollRef}>
+          <div
+            className="min-h-0 flex-1 overflow-y-auto p-2 font-mono text-xs"
+            ref={scrollRef}
+            data-testid="shell-transcript"
+          >
             {entries.length === 0 && (
               <div className="py-4 text-center text-muted-foreground">{t('mongoShell.console.cleared')}</div>
             )}

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { useTranslation } from 'react-i18next';
+import { useTabVisible } from '../workspace/tabVisibility';
 import {
   Activity,
   RefreshCw,
@@ -590,7 +591,17 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
     sectionRef.current = section;
   }, [section]);
 
+  // Kept-alive tabs stay mounted while hidden (#240), and `document.hidden`
+  // says nothing about that. While this tab is not on screen a poll fetches
+  // nothing and sets nothing; the interval keeps its rhythm but does no work,
+  // so pausing does not reset the sample history the way re-running the
+  // interval effect would. Coming back fetches at once rather than waiting
+  // out the rest of the interval.
+  const tabVisible = useTabVisible();
+  const tabVisibleRef = useRef(tabVisible);
+
   const pollOnce = useCallback(async () => {
+    if (!tabVisibleRef.current) return;
     if (typeof document !== 'undefined' && document.hidden) return;
     const [sRes, oRes, cRes] = await Promise.allSettled([
       serverStatus(connectionId),
@@ -621,6 +632,14 @@ export const MonitoringView: React.FC<MonitoringViewProps> = ({ connectionId }) 
       setClusterErr(String((cRes.reason as Error)?.message || cRes.reason));
     }
   }, [connectionId]);
+
+  // Declared before the interval effect so the ref is right before its first
+  // poll; on mount nothing has changed, so this adds no poll of its own.
+  useEffect(() => {
+    const wasVisible = tabVisibleRef.current;
+    tabVisibleRef.current = tabVisible;
+    if (tabVisible && !wasVisible) void pollOnce();
+  }, [tabVisible, pollOnce]);
 
   useEffect(() => {
     aliveRef.current = true;

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -29,6 +29,7 @@ import { SUPPORTED_LOCALES, SYSTEM_LOCALE, type LocaleSetting } from '@/lib/i18n
 import { getMcpStatus, mcpSetEnabled, mcpRegenerateToken, type McpStatusUi } from '@/lib/mcpApi';
 import type { ConnectionProfile } from '@/lib/connection';
 import { CHECK_UPDATE_EVENT } from './UpdatePrompt';
+import { useTabVisible } from '../workspace/tabVisibility';
 import {
   formatLastChecked,
   readUpdateCheckSnapshot,
@@ -277,10 +278,12 @@ const McpSettingsPanel: React.FC = () => {
 
   // Poll precedent: App.tsx's resource-usage/export-task polls (App.tsx
   // ~424-436) — `active` flag + `clearInterval` on cleanup, StrictMode-safe.
-  // Only runs while this tab is mounted AND the server is enabled, since
-  // there is nothing new to poll for while disabled.
+  // Only runs while this tab is on screen AND the server is enabled, since
+  // there is nothing new to poll for while disabled — and nobody to show it
+  // to while the Settings tab is kept mounted but hidden (#240).
+  const tabVisible = useTabVisible();
   useEffect(() => {
-    if (!status?.enabled) return;
+    if (!status?.enabled || !tabVisible) return;
     let active = true;
     const id = setInterval(() => {
       getMcpStatus()
@@ -291,7 +294,7 @@ const McpSettingsPanel: React.FC = () => {
       active = false;
       clearInterval(id);
     };
-  }, [status?.enabled]);
+  }, [status?.enabled, tabVisible]);
 
   const copy = (key: string, text: string) => {
     navigator.clipboard?.writeText(text);

--- a/src/components/WatchPanel.tsx
+++ b/src/components/WatchPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { List, type RowComponentProps } from 'react-window';
 import { useTranslation } from 'react-i18next';
+import { useTabVisible } from '../workspace/tabVisibility';
 import { Database, Layers, Pause, Play, Radio, Trash2, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -237,6 +238,16 @@ export const WatchPanel: React.FC<WatchPanelProps> = ({
   // tearing the cursor down here would drop its resume token and silently miss
   // every change until the user came back. The tab's close path stops it, the
   // same way a shell session is ended.
+  // Kept-alive tabs stay mounted while hidden (#240). A hidden Watch tab polls
+  // nothing: the backend keeps buffering for it — evicting the oldest past its
+  // cap and reporting how many it dropped, exactly as for any slow consumer —
+  // and the first tick after the tab is shown again drains what accumulated.
+  const tabVisible = useTabVisible();
+  const tabVisibleRef = useRef(tabVisible);
+  useEffect(() => {
+    tabVisibleRef.current = tabVisible;
+  }, [tabVisible]);
+
   useEffect(() => {
     // Nothing may start before the filter has been reconciled above, or the
     // first start would be the unfiltered one this is here to avoid.
@@ -327,8 +338,11 @@ export const WatchPanel: React.FC<WatchPanelProps> = ({
         polling = false;
       }
     };
-    const timer = setInterval(() => void tick(), POLL_MS);
-    void tick();
+    const run = () => {
+      if (tabVisibleRef.current) void tick();
+    };
+    const timer = setInterval(run, POLL_MS);
+    run();
 
     return () => {
       alive = false;

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { renderWithProviders } from '../../test/render-with-providers';
 import { resetUpdateTabStateDebounce } from '../../workspace/workspaceStore';
 import App, { tabLabelFor, tabTooltipFor, type QueryTab } from '../../App';
@@ -2616,22 +2616,27 @@ describe('App Component', () => {
     });
 
     const { fireEvent } = await import('@testing-library/react');
+    // Inactive tabs stay mounted now (#240), so a global query matches every
+    // mounted tab's editor. Scope to the one actually on screen — which is
+    // also what the user sees, and so what this test is really about.
+    const visibleTab = () =>
+      within(document.querySelector('[data-testid^="tab-content-"]:not([hidden])') as HTMLElement);
     renderWithProviders(<App />);
     await screen.findByTestId('mock-sidebar');
 
     // Open customers, type a custom filter.
     fireEvent.click(screen.getByTestId('select-collection-btn'));
-    await screen.findByText(/"Sample"/);
-    fireEvent.click(screen.getByTestId('toggle-query-builder'));
-    const filterInput = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    await screen.findAllByText(/"Sample"/);
+    fireEvent.click(visibleTab().getByTestId('toggle-query-builder'));
+    const filterInput = visibleTab().getByTestId('query-filter-input') as HTMLTextAreaElement;
     fireEvent.change(filterInput, { target: { value: '{"status":"active"}' } });
     expect(filterInput.value).toContain('"status"');
 
     // Switch to orders — editor must reset to the default empty filter, not carry over.
     fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
-    await screen.findByText(/"Sample"/);
-    fireEvent.click(screen.getByTestId('toggle-query-builder'));
-    const ordersFilter = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    await screen.findAllByText(/"Sample"/);
+    fireEvent.click(visibleTab().getByTestId('toggle-query-builder'));
+    const ordersFilter = visibleTab().getByTestId('query-filter-input') as HTMLTextAreaElement;
     expect(ordersFilter.value).toBe('');
 
     // Type a different filter on orders.
@@ -2640,16 +2645,16 @@ describe('App Component', () => {
 
     // Switch back to customers — customers filter must be restored.
     fireEvent.click(screen.getByTestId('select-collection-btn'));
-    await screen.findByText(/"Sample"/);
-    fireEvent.click(screen.getByTestId('toggle-query-builder'));
-    const customersFilterAgain = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    await screen.findAllByText(/"Sample"/);
+    fireEvent.click(visibleTab().getByTestId('toggle-query-builder'));
+    const customersFilterAgain = visibleTab().getByTestId('query-filter-input') as HTMLTextAreaElement;
     expect(customersFilterAgain.value).toContain('"status"');
 
     // Switch back to orders — orders filter must be restored.
     fireEvent.click(screen.getByTestId('select-orders-collection-btn'));
-    await screen.findByText(/"Sample"/);
-    fireEvent.click(screen.getByTestId('toggle-query-builder'));
-    const ordersFilterAgain = screen.getByTestId('query-filter-input') as HTMLTextAreaElement;
+    await screen.findAllByText(/"Sample"/);
+    fireEvent.click(visibleTab().getByTestId('toggle-query-builder'));
+    const ordersFilterAgain = visibleTab().getByTestId('query-filter-input') as HTMLTextAreaElement;
     expect(ordersFilterAgain.value).toContain('"shipped"');
   });
 

--- a/src/components/__tests__/ContextMenu.test.tsx
+++ b/src/components/__tests__/ContextMenu.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ContextMenu } from '../ContextMenu';
+import { TabVisibleContext } from '../../workspace/tabVisibility';
 
 describe('ContextMenu', () => {
   it('renders items and fires onClick then onClose', () => {
@@ -17,6 +18,24 @@ describe('ContextMenu', () => {
     expect(screen.getByTestId('context-menu')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Edit'));
     expect(edit).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes when the tab it belongs to is hidden', () => {
+    // It renders through a portal, outside the wrapper that hides a kept-alive
+    // tab (#240); left up, its actions would still act for the hidden tab.
+    const onClose = vi.fn();
+    const menu = (visible: boolean) => (
+      <TabVisibleContext.Provider value={visible}>
+        <ContextMenu x={0} y={0} items={[{ label: 'Delete', onClick: () => {}, danger: true }]} onClose={onClose} />
+      </TabVisibleContext.Provider>
+    );
+    const { rerender } = render(menu(true));
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+
+    rerender(menu(false));
+
+    expect(screen.queryByTestId('context-menu')).toBeNull();
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@/hooks/use-theme', () => ({
 }));
 
 import { DataGrid, getExplainTree } from '../DataGrid';
+import { TabVisibleContext } from '../../workspace/tabVisibility';
 import { resetResultsFindShortcutForTests } from '@/lib/resultsFindShortcut';
 
 // Collect every node name in the tree (depth-first) for assertions.
@@ -2184,5 +2185,48 @@ describe('DataGrid — tab guards survive StrictMode replay (#325 review)', () =
       </React.StrictMode>
     );
     expect(onActiveTabChange).toHaveBeenCalledWith('explain');
+  });
+});
+
+describe('DataGrid — a hidden tab does not answer the clipboard (#240)', () => {
+  const view = (visible: boolean) => (
+    <TabVisibleContext.Provider value={visible}>
+      <DataGrid documents={mockDocuments} />
+    </TabVisibleContext.Provider>
+  );
+
+  const pressSelectAll = (target: EventTarget) => {
+    const event = new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, bubbles: true, cancelable: true });
+    target.dispatchEvent(event);
+    return event;
+  };
+
+  it('leaves select-all alone once its tab is hidden', () => {
+    // The grid stays mounted (#240), so without this it would still claim the
+    // key pressed in the tab the user switched to.
+    const { rerender } = render(view(true));
+    const json = screen.getByTestId('json-view');
+    document.getSelection()?.removeAllRanges();
+    expect(pressSelectAll(json).defaultPrevented).toBe(true);
+
+    rerender(view(false));
+    expect(pressSelectAll(json).defaultPrevented).toBe(false);
+  });
+
+  it('leaves a copy alone once its tab is hidden', () => {
+    const { rerender } = render(view(true));
+    const json = screen.getByTestId('json-view');
+    document.getSelection()?.removeAllRanges();
+    pressSelectAll(json);
+    document.dispatchEvent(new Event('selectionchange'));
+
+    const shown = vi.fn();
+    fireEvent.copy(json, { clipboardData: { setData: shown, getData: () => '' } });
+    expect(shown).toHaveBeenCalled();
+
+    rerender(view(false));
+    const hidden = vi.fn();
+    fireEvent.copy(json, { clipboardData: { setData: hidden, getData: () => '' } });
+    expect(hidden).not.toHaveBeenCalled();
   });
 });

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MongoShell } from '../MongoShell';
 import { readShellSession, resetShellSessions, writeShellSession } from '../../lib/mongoshSession';
+import { TabVisibleContext } from '../../workspace/tabVisibility';
 
 const mockInvoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({
@@ -28,6 +29,35 @@ vi.mock('@monaco-editor/react', () => ({
 }));
 
 describe('MongoShell Component', () => {
+  it('scrolls the transcript to the newest output when its hidden tab is shown again', async () => {
+    // A kept-alive tab (#240) is display:none while another tab is on screen.
+    // There scrollHeight is 0, so scrolling on new output resets the position
+    // — and nothing scrolled again on reveal, leaving the user at the top of
+    // the transcript instead of at the command that finished meanwhile.
+    const view = (visible: boolean) => (
+      <TabVisibleContext.Provider value={visible}>
+        <MongoShell connectionId="conn-1" connectionName="Local" connectionUri="mongodb://localhost:27017" databaseName="sales_db" sessionKey="shell-tab" />
+      </TabVisibleContext.Provider>
+    );
+    const { rerender } = render(view(true));
+    await screen.findByTestId('shell-restart-session');
+    const transcript = screen.getByTestId('shell-transcript');
+    let shown = true;
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, get: () => (shown ? 500 : 0) });
+
+    shown = false;
+    rerender(view(false));
+    transcript.scrollTop = 0;
+    fireEvent.change(screen.getByLabelText('mongosh editor'), { target: { value: 'db.orders.countDocuments()' } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    await screen.findByText('mongosh result');
+    expect(transcript.scrollTop).toBe(0);
+
+    shown = true;
+    rerender(view(true));
+    expect(transcript.scrollTop).toBe(500);
+  });
+
   beforeEach(() => {
     resetShellSessions();
     vi.clearAllMocks();

--- a/src/components/__tests__/MonitoringView.test.tsx
+++ b/src/components/__tests__/MonitoringView.test.tsx
@@ -5,6 +5,7 @@ const mockInvoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: any[]) => mockInvoke(...a) }));
 
 import { MonitoringView } from '../MonitoringView';
+import { TabVisibleContext } from '../../workspace/tabVisibility';
 
 const STATUS = {
   host: 'h:27017', version: '7.0.0', uptimeSeconds: 3600,
@@ -48,6 +49,27 @@ beforeEach(() => {
 });
 
 describe('MonitoringView', () => {
+  it('does not poll while its tab is hidden, and fetches at once when it is shown again', async () => {
+    // A kept-alive tab stays mounted while another tab is on screen (#240).
+    const statusCalls = () => mockInvoke.mock.calls.filter((c) => c[0] === 'server_status').length;
+    const view = (visible: boolean) => (
+      <TabVisibleContext.Provider value={visible}>
+        <MonitoringView connectionId="c1" />
+      </TabVisibleContext.Provider>
+    );
+    const { rerender } = render(view(false));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(statusCalls()).toBe(0);
+
+    rerender(view(true));
+    await waitFor(() => expect(statusCalls()).toBe(1));
+
+    // Hidden again: the interval may fire, but it fetches nothing.
+    rerender(view(false));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(statusCalls()).toBe(1);
+  });
+
   it('renders server metrics and current operations', async () => {
     render(<MonitoringView connectionId="conn-1" />);
     expect(await screen.findByTestId('monitoring-view')).toBeInTheDocument();

--- a/src/components/__tests__/SettingsMcp.test.tsx
+++ b/src/components/__tests__/SettingsMcp.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { SettingsView } from '../SettingsModal';
+import { TabVisibleContext } from '../../workspace/tabVisibility';
 import type { McpStatusUi } from '../../lib/mcpApi';
 import type { ConnectionProfile } from '../../lib/connection';
 
@@ -82,6 +83,27 @@ describe('SettingsView MCP panel', () => {
       configurable: true,
     });
   });
+
+  it('pauses the status poll while the Settings tab is hidden, and resumes when it is shown', async () => {
+    // A kept-alive Settings tab (#240) stays mounted while another tab is on
+    // screen; the two-second status poll has nobody to show its result to.
+    setupInvoke({ status: enabledStatus() });
+    const statusCalls = () => mockInvoke.mock.calls.filter((c) => c[0] === 'mcp_get_status').length;
+    const view = (visible: boolean) => (
+      <TabVisibleContext.Provider value={visible}>
+        <SettingsView />
+      </TabVisibleContext.Provider>
+    );
+    const { rerender } = render(view(false));
+    await openMcpTab();
+    const afterOpen = statusCalls();
+
+    await new Promise((r) => setTimeout(r, 2300));
+    expect(statusCalls()).toBe(afterOpen);
+
+    rerender(view(true));
+    await waitFor(() => expect(statusCalls()).toBeGreaterThan(afterOpen), { timeout: 3000 });
+  }, 10000);
 
   it('toggling on invokes mcp_set_enabled with the configured port', async () => {
     setupInvoke({ status: disabledStatus() });

--- a/src/components/__tests__/WatchPanel.test.tsx
+++ b/src/components/__tests__/WatchPanel.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { WatchPanel } from '../WatchPanel';
+import { TabVisibleContext } from '../../workspace/tabVisibility';
 
 const invokeMock = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
@@ -75,6 +76,25 @@ describe('WatchPanel', () => {
     render(panel());
     await waitFor(() => expect(callsTo('start_change_stream')).toHaveLength(1));
     expect(callsTo('start_change_stream')[0][1]).toMatchObject({ operationTypes: [] });
+  });
+
+  it('does not poll while its tab is hidden, and resumes when it is shown', async () => {
+    // A kept-alive Watch tab stays mounted while another tab is on screen
+    // (#240). The stream keeps running and buffering on the backend; this
+    // panel just stops asking for it until someone can see it.
+    const view = (visible: boolean) => (
+      <TabVisibleContext.Provider value={visible}>{panel()}</TabVisibleContext.Provider>
+    );
+    const { rerender } = render(view(false));
+
+    await waitFor(() => expect(callsTo('start_change_stream')).toHaveLength(1));
+    await new Promise((r) => setTimeout(r, 900));
+    expect(callsTo('poll_change_stream')).toHaveLength(0);
+
+    rerender(view(true));
+    await waitFor(() => expect(callsTo('poll_change_stream').length).toBeGreaterThan(0), {
+      timeout: 2000,
+    });
   });
 
   it('does not poll until the stream it is polling exists', async () => {

--- a/src/components/layout/WorkspaceTabBar.tsx
+++ b/src/components/layout/WorkspaceTabBar.tsx
@@ -20,6 +20,10 @@ export interface WorkspaceTab {
   accentColor?: string;
   icon: React.ReactNode;
   pinned?: boolean;
+  /** The tab's kind, as `QueryTab['type']`. Not used for rendering: the pane
+   *  reads it to budget how many of each kind stay mounted, since a mongosh tab
+   *  costs two orders of magnitude more than a collection tab (#240). */
+  kind?: string;
 }
 
 interface WorkspaceTabBarProps {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,8 +3,30 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
+import { useTabVisible } from "@/workspace/tabVisibility";
 
-const Dialog = DialogPrimitive.Root;
+/**
+ * Radix's root, with one addition: a dialog belonging to a tab that is not on
+ * screen is closed.
+ *
+ * Kept-alive tabs (#240) stay mounted while hidden, but a dialog renders
+ * through a portal under `document.body`, outside the hidden wrapper. Left
+ * open, its overlay and focus trap would sit over the tab the user switched
+ * to, and a confirmation could act on the hidden tab's behalf. Closing — not
+ * merely hiding — is the only safe option: a modal dialog that stays mounted
+ * keeps its focus trap and `pointer-events: none` on the body.
+ *
+ * The owner's `open` state is untouched, so the dialog reopens when its tab
+ * is shown again; whatever `DialogContent` held is rebuilt then. Every
+ * dialog in the app is controlled through `open`.
+ */
+const Dialog: React.FC<React.ComponentProps<typeof DialogPrimitive.Root>> = ({
+  open,
+  ...props
+}) => {
+  const tabVisible = useTabVisible();
+  return <DialogPrimitive.Root {...props} open={tabVisible ? open : false} />;
+};
 const DialogTrigger = DialogPrimitive.Trigger;
 const DialogPortal = DialogPrimitive.Portal;
 const DialogClose = DialogPrimitive.Close;

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -2,8 +2,15 @@ import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useTabScopedOpen } from "@/workspace/tabVisibility";
 
-const DropdownMenu = DropdownMenuPrimitive.Root;
+/** Radix's root; the menu closes when the tab it belongs to is hidden (#240). */
+const DropdownMenu: React.FC<React.ComponentProps<typeof DropdownMenuPrimitive.Root>> = ({
+  open,
+  defaultOpen,
+  onOpenChange,
+  ...props
+}) => <DropdownMenuPrimitive.Root {...props} {...useTabScopedOpen({ open, defaultOpen, onOpenChange })} />;
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal;

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { cn } from '@/lib/utils';
+import { useTabScopedOpen } from '@/workspace/tabVisibility';
 
-const Popover = PopoverPrimitive.Root;
+/** Radix's root; the popover closes when the tab it belongs to is hidden (#240). */
+const Popover: React.FC<React.ComponentProps<typeof PopoverPrimitive.Root>> = ({
+  open,
+  defaultOpen,
+  onOpenChange,
+  ...props
+}) => <PopoverPrimitive.Root {...props} {...useTabScopedOpen({ open, defaultOpen, onOpenChange })} />;
 const PopoverTrigger = PopoverPrimitive.Trigger;
 const PopoverAnchor = PopoverPrimitive.Anchor;
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -2,8 +2,15 @@ import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useTabScopedOpen } from "@/workspace/tabVisibility";
 
-const Select = SelectPrimitive.Root;
+/** Radix's root; its list closes when the tab it belongs to is hidden (#240). */
+const Select: React.FC<React.ComponentProps<typeof SelectPrimitive.Root>> = ({
+  open,
+  defaultOpen,
+  onOpenChange,
+  ...props
+}) => <SelectPrimitive.Root {...props} {...useTabScopedOpen({ open, defaultOpen, onOpenChange })} />;
 const SelectGroup = SelectPrimitive.Group;
 const SelectValue = SelectPrimitive.Value;
 

--- a/src/lib/__tests__/useEscapeClose.test.tsx
+++ b/src/lib/__tests__/useEscapeClose.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { useEscapeClose } from '../useEscapeClose';
+import { TabVisibleContext } from '../../workspace/tabVisibility';
+
+function Modal({ onClose }: { onClose: () => void }) {
+  useEscapeClose(true, onClose);
+  return <div>modal</div>;
+}
+
+describe('useEscapeClose', () => {
+  it('closes on Escape while its tab is on screen', () => {
+    const onClose = vi.fn();
+    render(<Modal onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores Escape while its tab is hidden, and answers again once it is shown', () => {
+    // A kept-alive tab (#240) keeps its dialog open, out of sight, so it can
+    // come back with the tab. Escape pressed in the tab on screen belongs to
+    // that tab, not to every hidden dialog at once.
+    const onClose = vi.fn();
+    const view = (visible: boolean) => (
+      <TabVisibleContext.Provider value={visible}>
+        <Modal onClose={onClose} />
+      </TabVisibleContext.Provider>
+    );
+    const { rerender } = render(view(false));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+
+    rerender(view(true));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/resultsFindShortcut.ts
+++ b/src/lib/resultsFindShortcut.ts
@@ -79,9 +79,35 @@ function eventBelongsToAnEditor(target: EventTarget | null): boolean {
 }
 
 /** The registered pane containing `node`, if any. */
+/**
+ * A pane that is registered but not on screen.
+ *
+ * Inactive tabs stay mounted now, hidden with `hidden`/`display: none` (#240),
+ * so several panes can be registered while only one is visible. A hidden one
+ * must not answer for a shortcut: it cannot be pointed at or focused, and
+ * opening its find bar would do nothing the user could see.
+ *
+ * Tested by walking to a `[hidden]` ancestor rather than by measuring, because
+ * measuring is exactly what a hidden element cannot do — and because jsdom has
+ * no layout, so `offsetParent` would call every pane hidden and route nothing.
+ */
+function isHidden(el: HTMLElement): boolean {
+  return el.closest('[hidden]') !== null;
+}
+
+/** Registered panes that are actually on screen, in registration order. */
+function visiblePanes(): Map<number, Pane> {
+  const shown = new Map<number, Pane>();
+  for (const [id, pane] of panes) {
+    const el = pane.element();
+    if (el && !isHidden(el)) shown.set(id, pane);
+  }
+  return shown;
+}
+
 function paneContaining(node: EventTarget | null): Pane | undefined {
   if (!(node instanceof Node)) return undefined;
-  for (const pane of panes.values()) {
+  for (const pane of visiblePanes().values()) {
     const el = pane.element();
     if (el && el.contains(node)) return pane;
   }
@@ -123,7 +149,9 @@ function paneForEventTarget(target: EventTarget | null): Pane | undefined {
   if (!unfocused) return undefined;
 
   if (lastPointedId !== null) {
-    const pane = panes.get(lastPointedId);
+    // Visible only: the tab last pointed at may since have been switched away
+    // from and is now mounted but hidden.
+    const pane = visiblePanes().get(lastPointedId);
     if (pane?.element()) return pane;
   }
   return undefined;
@@ -147,7 +175,11 @@ function targetPane(event: KeyboardEvent): Pane | undefined {
     event.target === document.body ||
     event.target === document ||
     event.target === window;
-  return unfocused && panes.size === 1 ? [...panes.values()][0] : undefined;
+  // Counted over visible panes: with inactive tabs kept mounted there is
+  // almost always more than one registered, and the single-pane generosity
+  // this serves is about what the user can actually see (#240).
+  const shown = visiblePanes();
+  return unfocused && shown.size === 1 ? [...shown.values()][0] : undefined;
 }
 
 function onKeyDown(event: KeyboardEvent): void {

--- a/src/lib/useEscapeClose.ts
+++ b/src/lib/useEscapeClose.ts
@@ -1,13 +1,22 @@
 import { useEffect } from 'react';
+import { useTabVisible } from '@/workspace/tabVisibility';
 
 // Close an open modal on Escape — standard dialog affordance.
+//
+// Only while the tab it belongs to is on screen. A kept-alive tab (#240) stays
+// mounted while hidden, and its dialog stays open in its owner's state so it
+// can come back with the tab; an Escape pressed in the tab the user switched
+// to must not reach it — that would close every hidden dialog at once, and
+// with it discard, say, an unsaved user form that was meant to be there on
+// return.
 export function useEscapeClose(active: boolean, onClose: () => void) {
+  const tabVisible = useTabVisible();
   useEffect(() => {
-    if (!active) return;
+    if (!active || !tabVisible) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [active, onClose]);
+  }, [active, tabVisible, onClose]);
 }

--- a/src/workspace/PaneView.tsx
+++ b/src/workspace/PaneView.tsx
@@ -73,15 +73,16 @@ export function PaneView({
   const mounted = useMemo(
     () =>
       keepAliveTabs(
-        // The active tab is mounted even on the first render, before the effect
-        // above has had a chance to record it.
-        pane.activeTabId && !recency.includes(pane.activeTabId)
-          ? [pane.activeTabId, ...recency]
-          : recency,
+        // The active tab goes first on THIS render, not after the effect above
+        // has recorded it. A tab that was visited and has since fallen out of
+        // its budget is still in `recency`, further down; taken as is, the
+        // budget would exclude the very tab being shown, and the pane would
+        // paint empty once before the effect caught up.
+        withActiveFirst(recency, pane.activeTabId, liveIds),
         tabs.map((t) => ({ id: t.id, kind: t.kind ?? '' })),
         keepAliveLimits
       ),
-    [recency, pane.activeTabId, tabs, keepAliveLimits]
+    [recency, pane.activeTabId, liveIds, tabs, keepAliveLimits]
   );
 
   const onDragOver = useCallback((e: React.DragEvent) => {

--- a/src/workspace/PaneView.tsx
+++ b/src/workspace/PaneView.tsx
@@ -7,6 +7,7 @@ import {
  DEFAULT_KEEP_ALIVE_LIMITS,
  type KeepAliveLimits,
 } from './keepAlive';
+import { TabVisibleContext } from './tabVisibility';
 
 // Re-exported so existing `import { TAB_DRAG_MIME } from '../PaneView'` call sites
 // (e.g. tests) keep working. Owned by WorkspaceTabBar.tsx — see that file.
@@ -141,7 +142,11 @@ export function PaneView({
             the visible one still fills the pane. Monaco cannot measure inside a
             box with no layout, but every editor here runs with
             `automaticLayout`, whose ResizeObserver fires when the element gets
-            a box back — so revealing a tab re-lays it out without help. */}
+            a box back — so revealing a tab re-lays it out without help.
+
+            A hidden tab is told so through `TabVisibleContext`. Views that poll
+            on an interval — Monitoring, Watch — pause while hidden; otherwise
+            every kept tab would keep its backend traffic going unseen. */}
         {mounted.map((tabId) => (
           <div
             key={tabId}
@@ -149,7 +154,9 @@ export function PaneView({
             data-testid={`tab-content-${tabId}`}
             className="h-full min-h-0"
           >
-            {renderTabContent(tabId)}
+            <TabVisibleContext.Provider value={tabId === pane.activeTabId}>
+              {renderTabContent(tabId)}
+            </TabVisibleContext.Provider>
           </div>
         ))}
         {!pane.activeTabId && renderEmptyPane()}

--- a/src/workspace/PaneView.tsx
+++ b/src/workspace/PaneView.tsx
@@ -1,6 +1,12 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { WorkspaceTabBar, TAB_DRAG_MIME, type WorkspaceTab } from '../components/layout/WorkspaceTabBar';
 import type { PaneNode, WorkspaceAction, SplitDir, SplitSide } from './model';
+import {
+ keepAliveTabs,
+ withActiveFirst,
+ DEFAULT_KEEP_ALIVE_LIMITS,
+ type KeepAliveLimits,
+} from './keepAlive';
 
 // Re-exported so existing `import { TAB_DRAG_MIME } from '../PaneView'` call sites
 // (e.g. tests) keep working. Owned by WorkspaceTabBar.tsx — see that file.
@@ -39,12 +45,43 @@ export interface PaneViewProps {
   /** Right-click on a tab (Phase 3 Task 5) — forwarded straight to
    *  WorkspaceTabBar. Additive/optional, same as there. */
   onTabContextMenu?: (tabId: string, e: React.MouseEvent) => void;
+  /** Per-kind mounted-tab budgets. Injectable so tests can pin small numbers
+   *  rather than depending on the shipped defaults. */
+  keepAliveLimits?: KeepAliveLimits;
 }
 
 export function PaneView({
   pane, focused, multiPane, tabs, dispatch, renderTabContent, renderEmptyPane, onTabContextMenu,
+  keepAliveLimits = DEFAULT_KEEP_ALIVE_LIMITS,
 }: PaneViewProps) {
   const [zone, setZone] = useState<DropZone | null>(null);
+
+  // Which tabs this pane has shown, most recent first. The keep-alive set is
+  // taken from it, so the tabs that survive a switch are the ones the user has
+  // actually been moving between.
+  const [recency, setRecency] = useState<string[]>(() =>
+    pane.activeTabId ? [pane.activeTabId] : []
+  );
+  const liveIds = useMemo(() => new Set(tabs.map((t) => t.id)), [tabs]);
+  useEffect(() => {
+    // `withActiveFirst` returns the same array when nothing moved, so this
+    // settles immediately rather than re-rendering on every pass.
+    setRecency((prev) => withActiveFirst(prev, pane.activeTabId, liveIds));
+  }, [pane.activeTabId, liveIds]);
+
+  const mounted = useMemo(
+    () =>
+      keepAliveTabs(
+        // The active tab is mounted even on the first render, before the effect
+        // above has had a chance to record it.
+        pane.activeTabId && !recency.includes(pane.activeTabId)
+          ? [pane.activeTabId, ...recency]
+          : recency,
+        tabs.map((t) => ({ id: t.id, kind: t.kind ?? '' })),
+        keepAliveLimits
+      ),
+    [recency, pane.activeTabId, tabs, keepAliveLimits]
+  );
 
   const onDragOver = useCallback((e: React.DragEvent) => {
     if (!e.dataTransfer.types.includes(TAB_DRAG_MIME)) return;
@@ -95,7 +132,27 @@ export function PaneView({
         />
       )}
       <div className="relative min-h-0 flex-1">
-        {pane.activeTabId ? renderTabContent(pane.activeTabId) : renderEmptyPane()}
+        {/* Every kept tab stays mounted; the inactive ones are hidden rather
+            than removed. Rendering only the active tab is what unmounted the
+            whole subtree on every switch, taking the shell's session, the
+            builder state, the chat and the results view with it (#240).
+
+            `hidden` gives `display: none`, so a hidden tab occupies no space and
+            the visible one still fills the pane. Monaco cannot measure inside a
+            box with no layout, but every editor here runs with
+            `automaticLayout`, whose ResizeObserver fires when the element gets
+            a box back — so revealing a tab re-lays it out without help. */}
+        {mounted.map((tabId) => (
+          <div
+            key={tabId}
+            hidden={tabId !== pane.activeTabId}
+            data-testid={`tab-content-${tabId}`}
+            className="h-full min-h-0"
+          >
+            {renderTabContent(tabId)}
+          </div>
+        ))}
+        {!pane.activeTabId && renderEmptyPane()}
         {zone && (
           <div
             data-testid={`drop-indicator-${zone}`}

--- a/src/workspace/WorkspaceRoot.tsx
+++ b/src/workspace/WorkspaceRoot.tsx
@@ -14,10 +14,12 @@ export interface WorkspaceRootProps {
   /** Right-click on a tab (Phase 3 Task 5) — forwarded straight to
    *  PaneView/WorkspaceTabBar. Additive/optional, same as there. */
   onTabContextMenu?: (tabId: string, e: React.MouseEvent) => void;
+  /** Per-kind mounted-tab budgets, forwarded to every pane (#240). */
+  keepAliveLimits?: React.ComponentProps<typeof PaneView>['keepAliveLimits'];
 }
 
 function NodeView({ node, props }: { node: LayoutNode; props: WorkspaceRootProps }) {
-  const { layout, dispatch, tabsFor, renderTabContent, renderEmptyPane, onTabContextMenu } = props;
+  const { layout, dispatch, tabsFor, renderTabContent, renderEmptyPane, onTabContextMenu, keepAliveLimits } = props;
   if (node.kind === 'pane') {
     return (
       <PaneView
@@ -29,6 +31,7 @@ function NodeView({ node, props }: { node: LayoutNode; props: WorkspaceRootProps
         renderTabContent={renderTabContent}
         renderEmptyPane={renderEmptyPane}
         onTabContextMenu={onTabContextMenu}
+        keepAliveLimits={keepAliveLimits}
       />
     );
   }

--- a/src/workspace/__tests__/PaneView.keepAlive.test.tsx
+++ b/src/workspace/__tests__/PaneView.keepAlive.test.tsx
@@ -5,6 +5,13 @@ import { WorkspaceRoot } from '../WorkspaceRoot';
 import { createInitialLayout, workspaceReducer, type PaneNode } from '../model';
 import { useTabVisible } from '../tabVisibility';
 import { Dialog, DialogContent, DialogTitle } from '../../components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../../components/ui/dropdown-menu';
+import { Popover, PopoverContent, PopoverTrigger } from '../../components/ui/popover';
 
 /**
  * #240: a pane used to render only its active tab, so switching tabs unmounted
@@ -39,6 +46,16 @@ function Content({ tabId }: { tabId: string }) {
           <DialogTitle>dialog of {tabId}</DialogTitle>
         </DialogContent>
       </Dialog>
+      <DropdownMenu>
+        <DropdownMenuTrigger data-testid={`open-menu-${tabId}`}>menu</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>menu item of {tabId}</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Popover>
+        <PopoverTrigger data-testid={`open-popover-${tabId}`}>popover</PopoverTrigger>
+        <PopoverContent>popover of {tabId}</PopoverContent>
+      </Popover>
     </div>
   );
 }
@@ -131,6 +148,24 @@ describe('PaneView — inactive tabs stay mounted (#240)', () => {
     // The owner still has it open; showing the tab shows the dialog.
     switchTo('a');
     expect(screen.getByText('dialog of a')).toBeInTheDocument();
+  });
+
+  it('closes a hidden tab’s menu and popover, which portal out of the hidden wrapper too', () => {
+    // Unlike a dialog these are closed for good: a menu that is gone from
+    // under the pointer has no state worth bringing back.
+    render(<Harness tabIds={['a', 'b']} />);
+
+    fireEvent.pointerDown(screen.getByTestId('open-menu-a'), { button: 0, ctrlKey: false, pointerType: 'mouse' });
+    expect(screen.getByText('menu item of a')).toBeInTheDocument();
+    switchTo('b');
+    expect(screen.queryByText('menu item of a')).toBeNull();
+    switchTo('a');
+    expect(screen.queryByText('menu item of a')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('open-popover-a'));
+    expect(screen.getByText('popover of a')).toBeInTheDocument();
+    switchTo('b');
+    expect(screen.queryByText('popover of a')).toBeNull();
   });
 
   it('does not mount a tab until it has been visited', () => {

--- a/src/workspace/__tests__/PaneView.keepAlive.test.tsx
+++ b/src/workspace/__tests__/PaneView.keepAlive.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useReducer, useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WorkspaceRoot } from '../WorkspaceRoot';
+import { createInitialLayout, workspaceReducer, type PaneNode } from '../model';
+
+/**
+ * #240: a pane used to render only its active tab, so switching tabs unmounted
+ * the whole subtree — taking the shell's session, the builder state, the chat
+ * transcript and the results view with it. Four caches exist purely to rebuild
+ * what that destroyed.
+ *
+ * These drive the real reducer, because the point is what happens across an
+ * actual tab switch rather than what a prop does in isolation.
+ */
+
+/** Counts how many times each tab's content has been mounted. */
+const mounts = new Map<string, number>();
+
+function Content({ tabId }: { tabId: string }) {
+  const [typed, setTyped] = useState('');
+  useState(() => mounts.set(tabId, (mounts.get(tabId) ?? 0) + 1));
+  return (
+    <div data-testid={`content-${tabId}`}>
+      <input
+        data-testid={`input-${tabId}`}
+        value={typed}
+        onChange={(e) => setTyped(e.target.value)}
+      />
+    </div>
+  );
+}
+
+function Harness({
+  tabIds,
+  kinds = {},
+  limits,
+}: {
+  tabIds: string[];
+  kinds?: Record<string, string>;
+  limits?: { shell: number; other: number };
+}) {
+  const [layout, dispatch] = useReducer(workspaceReducer, createInitialLayout(tabIds, tabIds[0]));
+  return (
+    <WorkspaceRoot
+      layout={layout}
+      dispatch={dispatch}
+      tabsFor={(pane: PaneNode) =>
+        pane.tabIds.map((id) => ({
+          id,
+          label: id.toUpperCase(),
+          icon: null,
+          kind: kinds[id] ?? 'collection',
+        }))
+      }
+      renderTabContent={(tabId) => <Content tabId={tabId} />}
+      renderEmptyPane={() => <div data-testid="empty-pane" />}
+      keepAliveLimits={limits}
+    />
+  );
+}
+
+const switchTo = (id: string) => fireEvent.click(screen.getByText(id.toUpperCase()));
+const visible = (id: string) => {
+  const el = screen.getByTestId(`content-${id}`);
+  return el.closest('[hidden]') === null;
+};
+
+describe('PaneView — inactive tabs stay mounted (#240)', () => {
+  beforeEach(() => mounts.clear());
+
+  it('keeps a tab’s state across a switch away and back', () => {
+    render(<Harness tabIds={['a', 'b']} />);
+
+    fireEvent.change(screen.getByTestId('input-a'), { target: { value: 'half typed' } });
+    switchTo('b');
+    switchTo('a');
+
+    // The state itself, not a rebuilt copy: mounting once is what makes it the
+    // same component instance the user was working in.
+    expect((screen.getByTestId('input-a') as HTMLInputElement).value).toBe('half typed');
+    expect(mounts.get('a')).toBe(1);
+  });
+
+  it('hides the inactive tab rather than removing it', () => {
+    render(<Harness tabIds={['a', 'b']} />);
+    switchTo('b');
+
+    expect(screen.getByTestId('content-a')).toBeInTheDocument();
+    expect(visible('a')).toBe(false);
+    expect(visible('b')).toBe(true);
+  });
+
+  it('does not mount a tab until it has been visited', () => {
+    render(<Harness tabIds={['a', 'b']} />);
+    expect(screen.queryByTestId('content-b')).toBeNull();
+    expect(mounts.get('b')).toBeUndefined();
+  });
+
+  it('drops the least recently used tab once the budget is full', () => {
+    render(<Harness tabIds={['a', 'b', 'c']} limits={{ shell: 2, other: 2 }} />);
+    switchTo('b');
+    switchTo('c');
+
+    // 'a' is the oldest of three with room for two, so it goes.
+    expect(screen.queryByTestId('content-a')).toBeNull();
+    expect(screen.getByTestId('content-b')).toBeInTheDocument();
+    expect(screen.getByTestId('content-c')).toBeInTheDocument();
+  });
+
+  it('budgets shells apart, so opening shells does not evict collection tabs', () => {
+    // An idle mongosh session measured ~272 MB against the local replica set —
+    // two orders of magnitude more than a collection tab, which is why one
+    // shared budget would be the wrong shape.
+    render(
+      <Harness
+        tabIds={['c1', 's1', 's2', 's3']}
+        kinds={{ s1: 'shell', s2: 'shell', s3: 'shell' }}
+        limits={{ shell: 2, other: 3 }}
+      />
+    );
+    switchTo('s1');
+    switchTo('s2');
+    switchTo('s3');
+
+    // The collection tab survives three shells being opened after it...
+    expect(screen.getByTestId('content-c1')).toBeInTheDocument();
+    // ...and the shells are held to their own, smaller budget.
+    expect(screen.getByTestId('content-s3')).toBeInTheDocument();
+    expect(screen.getByTestId('content-s2')).toBeInTheDocument();
+    expect(screen.queryByTestId('content-s1')).toBeNull();
+  });
+});

--- a/src/workspace/__tests__/PaneView.keepAlive.test.tsx
+++ b/src/workspace/__tests__/PaneView.keepAlive.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useReducer, useState } from 'react';
+import { useLayoutEffect, useReducer, useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { WorkspaceRoot } from '../WorkspaceRoot';
 import { createInitialLayout, workspaceReducer, type PaneNode } from '../model';
@@ -25,12 +25,18 @@ import { Popover, PopoverContent, PopoverTrigger } from '../../components/ui/pop
 
 /** Counts how many times each tab's content has been mounted. */
 const mounts = new Map<string, number>();
+/** Whether tab a's content was in the document at each commit, as seen by tab c — the one
+ *  tab that stays mounted through the switch back to a under a budget of two. */
+const aPresentAtCommit: boolean[] = [];
 
 function Content({ tabId }: { tabId: string }) {
   const [typed, setTyped] = useState('');
   useState(() => mounts.set(tabId, (mounts.get(tabId) ?? 0) + 1));
   const tabVisible = useTabVisible();
   const [dialogOpen, setDialogOpen] = useState(false);
+  useLayoutEffect(() => {
+    if (tabId === 'c') aPresentAtCommit.push(document.querySelector('[data-testid="content-a"]') !== null);
+  });
   return (
     <div data-testid={`content-${tabId}`} data-tab-visible={String(tabVisible)}>
       <input
@@ -166,6 +172,24 @@ describe('PaneView — inactive tabs stay mounted (#240)', () => {
     expect(screen.getByText('popover of a')).toBeInTheDocument();
     switchTo('b');
     expect(screen.queryByText('popover of a')).toBeNull();
+  });
+
+  it('shows a tab that had fallen out of its budget on the very first paint', () => {
+    // a was visited, then evicted by c under a budget of two. Selecting a again
+    // finds it still listed in the pane's recency, further down; budgeting
+    // that list as it stands leaves a out, and the pane paints empty once
+    // before the effect that reorders recency catches up.
+    render(<Harness tabIds={['a', 'b', 'c']} limits={{ shell: 2, other: 2 }} />);
+    switchTo('b');
+    switchTo('c');
+    expect(screen.queryByTestId('content-a')).toBeNull();
+
+    aPresentAtCommit.length = 0;
+    switchTo('a');
+
+    expect(screen.getByTestId('content-a')).toBeInTheDocument();
+    expect(aPresentAtCommit.length).toBeGreaterThan(0);
+    expect(aPresentAtCommit.every(Boolean)).toBe(true);
   });
 
   it('does not mount a tab until it has been visited', () => {

--- a/src/workspace/__tests__/PaneView.keepAlive.test.tsx
+++ b/src/workspace/__tests__/PaneView.keepAlive.test.tsx
@@ -3,6 +3,7 @@ import { useReducer, useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { WorkspaceRoot } from '../WorkspaceRoot';
 import { createInitialLayout, workspaceReducer, type PaneNode } from '../model';
+import { useTabVisible } from '../tabVisibility';
 
 /**
  * #240: a pane used to render only its active tab, so switching tabs unmounted
@@ -20,8 +21,9 @@ const mounts = new Map<string, number>();
 function Content({ tabId }: { tabId: string }) {
   const [typed, setTyped] = useState('');
   useState(() => mounts.set(tabId, (mounts.get(tabId) ?? 0) + 1));
+  const tabVisible = useTabVisible();
   return (
-    <div data-testid={`content-${tabId}`}>
+    <div data-testid={`content-${tabId}`} data-tab-visible={String(tabVisible)}>
       <input
         data-testid={`input-${tabId}`}
         value={typed}
@@ -89,6 +91,20 @@ describe('PaneView — inactive tabs stay mounted (#240)', () => {
     expect(screen.getByTestId('content-a')).toBeInTheDocument();
     expect(visible('a')).toBe(false);
     expect(visible('b')).toBe(true);
+  });
+
+  it('tells a kept tab whether it is on screen, so a polling view can pause', () => {
+    // A hidden Monitoring or Watch tab would otherwise keep fetching for a
+    // view nobody is looking at; `document.hidden` cannot tell it apart.
+    render(<Harness tabIds={['a', 'b']} />);
+    expect(screen.getByTestId('content-a').dataset.tabVisible).toBe('true');
+
+    switchTo('b');
+    expect(screen.getByTestId('content-a').dataset.tabVisible).toBe('false');
+    expect(screen.getByTestId('content-b').dataset.tabVisible).toBe('true');
+
+    switchTo('a');
+    expect(screen.getByTestId('content-a').dataset.tabVisible).toBe('true');
   });
 
   it('does not mount a tab until it has been visited', () => {

--- a/src/workspace/__tests__/PaneView.keepAlive.test.tsx
+++ b/src/workspace/__tests__/PaneView.keepAlive.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { WorkspaceRoot } from '../WorkspaceRoot';
 import { createInitialLayout, workspaceReducer, type PaneNode } from '../model';
 import { useTabVisible } from '../tabVisibility';
+import { Dialog, DialogContent, DialogTitle } from '../../components/ui/dialog';
 
 /**
  * #240: a pane used to render only its active tab, so switching tabs unmounted
@@ -22,6 +23,7 @@ function Content({ tabId }: { tabId: string }) {
   const [typed, setTyped] = useState('');
   useState(() => mounts.set(tabId, (mounts.get(tabId) ?? 0) + 1));
   const tabVisible = useTabVisible();
+  const [dialogOpen, setDialogOpen] = useState(false);
   return (
     <div data-testid={`content-${tabId}`} data-tab-visible={String(tabVisible)}>
       <input
@@ -29,6 +31,14 @@ function Content({ tabId }: { tabId: string }) {
         value={typed}
         onChange={(e) => setTyped(e.target.value)}
       />
+      <button data-testid={`open-dialog-${tabId}`} onClick={() => setDialogOpen(true)}>
+        open
+      </button>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogTitle>dialog of {tabId}</DialogTitle>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -105,6 +115,22 @@ describe('PaneView — inactive tabs stay mounted (#240)', () => {
 
     switchTo('a');
     expect(screen.getByTestId('content-a').dataset.tabVisible).toBe('true');
+  });
+
+  it('closes a hidden tab’s dialog, and reopens it when the tab comes back', () => {
+    // A dialog renders through a portal under document.body, outside the
+    // hidden wrapper. Left open it would cover the tab the user switched to —
+    // overlay, focus trap, and a confirmation acting for a tab nobody can see.
+    render(<Harness tabIds={['a', 'b']} />);
+    fireEvent.click(screen.getByTestId('open-dialog-a'));
+    expect(screen.getByText('dialog of a')).toBeInTheDocument();
+
+    switchTo('b');
+    expect(screen.queryByText('dialog of a')).toBeNull();
+
+    // The owner still has it open; showing the tab shows the dialog.
+    switchTo('a');
+    expect(screen.getByText('dialog of a')).toBeInTheDocument();
   });
 
   it('does not mount a tab until it has been visited', () => {

--- a/src/workspace/__tests__/keepAlive.test.ts
+++ b/src/workspace/__tests__/keepAlive.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  keepAliveTabs,
+  withActiveFirst,
+  DEFAULT_KEEP_ALIVE_LIMITS,
+  type KeepAliveTab,
+} from '../keepAlive';
+
+const collection = (id: string): KeepAliveTab => ({ id, kind: 'collection' });
+const shell = (id: string): KeepAliveTab => ({ id, kind: 'shell' });
+
+describe('keepAliveTabs', () => {
+  const limits = { shell: 2, other: 3 };
+
+  it('keeps the most recently active tabs and drops the rest', () => {
+    const tabs = ['a', 'b', 'c', 'd', 'e'].map(collection);
+    expect(keepAliveTabs(['e', 'd', 'c', 'b', 'a'], tabs, limits)).toEqual(['e', 'd', 'c']);
+  });
+
+  it('budgets shells separately, so they cannot crowd out collection tabs', () => {
+    // #240: an idle mongosh session is ~272 MB, two orders of magnitude more
+    // than a collection tab. Sharing one budget would let three shells evict
+    // every collection tab the user was switching between.
+    const tabs = [shell('s1'), shell('s2'), shell('s3'), collection('c1'), collection('c2')];
+    const kept = keepAliveTabs(['s1', 's2', 's3', 'c1', 'c2'], tabs, limits);
+
+    expect(kept).toEqual(['s1', 's2', 'c1', 'c2']);
+    expect(kept).not.toContain('s3'); // third shell is over its own budget
+  });
+
+  it('does not let collection tabs consume the shell budget either', () => {
+    const tabs = [collection('c1'), collection('c2'), collection('c3'), shell('s1')];
+    const kept = keepAliveTabs(['c1', 'c2', 'c3', 's1'], tabs, limits);
+    expect(kept).toEqual(['c1', 'c2', 'c3', 's1']);
+  });
+
+  it('ignores ids for tabs that have closed or moved to another pane', () => {
+    const tabs = [collection('a'), collection('c')];
+    expect(keepAliveTabs(['a', 'gone', 'c'], tabs, limits)).toEqual(['a', 'c']);
+  });
+
+  it('mounts nothing for a tab that has never been active here', () => {
+    // Recency is what a pane has actually shown; an unopened tab is not mounted
+    // until the user goes to it.
+    const tabs = [collection('a'), collection('b')];
+    expect(keepAliveTabs(['a'], tabs, limits)).toEqual(['a']);
+  });
+
+  it('ships with a shell budget well below the others', () => {
+    // The whole point of separate caps. Guarded because raising this quietly
+    // would put ~272 MB per extra shell back into a "just a tab" change.
+    expect(DEFAULT_KEEP_ALIVE_LIMITS.shell).toBeLessThan(DEFAULT_KEEP_ALIVE_LIMITS.other);
+    expect(DEFAULT_KEEP_ALIVE_LIMITS.shell).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('withActiveFirst', () => {
+  const live = (...ids: string[]) => new Set(ids);
+
+  it('moves the active tab to the front', () => {
+    expect(withActiveFirst(['a', 'b', 'c'], 'c', live('a', 'b', 'c'))).toEqual(['c', 'a', 'b']);
+  });
+
+  it('adds an active tab that was not in the list yet', () => {
+    expect(withActiveFirst(['a'], 'b', live('a', 'b'))).toEqual(['b', 'a']);
+  });
+
+  it('drops ids whose tabs are gone', () => {
+    expect(withActiveFirst(['a', 'closed', 'b'], 'b', live('a', 'b'))).toEqual(['b', 'a']);
+  });
+
+  it('returns the same array when nothing moved, so state does not churn', () => {
+    // A caller holds this in state and sets it from an effect: a fresh array
+    // every pass would re-render forever.
+    const prev = ['a', 'b'];
+    expect(withActiveFirst(prev, 'a', live('a', 'b'))).toBe(prev);
+  });
+
+  it('keeps the list when there is no active tab, dropping only dead ids', () => {
+    const prev = ['a', 'b'];
+    expect(withActiveFirst(prev, null, live('a', 'b'))).toBe(prev);
+    expect(withActiveFirst(prev, null, live('a'))).toEqual(['a']);
+  });
+});

--- a/src/workspace/keepAlive.ts
+++ b/src/workspace/keepAlive.ts
@@ -1,0 +1,120 @@
+/**
+ * Which tabs stay mounted when they are not the one on screen.
+ *
+ * A pane used to render only its active tab, so switching tabs unmounted the
+ * whole subtree and destroyed everything the tab held (#240). Four separate
+ * caches exist purely to rebuild state that unmount threw away — builder state,
+ * chat transcripts, in-flight AI requests, the results view mode — and the
+ * results grid has been patched three times for the same reason.
+ *
+ * Keeping tabs mounted removes the cause. It cannot be unbounded, though, so
+ * the least recently active tabs are dropped, and a dropped tab behaves exactly
+ * as every tab does today: it unmounts, and comes back rebuilt from whatever
+ * survives outside the tree.
+ *
+ * ## Why shells are capped separately
+ *
+ * A mongosh tab is not a slightly heavier collection tab. Measured against the
+ * local replica set, an idle `mongosh --quiet` session is **~272 MB** of
+ * resident memory (265 MB in the process, 7.7 MB in a child), consistently
+ * across sessions — mongosh is a full Node application with the driver and REPL
+ * loaded, not the ~37 MB a bare node process costs.
+ *
+ * A collection tab is two orders of magnitude cheaper. One number cannot serve
+ * both: a cap of six that is comfortable for collection tabs is ~1.6 GB if they
+ * happen to be shells. So each kind gets its own budget, and a shell keeps its
+ * place only against other shells.
+ *
+ * Note that the session itself already outlives an unmounted shell tab — that
+ * is #240 Phase 1, and deliberate. This cap is about the React subtree and the
+ * editor it holds, not about the process, which ends when the tab closes.
+ */
+
+/** The part of a tab this needs: what it is, so it can be budgeted. */
+export interface KeepAliveTab {
+  id: string;
+  /** `QueryTab['type']` — only `shell` is budgeted separately today. */
+  kind: string;
+}
+
+export interface KeepAliveLimits {
+  /** Shell tabs kept mounted, the active one included. */
+  shell: number;
+  /** Every other kind, the active one included. */
+  other: number;
+}
+
+/**
+ * Deliberately small. At ~272 MB a session, three mounted shells cost more than
+ * the rest of the app put together, and a shell tab loses very little by
+ * unmounting: its process and scrollback are held outside the tree already, so
+ * coming back rebuilds a view over state that never went away.
+ *
+ * Six for everything else is a guess bounded by the reasoning rather than by a
+ * measurement — per-tab retention for a collection tab could not be measured
+ * from process memory, because working set does not track JS retention closely
+ * enough to see it (closing five tabs moved the total the wrong way by 85 MB).
+ * It wants a heap snapshot to refine. Six is chosen to comfortably cover the
+ * "switch between a few tabs while working" case that motivates this at all.
+ */
+export const DEFAULT_KEEP_ALIVE_LIMITS: KeepAliveLimits = { shell: 2, other: 6 };
+
+const limitFor = (kind: string, limits: KeepAliveLimits) =>
+  kind === 'shell' ? limits.shell : limits.other;
+
+/**
+ * The tabs to keep mounted, given how recently each was active.
+ *
+ * `recency` is most-recently-active first and may name tabs that have since
+ * closed or moved to another pane; only ids present in `tabs` are considered.
+ * A tab missing from `recency` has never been active in this pane and is not
+ * mounted until it is.
+ *
+ * Each kind is filled independently, so a run of shells cannot crowd out the
+ * collection tabs the user is actually switching between, and vice versa.
+ */
+export function keepAliveTabs(
+  recency: readonly string[],
+  tabs: readonly KeepAliveTab[],
+  limits: KeepAliveLimits = DEFAULT_KEEP_ALIVE_LIMITS
+): string[] {
+  const byId = new Map(tabs.map((t) => [t.id, t]));
+  const used = new Map<string, number>();
+  const kept: string[] = [];
+
+  for (const id of recency) {
+    const tab = byId.get(id);
+    if (!tab) continue;
+    // One budget per kind, so shells are counted against shells only.
+    const bucket = tab.kind === 'shell' ? 'shell' : 'other';
+    const taken = used.get(bucket) ?? 0;
+    if (taken >= limitFor(tab.kind, limits)) continue;
+    used.set(bucket, taken + 1);
+    kept.push(id);
+  }
+  return kept;
+}
+
+/**
+ * `recency` with `activeId` moved to the front, and ids for tabs that no longer
+ * exist dropped.
+ *
+ * Returns the array unchanged when nothing moved, so a caller holding this in
+ * state does not re-render on every pass.
+ */
+export function withActiveFirst(
+  recency: readonly string[],
+  activeId: string | null,
+  liveIds: ReadonlySet<string>
+): string[] {
+  const pruned = recency.filter((id) => liveIds.has(id));
+  if (activeId === null || !liveIds.has(activeId)) {
+    return sameOrder(recency, pruned) ? (recency as string[]) : pruned;
+  }
+  const next = [activeId, ...pruned.filter((id) => id !== activeId)];
+  return sameOrder(recency, next) ? (recency as string[]) : next;
+}
+
+function sameOrder(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
+}

--- a/src/workspace/tabVisibility.tsx
+++ b/src/workspace/tabVisibility.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Whether the tab a component sits in is the one on screen.
+ *
+ * Kept-alive tabs (#240) stay mounted while hidden, so an effect that polls on
+ * an interval keeps polling for a tab nobody can see — Monitoring every ten
+ * seconds, Watch every 700 ms — for as many hidden tabs as the budget keeps.
+ * `document.hidden` cannot tell: the document is visible, the tab is not.
+ * This is what tells.
+ *
+ * Defaults to `true`, so a component rendered outside a pane — a dialog, a
+ * test — behaves exactly as it always has.
+ */
+export const TabVisibleContext = createContext(true);
+
+export const useTabVisible = (): boolean => useContext(TabVisibleContext);

--- a/src/workspace/tabVisibility.tsx
+++ b/src/workspace/tabVisibility.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
 /**
  * Whether the tab a component sits in is the one on screen.
@@ -15,3 +15,45 @@ import { createContext, useContext } from 'react';
 export const TabVisibleContext = createContext(true);
 
 export const useTabVisible = (): boolean => useContext(TabVisibleContext);
+
+interface OpenProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+/**
+ * The `open`/`onOpenChange` pair for a transient overlay — a menu, a select
+ * list, a popover — rendered by a component inside a tab.
+ *
+ * Such content renders through a portal under `document.body`, so the wrapper
+ * that hides a kept-alive tab cannot hide it: switch tabs with a menu open and
+ * the old tab's menu stays up over the new tab, still catching focus and still
+ * able to run the hidden tab's actions. This closes it when the tab is hidden.
+ * Closing, not merely hiding: a menu that is gone from under the pointer has
+ * no state worth restoring, unlike a dialog.
+ *
+ * Owners may leave `open` undefined as usual. What Radix receives is always
+ * controlled, so nothing flips between controlled and uncontrolled (which
+ * Radix warns about) when the tab's visibility changes.
+ */
+export function useTabScopedOpen({ open, defaultOpen, onOpenChange }: OpenProps): {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+} {
+  const tabVisible = useTabVisible();
+  const [inner, setInner] = useState(defaultOpen ?? false);
+  const controlled = open !== undefined;
+  const actual = controlled ? open : inner;
+  const change = useCallback(
+    (next: boolean) => {
+      if (!controlled) setInner(next);
+      onOpenChange?.(next);
+    },
+    [controlled, onOpenChange]
+  );
+  useEffect(() => {
+    if (!tabVisible && actual) change(false);
+  }, [tabVisible, actual, change]);
+  return { open: tabVisible && actual, onOpenChange: change };
+}


### PR DESCRIPTION
#240 Phase 2. Phase 1 was already implemented — see [my status comment](https://github.com/mqlens/mqlens-mongodb/issues/240#issuecomment-5525644697).

## What changes

A pane rendered only its active tab, so switching unmounted the whole subtree. Recently used tabs now stay mounted, hidden with `hidden` rather than removed. A tab beyond its budget unmounts exactly as every tab does today, and comes back rebuilt from whatever survives outside the tree — so the existing caches remain correct, they are just no longer the only thing standing between the user and losing their work.

## Why shells are budgeted separately

I measured this before writing any of it, and the number decided the design.

An idle `mongosh --quiet` session against the local replica set is **~272 MB** resident — 265 MB in the process plus 7.7 MB in a child, across three sessions with no meaningful variance. mongosh is a full Node application with the driver and REPL loaded, not the ~37 MB the issue estimated for bare node.

A collection tab is two orders of magnitude cheaper, so a single budget is the wrong shape: six, which is comfortable for collection tabs, is ~1.6 GB if they happen to be shells. Each kind now gets its own, and a shell only competes with shells.

Defaults: **2 shells, 6 of everything else.**

Shell tabs lose very little by unmounting, which is what makes the small cap reasonable — Phase 1 already moved the session and scrollback outside the React tree, so remounting rebuilds a view over state that never went away.

## What is measured and what is reasoned

The **6** is reasoned, not measured, and I want that on the record. Per-tab retention for a collection tab could not be read from process memory: per-tab deltas ranged +12.9 to −76.8 MB, and a settled before/after showed closing five tabs *increasing* the total by 85 MB. Working set does not track JS retention closely enough to see it. That number wants a DevTools heap snapshot, and it can be refined without changing anything here — the limits are a single exported constant.

## Monaco on reveal

The issue flagged this as the risk, and it turns out to need nothing: every Monaco instance in the app runs with `automaticLayout: true`, which uses a ResizeObserver, and that fires when a hidden element gets its box back.

Shortcut routing did need work. `resultsFindShortcut` resolves which results pane a keypress belongs to, and with inactive tabs mounted there are now several registered panes at once. A hidden one must never answer — it cannot be pointed at, cannot hold focus, and opening its find bar would do nothing visible. Panes inside a `[hidden]` subtree are now excluded from every branch of that routing, including the "only one pane on screen" generosity, which would otherwise have stopped applying the moment a second tab was mounted.

Tested by walking to a `[hidden]` ancestor rather than by measuring: measuring is precisely what a hidden element cannot do, and jsdom has no layout, so `offsetParent` would call every pane hidden and route nothing.

## Tests

16 new, and I checked they are not passing for free — reverting to active-only rendering fails four of the five behavioural ones:

- state survives a switch away and back, asserted through a mount counter so it is the same instance rather than a rebuilt copy
- the inactive tab is hidden, not removed
- a tab is not mounted until it has been visited
- least-recently-used eviction once a budget is full
- three shells opened in a row do not evict the collection tab, and are held to their own budget

Plus 11 unit tests on the policy itself, including a guard that the shipped shell budget stays below the other one — raising it quietly would put ~272 MB per extra shell back into a "just a tab" change.

One existing test needed updating: `isolates query editor state per collection tab (#120)` used global queries that now match every mounted tab's editor. It is scoped to the visible tab, which is what it was always really asserting.

## Not verified in the app

The machine locked before I could exercise this in a running MQLens. Two things I would check first, neither of which jsdom can cover, since it has no layout:

1. **A Monaco editor revealed after being hidden actually re-lays out** — the reasoning above says it should, but this is the exact failure the issue predicted, and the issue notes it may already be visible in the Options panel.
2. **Switching between two collection tabs keeps scroll position and the results view**, which is the user-visible payoff.
