### PR TITLE
fix(results): keep the grid mounted across a run

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4561,15 +4561,11 @@ function Workspace() {
                     </Button>
                   </div>
                 )}
-                {tab.loading ? (
-                  <div className="flex-grow flex items-center justify-center text-muted-foreground bg-background">
-                    <div className="flex flex-col items-center gap-2 select-none">
-                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary"></div>
-                      <span className="text-xs">{t('documents:dataGrid.labels.streamingDocuments')}</span>
-                    </div>
-                  </div>
-                ) : (
-                  <DataGrid
+                {/* Always mounted: a run shows as an overlay inside the grid,
+                    so re-running a query no longer throws away the folds, the
+                    find bar, the scroll position and the rest (#344). */}
+                <DataGrid
+                    loading={tab.loading}
                     documents={tab.results}
                     density={density}
                     explainResult={tab.explainResult}
@@ -4599,7 +4595,6 @@ function Workspace() {
                       onPageSizeChange: (newLimit: number) => handlePageSizeChange(tab, newLimit),
                     } : {})}
                   />
-                )}
               </div>
             </DocumentViewer>
           );

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1098,25 +1098,31 @@ export const DataGrid: React.FC<DataGridProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parsedDocs, documents]);
 
-  // The result's shape: its documents in order, then every foldable block in
-  // order with where it sits (document, depth, key). Fold ids are positional,
-  // and this is the identity that makes them meaningful again on a new array:
-  // a re-run of the same query returns the same shape — the case where losing
-  // every fold on every run was the complaint (#344) — while another page,
-  // another query, or the same documents with their fields rearranged do not.
-  // Ids alone would not do: an aggregation's documents may all lack one.
+  // The result's identity: what was asked for — the query, the page — and the
+  // shape of what came back: its documents in order, then every foldable
+  // block in order with where it sits (document, depth, key). Fold ids are
+  // positional, and this is what makes them meaningful again on a new array:
+  // a re-run of the same query returns the same identity — the case where
+  // losing every fold on every run was the complaint (#344) — while another
+  // page, another query, or the same documents with their fields rearranged
+  // do not. Neither half would do alone: an aggregation's documents may all
+  // lack an _id, and a projection may drop it, so two pages can have the same
+  // shape; and the same query may return new documents.
   //
-  // Two things hang off it. Folds are kept across the same shape and reset
-  // otherwise. The scroll position likewise: a refresh keeps the user's place,
-  // a new page starts at its first row — now that the grid stays mounted,
-  // nothing else would move it there.
+  // Two things hang off it. Folds — JSON and tree — are kept across the same
+  // identity and reset otherwise. The scroll position likewise: a refresh
+  // keeps the user's place, a new page starts at its first row — now that the
+  // grid stays mounted, nothing else would move it there.
   const resultShape = useMemo(() => {
-    const parts: string[] = [documents.map(stableDocId).join('\u0000')];
+    const parts: string[] = [
+      JSON.stringify([querySpec, skip ?? null, limit ?? null]),
+      documents.map(stableDocId).join('\u0000'),
+    ];
     for (const line of jsonLines) {
       if (line.kind === 'open') parts.push(`${line.docIndex}/${line.depth}/${line.keyName ?? ''}`);
     }
     return parts.join('\u0001');
-  }, [jsonLines, documents]);
+  }, [querySpec, skip, limit, jsonLines, documents]);
   useEffect(() => {
     setCollapsedFolds(new Set());
     // `scrollToRow` throws on an out-of-range index, and an empty result has
@@ -1579,10 +1585,15 @@ export const DataGrid: React.FC<DataGridProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parsedDocs, documents]);
 
-  // Apply the default collapse set whenever the result set (and thus rows) changes.
+  // Apply the default collapse set when the result changes — by identity, not
+  // by array: a re-run of the same query rebuilds the rows and the defaults,
+  // but the tree the user has opened up is the same tree, so it stays (#344).
+  const treeShapeRef = React.useRef<string | null>(null);
   useEffect(() => {
+    if (treeShapeRef.current === resultShape) return;
+    treeShapeRef.current = resultShape;
     setTreeCollapsed(new Set(treeDefaultCollapsed));
-  }, [treeDefaultCollapsed]);
+  }, [resultShape, treeDefaultCollapsed]);
 
   // The text of one tree row: all three columns, since all three are on screen.
   // Container rows show their child count, so that label is searchable too.

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -36,8 +36,22 @@ import { getScaledRowHeight } from '@/lib/themes/ui-scale';
 import { cn } from '@/lib/utils';
 import type { SpacingDensity } from '@/lib/themes/schema';
 
