### PR TITLE
fix(shell): run scripts to completion, and never leave the REPL waiting

### DIFF
--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -90,6 +90,7 @@ const LOCAL_COMMANDS: &[&str] = &[
     "ai_provider_options",
     "list_ai_models_for",
     "stop_mongosh_session", // kills the local child process, no DB write
+    "await_mongosh_idle",   // waits on the local session lock, touches nothing
     // Per-tab shell state (session id, scrollback). In-process only — no DB
     // access, and clearing a tab's entry deliberately does not stop its child.
     "get_shell_tab_state",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -332,36 +332,83 @@ pub struct MongoshSessionInfo {
 /// left behind by an earlier command and must not be shown as output.
 const MONGOSH_MARKER_PREFIX: &str = "__MQLENS_DONE_";
 
-/// Is this line mongosh's prompt, rather than something the script printed?
+/// The prompt strings this session has been seen to print.
 ///
-/// Two shapes. `| ` is the continuation prompt the REPL emits each time it
-/// reads a line while a statement is still open. Everything else ends in `> `
-/// — `rs0 [direct: primary] test> ` — and is emitted after each statement
-/// evaluates, `--quiet` or not. Neither is output, and the continuation one is
-/// a signal in its own right (see `run_mongosh_command_on_session`).
+/// A prompt is not recognised by how it looks — a script can print anything,
+/// `print("ready> ")` included — but by how it arrives: it is the one thing
+/// mongosh writes with no newline after it, because it is waiting for input on
+/// the same line. Everything a script prints is newline-terminated. So a chunk
+/// that ends without a newline and looks like a prompt is a prompt, and once
+/// seen its exact text is known. From then on a line equal to it is dropped,
+/// and a line beginning with it is a prompt glued onto whatever the REPL wrote
+/// next — which the OS may well deliver in the same read — and is split.
 ///
-/// Bounded in length so a long document line that happens to end in `> `
-/// cannot be mistaken for one; a prompt is a short line.
-pub(crate) fn is_mongosh_prompt(line: &str) -> bool {
-    if line == "| " {
-        return true;
-    }
-    line.len() <= 200 && line.ends_with("> ") && line.trim_end() != ">"
+/// The set grows on `use <db>` and topology changes, when the prompt changes.
+#[derive(Default)]
+pub(crate) struct MongoshPrompts {
+    known: Vec<String>,
 }
 
-/// Take every complete line out of `buf`, and a trailing prompt as well.
+impl MongoshPrompts {
+    /// The continuation prompt is fixed and needs no learning: the REPL prints
+    /// exactly this each time it reads a line while a statement is still open.
+    const CONTINUATION: &'static str = "| ";
+
+    /// Could this newline-less tail be a prompt? Only asked of tails, where the
+    /// framing has already done most of the work; the shape check just keeps a
+    /// half-received output line from being mistaken for one.
+    fn looks_like_prompt(tail: &str) -> bool {
+        tail == Self::CONTINUATION
+            || (tail.len() <= 200 && tail.ends_with("> ") && tail.trim_end() != ">")
+    }
+
+    pub(crate) fn learn(&mut self, prompt: &str) {
+        if prompt != Self::CONTINUATION && !self.known.iter().any(|k| k == prompt) {
+            self.known.push(prompt.to_string());
+        }
+    }
+
+    /// A complete line that is nothing but a prompt.
+    fn is_prompt(&self, line: &str) -> bool {
+        line == Self::CONTINUATION || self.known.iter().any(|k| k == line)
+    }
+
+    /// Strip known prompts glued onto the front of `line`.
+    ///
+    /// Plural: `.break` on an idle REPL prints a prompt with nothing after it,
+    /// so the next output can sit behind two of them.
+    fn strip_leading<'a>(&self, line: &'a str) -> &'a str {
+        let mut rest = line;
+        loop {
+            let before = rest;
+            for k in &self.known {
+                if let Some(r) = rest.strip_prefix(k.as_str()) {
+                    rest = r;
+                }
+            }
+            if let Some(r) = rest.strip_prefix(Self::CONTINUATION) {
+                rest = r;
+            }
+            if rest.len() == before.len() {
+                return rest;
+            }
+        }
+    }
+}
+
+/// Take every complete output line out of `buf`, learning prompts on the way.
 ///
 /// A line reader on mongosh's stdout was subtly wrong: the REPL writes its
 /// prompt with no newline after it, so a `lines()` reader never saw the prompt
 /// as a line. It sat in the buffer until the NEXT output arrived and was glued
 /// to the front of it — the console showed `test> hello` — and a prompt with
 /// nothing after it, which is exactly what a REPL waiting for input produces,
-/// was never delivered at all. That prompt is the one piece of evidence that a
-/// script has stalled, so it is flushed the moment it is recognisable.
+/// was never delivered at all.
 ///
-/// `\r\n` is folded to `\n`; partial UTF-8 at the end of a chunk stays in the
-/// buffer until the rest of it arrives.
-pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>) -> Vec<String> {
+/// Prompts are consumed here and never delivered: nothing downstream needs
+/// them. Output glued behind one is delivered without it. `\r\n` is folded to
+/// `\n`; partial UTF-8 at the end of a chunk stays until the rest arrives.
+pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>, prompts: &mut MongoshPrompts) -> Vec<String> {
     let mut lines = Vec::new();
     while let Some(end) = buf.iter().position(|&b| b == b'\n') {
         let raw: Vec<u8> = buf.drain(..=end).collect();
@@ -369,11 +416,14 @@ pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>) -> Vec<String> {
         if text.ends_with('\r') {
             text.pop();
         }
-        lines.push(text);
+        if prompts.is_prompt(&text) {
+            continue;
+        }
+        lines.push(prompts.strip_leading(&text).to_string());
     }
     if let Ok(tail) = std::str::from_utf8(buf) {
-        if is_mongosh_prompt(tail) {
-            lines.push(tail.to_string());
+        if MongoshPrompts::looks_like_prompt(tail) {
+            prompts.learn(tail);
             buf.clear();
         }
     }
@@ -390,6 +440,7 @@ fn spawn_mongosh_reader<R>(
     tokio::spawn(async move {
         let mut reader = reader;
         let mut pending = Vec::new();
+        let mut prompts = MongoshPrompts::default();
         let mut chunk = [0u8; 4096];
         loop {
             let read = match reader.read(&mut chunk).await {
@@ -397,7 +448,7 @@ fn spawn_mongosh_reader<R>(
                 Ok(n) => n,
             };
             pending.extend_from_slice(&chunk[..read]);
-            for text in take_mongosh_lines(&mut pending) {
+            for text in take_mongosh_lines(&mut pending, &mut prompts) {
                 let _ = sender.send(MongoshLine {
                     stream: stream.clone(),
                     text,
@@ -424,9 +475,9 @@ async fn drain_mongosh_output(session: &MongoshSession) -> MongoshCommandOutput 
     loop {
         match tokio::time::timeout(Duration::from_millis(25), output.recv()).await {
             Ok(Some(line)) => {
-                // Prompts and leftover markers are not output, here any more
-                // than during a command.
-                if is_mongosh_prompt(&line.text) || line.text.contains(MONGOSH_MARKER_PREFIX) {
+                // Leftover markers are not output, here any more than during a
+                // command. Prompts never reach this channel: the reader eats them.
+                if line.text.contains(MONGOSH_MARKER_PREFIX) {
                     continue;
                 }
                 match line.stream {
@@ -539,9 +590,6 @@ async fn run_mongosh_command_on_session(
             Some(line) => line,
             None => return Err("mongosh session closed".to_string()),
         };
-        if is_mongosh_prompt(&line.text) {
-            continue;
-        }
         if line.text.trim() == recovered {
             break;
         }
@@ -582,11 +630,21 @@ async fn run_mongosh_command_on_session(
             stderr.extend(error.into_iter().filter(|l| !l.contains(&marker)));
             Ok(MongoshCommandOutput { stdout, stderr })
         }
-        MongoshCommandEnd::Incomplete => Err(
-            "Script is incomplete: an unclosed {, [ or ( left mongosh waiting for more input, \
-             so nothing was run. Close it and try again."
-                .to_string(),
-        ),
+        MongoshCommandEnd::Incomplete => {
+            // Only the trailing open statement was discarded. The REPL evaluates
+            // each statement as soon as it is complete, so anything before it
+            // has already run — a script ending in a stray `{` after an insert
+            // has done the insert. Saying "nothing ran" would invite the user to
+            // run it again. The output that was produced is kept for the same
+            // reason: it is the record of what did happen.
+            stderr.push(
+                "The last statement is incomplete: an unclosed {, [ or ( left mongosh waiting \
+                 for more input, so that statement was discarded. Any complete statements \
+                 before it have already run."
+                    .to_string(),
+            );
+            Ok(MongoshCommandOutput { stdout, stderr })
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -332,71 +332,27 @@ pub struct MongoshSessionInfo {
 /// left behind by an earlier command and must not be shown as output.
 const MONGOSH_MARKER_PREFIX: &str = "__MQLENS_DONE_";
 
-/// The prompt strings this session has been seen to print.
+/// Is this newline-less tail mongosh's prompt?
 ///
-/// A prompt is not recognised by how it looks — a script can print anything,
-/// `print("ready> ")` included — but by how it arrives: it is the one thing
-/// mongosh writes with no newline after it, because it is waiting for input on
-/// the same line. Everything a script prints is newline-terminated. So a chunk
-/// that ends without a newline and looks like a prompt is a prompt, and once
-/// seen its exact text is known. From then on a line equal to it is dropped,
-/// and a line beginning with it is a prompt glued onto whatever the REPL wrote
-/// next — which the OS may well deliver in the same read — and is split.
+/// Asked only of a chunk's tail — bytes with no newline after them. That is
+/// the framing that identifies a prompt: mongosh writes it and then waits for
+/// input on the same line, so it is the one thing the process writes without
+/// a newline. A script's output is newline-terminated, so it never ends a
+/// chunk this way except mid-line, and the shape check below is only there to
+/// keep a half-received output line from being taken for a prompt.
 ///
-/// The set grows on `use <db>` and topology changes, when the prompt changes.
-#[derive(Default)]
-pub(crate) struct MongoshPrompts {
-    known: Vec<String>,
+/// Nothing else is ever judged by shape. A complete line is output, whatever
+/// it looks like: `print("ready> ")` and `print("test> hello")` both come
+/// through untouched. And a prompt the OS delivered in the same read as the
+/// output before it is left glued on — rare, cosmetic, and the only safe
+/// choice, since prompt bytes and identical script bytes cannot be told apart
+/// once they share a line. The completion protocol does not need them told
+/// apart: it matches its markers by suffix (see `marker_line_kind`).
+pub(crate) fn tail_is_mongosh_prompt(tail: &str) -> bool {
+    tail == "| " || (tail.len() <= 200 && tail.ends_with("> ") && tail.trim_end() != ">")
 }
 
-impl MongoshPrompts {
-    /// The continuation prompt is fixed and needs no learning: the REPL prints
-    /// exactly this each time it reads a line while a statement is still open.
-    const CONTINUATION: &'static str = "| ";
-
-    /// Could this newline-less tail be a prompt? Only asked of tails, where the
-    /// framing has already done most of the work; the shape check just keeps a
-    /// half-received output line from being mistaken for one.
-    fn looks_like_prompt(tail: &str) -> bool {
-        tail == Self::CONTINUATION
-            || (tail.len() <= 200 && tail.ends_with("> ") && tail.trim_end() != ">")
-    }
-
-    pub(crate) fn learn(&mut self, prompt: &str) {
-        if prompt != Self::CONTINUATION && !self.known.iter().any(|k| k == prompt) {
-            self.known.push(prompt.to_string());
-        }
-    }
-
-    /// A complete line that is nothing but a prompt.
-    fn is_prompt(&self, line: &str) -> bool {
-        line == Self::CONTINUATION || self.known.iter().any(|k| k == line)
-    }
-
-    /// Strip known prompts glued onto the front of `line`.
-    ///
-    /// Plural: `.break` on an idle REPL prints a prompt with nothing after it,
-    /// so the next output can sit behind two of them.
-    fn strip_leading<'a>(&self, line: &'a str) -> &'a str {
-        let mut rest = line;
-        loop {
-            let before = rest;
-            for k in &self.known {
-                if let Some(r) = rest.strip_prefix(k.as_str()) {
-                    rest = r;
-                }
-            }
-            if let Some(r) = rest.strip_prefix(Self::CONTINUATION) {
-                rest = r;
-            }
-            if rest.len() == before.len() {
-                return rest;
-            }
-        }
-    }
-}
-
-/// Take every complete output line out of `buf`, learning prompts on the way.
+/// Take every complete output line out of `buf`, and drop a trailing prompt.
 ///
 /// A line reader on mongosh's stdout was subtly wrong: the REPL writes its
 /// prompt with no newline after it, so a `lines()` reader never saw the prompt
@@ -405,10 +361,9 @@ impl MongoshPrompts {
 /// nothing after it, which is exactly what a REPL waiting for input produces,
 /// was never delivered at all.
 ///
-/// Prompts are consumed here and never delivered: nothing downstream needs
-/// them. Output glued behind one is delivered without it. `\r\n` is folded to
-/// `\n`; partial UTF-8 at the end of a chunk stays until the rest arrives.
-pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>, prompts: &mut MongoshPrompts) -> Vec<String> {
+/// `\r\n` is folded to `\n`; partial UTF-8 at the end of a chunk stays until
+/// the rest of it arrives.
+pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>) -> Vec<String> {
     let mut lines = Vec::new();
     while let Some(end) = buf.iter().position(|&b| b == b'\n') {
         let raw: Vec<u8> = buf.drain(..=end).collect();
@@ -416,14 +371,10 @@ pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>, prompts: &mut MongoshPrompts
         if text.ends_with('\r') {
             text.pop();
         }
-        if prompts.is_prompt(&text) {
-            continue;
-        }
-        lines.push(prompts.strip_leading(&text).to_string());
+        lines.push(text);
     }
     if let Ok(tail) = std::str::from_utf8(buf) {
-        if MongoshPrompts::looks_like_prompt(tail) {
-            prompts.learn(tail);
+        if tail_is_mongosh_prompt(tail) {
             buf.clear();
         }
     }
@@ -440,7 +391,6 @@ fn spawn_mongosh_reader<R>(
     tokio::spawn(async move {
         let mut reader = reader;
         let mut pending = Vec::new();
-        let mut prompts = MongoshPrompts::default();
         let mut chunk = [0u8; 4096];
         loop {
             let read = match reader.read(&mut chunk).await {
@@ -448,7 +398,7 @@ fn spawn_mongosh_reader<R>(
                 Ok(n) => n,
             };
             pending.extend_from_slice(&chunk[..read]);
-            for text in take_mongosh_lines(&mut pending, &mut prompts) {
+            for text in take_mongosh_lines(&mut pending) {
                 let _ = sender.send(MongoshLine {
                     stream: stream.clone(),
                     text,
@@ -513,19 +463,30 @@ pub(crate) enum MongoshCommandEnd {
     SyntaxError,
 }
 
-/// Where a line that carries the marker came from: the `print` we asked for,
-/// or a SyntaxError code frame quoting our own line back at us.
+/// Where a line that carries the marker came from: the REPL echoing the marker
+/// expression we sent, or a SyntaxError code frame quoting our line back.
 ///
-///     > 2 | print('__MQLENS_DONE_…__')
+/// Matched by suffix, not equality. The marker is unique and nothing but the
+/// REPL's echo of it ever ends a line with it, so whatever precedes it on the
+/// line is a prompt the OS delivered in the same read — `test> __MQLENS_DONE_…__`
+/// — and is irrelevant. This is what keeps completion detection from ever
+/// depending on prompt recognition, which is heuristic and can lag: the very
+/// first prompt of a session can arrive coalesced with the marker of the `use`
+/// that starts it, before anything has been seen at all.
 ///
-/// is what the REPL prints when an open `(` on line 1 made line 2 part of the
-/// same statement. The marker is unique per command, so the frame can only be
-/// quoting this command.
+/// A code frame quoting our line ends with `'`, not the marker:
+///
+///     > 2 | '__MQLENS_DONE_…__'
+///
+/// so it is a different kind. With the marker sent as a bare expression that
+/// is rare — a string is valid inside most open constructs, so the REPL keeps
+/// reading rather than failing — but the REPL can still produce it, and it
+/// means the same thing: our line was swallowed into an unclosed statement.
 pub(crate) fn marker_line_kind(line: &str, marker: &str) -> Option<MongoshCommandEnd> {
     if !line.contains(marker) {
         return None;
     }
-    Some(if line.trim() == marker {
+    Some(if line.trim_end().ends_with(marker) {
         MongoshCommandEnd::Completed
     } else {
         MongoshCommandEnd::SyntaxError
@@ -558,11 +519,17 @@ async fn run_mongosh_command_on_session(
     // is merely slow, which is still evaluating and has not read it yet. And
     // when nothing is open it does nothing at all. The second marker prints
     // either way; it is the point at which we can say what happened.
+    //
+    // The markers are bare string expressions, not `print(...)` calls. The REPL
+    // echoes the value of every expression statement itself, and that is not
+    // something a script can reach: `print = () => {}` silences `print`, and
+    // would have silenced both markers with it, leaving a command that could
+    // only end by being stopped. The echo of a string is the bare text.
     let mut script = command.replace("\r\n", "\n");
     if !script.ends_with('\n') {
         script.push('\n');
     }
-    script.push_str(&format!("print('{marker}')\n.break\nprint('{recovered}')\n"));
+    script.push_str(&format!("'{marker}'\n.break\n'{recovered}'\n"));
     {
         let mut stdin = session.stdin.lock().await;
         stdin
@@ -590,7 +557,9 @@ async fn run_mongosh_command_on_session(
             Some(line) => line,
             None => return Err("mongosh session closed".to_string()),
         };
-        if line.text.trim() == recovered {
+        // Suffix, for the same reason `marker_line_kind` uses one: a prompt
+        // delivered in the same read sits in front of it.
+        if line.text.trim_end().ends_with(&recovered) {
             break;
         }
         match marker_line_kind(&line.text, &marker) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -193,6 +193,11 @@ pub struct MongoshSession {
     output: AsyncMutex<mpsc::UnboundedReceiver<MongoshLine>>,
     child: AsyncMutex<Child>,
     command_lock: AsyncMutex<()>,
+    /// The markers of the command before this one. A line ending in one of
+    /// them is that command's echo arriving late — after its caller gave up
+    /// on it — and not this command's output. Matched exactly: a script that
+    /// prints something merely resembling a marker is printing output.
+    stale_markers: AsyncMutex<Vec<String>>,
 }
 
 #[derive(Serialize, Clone)]
@@ -352,7 +357,7 @@ pub(crate) fn tail_is_mongosh_prompt(tail: &str) -> bool {
     tail == "| " || (tail.len() <= 200 && tail.ends_with("> ") && tail.trim_end() != ">")
 }
 
-/// Take every complete output line out of `buf`, and drop a trailing prompt.
+/// Take every complete output line out of `buf`.
 ///
 /// A line reader on mongosh's stdout was subtly wrong: the REPL writes its
 /// prompt with no newline after it, so a `lines()` reader never saw the prompt
@@ -361,8 +366,10 @@ pub(crate) fn tail_is_mongosh_prompt(tail: &str) -> bool {
 /// nothing after it, which is exactly what a REPL waiting for input produces,
 /// was never delivered at all.
 ///
-/// `\r\n` is folded to `\n`; partial UTF-8 at the end of a chunk stays until
-/// the rest of it arrives.
+/// Whatever is left in `buf` afterwards has no newline yet. It may be a prompt
+/// or the front of an output line the pipe split; `absorb_mongosh_chunk` is
+/// where that is decided, and only once the next bytes say which. `\r\n` is
+/// folded to `\n`; partial UTF-8 stays until the rest of it arrives.
 pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>) -> Vec<String> {
     let mut lines = Vec::new();
     while let Some(end) = buf.iter().position(|&b| b == b'\n') {
@@ -373,12 +380,38 @@ pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>) -> Vec<String> {
         }
         lines.push(text);
     }
-    if let Ok(tail) = std::str::from_utf8(buf) {
-        if tail_is_mongosh_prompt(tail) {
-            buf.clear();
+    lines
+}
+
+/// Add a chunk from the pipe to `pending` and return the complete lines.
+///
+/// The decision about a prompt-shaped tail is made HERE, on the next chunk,
+/// and not when the tail arrives. `AsyncRead::read` returns whatever the pipe
+/// has, at any boundary; `print("ready> ")` can be delivered as `ready> ` and
+/// then `\n`, and judged on its own the first part is indistinguishable from a
+/// prompt. The next bytes settle it: if they begin with the newline, the tail
+/// was the front of an output line and is kept; if they begin with anything
+/// else, nothing continues a line that way except the REPL writing what comes
+/// after a prompt, so the tail was a prompt and is dropped.
+///
+/// What this cannot tell apart, stated plainly: an output line the pipe split
+/// immediately after a `> ` in the middle of it — `foo> ` then `bar\n`. That
+/// needs a boundary at exactly that point and text following it that is not a
+/// newline; it is strictly narrower than the case above, and there is no
+/// framing that resolves it, because the bytes are identical to a prompt
+/// followed by output. The completion protocol does not depend on either
+/// reading — markers are matched by suffix — so it costs a line of output in
+/// a rare case, never a hang.
+pub(crate) fn absorb_mongosh_chunk(pending: &mut Vec<u8>, chunk: &[u8]) -> Vec<String> {
+    if chunk.first() != Some(&b'\n') {
+        if let Ok(tail) = std::str::from_utf8(pending) {
+            if tail_is_mongosh_prompt(tail) {
+                pending.clear();
+            }
         }
     }
-    lines
+    pending.extend_from_slice(chunk);
+    take_mongosh_lines(pending)
 }
 
 fn spawn_mongosh_reader<R>(
@@ -397,8 +430,7 @@ fn spawn_mongosh_reader<R>(
                 Ok(0) | Err(_) => break,
                 Ok(n) => n,
             };
-            pending.extend_from_slice(&chunk[..read]);
-            for text in take_mongosh_lines(&mut pending) {
+            for text in absorb_mongosh_chunk(&mut pending, &chunk[..read]) {
                 let _ = sender.send(MongoshLine {
                     stream: stream.clone(),
                     text,
@@ -406,28 +438,40 @@ fn spawn_mongosh_reader<R>(
             }
         }
         // Whatever the process wrote last without a newline still belongs to
-        // someone; the channel closing right after is what tells the reader
-        // the session ended.
-        if !pending.is_empty() {
-            let _ = sender.send(MongoshLine {
-                stream,
-                text: String::from_utf8_lossy(&pending).into_owned(),
-            });
+        // someone — unless it is the prompt the REPL was showing when it died,
+        // which is nobody's output. The channel closing right after is what
+        // tells the reader the session ended.
+        let leftover = String::from_utf8_lossy(&pending).into_owned();
+        if !leftover.is_empty() && !tail_is_mongosh_prompt(&leftover) {
+            let _ = sender.send(MongoshLine { stream, text: leftover });
         }
     });
+}
+
+/// Does this line end in one of the previous command's markers?
+///
+/// Exact markers, matched by suffix — the same rule as for the live ones. A
+/// prefix match would have swallowed any output that happened to contain the
+/// reserved-looking text, `printjson({ status: "__MQLENS_DONE_pending" })`
+/// included; only the two UUID markers an earlier command actually sent can
+/// be its echo arriving late.
+pub(crate) fn is_stale_marker_line(line: &str, stale: &[String]) -> bool {
+    let text = line.trim_end();
+    stale.iter().any(|m| text.ends_with(m.as_str()))
 }
 
 async fn drain_mongosh_output(session: &MongoshSession) -> MongoshCommandOutput {
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
+    let stale = session.stale_markers.lock().await.clone();
     let mut output = session.output.lock().await;
 
     loop {
         match tokio::time::timeout(Duration::from_millis(25), output.recv()).await {
             Ok(Some(line)) => {
-                // Leftover markers are not output, here any more than during a
-                // command. Prompts never reach this channel: the reader eats them.
-                if line.text.contains(MONGOSH_MARKER_PREFIX) {
+                // The previous command's markers are not output, here any more
+                // than during a command.
+                if is_stale_marker_line(&line.text, &stale) {
                     continue;
                 }
                 match line.stream {
@@ -501,7 +545,14 @@ async fn run_mongosh_command_on_session(
     let marker = format!("{MONGOSH_MARKER_PREFIX}{}__", Uuid::new_v4().simple());
     let recovered = format!("{MONGOSH_MARKER_PREFIX}{}__", Uuid::new_v4().simple());
 
+    // Whatever the previous command left behind is drained before this one
+    // starts; its markers stay known for the rest of this command, in case
+    // its echo arrives later still. Then this command's markers take over.
     let _ = drain_mongosh_output(session).await;
+    let stale = std::mem::replace(
+        &mut *session.stale_markers.lock().await,
+        vec![marker.clone(), recovered.clone()],
+    );
 
     // Sent as one write, in this order, and the order is the whole mechanism.
     //
@@ -574,9 +625,9 @@ async fn run_mongosh_command_on_session(
             }
             _ => {}
         }
-        if line.text.contains(MONGOSH_MARKER_PREFIX) {
-            // A marker from a command that ended before this one started —
-            // typically one the user stopped. Not this command's output.
+        if is_stale_marker_line(&line.text, &stale) {
+            // The previous command's echo arriving late — its caller gave up on
+            // it before the REPL finished. Not this command's output.
             continue;
         }
         match line.stream {
@@ -871,6 +922,7 @@ pub async fn start_mongosh_session_impl(
         output: AsyncMutex::new(receiver),
         child: AsyncMutex::new(child),
         command_lock: AsyncMutex::new(()),
+        stale_markers: AsyncMutex::new(Vec::new()),
     });
 
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ use serde_json;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, ChildStdin, Command as TokioCommand};
 use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use uuid::Uuid;
@@ -327,6 +327,59 @@ pub struct MongoshSessionInfo {
     pub stderr: Vec<String>,
 }
 
+/// Prefix of every completion marker this process has ever printed into a
+/// session. Any line carrying it that is not the marker being waited for was
+/// left behind by an earlier command and must not be shown as output.
+const MONGOSH_MARKER_PREFIX: &str = "__MQLENS_DONE_";
+
+/// Is this line mongosh's prompt, rather than something the script printed?
+///
+/// Two shapes. `| ` is the continuation prompt the REPL emits each time it
+/// reads a line while a statement is still open. Everything else ends in `> `
+/// — `rs0 [direct: primary] test> ` — and is emitted after each statement
+/// evaluates, `--quiet` or not. Neither is output, and the continuation one is
+/// a signal in its own right (see `run_mongosh_command_on_session`).
+///
+/// Bounded in length so a long document line that happens to end in `> `
+/// cannot be mistaken for one; a prompt is a short line.
+pub(crate) fn is_mongosh_prompt(line: &str) -> bool {
+    if line == "| " {
+        return true;
+    }
+    line.len() <= 200 && line.ends_with("> ") && line.trim_end() != ">"
+}
+
+/// Take every complete line out of `buf`, and a trailing prompt as well.
+///
+/// A line reader on mongosh's stdout was subtly wrong: the REPL writes its
+/// prompt with no newline after it, so a `lines()` reader never saw the prompt
+/// as a line. It sat in the buffer until the NEXT output arrived and was glued
+/// to the front of it — the console showed `test> hello` — and a prompt with
+/// nothing after it, which is exactly what a REPL waiting for input produces,
+/// was never delivered at all. That prompt is the one piece of evidence that a
+/// script has stalled, so it is flushed the moment it is recognisable.
+///
+/// `\r\n` is folded to `\n`; partial UTF-8 at the end of a chunk stays in the
+/// buffer until the rest of it arrives.
+pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>) -> Vec<String> {
+    let mut lines = Vec::new();
+    while let Some(end) = buf.iter().position(|&b| b == b'\n') {
+        let raw: Vec<u8> = buf.drain(..=end).collect();
+        let mut text = String::from_utf8_lossy(&raw[..raw.len() - 1]).into_owned();
+        if text.ends_with('\r') {
+            text.pop();
+        }
+        lines.push(text);
+    }
+    if let Ok(tail) = std::str::from_utf8(buf) {
+        if is_mongosh_prompt(tail) {
+            lines.push(tail.to_string());
+            buf.clear();
+        }
+    }
+    lines
+}
+
 fn spawn_mongosh_reader<R>(
     reader: R,
     stream: MongoshStream,
@@ -335,11 +388,29 @@ fn spawn_mongosh_reader<R>(
     R: AsyncRead + Unpin + Send + 'static,
 {
     tokio::spawn(async move {
-        let mut lines = BufReader::new(reader).lines();
-        while let Ok(Some(line)) = lines.next_line().await {
+        let mut reader = reader;
+        let mut pending = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            let read = match reader.read(&mut chunk).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => n,
+            };
+            pending.extend_from_slice(&chunk[..read]);
+            for text in take_mongosh_lines(&mut pending) {
+                let _ = sender.send(MongoshLine {
+                    stream: stream.clone(),
+                    text,
+                });
+            }
+        }
+        // Whatever the process wrote last without a newline still belongs to
+        // someone; the channel closing right after is what tells the reader
+        // the session ended.
+        if !pending.is_empty() {
             let _ = sender.send(MongoshLine {
-                stream: stream.clone(),
-                text: line,
+                stream,
+                text: String::from_utf8_lossy(&pending).into_owned(),
             });
         }
     });
@@ -352,10 +423,17 @@ async fn drain_mongosh_output(session: &MongoshSession) -> MongoshCommandOutput 
 
     loop {
         match tokio::time::timeout(Duration::from_millis(25), output.recv()).await {
-            Ok(Some(line)) => match line.stream {
-                MongoshStream::Stdout => push_mongosh_line(&mut stdout, line.text),
-                MongoshStream::Stderr => push_mongosh_line(&mut stderr, line.text),
-            },
+            Ok(Some(line)) => {
+                // Prompts and leftover markers are not output, here any more
+                // than during a command.
+                if is_mongosh_prompt(&line.text) || line.text.contains(MONGOSH_MARKER_PREFIX) {
+                    continue;
+                }
+                match line.stream {
+                    MongoshStream::Stdout => push_mongosh_line(&mut stdout, line.text),
+                    MongoshStream::Stderr => push_mongosh_line(&mut stderr, line.text),
+                }
+            }
             _ => break,
         }
     }
@@ -363,64 +441,153 @@ async fn drain_mongosh_output(session: &MongoshSession) -> MongoshCommandOutput 
     MongoshCommandOutput { stdout, stderr }
 }
 
+/// How a command's turn at the REPL ended, read off the marker lines.
+///
+/// The three outcomes are distinguishable only because of what follows the
+/// command on stdin: its own marker, then `.break`, then a second marker.
+/// `.break` is the REPL's own command to abandon a half-typed statement — a
+/// no-op when nothing is open, so it costs nothing on the happy path — and the
+/// second marker prints in every case, which is what makes the first marker's
+/// absence meaningful rather than merely silence.
+#[derive(Debug, PartialEq)]
+pub(crate) enum MongoshCommandEnd {
+    /// The marker printed: the script ran to the end, whatever it printed.
+    Completed,
+    /// The marker never printed and no error mentioned it: an unclosed brace or
+    /// bracket left the REPL reading our marker as more of the script, and
+    /// `.break` threw the whole thing away. Nothing ran.
+    Incomplete,
+    /// The marker was swallowed into a statement that then failed to parse. The
+    /// REPL reported the SyntaxError itself — it just never got to print.
+    SyntaxError,
+}
+
+/// Where a line that carries the marker came from: the `print` we asked for,
+/// or a SyntaxError code frame quoting our own line back at us.
+///
+///     > 2 | print('__MQLENS_DONE_…__')
+///
+/// is what the REPL prints when an open `(` on line 1 made line 2 part of the
+/// same statement. The marker is unique per command, so the frame can only be
+/// quoting this command.
+pub(crate) fn marker_line_kind(line: &str, marker: &str) -> Option<MongoshCommandEnd> {
+    if !line.contains(marker) {
+        return None;
+    }
+    Some(if line.trim() == marker {
+        MongoshCommandEnd::Completed
+    } else {
+        MongoshCommandEnd::SyntaxError
+    })
+}
+
 async fn run_mongosh_command_on_session(
     session: &MongoshSession,
     command: &str,
 ) -> Result<MongoshCommandOutput, String> {
     let _command_guard = session.command_lock.lock().await;
-    let marker = format!("__MQLENS_DONE_{}__", Uuid::new_v4().simple());
+    let marker = format!("{MONGOSH_MARKER_PREFIX}{}__", Uuid::new_v4().simple());
+    let recovered = format!("{MONGOSH_MARKER_PREFIX}{}__", Uuid::new_v4().simple());
 
     let _ = drain_mongosh_output(session).await;
 
+    // Sent as one write, in this order, and the order is the whole mechanism.
+    //
+    // The REPL reads a line at a time and only evaluates once a statement is
+    // complete. Left open — an unclosed `{`, a `find(` with no `)` — it does not
+    // report anything; it reads the next line as more of the same statement,
+    // and the next, our marker included, and waits. Every later command the
+    // user sends lands in that same buffer. That is what a "timeout" looked
+    // like from the outside: twenty seconds of nothing, then an error, then a
+    // shell that no longer answers anything.
+    //
+    // `.break` after the marker is the REPL's own escape from that state. It
+    // sits in the pipe behind every line of the script and the marker, so it
+    // can only ever discard a statement those lines left open — never one that
+    // is merely slow, which is still evaluating and has not read it yet. And
+    // when nothing is open it does nothing at all. The second marker prints
+    // either way; it is the point at which we can say what happened.
+    let mut script = command.replace("\r\n", "\n");
+    if !script.ends_with('\n') {
+        script.push('\n');
+    }
+    script.push_str(&format!("print('{marker}')\n.break\nprint('{recovered}')\n"));
     {
         let mut stdin = session.stdin.lock().await;
         stdin
-            .write_all(command.as_bytes())
+            .write_all(script.as_bytes())
             .await
             .map_err(|e| format!("Failed to write to mongosh: {}", e))?;
-        if !command.ends_with('\n') {
-            stdin
-                .write_all(b"\n")
-                .await
-                .map_err(|e| format!("Failed to write to mongosh: {}", e))?;
-        }
-        stdin
-            .write_all(format!("print('{}')\n", marker).as_bytes())
-            .await
-            .map_err(|e| format!("Failed to write command marker to mongosh: {}", e))?;
         stdin
             .flush()
             .await
             .map_err(|e| format!("Failed to flush mongosh stdin: {}", e))?;
     }
 
-    let deadline = Instant::now() + Duration::from_secs(20);
+    // No deadline. A script takes as long as it takes — an index build, an
+    // aggregation over a large collection, a `sleep` — and cutting it off after
+    // a fixed twenty seconds did not stop it: mongosh kept running, and its
+    // output, marker included, arrived during whatever the user ran next. The
+    // wait ends when the REPL says the turn is over, or when the session is
+    // gone, which is how the user stops a command they no longer want.
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
+    let mut end = MongoshCommandEnd::Incomplete;
     let mut output = session.output.lock().await;
-
     loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            return Err("mongosh command timed out".to_string());
+        let line = match output.recv().await {
+            Some(line) => line,
+            None => return Err("mongosh session closed".to_string()),
+        };
+        if is_mongosh_prompt(&line.text) {
+            continue;
         }
-
-        match tokio::time::timeout(remaining, output.recv()).await {
-            Ok(Some(line)) => {
-                if line.text.contains(&marker) {
-                    break;
-                }
-                match line.stream {
-                    MongoshStream::Stdout => push_mongosh_line(&mut stdout, line.text),
-                    MongoshStream::Stderr => push_mongosh_line(&mut stderr, line.text),
-                }
+        if line.text.trim() == recovered {
+            break;
+        }
+        match marker_line_kind(&line.text, &marker) {
+            Some(MongoshCommandEnd::Completed) => {
+                end = MongoshCommandEnd::Completed;
+                continue;
             }
-            Ok(None) => return Err("mongosh session closed".to_string()),
-            Err(_) => return Err("mongosh command timed out".to_string()),
+            Some(MongoshCommandEnd::SyntaxError) => {
+                // Keep reading: the rest of the error is still coming.
+                end = MongoshCommandEnd::SyntaxError;
+                continue;
+            }
+            _ => {}
+        }
+        if line.text.contains(MONGOSH_MARKER_PREFIX) {
+            // A marker from a command that ended before this one started —
+            // typically one the user stopped. Not this command's output.
+            continue;
+        }
+        match line.stream {
+            MongoshStream::Stdout => push_mongosh_line(&mut stdout, line.text),
+            MongoshStream::Stderr => push_mongosh_line(&mut stderr, line.text),
         }
     }
 
-    Ok(MongoshCommandOutput { stdout, stderr })
+    match end {
+        MongoshCommandEnd::Completed => Ok(MongoshCommandOutput { stdout, stderr }),
+        MongoshCommandEnd::SyntaxError => {
+            // The REPL's own report, moved to stderr so it reads as the error it
+            // is. The code frame quoted our marker as if it were the script's
+            // last line; that line is ours, not the user's, and goes.
+            let at = stdout
+                .iter()
+                .position(|l| l.starts_with("Uncaught"))
+                .unwrap_or(stdout.len());
+            let error: Vec<String> = stdout.split_off(at);
+            stderr.extend(error.into_iter().filter(|l| !l.contains(&marker)));
+            Ok(MongoshCommandOutput { stdout, stderr })
+        }
+        MongoshCommandEnd::Incomplete => Err(
+            "Script is incomplete: an unclosed {, [ or ( left mongosh waiting for more input, \
+             so nothing was run. Close it and try again."
+                .to_string(),
+        ),
+    }
 }
 
 fn push_mongosh_line(lines: &mut Vec<String>, text: String) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -403,7 +403,11 @@ pub(crate) fn take_mongosh_lines(buf: &mut Vec<u8>) -> Vec<String> {
 /// reading — markers are matched by suffix — so it costs a line of output in
 /// a rare case, never a hang.
 pub(crate) fn absorb_mongosh_chunk(pending: &mut Vec<u8>, chunk: &[u8]) -> Vec<String> {
-    if chunk.first() != Some(&b'\n') {
+    // A chunk that opens with a line ending — `\n`, or the `\r` of a `\r\n` —
+    // is finishing the pending line, so what is pending was output, however
+    // prompt-shaped. Only output that starts something new proves the pending
+    // text was a prompt.
+    if !matches!(chunk.first(), Some(b'\n') | Some(b'\r')) {
         if let Ok(tail) = std::str::from_utf8(pending) {
             if tail_is_mongosh_prompt(tail) {
                 pending.clear();
@@ -1827,6 +1831,24 @@ async fn run_mongosh_command(
     command: String,
 ) -> Result<MongoshCommandOutput, String> {
     run_mongosh_command_impl(&state, &session_id, &command).await
+}
+
+/// Resolves once `session_id` is not running a command.
+///
+/// A shell that reopens — a window refresh, a tab moved to another window —
+/// can find a command recorded as running whose caller is gone, and nothing
+/// else would ever tell it when that command ends. The command holds
+/// `command_lock` for as long as it runs, so waiting on that lock is the
+/// honest signal. Stopping the session ends the command and releases the lock,
+/// so this resolves then too.
+#[tauri::command]
+async fn await_mongosh_idle(
+    state: tauri::State<'_, AppState>,
+    session_id: String,
+) -> Result<(), String> {
+    let session = get_mongosh_session(&state, &session_id)?;
+    let _idle = session.command_lock.lock().await;
+    Ok(())
 }
 
 #[tauri::command]
@@ -3351,6 +3373,7 @@ pub fn run() {
             get_mongodb_version,
             start_mongosh_session,
             run_mongosh_command,
+            await_mongosh_idle,
             stop_mongosh_session,
             get_shell_tab_state,
             set_shell_tab_state,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3052,6 +3052,21 @@ mod tests {
     }
 
     #[test]
+    fn output_split_before_its_crlf_is_kept_whole() {
+        use crate::absorb_mongosh_chunk;
+        // The same split, but the line ends in `\r\n` (mongosh on Windows) and
+        // the read boundary falls before the `\r`. A leading carriage return is
+        // a line ending arriving, not new output after a prompt.
+        let mut pending = Vec::new();
+        assert!(absorb_mongosh_chunk(&mut pending, b"ready> ").is_empty());
+        assert_eq!(absorb_mongosh_chunk(&mut pending, b"\r\n"), vec!["ready> ".to_string()]);
+        // And split again, between the `\r` and the `\n`.
+        assert!(absorb_mongosh_chunk(&mut pending, b"status> ").is_empty());
+        assert!(absorb_mongosh_chunk(&mut pending, b"\r").is_empty());
+        assert_eq!(absorb_mongosh_chunk(&mut pending, b"\n"), vec!["status> ".to_string()]);
+    }
+
+    #[test]
     fn complete_lines_are_never_rewritten() {
         use crate::absorb_mongosh_chunk;
         // A script may print anything, including things shaped like a prompt,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3022,50 +3022,75 @@ mod tests {
     // was glued to the front of it, and a prompt with nothing after it — the
     // REPL waiting for input, which is what a stalled script looks like — was
     // never delivered at all.
+    //
+    // A prompt is recognised by that framing, not by its shape: it arrives as a
+    // tail with no newline. Once seen, its exact text is known, and only that
+    // exact text is ever treated as a prompt again — so output that merely
+    // resembles one is left alone.
 
     #[test]
-    fn a_prompt_with_no_newline_is_delivered_as_its_own_line() {
-        use crate::take_mongosh_lines;
+    fn a_prompt_arriving_without_a_newline_is_learned_and_dropped() {
+        use crate::{take_mongosh_lines, MongoshPrompts};
+        let mut prompts = MongoshPrompts::default();
         let mut buf = b"hello\nrs0 [direct: primary] test> ".to_vec();
-        assert_eq!(
-            take_mongosh_lines(&mut buf),
-            vec!["hello".to_string(), "rs0 [direct: primary] test> ".to_string()]
-        );
-        assert!(buf.is_empty(), "a recognised prompt is consumed, not left to glue onto later output");
+        assert_eq!(take_mongosh_lines(&mut buf, &mut prompts), vec!["hello".to_string()]);
+        assert!(buf.is_empty(), "the prompt is consumed, not left to glue onto later output");
     }
 
     #[test]
-    fn a_continuation_prompt_is_delivered_too() {
-        use crate::take_mongosh_lines;
-        // `| ` is what the REPL prints each time it reads a line while a
-        // statement is still open — the signal that a script is incomplete.
-        let mut buf = b"| ".to_vec();
-        assert_eq!(take_mongosh_lines(&mut buf), vec!["| ".to_string()]);
-        assert!(buf.is_empty());
+    fn a_prompt_glued_to_output_in_one_read_is_split_off() {
+        use crate::{take_mongosh_lines, MongoshPrompts};
+        // The OS can hand the reader a prompt and the next line together. The
+        // recovery marker is compared exactly, so `test> __MQLENS_DONE_x__`
+        // delivered as one line would never match — and with no ceiling on a
+        // command any more, that is a wait with no end.
+        let mut prompts = MongoshPrompts::default();
+        prompts.learn("test> ");
+        let mut buf = b"test> __MQLENS_DONE_x__\n".to_vec();
+        assert_eq!(take_mongosh_lines(&mut buf, &mut prompts), vec!["__MQLENS_DONE_x__".to_string()]);
+
+        // Two prompts can precede it: `.break` on an idle REPL prints one more.
+        let mut buf = b"test> test> __MQLENS_DONE_x__\n".to_vec();
+        assert_eq!(take_mongosh_lines(&mut buf, &mut prompts), vec!["__MQLENS_DONE_x__".to_string()]);
+    }
+
+    #[test]
+    fn output_that_merely_resembles_a_prompt_is_kept() {
+        use crate::{take_mongosh_lines, MongoshPrompts};
+        // A script may print anything. Only the exact prompt this session has
+        // been seen to write is a prompt; a line ending in `> ` is not.
+        let mut prompts = MongoshPrompts::default();
+        prompts.learn("test> ");
+        let mut buf = b"ready> \nstatus> ok\n".to_vec();
+        assert_eq!(
+            take_mongosh_lines(&mut buf, &mut prompts),
+            vec!["ready> ".to_string(), "status> ok".to_string()]
+        );
     }
 
     #[test]
     fn a_partial_output_line_waits_for_its_newline() {
-        use crate::take_mongosh_lines;
+        use crate::{take_mongosh_lines, MongoshPrompts};
+        let mut prompts = MongoshPrompts::default();
         let mut buf = b"{ _id: 1, name: 'half".to_vec();
-        assert!(take_mongosh_lines(&mut buf).is_empty());
+        assert!(take_mongosh_lines(&mut buf, &mut prompts).is_empty());
         assert_eq!(buf, b"{ _id: 1, name: 'half".to_vec(), "not a prompt, so it stays buffered");
 
         buf.extend_from_slice(b" typed' }\r\n");
-        assert_eq!(take_mongosh_lines(&mut buf), vec!["{ _id: 1, name: 'half typed' }".to_string()]);
+        assert_eq!(
+            take_mongosh_lines(&mut buf, &mut prompts),
+            vec!["{ _id: 1, name: 'half typed' }".to_string()]
+        );
     }
 
     #[test]
-    fn prompt_detection_is_narrow() {
-        use crate::is_mongosh_prompt;
-        assert!(is_mongosh_prompt("rs0 [direct: primary] test> "));
-        assert!(is_mongosh_prompt("hello> "));
-        assert!(is_mongosh_prompt("| "));
-        // Output that merely ends in the same characters is not a prompt.
-        assert!(!is_mongosh_prompt("{ a: 1 }"));
-        assert!(!is_mongosh_prompt("> 2 | print('x')")); // a SyntaxError code frame
-        assert!(!is_mongosh_prompt("> "));
-        assert!(!is_mongosh_prompt(&format!("{}> ", "x".repeat(300))));
+    fn the_continuation_prompt_needs_no_learning() {
+        use crate::{take_mongosh_lines, MongoshPrompts};
+        // `| ` is what the REPL prints each time it reads a line while a
+        // statement is still open. It is the same string in every session.
+        let mut prompts = MongoshPrompts::default();
+        let mut buf = b"| \n| item 1\n".to_vec();
+        assert_eq!(take_mongosh_lines(&mut buf, &mut prompts), vec!["item 1".to_string()]);
     }
 
     #[test]
@@ -3085,7 +3110,6 @@ mod tests {
         assert_eq!(marker_line_kind("hello", marker), None);
         assert_eq!(marker_line_kind("__MQLENS_DONE_other__", marker), None);
     }
-
 
     #[tokio::test]
     async fn test_mongosh_session_not_found() {

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3023,46 +3023,54 @@ mod tests {
     // REPL waiting for input, which is what a stalled script looks like — was
     // never delivered at all.
     //
-    // A prompt is recognised by that framing alone: it is a chunk's newline-less
-    // tail. Complete lines are never judged by shape and never rewritten, so
-    // output that resembles a prompt is output. Completion does not depend on
-    // prompt recognition at all — markers are matched by suffix.
+    // A prompt-shaped tail is judged only by what comes next: a newline means
+    // it was output the pipe split, anything else means it was a prompt. Complete
+    // lines are never rewritten. Completion does not depend on prompt handling
+    // at all — markers are matched by suffix.
 
     #[test]
-    fn a_prompt_arriving_without_a_newline_is_dropped() {
-        use crate::take_mongosh_lines;
-        let mut buf = b"hello\nrs0 [direct: primary] test> ".to_vec();
-        assert_eq!(take_mongosh_lines(&mut buf), vec!["hello".to_string()]);
-        assert!(buf.is_empty(), "the prompt is consumed, not left to glue onto later output");
+    fn a_prompt_is_dropped_once_the_next_output_shows_it_was_one() {
+        use crate::absorb_mongosh_chunk;
+        let mut pending = Vec::new();
+        assert_eq!(absorb_mongosh_chunk(&mut pending, b"hello\nrs0 [direct: primary] test> "), vec!["hello".to_string()]);
+        // Held, not decided: it could still be the front of an output line.
+        assert_eq!(pending, b"rs0 [direct: primary] test> ".to_vec());
+        // The next chunk starts with output, so the tail was a prompt.
+        assert_eq!(absorb_mongosh_chunk(&mut pending, b"world\n"), vec!["world".to_string()]);
+        assert!(pending.is_empty());
+    }
 
-        // The continuation prompt is the same string in every session.
-        let mut buf = b"| ".to_vec();
-        assert!(take_mongosh_lines(&mut buf).is_empty());
-        assert!(buf.is_empty());
+    #[test]
+    fn output_split_right_before_its_newline_is_kept_whole() {
+        use crate::absorb_mongosh_chunk;
+        // `print("ready> ")` delivered as `ready> ` and then `\n`. Judged on its
+        // own the first part looks exactly like a prompt; the newline that
+        // follows is what says it was not.
+        let mut pending = Vec::new();
+        assert!(absorb_mongosh_chunk(&mut pending, b"ready> ").is_empty());
+        assert_eq!(absorb_mongosh_chunk(&mut pending, b"\n"), vec!["ready> ".to_string()]);
     }
 
     #[test]
     fn complete_lines_are_never_rewritten() {
-        use crate::take_mongosh_lines;
+        use crate::absorb_mongosh_chunk;
         // A script may print anything, including things shaped like a prompt,
         // and a prompt the OS delivered in the same read as the output after it
         // is left glued on rather than guessed at. Both are delivered verbatim.
-        let mut buf = b"ready> \ntest> hello\nstatus> ok\n".to_vec();
+        let mut pending = Vec::new();
         assert_eq!(
-            take_mongosh_lines(&mut buf),
+            absorb_mongosh_chunk(&mut pending, b"ready> \ntest> hello\nstatus> ok\n"),
             vec!["ready> ".to_string(), "test> hello".to_string(), "status> ok".to_string()]
         );
     }
 
     #[test]
     fn a_partial_output_line_waits_for_its_newline() {
-        use crate::take_mongosh_lines;
-        let mut buf = b"{ _id: 1, name: 'half".to_vec();
-        assert!(take_mongosh_lines(&mut buf).is_empty());
-        assert_eq!(buf, b"{ _id: 1, name: 'half".to_vec(), "not a prompt, so it stays buffered");
-
-        buf.extend_from_slice(b" typed' }\r\n");
-        assert_eq!(take_mongosh_lines(&mut buf), vec!["{ _id: 1, name: 'half typed' }".to_string()]);
+        use crate::absorb_mongosh_chunk;
+        let mut pending = Vec::new();
+        assert!(absorb_mongosh_chunk(&mut pending, b"{ _id: 1, name: 'half").is_empty());
+        assert_eq!(pending, b"{ _id: 1, name: 'half".to_vec(), "not prompt-shaped, so it stays buffered");
+        assert_eq!(absorb_mongosh_chunk(&mut pending, b" typed' }\r\n"), vec!["{ _id: 1, name: 'half typed' }".to_string()]);
     }
 
     #[test]
@@ -3079,16 +3087,26 @@ mod tests {
             marker_line_kind("rs0 [direct: primary] test> __MQLENS_DONE_abc__", marker),
             Some(MongoshCommandEnd::Completed)
         );
-        assert_eq!(
-            marker_line_kind("test> test> __MQLENS_DONE_abc__", marker),
-            Some(MongoshCommandEnd::Completed)
-        );
+        assert_eq!(marker_line_kind("test> test> __MQLENS_DONE_abc__", marker), Some(MongoshCommandEnd::Completed));
         // Quoted back inside a SyntaxError code frame: our line was swallowed
         // into an unclosed statement that then failed to parse.
         assert_eq!(marker_line_kind("> 2 | '__MQLENS_DONE_abc__'", marker), Some(MongoshCommandEnd::SyntaxError));
         // Anything else is ordinary output.
         assert_eq!(marker_line_kind("hello", marker), None);
         assert_eq!(marker_line_kind("__MQLENS_DONE_other__", marker), None);
+    }
+
+    #[test]
+    fn only_the_previous_commands_own_markers_are_stale() {
+        use crate::is_stale_marker_line;
+        let stale = vec!["__MQLENS_DONE_old1__".to_string(), "__MQLENS_DONE_old2__".to_string()];
+        // Its echo arriving late, glued prompt or not.
+        assert!(is_stale_marker_line("__MQLENS_DONE_old1__", &stale));
+        assert!(is_stale_marker_line("test> __MQLENS_DONE_old2__", &stale));
+        // Output that merely contains the reserved-looking text is output.
+        assert!(!is_stale_marker_line("{ status: \"__MQLENS_DONE_pending\" }", &stale));
+        assert!(!is_stale_marker_line("__MQLENS_DONE_old1__ was printed", &stale));
+        assert!(!is_stale_marker_line("hello", &stale));
     }
 
     #[tokio::test]

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3015,6 +3015,78 @@ mod tests {
         );
     }
 
+    // ── mongosh output framing (shell reliability) ──────────────────────────
+    //
+    // mongosh writes its prompt with no newline after it. A line reader never
+    // saw the prompt as a line: it sat in the buffer until the next output and
+    // was glued to the front of it, and a prompt with nothing after it — the
+    // REPL waiting for input, which is what a stalled script looks like — was
+    // never delivered at all.
+
+    #[test]
+    fn a_prompt_with_no_newline_is_delivered_as_its_own_line() {
+        use crate::take_mongosh_lines;
+        let mut buf = b"hello\nrs0 [direct: primary] test> ".to_vec();
+        assert_eq!(
+            take_mongosh_lines(&mut buf),
+            vec!["hello".to_string(), "rs0 [direct: primary] test> ".to_string()]
+        );
+        assert!(buf.is_empty(), "a recognised prompt is consumed, not left to glue onto later output");
+    }
+
+    #[test]
+    fn a_continuation_prompt_is_delivered_too() {
+        use crate::take_mongosh_lines;
+        // `| ` is what the REPL prints each time it reads a line while a
+        // statement is still open — the signal that a script is incomplete.
+        let mut buf = b"| ".to_vec();
+        assert_eq!(take_mongosh_lines(&mut buf), vec!["| ".to_string()]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn a_partial_output_line_waits_for_its_newline() {
+        use crate::take_mongosh_lines;
+        let mut buf = b"{ _id: 1, name: 'half".to_vec();
+        assert!(take_mongosh_lines(&mut buf).is_empty());
+        assert_eq!(buf, b"{ _id: 1, name: 'half".to_vec(), "not a prompt, so it stays buffered");
+
+        buf.extend_from_slice(b" typed' }\r\n");
+        assert_eq!(take_mongosh_lines(&mut buf), vec!["{ _id: 1, name: 'half typed' }".to_string()]);
+    }
+
+    #[test]
+    fn prompt_detection_is_narrow() {
+        use crate::is_mongosh_prompt;
+        assert!(is_mongosh_prompt("rs0 [direct: primary] test> "));
+        assert!(is_mongosh_prompt("hello> "));
+        assert!(is_mongosh_prompt("| "));
+        // Output that merely ends in the same characters is not a prompt.
+        assert!(!is_mongosh_prompt("{ a: 1 }"));
+        assert!(!is_mongosh_prompt("> 2 | print('x')")); // a SyntaxError code frame
+        assert!(!is_mongosh_prompt("> "));
+        assert!(!is_mongosh_prompt(&format!("{}> ", "x".repeat(300))));
+    }
+
+    #[test]
+    fn the_marker_is_told_apart_from_a_code_frame_quoting_it() {
+        use crate::{marker_line_kind, MongoshCommandEnd};
+        let marker = "__MQLENS_DONE_abc__";
+        // Printed by our own `print(...)`: the command completed.
+        assert_eq!(marker_line_kind(marker, marker), Some(MongoshCommandEnd::Completed));
+        assert_eq!(marker_line_kind("  __MQLENS_DONE_abc__  ", marker), Some(MongoshCommandEnd::Completed));
+        // Quoted back by the REPL's SyntaxError: our line was swallowed into
+        // an unclosed statement that then failed to parse.
+        assert_eq!(
+            marker_line_kind("> 2 | print('__MQLENS_DONE_abc__')", marker),
+            Some(MongoshCommandEnd::SyntaxError)
+        );
+        // Anything else is ordinary output.
+        assert_eq!(marker_line_kind("hello", marker), None);
+        assert_eq!(marker_line_kind("__MQLENS_DONE_other__", marker), None);
+    }
+
+
     #[tokio::test]
     async fn test_mongosh_session_not_found() {
         use crate::{run_mongosh_command_impl, stop_mongosh_session_impl};

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -3023,89 +3023,69 @@ mod tests {
     // REPL waiting for input, which is what a stalled script looks like — was
     // never delivered at all.
     //
-    // A prompt is recognised by that framing, not by its shape: it arrives as a
-    // tail with no newline. Once seen, its exact text is known, and only that
-    // exact text is ever treated as a prompt again — so output that merely
-    // resembles one is left alone.
+    // A prompt is recognised by that framing alone: it is a chunk's newline-less
+    // tail. Complete lines are never judged by shape and never rewritten, so
+    // output that resembles a prompt is output. Completion does not depend on
+    // prompt recognition at all — markers are matched by suffix.
 
     #[test]
-    fn a_prompt_arriving_without_a_newline_is_learned_and_dropped() {
-        use crate::{take_mongosh_lines, MongoshPrompts};
-        let mut prompts = MongoshPrompts::default();
+    fn a_prompt_arriving_without_a_newline_is_dropped() {
+        use crate::take_mongosh_lines;
         let mut buf = b"hello\nrs0 [direct: primary] test> ".to_vec();
-        assert_eq!(take_mongosh_lines(&mut buf, &mut prompts), vec!["hello".to_string()]);
+        assert_eq!(take_mongosh_lines(&mut buf), vec!["hello".to_string()]);
         assert!(buf.is_empty(), "the prompt is consumed, not left to glue onto later output");
+
+        // The continuation prompt is the same string in every session.
+        let mut buf = b"| ".to_vec();
+        assert!(take_mongosh_lines(&mut buf).is_empty());
+        assert!(buf.is_empty());
     }
 
     #[test]
-    fn a_prompt_glued_to_output_in_one_read_is_split_off() {
-        use crate::{take_mongosh_lines, MongoshPrompts};
-        // The OS can hand the reader a prompt and the next line together. The
-        // recovery marker is compared exactly, so `test> __MQLENS_DONE_x__`
-        // delivered as one line would never match — and with no ceiling on a
-        // command any more, that is a wait with no end.
-        let mut prompts = MongoshPrompts::default();
-        prompts.learn("test> ");
-        let mut buf = b"test> __MQLENS_DONE_x__\n".to_vec();
-        assert_eq!(take_mongosh_lines(&mut buf, &mut prompts), vec!["__MQLENS_DONE_x__".to_string()]);
-
-        // Two prompts can precede it: `.break` on an idle REPL prints one more.
-        let mut buf = b"test> test> __MQLENS_DONE_x__\n".to_vec();
-        assert_eq!(take_mongosh_lines(&mut buf, &mut prompts), vec!["__MQLENS_DONE_x__".to_string()]);
-    }
-
-    #[test]
-    fn output_that_merely_resembles_a_prompt_is_kept() {
-        use crate::{take_mongosh_lines, MongoshPrompts};
-        // A script may print anything. Only the exact prompt this session has
-        // been seen to write is a prompt; a line ending in `> ` is not.
-        let mut prompts = MongoshPrompts::default();
-        prompts.learn("test> ");
-        let mut buf = b"ready> \nstatus> ok\n".to_vec();
+    fn complete_lines_are_never_rewritten() {
+        use crate::take_mongosh_lines;
+        // A script may print anything, including things shaped like a prompt,
+        // and a prompt the OS delivered in the same read as the output after it
+        // is left glued on rather than guessed at. Both are delivered verbatim.
+        let mut buf = b"ready> \ntest> hello\nstatus> ok\n".to_vec();
         assert_eq!(
-            take_mongosh_lines(&mut buf, &mut prompts),
-            vec!["ready> ".to_string(), "status> ok".to_string()]
+            take_mongosh_lines(&mut buf),
+            vec!["ready> ".to_string(), "test> hello".to_string(), "status> ok".to_string()]
         );
     }
 
     #[test]
     fn a_partial_output_line_waits_for_its_newline() {
-        use crate::{take_mongosh_lines, MongoshPrompts};
-        let mut prompts = MongoshPrompts::default();
+        use crate::take_mongosh_lines;
         let mut buf = b"{ _id: 1, name: 'half".to_vec();
-        assert!(take_mongosh_lines(&mut buf, &mut prompts).is_empty());
+        assert!(take_mongosh_lines(&mut buf).is_empty());
         assert_eq!(buf, b"{ _id: 1, name: 'half".to_vec(), "not a prompt, so it stays buffered");
 
         buf.extend_from_slice(b" typed' }\r\n");
-        assert_eq!(
-            take_mongosh_lines(&mut buf, &mut prompts),
-            vec!["{ _id: 1, name: 'half typed' }".to_string()]
-        );
+        assert_eq!(take_mongosh_lines(&mut buf), vec!["{ _id: 1, name: 'half typed' }".to_string()]);
     }
 
     #[test]
-    fn the_continuation_prompt_needs_no_learning() {
-        use crate::{take_mongosh_lines, MongoshPrompts};
-        // `| ` is what the REPL prints each time it reads a line while a
-        // statement is still open. It is the same string in every session.
-        let mut prompts = MongoshPrompts::default();
-        let mut buf = b"| \n| item 1\n".to_vec();
-        assert_eq!(take_mongosh_lines(&mut buf, &mut prompts), vec!["item 1".to_string()]);
-    }
-
-    #[test]
-    fn the_marker_is_told_apart_from_a_code_frame_quoting_it() {
+    fn the_marker_is_matched_by_suffix_so_a_glued_prompt_cannot_hide_it() {
         use crate::{marker_line_kind, MongoshCommandEnd};
         let marker = "__MQLENS_DONE_abc__";
-        // Printed by our own `print(...)`: the command completed.
+        // The REPL's echo of the marker expression: the command completed.
         assert_eq!(marker_line_kind(marker, marker), Some(MongoshCommandEnd::Completed));
-        assert_eq!(marker_line_kind("  __MQLENS_DONE_abc__  ", marker), Some(MongoshCommandEnd::Completed));
-        // Quoted back by the REPL's SyntaxError: our line was swallowed into
-        // an unclosed statement that then failed to parse.
+        // With the previous prompt delivered in the same read — the case that
+        // would otherwise wait forever, now that a command has no ceiling. It
+        // needs no prompt to have been seen first: the first prompt of a session
+        // can arrive coalesced with the marker of the `use` that starts it.
         assert_eq!(
-            marker_line_kind("> 2 | print('__MQLENS_DONE_abc__')", marker),
-            Some(MongoshCommandEnd::SyntaxError)
+            marker_line_kind("rs0 [direct: primary] test> __MQLENS_DONE_abc__", marker),
+            Some(MongoshCommandEnd::Completed)
         );
+        assert_eq!(
+            marker_line_kind("test> test> __MQLENS_DONE_abc__", marker),
+            Some(MongoshCommandEnd::Completed)
+        );
+        // Quoted back inside a SyntaxError code frame: our line was swallowed
+        // into an unclosed statement that then failed to parse.
+        assert_eq!(marker_line_kind("> 2 | '__MQLENS_DONE_abc__'", marker), Some(MongoshCommandEnd::SyntaxError));
         // Anything else is ordinary output.
         assert_eq!(marker_line_kind("hello", marker), None);
         assert_eq!(marker_line_kind("__MQLENS_DONE_other__", marker), None);

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -4,7 +4,7 @@ import Editor from '@monaco-editor/react';
 import { invoke } from '@tauri-apps/api/core';
 import { open as openFileDialog } from '@tauri-apps/plugin-dialog';
 import { openUrl } from '@tauri-apps/plugin-opener';
-import { AlertCircle, Braces, CornerDownLeft, Eraser, Play, RotateCcw, Sparkles, Terminal } from 'lucide-react';
+import { AlertCircle, Braces, CornerDownLeft, Eraser, Play, RotateCcw, Sparkles, Square, Terminal } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -299,6 +299,28 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   const [viewer, setViewer] = useState<{ docs: Record<string, any>[]; label: string; ms: number } | null>(null);
   const [tab, setTab] = useState<ShellTab>('console');
   const [running, setRunning] = useState(false);
+  // Set by the Stop button just before it restarts the session. The pending
+  // `run_mongosh_command` then fails with "session closed", and this is how the
+  // catch below tells a stop the user asked for from a session that died on its
+  // own — the same rejection, two very different messages.
+  const cancelRequestedRef = useRef(false);
+  // Seconds the current command has been running, so a long script reads as
+  // "still going" rather than "hung". A script takes as long as it takes now:
+  // the backend no longer cuts it off, and the only thing that ends it early is
+  // the user pressing Stop.
+  const [runningFor, setRunningFor] = useState(0);
+  useEffect(() => {
+    if (!running) {
+      setRunningFor(0);
+      return;
+    }
+    const startedAt = Date.now();
+    const tick = window.setInterval(
+      () => setRunningFor(Math.floor((Date.now() - startedAt) / 1000)),
+      1000
+    );
+    return () => window.clearInterval(tick);
+  }, [running]);
   const [topHeight, setTopHeight] = useState<number | null>(null);
   const [mongoshPath, setMongoshPath] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(storedSession?.sessionId ?? null);
@@ -956,11 +978,29 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       if (ranExternally) return;
       throw new Error(t('mongoShell.errors.sessionRequiredForScripts'));
     } catch (err: any) {
-      appendEntries([{ kind: 'error', message: err.message || String(err) }]);
+      if (cancelRequestedRef.current) {
+        // The rejection is the session being killed, and the user is the one
+        // who killed it. That is not an error; it is what Stop does.
+        cancelRequestedRef.current = false;
+        appendEntries([{ kind: 'note', text: t('mongoShell.notes.commandStopped') }]);
+      } else {
+        appendEntries([{ kind: 'error', message: err.message || String(err) }]);
+      }
       setTab('console');
     } finally {
       setRunning(false);
     }
+  };
+
+  // Stop the running command. mongosh has no way to interrupt a statement over
+  // a pipe — Ctrl+C is a terminal affordance, and the process is not on one —
+  // so the only reliable stop is ending the session and starting a fresh one.
+  // The transcript survives that; `restartSession` keeps it. What the user
+  // loses is the session's variables and `use` state, which is the honest
+  // price of stopping a script that will not stop on its own.
+  const stopCommand = () => {
+    cancelRequestedRef.current = true;
+    void restartSession();
   };
 
   runRef.current = () => runCommand();
@@ -1089,13 +1129,36 @@ export const MongoShell: React.FC<MongoShellProps> = ({
           <span className="text-xs font-semibold text-foreground">mongosh</span>
           <span className="font-mono text-[11px] text-muted-foreground">{connectionName} · {currentDb}</span>
           <span className="flex-1" />
-          <span className="font-mono text-[10px] text-muted-foreground">
-            {formatShortcut(shortcutById('run-query')!)}
-          </span>
-          <Button size="sm" onClick={() => runRef.current()} disabled={running}>
-            <Play size={11} />
-            {t('mongoShell.toolbar.run')}
-          </Button>
+          {running ? (
+            <span
+              className="font-mono text-[10px] text-muted-foreground"
+              data-testid="shell-running-for"
+            >
+              {t('mongoShell.notes.runningFor', { seconds: runningFor })}
+            </span>
+          ) : (
+            <span className="font-mono text-[10px] text-muted-foreground">
+              {formatShortcut(shortcutById('run-query')!)}
+            </span>
+          )}
+          {running ? (
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={stopCommand}
+              disabled={restarting}
+              data-testid="shell-stop-command"
+              title={t('mongoShell.toolbar.stopTitle')}
+            >
+              <Square size={11} />
+              {t('mongoShell.toolbar.stop')}
+            </Button>
+          ) : (
+            <Button size="sm" onClick={() => runRef.current()}>
+              <Play size={11} />
+              {t('mongoShell.toolbar.run')}
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -304,6 +304,12 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   // catch below tells a stop the user asked for from a session that died on its
   // own — the same rejection, two very different messages.
   const cancelRequestedRef = useRef(false);
+  // Whether the running command is inside mongosh right now. A recognised
+  // `find`/`aggregate`/`count` runs through mongosh and then makes a driver
+  // call to fill the viewer; Stop only restarts mongosh, so during that second
+  // phase it would stop nothing and the result would still land. Stop is
+  // offered only while this is true.
+  const [inMongosh, setInMongosh] = useState(false);
   // Seconds the current command has been running, so a long script reads as
   // "still going" rather than "hung". A script takes as long as it takes now:
   // the backend no longer cuts it off, and the only thing that ends it early is
@@ -891,7 +897,15 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         setTab('console');
         return;
       }
-      const ranExternally = await runExternalMongoshCommand(raw);
+      setInMongosh(true);
+      let ranExternally: boolean;
+      try {
+        ranExternally = await runExternalMongoshCommand(raw);
+      } finally {
+        // Whatever follows — a driver call for a recognised command, or
+        // nothing — is not something Stop can end.
+        setInMongosh(false);
+      }
 
       if (raw === 'db') {
         if (ranExternally) return;
@@ -1141,7 +1155,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
               {formatShortcut(shortcutById('run-query')!)}
             </span>
           )}
-          {running ? (
+          {running && inMongosh ? (
             <Button
               size="sm"
               variant="destructive"
@@ -1154,7 +1168,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
               {t('mongoShell.toolbar.stop')}
             </Button>
           ) : (
-            <Button size="sm" onClick={() => runRef.current()}>
+            // Disabled rather than replaced while a recognised command is in
+            // its driver phase: Stop could not end that, so it is not offered.
+            <Button size="sm" onClick={() => runRef.current()} disabled={running}>
               <Play size={11} />
               {t('mongoShell.toolbar.run')}
             </Button>

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -29,11 +29,13 @@ type ShellTab = 'console' | 'viewer';
 import {
   dropPendingShellStart,
   loadShellSession,
+  readShellCommand,
   readShellSession,
   shareShellStart,
   shellSessionEpoch,
   watchShellSession,
   stopShellSessionProcess,
+  writeShellCommand,
   writeShellSession,
   type ActiveShellCommand,
   type ShellEntry,
@@ -319,6 +321,18 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     setActiveCommand(next);
     persistSession({ activeCommand: next });
   };
+  // Progress of the command that started at `since`: its move into the driver
+  // phase, a Stop, its end. Written by command identity rather than by this
+  // mount's epoch, because the tab may have been renamed underneath a running
+  // command — that remounts the shell under a new key and closes this one's
+  // epoch, and an epoch-checked completion would be dropped, leaving the
+  // renamed shell busy for good.
+  const updateCommand = (since: number, patch: Partial<ActiveShellCommand> | null) => {
+    setActiveCommand((prev) =>
+      prev && prev.since === since ? (patch === null ? null : { ...prev, ...patch }) : prev
+    );
+    if (sessionKey) writeShellCommand(sessionKey, since, patch);
+  };
   // Set by the Stop button just before it restarts the session. The pending
   // `run_mongosh_command` then fails with "session closed", and this is how the
   // catch below tells a stop the user asked for from a session that died on its
@@ -369,6 +383,25 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         setIsAIOpenState(restored.aiOpen);
         setAiChatId(restored.aiChatId);
         autoRunRef.current = restored.autoRanCommand;
+        // A command recorded as running whose caller is not in this renderer:
+        // the window was reloaded, or the tab arrived from another window,
+        // while a script ran. Its result went to the view it started in. What
+        // still matters is that the backend is busy with it — a shell that
+        // believed itself idle would queue the next command behind it with no
+        // Stop on screen — so show it running, keep Stop available, and wait
+        // on the backend to learn when it ends. Nothing else here ever would.
+        const orphan = restored.activeCommand;
+        if (orphan && orphan.phase === 'mongosh' && restored.sessionId) {
+          setActiveCommand(orphan);
+          appendEntries([{ kind: 'note', text: t('mongoShell.notes.commandReattached') }]);
+          void invoke('await_mongosh_idle', { sessionId: restored.sessionId })
+            .catch(() => undefined)
+            .then(() => writeShellCommand(sessionKey, orphan.since, null));
+        } else if (orphan) {
+          // Past mongosh already: the lock is free and there is nothing left to
+          // stop or wait for.
+          writeShellCommand(sessionKey, orphan.since, null);
+        }
         if (restored.sessionId) {
           setSessionId(restored.sessionId);
           setSessionAttempted(true);
@@ -901,7 +934,8 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     const raw = (commandOverride ?? command).trim().replace(/;$/, '');
     if (!raw || running) return;
     appendEntries([{ kind: 'input', db: currentDb, text: raw }]);
-    setActive({ since: Date.now(), phase: 'mongosh', stopRequested: false });
+    const started: ActiveShellCommand = { since: Date.now(), phase: 'mongosh', stopRequested: false };
+    setActive(started);
     try {
       if (/^(cls|clear)$/i.test(raw)) {
         setEntries([]);
@@ -918,8 +952,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       // Whatever follows — a driver call for a recognised command, or nothing —
       // is not something Stop can end. Read live: Stop may have been pressed,
       // and `stopRequested` must not be lost by overwriting the record.
-      const live = sessionKey ? readShellSession(sessionKey)?.activeCommand : activeCommand;
-      setActive({ since: live?.since ?? Date.now(), phase: 'driver', stopRequested: live?.stopRequested ?? false });
+      updateCommand(started.since, { phase: 'driver' });
 
       if (raw === 'db') {
         if (ranExternally) return;
@@ -1010,7 +1043,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       // now if this tab was switched away and back; the session knows either way.
       const stopped =
         cancelRequestedRef.current ||
-        (sessionKey ? readShellSession(sessionKey)?.activeCommand?.stopRequested === true : false);
+        (sessionKey ? readShellCommand(sessionKey, started.since)?.stopRequested === true : false);
       if (stopped) {
         // The rejection is the session being killed, and the user is the one
         // who killed it. That is not an error; it is what Stop does.
@@ -1024,7 +1057,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       // command that completes first, the catch never runs and a flag left set
       // would report the NEXT command's genuine failure as a stop.
       cancelRequestedRef.current = false;
-      setActive(null);
+      updateCommand(started.since, null);
     }
   };
 
@@ -1036,7 +1069,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   // price of stopping a script that will not stop on its own.
   const stopCommand = () => {
     cancelRequestedRef.current = true;
-    if (activeCommand) setActive({ ...activeCommand, stopRequested: true });
+    if (activeCommand) updateCommand(activeCommand.since, { stopRequested: true });
     void restartSession();
   };
 

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -35,6 +35,7 @@ import {
   watchShellSession,
   stopShellSessionProcess,
   writeShellSession,
+  type ActiveShellCommand,
   type ShellEntry,
   type ShellSession,
 } from '../lib/mongoshSession';
@@ -298,35 +299,48 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   entriesRef.current = entries;
   const [viewer, setViewer] = useState<{ docs: Record<string, any>[]; label: string; ms: number } | null>(null);
   const [tab, setTab] = useState<ShellTab>('console');
-  const [running, setRunning] = useState(false);
-  // Set by the Stop button just before it restarts the session. The pending
-  // `run_mongosh_command` then fails with "session closed", and this is how the
-  // catch below tells a stop the user asked for from a session that died on its
-  // own — the same rejection, two very different messages.
-  const cancelRequestedRef = useRef(false);
+  // The command running in this tab's session, if any. Read from the retained
+  // session rather than held here, because this component unmounts on a tab
+  // switch while the backend carries on: a remounted shell that believed
+  // itself idle enabled Run, and the next command queued behind the first on
+  // the backend's command lock — with no Stop on screen to end either, and no
+  // ceiling on the first, that is a wait with no end (#346 review).
+  const [activeCommand, setActiveCommand] = useState<ActiveShellCommand | null>(
+    storedSession?.activeCommand ?? null
+  );
+  const running = activeCommand !== null;
   // Whether the running command is inside mongosh right now. A recognised
   // `find`/`aggregate`/`count` runs through mongosh and then makes a driver
   // call to fill the viewer; Stop only restarts mongosh, so during that second
   // phase it would stop nothing and the result would still land. Stop is
   // offered only while this is true.
-  const [inMongosh, setInMongosh] = useState(false);
+  const inMongosh = activeCommand?.phase === 'mongosh';
+  const setActive = (next: ActiveShellCommand | null) => {
+    setActiveCommand(next);
+    persistSession({ activeCommand: next });
+  };
+  // Set by the Stop button just before it restarts the session. The pending
+  // `run_mongosh_command` then fails with "session closed", and this is how the
+  // catch below tells a stop the user asked for from a session that died on its
+  // own — the same rejection, two very different messages. Kept in the session
+  // as well as here, because the instance that presses Stop may not be the one
+  // that started the command.
+  const cancelRequestedRef = useRef(false);
   // Seconds the current command has been running, so a long script reads as
-  // "still going" rather than "hung". A script takes as long as it takes now:
-  // the backend no longer cuts it off, and the only thing that ends it early is
-  // the user pressing Stop.
+  // "still going" rather than "hung". Measured from when it started rather than
+  // from mount, so it survives a remount too.
   const [runningFor, setRunningFor] = useState(0);
   useEffect(() => {
-    if (!running) {
+    if (!activeCommand) {
       setRunningFor(0);
       return;
     }
-    const startedAt = Date.now();
-    const tick = window.setInterval(
-      () => setRunningFor(Math.floor((Date.now() - startedAt) / 1000)),
-      1000
-    );
+    const since = activeCommand.since;
+    const update = () => setRunningFor(Math.max(0, Math.floor((Date.now() - since) / 1000)));
+    update();
+    const tick = window.setInterval(update, 1000);
     return () => window.clearInterval(tick);
-  }, [running]);
+  }, [activeCommand]);
   const [topHeight, setTopHeight] = useState<number | null>(null);
   const [mongoshPath, setMongoshPath] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(storedSession?.sessionId ?? null);
@@ -408,6 +422,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       setEntries((prev) => (session.entries === prev ? prev : session.entries));
       entriesRef.current = session.entries;
       if (session.currentDb) setCurrentDb(session.currentDb);
+      // The instance that started a command may be unmounted by now; this one
+      // still has to show it running, offer Stop, and see it finish.
+      setActiveCommand(session.activeCommand ?? null);
     });
   }, [sessionKey]);
   // Guided setup on session failure: a working mongosh found outside the
@@ -884,7 +901,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     const raw = (commandOverride ?? command).trim().replace(/;$/, '');
     if (!raw || running) return;
     appendEntries([{ kind: 'input', db: currentDb, text: raw }]);
-    setRunning(true);
+    setActive({ since: Date.now(), phase: 'mongosh', stopRequested: false });
     try {
       if (/^(cls|clear)$/i.test(raw)) {
         setEntries([]);
@@ -897,15 +914,12 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         setTab('console');
         return;
       }
-      setInMongosh(true);
-      let ranExternally: boolean;
-      try {
-        ranExternally = await runExternalMongoshCommand(raw);
-      } finally {
-        // Whatever follows — a driver call for a recognised command, or
-        // nothing — is not something Stop can end.
-        setInMongosh(false);
-      }
+      const ranExternally = await runExternalMongoshCommand(raw);
+      // Whatever follows — a driver call for a recognised command, or nothing —
+      // is not something Stop can end. Read live: Stop may have been pressed,
+      // and `stopRequested` must not be lost by overwriting the record.
+      const live = sessionKey ? readShellSession(sessionKey)?.activeCommand : activeCommand;
+      setActive({ since: live?.since ?? Date.now(), phase: 'driver', stopRequested: live?.stopRequested ?? false });
 
       if (raw === 'db') {
         if (ranExternally) return;
@@ -992,17 +1006,25 @@ export const MongoShell: React.FC<MongoShellProps> = ({
       if (ranExternally) return;
       throw new Error(t('mongoShell.errors.sessionRequiredForScripts'));
     } catch (err: any) {
-      if (cancelRequestedRef.current) {
+      // Stop may have been pressed by this instance, or by the one on screen
+      // now if this tab was switched away and back; the session knows either way.
+      const stopped =
+        cancelRequestedRef.current ||
+        (sessionKey ? readShellSession(sessionKey)?.activeCommand?.stopRequested === true : false);
+      if (stopped) {
         // The rejection is the session being killed, and the user is the one
         // who killed it. That is not an error; it is what Stop does.
-        cancelRequestedRef.current = false;
         appendEntries([{ kind: 'note', text: t('mongoShell.notes.commandStopped') }]);
       } else {
         appendEntries([{ kind: 'error', message: err.message || String(err) }]);
       }
       setTab('console');
     } finally {
-      setRunning(false);
+      // Cleared here, on every exit, and not only in the catch: if Stop races a
+      // command that completes first, the catch never runs and a flag left set
+      // would report the NEXT command's genuine failure as a stop.
+      cancelRequestedRef.current = false;
+      setActive(null);
     }
   };
 
@@ -1014,6 +1036,7 @@ export const MongoShell: React.FC<MongoShellProps> = ({
   // price of stopping a script that will not stop on its own.
   const stopCommand = () => {
     cancelRequestedRef.current = true;
+    if (activeCommand) setActive({ ...activeCommand, stopRequested: true });
     void restartSession();
   };
 

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -962,4 +962,35 @@ describe('MongoShell Component', () => {
     expect(await screen.findByRole('button', { name: /^run$/i })).toBeInTheDocument();
   });
 
+  it('does not offer Stop while a recognised command is in its driver phase', async () => {
+    // `find` runs through mongosh and then makes a driver call to fill the
+    // viewer. Stop only restarts mongosh, so during that second phase it would
+    // stop nothing and the result would still land — better not to offer it.
+    let resolveDriver!: (v: unknown) => void;
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '/usr/local/bin/mongosh' });
+      if (cmd === 'test_mongosh_path') return Promise.resolve('2.1.1');
+      if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+      if (cmd === 'start_mongosh_session') return Promise.resolve({ session_id: 'shell-session-1', stdout: [], stderr: [] });
+      if (cmd === 'run_mongosh_command') return Promise.resolve({ stdout: ['{ _id: 1 }'], stderr: [] });
+      if (cmd === 'execute_mql_query') return new Promise((resolve) => { resolveDriver = resolve; });
+      if (cmd === 'get_shell_tab_state') return Promise.resolve(null);
+      return Promise.resolve([]);
+    });
+
+    render(<MongoShell connectionId="conn-1" connectionName="Local" connectionUri="mongodb://localhost:27017" databaseName="sales_db" />);
+    await screen.findByTestId('shell-restart-session');
+
+    fireEvent.change(screen.getByLabelText('mongosh editor'), { target: { value: 'db.customers.find({})' } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+
+    // mongosh has answered; the driver call is what is pending now.
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith('execute_mql_query', expect.anything()));
+    expect(screen.queryByTestId('shell-stop-command')).toBeNull();
+    expect(screen.getByRole('button', { name: /^run$/i })).toBeDisabled();
+
+    resolveDriver([JSON.stringify({ _id: 1 })]);
+    await waitFor(() => expect(screen.getByRole('button', { name: /^run$/i })).not.toBeDisabled());
+  });
+
 });

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -925,4 +925,41 @@ describe('MongoShell Component', () => {
       await waitFor(() => expect(stopCalls()).toBe(1));
     });
   });
+  it('Stop ends the running command by restarting the session, and says so', async () => {
+    // A script takes as long as it takes now — the backend no longer cuts it
+    // off — so the user needs a way out. mongosh cannot be interrupted over a
+    // pipe, so Stop restarts the session, and the pending call fails with
+    // "session closed". That is the user's doing, not an error, and it must
+    // read that way.
+    let rejectRun!: (e: Error) => void;
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '/usr/local/bin/mongosh' });
+      if (cmd === 'test_mongosh_path') return Promise.resolve('2.1.1');
+      if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+      if (cmd === 'start_mongosh_session') return Promise.resolve({ session_id: 'shell-session-1', stdout: [], stderr: [] });
+      if (cmd === 'run_mongosh_command') return new Promise((_, reject) => { rejectRun = reject; });
+      if (cmd === 'stop_mongosh_session') { rejectRun(new Error('mongosh session closed')); return Promise.resolve(); }
+      if (cmd === 'get_shell_tab_state') return Promise.resolve(null);
+      return Promise.resolve([]);
+    });
+
+    render(<MongoShell connectionId="conn-1" connectionName="Local" connectionUri="mongodb://localhost:27017" databaseName="sales_db" />);
+    await screen.findByTestId('shell-restart-session');
+
+    fireEvent.change(screen.getByLabelText('mongosh editor'), { target: { value: 'sleep(60000)' } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+
+    // While it runs: an elapsed indicator and a Stop button in place of Run.
+    const stop = await screen.findByTestId('shell-stop-command');
+    expect(screen.getByTestId('shell-running-for')).toBeInTheDocument();
+
+    fireEvent.click(stop);
+
+    await waitFor(() => expect(screen.getByText('Command stopped.')).toBeInTheDocument());
+    // Reported as stopped, never as a session error.
+    expect(screen.queryByText(/mongosh session closed/)).toBeNull();
+    // And ready to run again.
+    expect(await screen.findByRole('button', { name: /^run$/i })).toBeInTheDocument();
+  });
+
 });

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MongoShell } from '../MongoShell';
-import { readShellSession, resetShellSessions, writeShellSession } from '../../lib/mongoshSession';
+import {
+  readShellSession,
+  renameShellSession,
+  resetShellSessions,
+  writeShellSession,
+} from '../../lib/mongoshSession';
 
 const mockInvoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({
@@ -1050,6 +1055,96 @@ describe('MongoShell Component', () => {
     fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
     expect(await screen.findByText(/genuine failure/)).toBeInTheDocument();
     expect(screen.queryAllByText('Command stopped.').length).toBeLessThanOrEqual(1);
+  });
+
+  it('reattaches to a command still running on the backend after a reload, and frees the shell when it ends', async () => {
+    // The renderer was reloaded mid-script: the registry is empty, the backend
+    // still records the command, and whoever awaited it is gone.
+    let idle!: () => void;
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '/usr/local/bin/mongosh' });
+      if (cmd === 'test_mongosh_path') return Promise.resolve('2.1.1');
+      if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+      if (cmd === 'claim_shell_tab_state') {
+        return Promise.resolve({
+          sessionId: 'shell-session-9',
+          entries: [],
+          currentDb: 'sales_db',
+          activeCommand: { since: Date.now() - 5_000, phase: 'mongosh', stopRequested: false },
+        });
+      }
+      if (cmd === 'await_mongosh_idle') return new Promise<void>((resolve) => { idle = resolve; });
+      return Promise.resolve();
+    });
+
+    render(<MongoShell connectionId="conn-1" connectionName="Local" connectionUri="mongodb://localhost:27017" databaseName="sales_db" sessionKey="shell-tab" />);
+
+    expect(await screen.findByTestId('shell-stop-command')).toBeInTheDocument();
+    expect(screen.getByText(/still running when this shell reopened/)).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith('await_mongosh_idle', { sessionId: 'shell-session-9' });
+
+    idle();
+    expect(await screen.findByRole('button', { name: /^run$/i })).not.toBeDisabled();
+    expect(readShellSession('shell-tab')?.activeCommand).toBeNull();
+  });
+
+  it('drops a reloaded command that was already past mongosh, since nothing holds the session', async () => {
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '/usr/local/bin/mongosh' });
+      if (cmd === 'test_mongosh_path') return Promise.resolve('2.1.1');
+      if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+      if (cmd === 'claim_shell_tab_state') {
+        return Promise.resolve({
+          sessionId: 'shell-session-9',
+          entries: [],
+          currentDb: 'sales_db',
+          activeCommand: { since: Date.now() - 5_000, phase: 'driver', stopRequested: false },
+        });
+      }
+      return Promise.resolve();
+    });
+
+    render(<MongoShell connectionId="conn-1" connectionName="Local" connectionUri="mongodb://localhost:27017" databaseName="sales_db" sessionKey="shell-tab" />);
+
+    // Hydration has landed once the backend's session id is in the registry;
+    // until then the registry holds only this mount's own first write.
+    await waitFor(() => expect(readShellSession('shell-tab')?.sessionId).toBe('shell-session-9'));
+    expect(readShellSession('shell-tab')?.activeCommand).toBeNull();
+    expect(mockInvoke).not.toHaveBeenCalledWith('await_mongosh_idle', expect.anything());
+    expect(screen.queryByTestId('shell-stop-command')).toBeNull();
+  });
+
+  it('frees a renamed tab when the command its old shell started finishes', async () => {
+    // The collection is renamed while a script runs: the registry re-keys the
+    // session and React remounts the shell under the new key. The completion
+    // arrives from the old instance, under the old key, with an ended epoch.
+    let finish!: (v: unknown) => void;
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '/usr/local/bin/mongosh' });
+      if (cmd === 'test_mongosh_path') return Promise.resolve('2.1.1');
+      if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+      if (cmd === 'start_mongosh_session') return Promise.resolve({ session_id: 'shell-session-1', stdout: [], stderr: [] });
+      if (cmd === 'run_mongosh_command') return new Promise((resolve) => { finish = resolve; });
+      if (cmd === 'claim_shell_tab_state') return Promise.resolve(null);
+      return Promise.resolve();
+    });
+    const shell = (key: string, sessionKey: string) => (
+      <MongoShell key={key} connectionId="conn-1" connectionName="Local" connectionUri="mongodb://localhost:27017" databaseName="sales_db" sessionKey={sessionKey} />
+    );
+    const { rerender } = render(shell('old', 'coll-old'));
+    await screen.findByTestId('shell-restart-session');
+    fireEvent.change(screen.getByLabelText('mongosh editor'), { target: { value: 'sleep(1)' } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    await screen.findByTestId('shell-stop-command');
+
+    void renameShellSession('coll-old', 'coll-new');
+    rerender(shell('new', 'coll-new'));
+    // Still running, as far as the renamed shell is concerned.
+    expect(await screen.findByTestId('shell-stop-command')).toBeInTheDocument();
+
+    finish({ stdout: ['done'], stderr: [] });
+    expect(await screen.findByRole('button', { name: /^run$/i })).not.toBeDisabled();
+    expect(readShellSession('coll-new')?.activeCommand).toBeNull();
   });
 
 });

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -993,4 +993,63 @@ describe('MongoShell Component', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /^run$/i })).not.toBeDisabled());
   });
 
+  it('still shows a command as running after a remount, with Stop and Run disabled', async () => {
+    // The tab was switched away and back while a script was running. The
+    // backend is still running it; a shell that believed itself idle would
+    // enable Run, and the next command would queue behind the first on the
+    // backend lock with no Stop on screen to end either.
+    writeShellSession('shell-tab', {
+      sessionId: 'shell-session-1',
+      entries: [],
+      currentDb: 'sales_db',
+      activeCommand: { since: Date.now() - 12_000, phase: 'mongosh', stopRequested: false },
+    });
+    render(<MongoShell connectionId="conn-1" connectionName="Local" connectionUri="mongodb://localhost:27017" databaseName="sales_db" sessionKey="shell-tab" />);
+
+    expect(await screen.findByTestId('shell-stop-command')).toBeInTheDocument();
+    expect(screen.getByTestId('shell-running-for')).toHaveTextContent(/1[0-9]s/);
+    expect(screen.queryByRole('button', { name: /^run$/i })).toBeNull();
+
+    // When the instance that started it finishes, this one sees it.
+    writeShellSession('shell-tab', { activeCommand: null });
+    expect(await screen.findByRole('button', { name: /^run$/i })).not.toBeDisabled();
+  });
+
+  it('does not report a later failure as a stop after Stop raced a completing command', async () => {
+    // Stop pressed, but the command resolved before the process died: the catch
+    // never ran. The flag must not survive into the next command.
+    let resolveRun!: (v: unknown) => void;
+    let calls = 0;
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === 'load_app_settings') return Promise.resolve({ mongosh_path: '/usr/local/bin/mongosh' });
+      if (cmd === 'test_mongosh_path') return Promise.resolve('2.1.1');
+      if (cmd === 'get_mongodb_version') return Promise.resolve('7.0.5');
+      if (cmd === 'start_mongosh_session') return Promise.resolve({ session_id: 'shell-session-' + (++calls), stdout: [], stderr: [] });
+      if (cmd === 'run_mongosh_command') {
+        if (calls === 1) return new Promise((resolve) => { resolveRun = resolve; });
+        return Promise.reject(new Error('genuine failure'));
+      }
+      if (cmd === 'stop_mongosh_session') { resolveRun({ stdout: ['done'], stderr: [] }); return Promise.resolve(); }
+      if (cmd === 'get_shell_tab_state') return Promise.resolve(null);
+      return Promise.resolve([]);
+    });
+
+    render(<MongoShell connectionId="conn-1" connectionName="Local" connectionUri="mongodb://localhost:27017" databaseName="sales_db" />);
+    await screen.findByTestId('shell-restart-session');
+
+    fireEvent.change(screen.getByLabelText('mongosh editor'), { target: { value: 'sleep(1)' } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    fireEvent.click(await screen.findByTestId('shell-stop-command'));
+    // The command completed — the stop lost the race.
+    expect(await screen.findByText('done')).toBeInTheDocument();
+    await screen.findByTestId('shell-restart-session');
+    await waitFor(() => expect(screen.getByRole('button', { name: /^run$/i })).not.toBeDisabled());
+
+    // A later, unrelated failure must read as a failure.
+    fireEvent.change(screen.getByLabelText('mongosh editor'), { target: { value: 'boom()' } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    expect(await screen.findByText(/genuine failure/)).toBeInTheDocument();
+    expect(screen.queryAllByText('Command stopped.').length).toBeLessThanOrEqual(1);
+  });
+
 });

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -552,6 +552,18 @@ describe('mongosh session registry (#240)', () => {
     expect(seen).toEqual([null]);
   });
 
+  it('stops forwarding once the old key has a shell of its own again', () => {
+    // Renamed a → b, then a collection named a is created and its shell opened.
+    writeShellSession('coll-a', { sessionId: 'sess-1', activeCommand: { since: 5, phase: 'mongosh', stopRequested: false } });
+    void renameShellSession('coll-a', 'coll-b');
+    writeShellSession('coll-a', { sessionId: 'sess-2', activeCommand: { since: 9, phase: 'mongosh', stopRequested: false } });
+
+    writeShellCommand('coll-a', 9, null);
+
+    expect(readShellSession('coll-a')?.activeCommand).toBeNull();
+    expect(readShellSession('coll-b')?.activeCommand).toEqual({ since: 5, phase: 'mongosh', stopRequested: false });
+  });
+
   it('only touches the command it was told about', () => {
     writeShellSession('tab-1', {
       sessionId: 'sess-1',

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -4,7 +4,9 @@ import {
   dropPendingShellStart,
   shareShellStart,
   watchShellSession,
+  writeShellCommand,
   loadShellSession,
+  type ActiveShellCommand,
   renameShellSession,
   shellSessionEpoch,
   retargetShellSessionDatabase,
@@ -531,6 +533,34 @@ describe('mongosh session registry (#240)', () => {
     });
     const loaded = await loadShellSession('tab-9');
     expect(loaded?.activeCommand).toBeNull();
+  });
+
+  it('follows a rename, so a command finishing under the old key frees the renamed tab', () => {
+    writeShellSession('coll-old', {
+      sessionId: 'sess-1',
+      activeCommand: { since: 5, phase: 'mongosh', stopRequested: false },
+    });
+    void renameShellSession('coll-old', 'coll-new');
+    const seen: Array<ActiveShellCommand | null> = [];
+    watchShellSession('coll-new', (s) => seen.push(s.activeCommand ?? null));
+
+    // The old shell's completion arrives under the key it mounted with, whose
+    // epoch the rename has since ended. It must still land.
+    writeShellCommand('coll-old', 5, null);
+
+    expect(readShellSession('coll-new')?.activeCommand).toBeNull();
+    expect(seen).toEqual([null]);
+  });
+
+  it('only touches the command it was told about', () => {
+    writeShellSession('tab-1', {
+      sessionId: 'sess-1',
+      activeCommand: { since: 7, phase: 'mongosh', stopRequested: false },
+    });
+    // An older command's late completion is not this command's.
+    writeShellCommand('tab-1', 6, null);
+    writeShellCommand('tab-1', 7, { phase: 'driver' });
+    expect(readShellSession('tab-1')?.activeCommand).toEqual({ since: 7, phase: 'driver', stopRequested: false });
   });
 
 });

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -584,6 +584,27 @@ describe('mongosh session registry (#240)', () => {
     expect(readShellSession('coll-a')?.activeCommand).toEqual({ since: 9, phase: 'mongosh', stopRequested: false });
   });
 
+  it('keeps reaching a moved command after its old key is reused and renamed again', () => {
+    // a's command moves to b; a new a opens and is itself renamed to x, all
+    // before the first command finishes.
+    writeShellSession('coll-a', {
+      sessionId: 'sess-1',
+      activeCommand: { since: 5, phase: 'mongosh', stopRequested: false },
+    });
+    void renameShellSession('coll-a', 'coll-b');
+    writeShellSession('coll-a', {
+      sessionId: 'sess-2',
+      activeCommand: { since: 9, phase: 'mongosh', stopRequested: false },
+    });
+    void renameShellSession('coll-a', 'coll-x');
+
+    writeShellCommand('coll-a', 5, null);
+    writeShellCommand('coll-a', 9, { phase: 'driver' });
+
+    expect(readShellSession('coll-b')?.activeCommand).toBeNull();
+    expect(readShellSession('coll-x')?.activeCommand).toEqual({ since: 9, phase: 'driver', stopRequested: false });
+  });
+
   it('only touches the command it was told about', () => {
     writeShellSession('tab-1', {
       sessionId: 'sess-1',

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -41,6 +41,7 @@ describe('mongosh session registry (#240)', () => {
       autoRanCommand: false,
       aiOpen: false,
       aiMessages: [],
+      activeCommand: null,
     });
     // Writes now mirror to the backend; what must NOT happen is the child being
     // killed just because the component went away.
@@ -58,6 +59,7 @@ describe('mongosh session registry (#240)', () => {
       autoRanCommand: false,
       aiOpen: false,
       aiMessages: [],
+      activeCommand: null,
     });
   });
 
@@ -508,4 +510,27 @@ describe('mongosh session registry (#240)', () => {
     expect(await loadShellSession('tab-1')).toBeUndefined();
     expect(readShellSession('tab-1')).toBeUndefined();
   });
+  it('keeps the running command with the session, and clears it on an explicit null', () => {
+    // A tab can unmount mid-command. The record of the command belongs to the
+    // session, like the transcript, so a remounted shell knows it is busy.
+    writeShellSession('tab-1', { sessionId: 'sess-1', activeCommand: { since: 1000, phase: 'mongosh', stopRequested: false } });
+    // A patch that does not mention it leaves it alone.
+    writeShellSession('tab-1', { currentDb: 'sales' });
+    expect(readShellSession('tab-1')?.activeCommand).toEqual({ since: 1000, phase: 'mongosh', stopRequested: false });
+    // `null` is a deliberate write: the command is over.
+    writeShellSession('tab-1', { activeCommand: null });
+    expect(readShellSession('tab-1')?.activeCommand).toBeNull();
+  });
+
+  it('treats a malformed running-command record as nothing running', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'claim_shell_tab_state') {
+        return Promise.resolve({ sessionId: 's', entries: [], currentDb: 'x', activeCommand: { since: 'yesterday' } });
+      }
+      return Promise.resolve();
+    });
+    const loaded = await loadShellSession('tab-9');
+    expect(loaded?.activeCommand).toBeNull();
+  });
+
 });

--- a/src/lib/__tests__/mongoshSession.test.ts
+++ b/src/lib/__tests__/mongoshSession.test.ts
@@ -564,6 +564,26 @@ describe('mongosh session registry (#240)', () => {
     expect(readShellSession('coll-b')?.activeCommand).toEqual({ since: 5, phase: 'mongosh', stopRequested: false });
   });
 
+  it('still finds a moved command after its old key is reused', () => {
+    // Renamed a → b while a's command runs; a new collection a, with its own
+    // shell and command, opens before the moved command finishes.
+    writeShellSession('coll-a', {
+      sessionId: 'sess-1',
+      activeCommand: { since: 5, phase: 'mongosh', stopRequested: false },
+    });
+    void renameShellSession('coll-a', 'coll-b');
+    writeShellSession('coll-a', {
+      sessionId: 'sess-2',
+      activeCommand: { since: 9, phase: 'mongosh', stopRequested: false },
+    });
+
+    // The moved command completes, under the key it started with.
+    writeShellCommand('coll-a', 5, null);
+
+    expect(readShellSession('coll-b')?.activeCommand).toBeNull();
+    expect(readShellSession('coll-a')?.activeCommand).toEqual({ since: 9, phase: 'mongosh', stopRequested: false });
+  });
+
   it('only touches the command it was told about', () => {
     writeShellSession('tab-1', {
       sessionId: 'sess-1',

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -47,6 +47,25 @@ export interface ShellSession {
   /** Which conversation in the backend chat store this tab has open. The
    *  transcript is not stored here — only the choice of which one. */
   aiChatId?: string;
+  /** The command running in this tab's session right now, if any.
+   *
+   *  Held here for the same reason the transcript is: the tab can unmount while
+   *  a command is still running, and a remounted shell that believed itself
+   *  idle would enable Run — and a second command then queues behind the first
+   *  on the backend's command lock, with no Stop on screen to end either. The
+   *  backend session is doing the work; this is the record that it is.
+   *
+   *  `phase` is where execution is: only `mongosh` can be stopped by restarting
+   *  the session. `stopRequested` lets the instance that started the command,
+   *  which may no longer be the one on screen, report a stop as a stop. */
+  activeCommand?: ActiveShellCommand | null;
+}
+
+export interface ActiveShellCommand {
+  /** When it started, so an elapsed counter survives a remount. */
+  since: number;
+  phase: 'mongosh' | 'driver';
+  stopRequested: boolean;
 }
 
 /**
@@ -204,7 +223,16 @@ function normalizeStoredSession(stored: unknown): ShellSession | undefined {
     aiOpen: candidate.aiOpen ?? false,
     aiMessages: Array.isArray(candidate.aiMessages) ? candidate.aiMessages : [],
     aiChatId: typeof candidate.aiChatId === 'string' ? candidate.aiChatId : undefined,
+    activeCommand: normaliseActiveCommand(candidate.activeCommand),
   };
+}
+
+/** Only a well-formed record counts; anything else means "nothing running". */
+function normaliseActiveCommand(value: unknown): ActiveShellCommand | null {
+  if (!value || typeof value !== 'object') return null;
+  const c = value as Partial<ActiveShellCommand>;
+  if (typeof c.since !== 'number' || (c.phase !== 'mongosh' && c.phase !== 'driver')) return null;
+  return { since: c.since, phase: c.phase, stopRequested: c.stopRequested === true };
 }
 
 /** Write-through to the backend. Fire-and-forget: the cache is already updated,
@@ -291,6 +319,10 @@ export function writeShellSession(
     aiOpen: patch.aiOpen ?? prev?.aiOpen ?? false,
     aiMessages: patch.aiMessages ?? prev?.aiMessages ?? [],
     aiChatId: patch.aiChatId ?? prev?.aiChatId,
+    // `null` is a deliberate write ("nothing running now"); only an absent key
+    // keeps the previous value, like `sessionId`.
+    activeCommand:
+      patch.activeCommand !== undefined ? patch.activeCommand : (prev?.activeCommand ?? null),
   };
   sessions.set(key, next);
   persist(key, next);

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -196,29 +196,50 @@ const watchers: Map<string, Set<(session: ShellSession) => void>> = new Map();
  * "running" for good, with nothing on screen able to end it (#346 review).
  */
 const forwards: Map<string, string> = new Map();
-function followForwards(key: string): string {
-  const seen = new Set<string>();
+
+/**
+ * Every key the session mounted under `key` may live under now: the key
+ * itself, then wherever renames have moved it since. Oldest first.
+ */
+function keysReachableFrom(key: string): string[] {
+  const keys = [key];
+  const seen = new Set(keys);
   let current = key;
-  // A key with a live session is where writes for that key go, forward or no
-  // forward: a collection renamed away and then recreated under its old name
-  // gets a new shell under the old key, and that shell's own command must not
-  // be redirected to the renamed one's session (#346 review).
-  while (forwards.has(current) && !sessions.has(current) && !seen.has(current)) {
-    seen.add(current);
+  while (forwards.has(current)) {
     current = forwards.get(current)!;
+    if (seen.has(current)) break;
+    seen.add(current);
+    keys.push(current);
   }
-  return current;
+  return keys;
+}
+
+/**
+ * Find the command that started at `since` under `key`, wherever it is now.
+ * Matched by the command's identity, not by the key alone: a collection renamed
+ * away and recreated under its old name has a NEW shell — with its own command
+ * — under the old key while the moved command is still running under the new
+ * one, and each completion must find its own record (#346 review).
+ */
+function locateShellCommand(
+  key: string,
+  since: number
+): { key: string; command: ActiveShellCommand } | null {
+  for (const candidate of keysReachableFrom(key)) {
+    const command = sessions.get(candidate)?.activeCommand;
+    if (command && command.since === since) return { key: candidate, command };
+  }
+  return null;
 }
 
 /** The running-command record for the command that started at `since`, wherever its session lives now. */
 export function readShellCommand(key: string, since: number): ActiveShellCommand | null {
-  const command = sessions.get(followForwards(key))?.activeCommand ?? null;
-  return command && command.since === since ? command : null;
+  return locateShellCommand(key, since)?.command ?? null;
 }
 
 /**
  * Update the running-command record for the command that started at `since`,
- * wherever its session lives now, and only while that command is the one
+ * wherever its session lives now, and only while that command is still
  * recorded. `null` ends it; a partial patch merges into it.
  *
  * Deliberately not epoch-checked. The epoch says which mount may write a key;
@@ -230,13 +251,13 @@ export function writeShellCommand(
   since: number,
   patch: Partial<ActiveShellCommand> | null
 ): void {
-  const target = followForwards(key);
-  const current = sessions.get(target)?.activeCommand;
-  if (!current || current.since !== since) return;
-  writeShellSession(target, { activeCommand: patch === null ? null : { ...current, ...patch } });
+  const found = locateShellCommand(key, since);
+  if (!found) return;
+  writeShellSession(found.key, {
+    activeCommand: patch === null ? null : { ...found.command, ...patch },
+  });
 }
 
-/** Subscribe to changes for `key`; returns an unsubscribe. */
 export function watchShellSession(key: string, fn: (session: ShellSession) => void): () => void {
   const forKey = watchers.get(key) ?? new Set();
   forKey.add(fn);
@@ -334,7 +355,6 @@ export async function loadShellSession(key: string): Promise<ShellSession | unde
   }
   const session = normalizeStoredSession(stored);
   if (!session) return undefined;
-  forwards.delete(key);
   sessions.set(key, session);
   return session;
 }
@@ -360,8 +380,6 @@ export function writeShellSession(
 ): void {
   if (epoch !== undefined && epoch !== shellSessionEpoch(key)) return;
   const prev = sessions.get(key);
-  // The key is live again; a forward left by an earlier rename is obsolete.
-  if (!prev) forwards.delete(key);
   const next: ShellSession = {
     sessionId: patch.sessionId !== undefined ? patch.sessionId : (prev?.sessionId ?? null),
     entries: patch.entries ?? prev?.entries ?? [],

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -199,7 +199,11 @@ const forwards: Map<string, string> = new Map();
 function followForwards(key: string): string {
   const seen = new Set<string>();
   let current = key;
-  while (forwards.has(current) && !seen.has(current)) {
+  // A key with a live session is where writes for that key go, forward or no
+  // forward: a collection renamed away and then recreated under its old name
+  // gets a new shell under the old key, and that shell's own command must not
+  // be redirected to the renamed one's session (#346 review).
+  while (forwards.has(current) && !sessions.has(current) && !seen.has(current)) {
     seen.add(current);
     current = forwards.get(current)!;
   }
@@ -330,6 +334,7 @@ export async function loadShellSession(key: string): Promise<ShellSession | unde
   }
   const session = normalizeStoredSession(stored);
   if (!session) return undefined;
+  forwards.delete(key);
   sessions.set(key, session);
   return session;
 }
@@ -355,6 +360,8 @@ export function writeShellSession(
 ): void {
   if (epoch !== undefined && epoch !== shellSessionEpoch(key)) return;
   const prev = sessions.get(key);
+  // The key is live again; a forward left by an earlier rename is obsolete.
+  if (!prev) forwards.delete(key);
   const next: ShellSession = {
     sessionId: patch.sessionId !== undefined ? patch.sessionId : (prev?.sessionId ?? null),
     entries: patch.entries ?? prev?.entries ?? [],

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -195,21 +195,25 @@ const watchers: Map<string, Set<(session: ShellSession) => void>> = new Map();
  * the write must follow the session to its new key or the renamed shell stays
  * "running" for good, with nothing on screen able to end it (#346 review).
  */
-const forwards: Map<string, string> = new Map();
+const forwards: Map<string, string[]> = new Map();
 
 /**
- * Every key the session mounted under `key` may live under now: the key
- * itself, then wherever renames have moved it since. Oldest first.
+ * Every key a session mounted under `key` may live under now: the key itself,
+ * then wherever renames have moved anything that was ever under it. Every
+ * rename edge is kept, because a key can be reused and renamed again while a
+ * command moved off it earlier is still running — `a → b`, a new `a`, then
+ * `a → x` — and that command's completion must still reach `b`. Matching by
+ * the command's identity is what keeps the extra reach harmless.
  */
 function keysReachableFrom(key: string): string[] {
   const keys = [key];
   const seen = new Set(keys);
-  let current = key;
-  while (forwards.has(current)) {
-    current = forwards.get(current)!;
-    if (seen.has(current)) break;
-    seen.add(current);
-    keys.push(current);
+  for (let i = 0; i < keys.length; i++) {
+    for (const next of forwards.get(keys[i]) ?? []) {
+      if (seen.has(next)) continue;
+      seen.add(next);
+      keys.push(next);
+    }
   }
   return keys;
 }
@@ -468,9 +472,7 @@ export function renameShellSession(oldKey: string, newKey: string): Promise<void
   // a session mapping that the renamed tab's close will never clear — and the
   // output would land there instead of in the tab the user is looking at.
   endEpoch(oldKey);
-  // Renaming back (new → old) removes the forward that would otherwise loop.
-  forwards.delete(newKey);
-  forwards.set(oldKey, newKey);
+  forwards.set(oldKey, [...(forwards.get(oldKey) ?? []), newKey]);
   const session = sessions.get(oldKey);
   if (session) {
     sessions.delete(oldKey);

--- a/src/lib/mongoshSession.ts
+++ b/src/lib/mongoshSession.ts
@@ -188,6 +188,50 @@ export function dropPendingShellStart(key: string): void {
  */
 const watchers: Map<string, Set<(session: ShellSession) => void>> = new Map();
 
+/**
+ * Where a renamed key's session went. A command's completion is written under
+ * the key its shell mounted with; if the tab was renamed meanwhile — its
+ * collection or database renamed while a script ran — that key is closed, and
+ * the write must follow the session to its new key or the renamed shell stays
+ * "running" for good, with nothing on screen able to end it (#346 review).
+ */
+const forwards: Map<string, string> = new Map();
+function followForwards(key: string): string {
+  const seen = new Set<string>();
+  let current = key;
+  while (forwards.has(current) && !seen.has(current)) {
+    seen.add(current);
+    current = forwards.get(current)!;
+  }
+  return current;
+}
+
+/** The running-command record for the command that started at `since`, wherever its session lives now. */
+export function readShellCommand(key: string, since: number): ActiveShellCommand | null {
+  const command = sessions.get(followForwards(key))?.activeCommand ?? null;
+  return command && command.since === since ? command : null;
+}
+
+/**
+ * Update the running-command record for the command that started at `since`,
+ * wherever its session lives now, and only while that command is the one
+ * recorded. `null` ends it; a partial patch merges into it.
+ *
+ * Deliberately not epoch-checked. The epoch says which mount may write a key;
+ * but a command's own progress is true whoever owns the tab now, and dropping
+ * its completion would leave that owner busy forever.
+ */
+export function writeShellCommand(
+  key: string,
+  since: number,
+  patch: Partial<ActiveShellCommand> | null
+): void {
+  const target = followForwards(key);
+  const current = sessions.get(target)?.activeCommand;
+  if (!current || current.since !== since) return;
+  writeShellSession(target, { activeCommand: patch === null ? null : { ...current, ...patch } });
+}
+
 /** Subscribe to changes for `key`; returns an unsubscribe. */
 export function watchShellSession(key: string, fn: (session: ShellSession) => void): () => void {
   const forKey = watchers.get(key) ?? new Set();
@@ -399,6 +443,9 @@ export function renameShellSession(oldKey: string, newKey: string): Promise<void
   // a session mapping that the renamed tab's close will never clear — and the
   // output would land there instead of in the tab the user is looking at.
   endEpoch(oldKey);
+  // Renaming back (new → old) removes the forward that would otherwise loop.
+  forwards.delete(newKey);
+  forwards.set(oldKey, newKey);
   const session = sessions.get(oldKey);
   if (session) {
     sessions.delete(oldKey);
@@ -478,6 +525,7 @@ export function forgetShellSession(key: string): void {
 /** Test seam: forget everything without touching the backend. */
 export function resetShellSessions(): void {
   sessions.clear();
+  forwards.clear();
   epochs.clear();
   pendingStarts.clear();
   watchers.clear();

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -312,6 +312,8 @@
       "resultToDataViewer_one": "{{count}} Dokument -> Datenansicht",
       "resultToDataViewer_other": "{{count}} Dokumente -> Datenansicht",
       "sessionAttached": "mongosh-Sitzung verbunden",
+      "commandStopped": "Befehl gestoppt.",
+      "runningFor": "läuft… {{seconds}}s",
       "sessionRestarting": "mongosh-Sitzung wird neu gestartet…",
       "sessionUnavailable": "mongosh-Sitzung nicht verfügbar: {{detail}}",
       "switchedToDb": "zur Datenbank {{db}} gewechselt"
@@ -319,6 +321,8 @@
     "toolbar": {
       "aiToggleLabel": "KI",
       "aiToggleTitle": "KI-Assistent",
+      "stop": "Stopp",
+      "stopTitle": "Laufenden Befehl stoppen, indem die mongosh-Sitzung neu gestartet wird",
       "restartSession": "Neu starten",
       "restartSessionTitle": "Diese mongosh-Sitzung beenden und eine neue starten",
       "run": "Ausführen"

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -312,6 +312,7 @@
       "resultToDataViewer_one": "{{count}} Dokument -> Datenansicht",
       "resultToDataViewer_other": "{{count}} Dokumente -> Datenansicht",
       "sessionAttached": "mongosh-Sitzung verbunden",
+      "commandReattached": "Beim erneuten Öffnen dieser Shell lief noch ein Befehl. Seine Ausgabe blieb in der Ansicht, in der er gestartet wurde; es wird auf sein Ende gewartet – Stopp beendet ihn.",
       "commandStopped": "Befehl gestoppt.",
       "runningFor": "läuft… {{seconds}}s",
       "sessionRestarting": "mongosh-Sitzung wird neu gestartet…",

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -364,9 +364,11 @@
       "useDb": "  use <db>                 switch current database"
     },
     "notes": {
+      "commandStopped": "Command stopped.",
       "destructiveCancelled": "Destructive command cancelled.",
       "resultToDataViewer_one": "{{count}} document -> Data Viewer",
       "resultToDataViewer_other": "{{count}} documents -> Data Viewer",
+      "runningFor": "running… {{seconds}}s",
       "sessionAttached": "mongosh session attached",
       "sessionRestarting": "restarting mongosh session…",
       "sessionUnavailable": "mongosh session unavailable: {{detail}}",
@@ -377,7 +379,9 @@
       "aiToggleTitle": "AI assistant",
       "restartSession": "Restart",
       "restartSessionTitle": "Stop this mongosh session and start a new one",
-      "run": "Run"
+      "run": "Run",
+      "stop": "Stop",
+      "stopTitle": "Stop the running command by restarting the mongosh session"
     }
   },
   "quickStart": {

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -364,6 +364,7 @@
       "useDb": "  use <db>                 switch current database"
     },
     "notes": {
+      "commandReattached": "A command was still running when this shell reopened here. Its output stayed with the view it started in; waiting for it to finish — Stop ends it.",
       "commandStopped": "Command stopped.",
       "destructiveCancelled": "Destructive command cancelled.",
       "resultToDataViewer_one": "{{count}} document -> Data Viewer",

--- a/src/locales/zh-Hans/shell.json
+++ b/src/locales/zh-Hans/shell.json
@@ -308,6 +308,7 @@
       "destructiveCancelled": "已取消该破坏性命令。",
       "resultToDataViewer_other": "{{count}} 个文档 -> 数据视图",
       "sessionAttached": "已接入 mongosh 会话",
+      "commandReattached": "重新打开此 Shell 时仍有命令在运行。其输出留在启动它的视图中；正在等待其完成，按“停止”可将其结束。",
       "commandStopped": "命令已停止。",
       "runningFor": "运行中… {{seconds}}秒",
       "sessionRestarting": "正在重启 mongosh 会话…",

--- a/src/locales/zh-Hans/shell.json
+++ b/src/locales/zh-Hans/shell.json
@@ -308,6 +308,8 @@
       "destructiveCancelled": "已取消该破坏性命令。",
       "resultToDataViewer_other": "{{count}} 个文档 -> 数据视图",
       "sessionAttached": "已接入 mongosh 会话",
+      "commandStopped": "命令已停止。",
+      "runningFor": "运行中… {{seconds}}秒",
       "sessionRestarting": "正在重启 mongosh 会话…",
       "sessionUnavailable": "mongosh 会话不可用：{{detail}}",
       "switchedToDb": "已切换到数据库 {{db}}"
@@ -315,6 +317,8 @@
     "toolbar": {
       "aiToggleLabel": "AI",
       "aiToggleTitle": "AI 助手",
+      "stop": "停止",
+      "stopTitle": "通过重启 mongosh 会话来停止正在运行的命令",
       "restartSession": "重启",
       "restartSessionTitle": "停止当前 mongosh 会话并启动新会话",
       "run": "运行"


### PR DESCRIPTION
Shell scripts "timed out" unpredictably. The timeout was not measuring the script — three separate faults produced the same twenty-second wait, and this fixes all three.

## What was actually happening

I reproduced each case against the real mongosh 2.9.2 over a pipe, exactly as the app drives it (`mongosh --quiet <uri>` with piped stdio). Timestamps are from those runs.

**1. An unclosed `{` or `find(` hung forever, then broke every later command.**

```
> [1].forEach(function (x) {          ← sent with our completion marker after it
| 
| 
                                       ← nothing, ever
```

The REPL reads a line at a time and only evaluates once a statement is complete. Left open, it does not report anything — it reads the next line as more of the same statement, our marker included, and waits. MQLens waited twenty seconds for a marker that had been swallowed, reported a timeout, and left the REPL still waiting. Every command the user sent after that landed in the same open buffer. That is the "highly unpredictable" part: one stray brace and the shell answers nothing from then on.

**2. A slow script poisoned the next one.**

```
sleep(25000); print('AFTER_SLEEP')   ← sent 23:10:19
AFTER_SLEEP                           ← 23:10:44
__MQLENS_DONE_…__                     ← 23:10:44
```

The twenty-second ceiling fired at 23:10:39 and reported a timeout. It did not stop anything: mongosh kept running, and both lines arrived five seconds later — into the channel the *next* command would read from. Any script slower than twenty seconds — an aggregation, an index build — timed out *and* corrupted whatever ran next.

**3. Prompts were never seen as lines.**

mongosh writes its prompt with no newline after it. A line reader therefore never delivered a prompt as a line: it sat in the buffer until the next output arrived and was glued to the front of it — the console showed `test> hello` — and a prompt with nothing after it, which is exactly what a REPL waiting for input produces, never arrived at all. That prompt is the one piece of evidence that a script has stalled, and the old reader was structurally unable to see it.

## The fix

**Reader.** Reads chunks, not lines, and decides what a prompt-shaped tail was by what arrives next: output that follows it without a newline proves it was a prompt and it is dropped; a newline proves it was output and it is kept whole. Complete lines are delivered verbatim, never rewritten. Markers are matched by suffix, so a prompt glued to the front of one cannot hide it, and they are echoed as expressions — the REPL prints those itself, so a script that shadows `print` cannot swallow them.

**Completion protocol.** Every command is followed by its marker, then `.break`, then a second marker. `.break` is the REPL's own command to abandon a half-typed statement, and a no-op otherwise. It sits behind every line of the script in the pipe, so it can only ever discard a statement those lines left open — never one that is merely slow, which is still evaluating and has not read it yet. The second marker prints in every case, which is what makes the first one's absence *meaningful* rather than silence:

| First marker | Second marker | Meaning |
| --- | --- | --- |
| printed | printed | ran to completion |
| quoted inside a SyntaxError code frame | printed | the REPL already reported the error; returned as the error, our line dropped from the frame |
| absent | printed | the last statement was left open and `.break` discarded it; complete statements before it have already run — reported at once, with the output they produced |

**No ceiling.** A script takes as long as it takes. The wait ends when the REPL says the turn is over, or when the session is gone.

**Stop.** mongosh cannot be interrupted over a pipe — Ctrl+C is a terminal affordance — so the only reliable stop is ending the session and starting a fresh one, which the existing restart path already does and which keeps the transcript. A Stop button replaces Run while a command is running, and the resulting rejection is reported as a stop, not as a session error. An elapsed counter keeps a long script from reading as a hang. Stop is offered only while the command is inside mongosh; a recognised `find`/`aggregate`/`count` then makes a driver call to fill the viewer, which a restart would not stop.

**The running command belongs to the session, not the component.** Switching tabs unmounts the shell while the backend carries on, so the record of the running command (start time, phase, whether Stop was pressed) lives in the retained shell session. A remounted shell reads it back, every mounted instance stays in step, and the one that finishes the command clears it for all of them. Two harder cases follow from that:

- *Reload, or a tab moved to another window*: the session is hydrated from the backend with a command still recorded as running, but whoever awaited it is gone. The shell shows it running with Stop available and waits on a new backend command, `await_mongosh_idle`, which just takes the session's command lock — it resolves when the orphaned command ends, or when Stop restarts the session. A command already past mongosh holds nothing and is cleared at once.
- *A collection or database renamed under a running command*: the tab remounts under a new key and the old key's write epoch is ended, which would drop the completion. The registry keeps every rename edge and locates a command by its own start time across all keys its session may live under, so each completion finds its own record — including when the old key is reused, and renamed again, before the first command finishes.

## Verified

Every path, against real mongosh over a pipe, with the exact four-line protocol the backend now sends:

| Script | Result |
| --- | --- |
| `print('hello')` | MARK, RECOVERED — completed |
| multi-line `forEach(function…)` | `\|` `\|` output, MARK, RECOVERED — completed |
| `throw new Error('boom')` | error text, MARK, RECOVERED — completed |
| `db.foo.find({` | code frame quoting `print('MARK')`, RECOVERED — **SyntaxError, instant** |
| `[1].forEach(function (x) {` | `\|` `\|` RECOVERED, no MARK — **incomplete, instant** |
| `sleep(5000)` | output at +5s, MARK, RECOVERED — completed, no timeout |

`.break` on a clean REPL prints one extra prompt and nothing else.

Tests: seven Rust unit tests on the reader and classification (the local test binary cannot launch on this machine; they pass in CI), and frontend tests for Stop, the driver phase, remount, the Stop-race, reload reattachment, rename forwarding and key reuse — each mutation-checked against the line it guards. Full suite: the same 5 pre-existing failures as clean `dev`.

**Not exercised in the running app** — the workstation was locked throughout. The probes above are against the identical binary and protocol, but the app end-to-end (editor → backend → console) is the one thing left unverified.

## Not in this PR

Output is still delivered when the command finishes, not streamed as it is produced. For a script that prints progressively over a minute, that is the remaining gap between this and Studio 3T's shell, and it is a separate change — the reader now delivers lines as they arrive, so it is a matter of emitting them to the UI rather than accumulating them. Happy to open an issue.