+/** A document's identity for comparing result sets, tolerant of any `_id` shape. */
+function stableDocId(doc: Record<string, any>): string {
+  try {
+    return JSON.stringify(doc?._id ?? null);
+  } catch {
+    return '';
+  }
+}
+
 interface DataGridProps {
   documents: Array<Record<string, any>>;
+  /** A run is in flight. The grid stays mounted and keeps showing the previous
+   *  results under a loading overlay, rather than being replaced by a spinner
+   *  — which unmounted it on every run and threw away its folds, its find bar,
+   *  its scroll position and everything else it holds (#344). */
+  loading?: boolean;
   density?: 'roomy' | 'cozy' | 'compact';
   explainResult?: string | null;
   // The query that produced these results, rendered as runnable driver code
@@ -58,10 +72,11 @@ interface DataGridProps {
   onPageChange?: (newSkip: number) => void;
   onPageSizeChange?: (newLimit: number) => void;
   /** Results view mode, owned by the caller so it survives this grid being
-   *  unmounted. The results pane renders `{loading ? <spinner/> : <DataGrid/>}`,
-   *  so the grid remounts on EVERY run, and switching tabs unmounts the whole
-   *  DocumentViewer subtree — local state reset to 'json' both times. Omit both
-   *  props to keep the old self-managed behaviour (MongoShell does). */
+   *  unmounted. The results pane used to render
+   *  `{loading ? <spinner/> : <DataGrid/>}`, remounting the grid on every run;
+   *  that is gone (#344), but switching tabs can still unmount the whole
+   *  DocumentViewer subtree, so the mode stays lifted. Omit both props to keep
+   *  the self-managed behaviour (MongoShell does). */
   viewMode?: ViewMode;
   onViewModeChange?: (mode: ViewMode) => void;
   /** Which results tab is showing. Owned by the caller for the same reason as
@@ -560,6 +575,7 @@ const JsonRow = ({
 
 export const DataGrid: React.FC<DataGridProps> = ({
   documents,
+  loading = false,
   density: densityProp,
   explainResult = null,
   querySpec = null,
@@ -859,10 +875,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // Collapsed rows in the tree-table view (separate id space from JSON folds).
   const [treeCollapsed, setTreeCollapsed] = useState<Set<number>>(new Set());
 
-  // Reset JSON fold state whenever the result set changes (fold ids are positional).
-  useEffect(() => {
-    setCollapsedFolds(new Set());
-  }, [documents]);
+  // JSON folds are reset further down, once the lines they index are known.
 
   // Switch to the explain tab when a NEW plan arrives — not merely because one
   // exists.
@@ -1084,6 +1097,20 @@ export const DataGrid: React.FC<DataGridProps> = ({
     return { jsonLines: lines, jsonMaxWidthPx: maxWidthPx };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parsedDocs, documents]);
+
+  // Fold ids are positional, so folds only stay meaningful over a result with
+  // the same documents in the same order and the same number of foldable
+  // blocks. That is exactly what a re-run of the same query returns — the case
+  // where losing every fold on every run was the complaint (#344) — so folds
+  // survive it. Any other change to the result set resets them.
+  const foldShape = useMemo(() => {
+    let blocks = 0;
+    for (const line of jsonLines) if (line.kind === 'open') blocks++;
+    return `${blocks}\u0000${documents.map(stableDocId).join('\u0000')}`;
+  }, [jsonLines, documents]);
+  useEffect(() => {
+    setCollapsedFolds(new Set());
+  }, [foldShape]);
 
   // Only the lines not hidden inside a collapsed fold are rendered/virtualized.
   const visibleJsonLines = useMemo(
@@ -1920,8 +1947,24 @@ export const DataGrid: React.FC<DataGridProps> = ({
   return (
     <div
       ref={paneRootRef}
-      className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-background"
+      className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-background"
+      aria-busy={loading || undefined}
     >
+      {/* A run in flight. Over the previous results, not in their place: the
+          grid stays mounted, so nothing it holds is lost, and the last result
+          stays readable until the next one lands (#344). */}
+      {loading && (
+        <div
+          role="status"
+          data-testid="results-loading"
+          className="absolute inset-0 z-40 flex items-center justify-center bg-background/60 text-muted-foreground"
+        >
+          <div className="flex select-none flex-col items-center gap-2">
+            <div className="h-5 w-5 animate-spin rounded-full border-b-2 border-primary" />
+            <span className="text-xs">{t('documents:dataGrid.labels.streamingDocuments')}</span>
+          </div>
+        </div>
+      )}
       {/* Control Bar — omitted for a chromeless render, where none of these
           controls have anything to act on. */}
       {!chromeless && (

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -619,6 +619,14 @@ export const DataGrid: React.FC<DataGridProps> = ({
   );
 
   // Right-click context menu shared by all result views (Table / Tree / JSON).
+  // A run in flight takes the grid out of reach: the overlay covers it, and
+  // `inert` takes the controls under it out of the tab order too, so a stale
+  // row cannot be acted on by keyboard either. An open context menu is
+  // portaled outside that subtree, so it is closed rather than covered.
+  useEffect(() => {
+    if (loading) setCtxMenu(null);
+  }, [loading]);
+
   const [ctxMenu, setCtxMenu] = useState<
     { x: number; y: number; doc: Record<string, any>; field?: string; value?: any } | null
   >(null);
@@ -1119,7 +1127,14 @@ export const DataGrid: React.FC<DataGridProps> = ({
       documents.map(stableDocId).join('\u0000'),
     ];
     for (const line of jsonLines) {
-      if (line.kind === 'open') parts.push(`${line.docIndex}/${line.depth}/${line.keyName ?? ''}`);
+      // `empty` as well as `open`: an empty object or array is not foldable in
+      // the JSON view, but the tree walker still gives it a fold id, so one
+      // appearing or vanishing shifts every id after it. Left out of the
+      // identity, an otherwise identical result would keep tree folds that now
+      // point at different nodes.
+      if (line.kind === 'open' || line.kind === 'empty') {
+        parts.push(`${line.kind}/${line.docIndex}/${line.depth}/${line.keyName ?? ''}`);
+      }
     }
     return parts.join('\u0001');
   }, [querySpec, skip, limit, jsonLines, documents]);
@@ -1975,6 +1990,12 @@ export const DataGrid: React.FC<DataGridProps> = ({
       ref={paneRootRef}
       className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-background"
       aria-busy={loading || undefined}
+      // Everything under the overlay — row actions, paging, the write buttons —
+      // is unreachable while a run is in flight, by pointer and by keyboard
+      // alike. The overlay is a child, but `inert` on an ancestor does not
+      // disable a `role="status"` announcement, and the overlay has nothing to
+      // interact with.
+      inert={loading || undefined}
     >
       {/* A run in flight. Over the previous results, not in their place: the
           grid stays mounted, so nothing it holds is lost, and the last result
@@ -1983,7 +2004,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
         <div
           role="status"
           data-testid="results-loading"
-          className="absolute inset-0 z-40 flex items-center justify-center bg-background/60 text-muted-foreground"
+          className="absolute inset-0 z-50 flex items-center justify-center bg-background/60 text-muted-foreground"
         >
           <div className="flex select-none flex-col items-center gap-2">
             <div className="h-5 w-5 animate-spin rounded-full border-b-2 border-primary" />

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1098,19 +1098,34 @@ export const DataGrid: React.FC<DataGridProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parsedDocs, documents]);
 
-  // Fold ids are positional, so folds only stay meaningful over a result with
-  // the same documents in the same order and the same number of foldable
-  // blocks. That is exactly what a re-run of the same query returns — the case
-  // where losing every fold on every run was the complaint (#344) — so folds
-  // survive it. Any other change to the result set resets them.
-  const foldShape = useMemo(() => {
-    let blocks = 0;
-    for (const line of jsonLines) if (line.kind === 'open') blocks++;
-    return `${blocks}\u0000${documents.map(stableDocId).join('\u0000')}`;
+  // The result's shape: its documents in order, then every foldable block in
+  // order with where it sits (document, depth, key). Fold ids are positional,
+  // and this is the identity that makes them meaningful again on a new array:
+  // a re-run of the same query returns the same shape — the case where losing
+  // every fold on every run was the complaint (#344) — while another page,
+  // another query, or the same documents with their fields rearranged do not.
+  // Ids alone would not do: an aggregation's documents may all lack one.
+  //
+  // Two things hang off it. Folds are kept across the same shape and reset
+  // otherwise. The scroll position likewise: a refresh keeps the user's place,
+  // a new page starts at its first row — now that the grid stays mounted,
+  // nothing else would move it there.
+  const resultShape = useMemo(() => {
+    const parts: string[] = [documents.map(stableDocId).join('\u0000')];
+    for (const line of jsonLines) {
+      if (line.kind === 'open') parts.push(`${line.docIndex}/${line.depth}/${line.keyName ?? ''}`);
+    }
+    return parts.join('\u0001');
   }, [jsonLines, documents]);
   useEffect(() => {
     setCollapsedFolds(new Set());
-  }, [foldShape]);
+    // `scrollToRow` throws on an out-of-range index, and an empty result has
+    // no row 0. Only the mounted view has a list; the others are null.
+    if (documents.length === 0) return;
+    for (const list of [jsonListRef, treeListRef, tableListRef]) {
+      list.current?.scrollToRow({ index: 0, align: 'start' });
+    }
+  }, [resultShape]);
 
   // Only the lines not hidden inside a collapsed fold are rendered/virtualized.
   const visibleJsonLines = useMemo(

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -745,6 +745,10 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // the body's horizontal scroll onto the header.
   const tableHeaderRef = React.useRef<HTMLDivElement>(null);
   const tableBodyRef = React.useRef<HTMLDivElement>(null);
+  // The JSON view's horizontal scroller is the overflow-auto wrapper around its
+  // list, not the list element: the list is widened to `jsonMaxWidthPx`, so the
+  // wrapper is what carries scrollLeft.
+  const jsonScrollRef = React.useRef<HTMLDivElement>(null);
   useEffect(() => {
     const body = tableBodyRef.current;
     if (!body) return;
@@ -1143,15 +1147,18 @@ export const DataGrid: React.FC<DataGridProps> = ({
     setCollapsedFolds(new Set());
     // A different result opens at the top-left, not wherever the last one was
     // left scrolled. `scrollToRow` resets only the vertical offset and throws
-    // on an out-of-range index, so it is guarded; the horizontal offset of each
-    // scroller — and the table header that mirrors it — is reset directly,
-    // which an empty result can do safely too.
+    // on an out-of-range index, so it is guarded.
     for (const list of [jsonListRef, treeListRef, tableListRef]) {
-      const el = list.current?.element;
-      if (el) el.scrollLeft = 0;
       if (documents.length > 0) list.current?.scrollToRow({ index: 0, align: 'start' });
     }
-    if (tableHeaderRef.current) tableHeaderRef.current.scrollLeft = 0;
+    // The horizontal offset lives on the overflow-auto wrappers, not the List
+    // elements: the JSON list is widened to `jsonMaxWidthPx` and the table body
+    // to its total column width, so those wrappers carry scrollLeft. The table
+    // header mirrors the body and is reset with it. (The tree view is
+    // full-width with no horizontal scroll.)
+    for (const scroller of [jsonScrollRef.current, tableBodyRef.current, tableHeaderRef.current]) {
+      if (scroller) scroller.scrollLeft = 0;
+    }
   }, [resultShape]);
 
   // Only the lines not hidden inside a collapsed fold are rendered/virtualized.
@@ -2271,7 +2278,11 @@ export const DataGrid: React.FC<DataGridProps> = ({
             className="flex min-h-0 min-w-0 flex-1 flex-col bg-background font-mono text-xs leading-relaxed"
             data-testid="json-view"
           >
-            <div className="min-h-0 flex-1 min-w-0 overflow-auto">
+            <div
+              ref={jsonScrollRef}
+              data-testid="json-scroll"
+              className="min-h-0 flex-1 min-w-0 overflow-auto"
+            >
               <List<JsonRowExtra>
                 rowCount={visibleJsonLines.length}
                 listRef={jsonListRef}

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1127,21 +1127,25 @@ export const DataGrid: React.FC<DataGridProps> = ({
   // keeps the user's place, a new page starts at its first row — now that the
   // grid stays mounted, nothing else would move it there.
   const resultShape = useMemo(() => {
-    const parts: string[] = [
-      JSON.stringify([querySpec, skip ?? null, limit ?? null]),
-      documents.map(stableDocId).join('\u0000'),
-    ];
+    // One JSON serialization of everything that identifies the result, so no
+    // field name can impersonate a delimiter: an unescaped separator let a key
+    // like `x\u0001open/0/2/y` reproduce two fold-path parts and collide two
+    // structurally different results (#344 review). `empty` lines count
+    // alongside `open`: an empty container is not foldable in the JSON view but
+    // still takes a fold id in the tree, so one shifts every id after it.
+    const folds: Array<[string, number, number, string]> = [];
     for (const line of jsonLines) {
-      // `empty` as well as `open`: an empty object or array is not foldable in
-      // the JSON view, but the tree walker still gives it a fold id, so one
-      // appearing or vanishing shifts every id after it. Left out of the
-      // identity, an otherwise identical result would keep tree folds that now
-      // point at different nodes.
       if (line.kind === 'open' || line.kind === 'empty') {
-        parts.push(`${line.kind}/${line.docIndex}/${line.depth}/${line.keyName ?? ''}`);
+        folds.push([line.kind, line.docIndex, line.depth, line.keyName ?? '']);
       }
     }
-    return parts.join('\u0001');
+    return JSON.stringify([
+      querySpec ?? null,
+      skip ?? null,
+      limit ?? null,
+      documents.map(stableDocId),
+      folds,
+    ]);
   }, [querySpec, skip, limit, jsonLines, documents]);
   useEffect(() => {
     setCollapsedFolds(new Set());

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -1141,12 +1141,17 @@ export const DataGrid: React.FC<DataGridProps> = ({
   }, [querySpec, skip, limit, jsonLines, documents]);
   useEffect(() => {
     setCollapsedFolds(new Set());
-    // `scrollToRow` throws on an out-of-range index, and an empty result has
-    // no row 0. Only the mounted view has a list; the others are null.
-    if (documents.length === 0) return;
+    // A different result opens at the top-left, not wherever the last one was
+    // left scrolled. `scrollToRow` resets only the vertical offset and throws
+    // on an out-of-range index, so it is guarded; the horizontal offset of each
+    // scroller — and the table header that mirrors it — is reset directly,
+    // which an empty result can do safely too.
     for (const list of [jsonListRef, treeListRef, tableListRef]) {
-      list.current?.scrollToRow({ index: 0, align: 'start' });
+      const el = list.current?.element;
+      if (el) el.scrollLeft = 0;
+      if (documents.length > 0) list.current?.scrollToRow({ index: 0, align: 'start' });
     }
+    if (tableHeaderRef.current) tableHeaderRef.current.scrollLeft = 0;
   }, [resultShape]);
 
   // Only the lines not hidden inside a collapsed fold are rendered/virtualized.
@@ -1994,15 +1999,24 @@ export const DataGrid: React.FC<DataGridProps> = ({
     );
   };
   return (
+    <>
+      {/* The accessible announcement of a run in flight, kept OUTSIDE the inert
+          root below. `inert` removes its whole subtree from the accessibility
+          tree, so a live region rendered inside it would be silent to a screen
+          reader (#344 review). */}
+      {loading && (
+        <div role="status" className="sr-only">
+          {t('documents:dataGrid.labels.streamingDocuments')}
+        </div>
+      )}
     <div
       ref={paneRootRef}
       className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-background"
       aria-busy={loading || undefined}
-      // Everything under the overlay — row actions, paging, the write buttons —
-      // is unreachable while a run is in flight, by pointer and by keyboard
-      // alike. The overlay is a child, but `inert` on an ancestor does not
-      // disable a `role="status"` announcement, and the overlay has nothing to
-      // interact with.
+      // Everything under it — row actions, paging, the write buttons — is
+      // unreachable while a run is in flight, by pointer and by keyboard alike.
+      // The overlay below is decorative (aria-hidden); its accessible
+      // counterpart is the live region above, outside this inert subtree.
       inert={loading || undefined}
     >
       {/* A run in flight. Over the previous results, not in their place: the
@@ -2010,7 +2024,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
           stays readable until the next one lands (#344). */}
       {loading && (
         <div
-          role="status"
+          aria-hidden
           data-testid="results-loading"
           className="absolute inset-0 z-50 flex items-center justify-center bg-background/60 text-muted-foreground"
         >
@@ -2570,5 +2584,6 @@ export const DataGrid: React.FC<DataGridProps> = ({
         />
       )}
     </div>
+    </>
   );
 };

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -2186,3 +2186,42 @@ describe('DataGrid — tab guards survive StrictMode replay (#325 review)', () =
     expect(onActiveTabChange).toHaveBeenCalledWith('explain');
   });
 });
+
+describe('DataGrid — stays mounted across a run (#344)', () => {
+  const docs = () => [{ _id: '1', name: 'Alice Smith', address: { city: 'Oslo' } }];
+  const firstFold = () => screen.getAllByTestId('json-fold-btn')[0];
+
+  it('keeps a fold collapsed across a run that returns the same documents', () => {
+    // Re-running a query gives a fresh array of the same result. The fold ids
+    // are positional, and the positions have not moved.
+    const { rerender } = render(<DataGrid documents={docs()} />);
+    fireEvent.click(firstFold());
+    expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/expand/i));
+
+    rerender(<DataGrid documents={docs()} loading />);
+    rerender(<DataGrid documents={docs()} />);
+
+    expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/expand/i));
+  });
+
+  it('resets folds when a different result set arrives', () => {
+    const { rerender } = render(<DataGrid documents={docs()} />);
+    fireEvent.click(firstFold());
+
+    rerender(<DataGrid documents={[{ _id: '2', name: 'Bob', address: { city: 'Rome' } }]} />);
+
+    expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/collapse/i));
+  });
+
+  it('shows a run in flight over the previous results, not in their place', () => {
+    const { rerender } = render(<DataGrid documents={docs()} />);
+    expect(screen.queryByTestId('results-loading')).toBeNull();
+
+    rerender(<DataGrid documents={docs()} loading />);
+    expect(screen.getByTestId('results-loading')).toBeInTheDocument();
+    expect(screen.getByText(/"Alice Smith"/)).toBeInTheDocument();
+
+    rerender(<DataGrid documents={docs()} />);
+    expect(screen.queryByTestId('results-loading')).toBeNull();
+  });
+});

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -2248,6 +2248,53 @@ describe('DataGrid — stays mounted across a run (#344)', () => {
     expect(list.scrollTop).toBe(0);
   });
 
+  it('starts the next page at its first row even when a projection hides every _id', () => {
+    // Projected out, the ids say nothing; the page asked for does.
+    const page = (skip: number) =>
+      Array.from({ length: 40 }, (_, i) => ({ name: `doc ${skip + i}` }));
+    const { rerender } = render(<DataGrid documents={page(0)} skip={0} limit={40} />);
+    const list = within(screen.getByTestId('json-view')).getByRole('list');
+    Object.defineProperty(list, 'scrollTo', {
+      configurable: true,
+      value: ({ top }: { top: number }) => {
+        list.scrollTop = top;
+      },
+    });
+    list.scrollTop = 300;
+
+    rerender(<DataGrid documents={page(0)} skip={0} limit={40} />);
+    expect(list.scrollTop).toBe(300);
+
+    rerender(<DataGrid documents={page(40)} skip={40} limit={40} />);
+    expect(list.scrollTop).toBe(0);
+  });
+
+  it('keeps tree folds across a run that returns the same documents', () => {
+    const nested = () => [{ _id: '1', g: { a: { akey: 'one' } } }];
+    const foldState = (keyName: string): 'open' | 'closed' => {
+      const row = screen.getByTitle(keyName).closest('[data-doc-even]');
+      const button = row?.querySelector('[data-testid="tree-fold-btn"]');
+      const label = button?.getAttribute('aria-label') ?? '';
+      if (/expand/i.test(label)) return 'closed';
+      if (/collapse/i.test(label)) return 'open';
+      throw new Error(`no fold for ${keyName}: ${label}`);
+    };
+    const { rerender } = render(<DataGrid documents={nested()} />);
+    fireEvent.click(screen.getByRole('button', { name: /tree/i }));
+    // Depth >= 2 starts collapsed; the user opens it.
+    expect(foldState('a')).toBe('closed');
+    fireEvent.click(screen.getByTitle('a').closest('[data-doc-even]')!.querySelector('[data-testid="tree-fold-btn"]')!);
+    expect(foldState('a')).toBe('open');
+
+    rerender(<DataGrid documents={nested()} loading />);
+    rerender(<DataGrid documents={nested()} />);
+    expect(foldState('a')).toBe('open');
+
+    // A different result: back to the defaults.
+    rerender(<DataGrid documents={[{ _id: '2', g: { a: { akey: 'two' } } }]} />);
+    expect(foldState('a')).toBe('closed');
+  });
+
   it('shows a run in flight over the previous results, not in their place', () => {
     const { rerender } = render(<DataGrid documents={docs()} />);
     expect(screen.queryByTestId('results-loading')).toBeNull();

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -2213,6 +2213,41 @@ describe('DataGrid — stays mounted across a run (#344)', () => {
     expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/collapse/i));
   });
 
+  it('resets folds for a result with the same ids and block count but a different structure', () => {
+    // Aggregation output may carry no _id at all; the structure of the folds
+    // is what tells one such result from another.
+    const { rerender } = render(<DataGrid documents={[{ _id: null, a: { x: 1 } }]} />);
+    fireEvent.click(firstFold());
+    expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/expand/i));
+
+    rerender(<DataGrid documents={[{ _id: null, b: { y: 1 } }]} />);
+
+    expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/collapse/i));
+  });
+
+  it('keeps the scroll position across a refresh, and starts a new page at its first row', () => {
+    const page = (from: number) =>
+      Array.from({ length: 40 }, (_, i) => ({ _id: String(from + i), name: `doc ${from + i}` }));
+    const { rerender } = render(<DataGrid documents={page(0)} />);
+    const list = within(screen.getByTestId('json-view')).getByRole('list');
+    // jsdom lays nothing out and scrolls nothing; record what the list is told.
+    Object.defineProperty(list, 'scrollTo', {
+      configurable: true,
+      value: ({ top }: { top: number }) => {
+        list.scrollTop = top;
+      },
+    });
+    list.scrollTop = 300;
+
+    // The same result again: the user's place is kept.
+    rerender(<DataGrid documents={page(0)} />);
+    expect(list.scrollTop).toBe(300);
+
+    // The next page: it starts at its first row.
+    rerender(<DataGrid documents={page(40)} />);
+    expect(list.scrollTop).toBe(0);
+  });
+
   it('shows a run in flight over the previous results, not in their place', () => {
     const { rerender } = render(<DataGrid documents={docs()} />);
     expect(screen.queryByTestId('results-loading')).toBeNull();

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -2295,6 +2295,48 @@ describe('DataGrid — stays mounted across a run (#344)', () => {
     expect(foldState('a')).toBe('closed');
   });
 
+  it('resets folds when an empty container shifts every fold id', () => {
+    // An empty object is not foldable in the JSON view, so it was left out of
+    // the identity — but the tree walker still gives it a fold id, and every
+    // id after it moves. Folds kept over that shift would point at other nodes.
+    const before = [{ _id: '1', g: { a: { akey: 'one' } } }];
+    const after = [{ _id: '1', g: { empty: {}, a: { akey: 'one' } } }];
+    const { rerender } = render(<DataGrid documents={before} />);
+    fireEvent.click(firstFold());
+    expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/expand/i));
+
+    rerender(<DataGrid documents={after} />);
+
+    expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/collapse/i));
+  });
+
+  it('puts the grid out of reach while a run is in flight', () => {
+    // The overlay stops the pointer; the inert attribute stops the keyboard, so a stale
+    // row cannot be acted on by tabbing to its buttons.
+    const { container, rerender } = render(<DataGrid documents={docs()} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.hasAttribute('inert')).toBe(false);
+
+    rerender(<DataGrid documents={docs()} loading />);
+    expect(root.hasAttribute('inert')).toBe(true);
+
+    rerender(<DataGrid documents={docs()} />);
+    expect(root.hasAttribute('inert')).toBe(false);
+  });
+
+  it('closes an open context menu when a run starts', () => {
+    // It is portaled out of the grid, above the overlay, so covering it is
+    // not enough — its actions would still run against the stale result.
+    const { rerender } = render(<DataGrid documents={docs()} onDeleteDocument={() => {}} />);
+    const line = screen.getByTestId('json-view').querySelector('[data-json-line]') as HTMLElement;
+    fireEvent.contextMenu(line, { clientX: 10, clientY: 10 });
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+
+    rerender(<DataGrid documents={docs()} onDeleteDocument={() => {}} loading />);
+
+    expect(screen.queryByTestId('context-menu')).toBeNull();
+  });
+
   it('shows a run in flight over the previous results, not in their place', () => {
     const { rerender } = render(<DataGrid documents={docs()} />);
     expect(screen.queryByTestId('results-loading')).toBeNull();

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -2338,6 +2338,38 @@ describe('DataGrid — stays mounted across a run (#344)', () => {
     expect(screen.queryByTestId('context-menu')).toBeNull();
   });
 
+  it('opens a different result at the left edge, but keeps the scroll on a refresh', () => {
+    // scrollToRow only resets the vertical axis; a wide result left scrolled
+    // right would otherwise open with its first fields off-screen.
+    const page = (from: number) =>
+      Array.from({ length: 40 }, (_, i) => ({ _id: String(from + i), name: `doc ${from + i}` }));
+    const { rerender } = render(<DataGrid documents={page(0)} skip={0} limit={40} />);
+    const list = within(screen.getByTestId('json-view')).getByRole('list');
+    list.scrollLeft = 120;
+
+    // Same result: the user's place is kept.
+    rerender(<DataGrid documents={page(0)} skip={0} limit={40} />);
+    expect(list.scrollLeft).toBe(120);
+
+    // A different page: back to the left edge.
+    rerender(<DataGrid documents={page(40)} skip={40} limit={40} />);
+    expect(list.scrollLeft).toBe(0);
+  });
+
+  it('announces a run in flight outside the inert subtree, so a screen reader hears it', () => {
+    // inert removes its whole subtree from the accessibility tree, so a status
+    // inside the inert root would be silent. It has to sit outside.
+    const { container, rerender } = render(<DataGrid documents={docs()} />);
+    expect(screen.queryByRole('status')).toBeNull();
+
+    rerender(<DataGrid documents={docs()} loading />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent(/\S/);
+    const paneRoot = container.querySelector('[aria-busy]') as HTMLElement;
+    expect(paneRoot.hasAttribute('inert')).toBe(true);
+    expect(paneRoot.contains(status)).toBe(false);
+  });
+
   it('shows a run in flight over the previous results, not in their place', () => {
     const { rerender } = render(<DataGrid documents={docs()} />);
     expect(screen.queryByTestId('results-loading')).toBeNull();

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -2344,16 +2344,17 @@ describe('DataGrid — stays mounted across a run (#344)', () => {
     const page = (from: number) =>
       Array.from({ length: 40 }, (_, i) => ({ _id: String(from + i), name: `doc ${from + i}` }));
     const { rerender } = render(<DataGrid documents={page(0)} skip={0} limit={40} />);
-    const list = within(screen.getByTestId('json-view')).getByRole('list');
-    list.scrollLeft = 120;
+    // The real horizontal scroller is the overflow-auto wrapper, not the list.
+    const scroller = screen.getByTestId('json-scroll');
+    scroller.scrollLeft = 120;
 
     // Same result: the user's place is kept.
     rerender(<DataGrid documents={page(0)} skip={0} limit={40} />);
-    expect(list.scrollLeft).toBe(120);
+    expect(scroller.scrollLeft).toBe(120);
 
     // A different page: back to the left edge.
     rerender(<DataGrid documents={page(40)} skip={40} limit={40} />);
-    expect(list.scrollLeft).toBe(0);
+    expect(scroller.scrollLeft).toBe(0);
   });
 
   it('announces a run in flight outside the inert subtree, so a screen reader hears it', () => {

--- a/src/components/__tests__/DataGrid.test.tsx
+++ b/src/components/__tests__/DataGrid.test.tsx
@@ -2338,6 +2338,22 @@ describe('DataGrid — stays mounted across a run (#344)', () => {
     expect(screen.queryByTestId('context-menu')).toBeNull();
   });
 
+  it('does not let a field name impersonate the result-identity delimiters', () => {
+    // Under an unescaped `/`-joined-then-`\u0001`-joined key, a single fold
+    // path could look like two, colliding two different structures. The key
+    // `x\u0001open/0/2/y` is exactly such a forgery of two nested paths.
+    const nested = [{ _id: '1', x: { y: { n: 1 } } }];
+    const crafted = [{ _id: '1', ['x\u0001open/0/2/y']: { n: 1 } }];
+    const { rerender } = render(<DataGrid documents={nested} />);
+    fireEvent.click(firstFold());
+    expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/expand/i));
+
+    rerender(<DataGrid documents={crafted} />);
+
+    // Different structure, so the identity changed and folds reset to default.
+    expect(firstFold()).toHaveAttribute('aria-label', expect.stringMatching(/collapse/i));
+  });
+
   it('opens a different result at the left edge, but keeps the scroll on a refresh', () => {
     // scrollToRow only resets the vertical axis; a wide result left scrolled
     // right would otherwise open with its first fields off-screen.


### PR DESCRIPTION
Closes #344.

## What was happening

The results pane rendered `{tab.loading ? <spinner/> : <DataGrid/>}`, so every run unmounted the grid and destroyed everything it held in local state. Three properties had been lifted to the tab one at a time (#218 view mode, #281 explain tab, #268 column widths); each fix left the cause in place, and folds, the tree collapse state, the find bar and its query, the explain view, the scroll position and a document armed for comparison all still reset on every run.

## The fix

**The grid stays mounted.** `DataGrid` takes a `loading` prop and the results pane always renders it. A run in flight shows as an overlay inside the grid (`role="status"`, the same spinner and label as before) over the previous results, which stay readable until the next result lands — the pane no longer goes blank between runs. The overlay dims the grid and takes pointer events while it is up, so a stale row cannot be acted on mid-run.

**Folds survive a re-run.** The grid also reset its JSON folds itself on every change to `documents`, because fold ids are positional. They now reset only when the result's *shape* changes — its `_id`s in order, plus every foldable block in order with where it sits (document, depth, key), so aggregation output without ids and rearranged fields count as different. A re-run of the same query returns the same shape, so its folds stay; a different result set still resets them.

**Scroll follows the same rule.** Now that the lists stay mounted they keep their offset; a refresh of the same result keeps the user's place, and any other shape (the next page, a new query) starts at its first row. A document armed for comparison is still dropped on any new result — that guard matches by reference and is deliberate.

The three lifted properties stay lifted: switching tabs can still unmount the `DocumentViewer` subtree, which is a separate cause with the same effect (#240 / #345 address that one).

## Design note

The loading state's appearance changes from "spinner in place of the results" to "spinner over dimmed results". This is the Compass behaviour the issue asked for; the dim is `bg-background/60`, so the previous result stays legible underneath. Worth a look on the design side, as the issue anticipated.

## Tests

`DataGrid.test.tsx`, "stays mounted across a run (#344)": a fold survives a loading cycle that returns the same documents; folds reset when a different result set arrives; the overlay shows over the previous results and goes away after; a result with the same ids and block count but a different structure still resets folds; the scroll position survives a refresh and resets for the next page. Each fails with the guard it covers removed.

Full suite: the same 5 pre-existing environment-dependent failures as clean `dev` on this machine; they pass in CI.

**Not yet exercised in the running app** — the workstation is locked. That is the remaining verification: run a query twice with a fold collapsed and the find bar open, and watch neither reset.

