### PR TITLE
fix(shell): run multi-line scripts one-shot in JavaScript mode

### DIFF
--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -200,6 +200,7 @@ const GUARDED_WRITE_COMMANDS: &[&str] = &[
     "start_restore_task",
     "start_mongosh_session",
     "run_mongosh_command",
+    "run_mongosh_script",
     "create_index",
     "delete_index",
     "delete_document",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -989,6 +989,126 @@ pub async fn run_mongosh_command_impl(
     result
 }
 
+/// Split mongosh's captured output into lines, folding CRLF and dropping the
+/// single empty element a trailing newline leaves behind, so a clean run does
+/// not end in a blank line.
+pub(crate) fn split_mongosh_output_lines(bytes: &[u8]) -> Vec<String> {
+    let text = String::from_utf8_lossy(bytes);
+    let mut lines: Vec<String> = text
+        .split('\n')
+        .map(|l| l.strip_suffix('\r').unwrap_or(l).to_string())
+        .collect();
+    if lines.last().map(|l| l.is_empty()).unwrap_or(false) {
+        lines.pop();
+    }
+    lines
+}
+
+/// Run a whole script as a one-shot `mongosh --file` program, the way a script
+/// is meant to run: parsed and executed as one unit, then the process exits.
+///
+/// This is the counterpart to the persistent REPL session. Feeding a script to
+/// the REPL a line at a time is what made big pastes unpredictable — an
+/// unclosed brace left the REPL waiting, and a script that called `quit()` (as
+/// diagnostic scripts routinely do) tore the session down before its completion
+/// marker could return, which surfaced as "session closed". None of that
+/// applies here: `--file` handles `quit()`, `use`/`show`, unclosed braces and
+/// syntax errors on its own, reporting an error once and exiting non-zero.
+///
+/// The cost is that nothing carries over between runs. The one piece of state
+/// that matters in practice, the current database, is passed in and applied
+/// with a leading `use`, exactly as the REPL session does on startup, so `db`
+/// still points where the tab expects. A script may `use` elsewhere itself.
+pub async fn run_mongosh_script_impl(
+    state: &AppState,
+    connection_id: &str,
+    uri: &str,
+    database: &str,
+    mongosh_path: &str,
+    script: &str,
+) -> Result<MongoshCommandOutput, String> {
+    if write_guard::connection_mode(state, connection_id)? == connections::ConnectionMode::ReadOnly
+    {
+        return Err(write_guard::READ_ONLY_MSG.to_string());
+    }
+    let is_mock = {
+        let mocks = state.mocks.lock_safe()?;
+        *mocks
+            .get(connection_id)
+            .ok_or_else(|| "Connection not found".to_string())?
+    };
+    if is_mock || uri.starts_with("mongodb://mock") {
+        return Err("External mongosh sessions require a real MongoDB URI".to_string());
+    }
+
+    let executable = if mongosh_path.trim().is_empty() {
+        "mongosh".to_string()
+    } else {
+        mongosh_path.trim().to_string()
+    };
+
+    // The script goes in a temp file, not an `--eval` argument: it can be large,
+    // and a file sidesteps every argument-length and shell-quoting limit.
+    let path =
+        std::env::temp_dir().join(format!("mqlens-shell-{}.js", Uuid::new_v4().simple()));
+    tokio::fs::write(&path, script.as_bytes())
+        .await
+        .map_err(|e| format!("Failed to stage the script: {}", e))?;
+
+    let started = std::time::Instant::now();
+    let mut command = TokioCommand::new(&executable);
+    command
+        .arg("--quiet")
+        .arg(connections::normalize_mongodb_uri_options(uri));
+    // `use <db>` only when the name is a plain one — a control character could
+    // not appear in a real database name and must never reach the argument.
+    let db = database.trim();
+    if !db.is_empty() && !db.chars().any(|c| c.is_control()) {
+        command.arg("--eval").arg(format!("use {}", db));
+    }
+    command.arg("--file").arg(&path);
+
+    let spawned = command.output().await;
+    // Best effort: a leaked temp file must never fail an otherwise good run.
+    let _ = tokio::fs::remove_file(&path).await;
+
+    let result: Result<MongoshCommandOutput, String> = match spawned {
+        Ok(output) => {
+            let stdout = split_mongosh_output_lines(&output.stdout);
+            let mut stderr = split_mongosh_output_lines(&output.stderr);
+            // A non-zero exit with nothing on stderr still has to read as a
+            // failure rather than a silent, empty success.
+            if !output.status.success() && stderr.is_empty() {
+                stderr.push(format!(
+                    "mongosh exited with status {}",
+                    output
+                        .status
+                        .code()
+                        .map(|c| c.to_string())
+                        .unwrap_or_else(|| "unknown".to_string())
+                ));
+            }
+            Ok(MongoshCommandOutput { stdout, stderr })
+        }
+        Err(e) => Err(format!("Failed to run mongosh: {}", e)),
+    };
+
+    crate::audit::maybe_record_result(
+        state,
+        Some(connection_id),
+        None,
+        None,
+        "run_mongosh_script",
+        crate::audit::OpClass::Shell,
+        Some("shell"),
+        started,
+        "mongosh",
+        Some(script),
+        &result,
+    );
+    result
+}
+
 /// Per-tab shell state, held backend-side so a frontend hot reload or window
 /// refresh cannot lose the mapping from a tab to its running mongosh process.
 ///
@@ -1849,6 +1969,18 @@ async fn await_mongosh_idle(
     let session = get_mongosh_session(&state, &session_id)?;
     let _idle = session.command_lock.lock().await;
     Ok(())
+}
+
+#[tauri::command]
+async fn run_mongosh_script(
+    state: tauri::State<'_, AppState>,
+    connection_id: String,
+    uri: String,
+    database: String,
+    mongosh_path: String,
+    script: String,
+) -> Result<MongoshCommandOutput, String> {
+    run_mongosh_script_impl(&state, &connection_id, &uri, &database, &mongosh_path, &script).await
 }
 
 #[tauri::command]
@@ -3373,6 +3505,7 @@ pub fn run() {
             get_mongodb_version,
             start_mongosh_session,
             run_mongosh_command,
+            run_mongosh_script,
             await_mongosh_idle,
             stop_mongosh_session,
             get_shell_tab_state,

--- a/src/components/MongoShell.tsx
+++ b/src/components/MongoShell.tsx
@@ -905,6 +905,27 @@ export const MongoShell: React.FC<MongoShellProps> = ({
     return true;
   };
 
+  // A multi-line script runs as one non-interactive `mongosh --file` program
+  // rather than being fed to the REPL a line at a time. That is what makes a
+  // pasted diagnostic script reliable: it is parsed and run as a unit, so an
+  // unclosed brace is a single reported error rather than a hang, and a
+  // `quit()` inside it just ends the run instead of tearing down the session
+  // (#344 shell reliability). It is one-shot, so it does not need the warm
+  // session; the current database is passed so `db` still points at the tab's.
+  const runMongoshScriptOnce = async (script: string) => {
+    if (mongoshPath === null || !connectionUri) return false;
+    const output = await invoke<MongoshCommandOutput>('run_mongosh_script', {
+      connectionId,
+      uri: connectionUri,
+      database: currentDb,
+      mongoshPath,
+      script,
+    });
+    appendCommandOutput(output);
+    setTab('console');
+    return true;
+  };
+
   // The shell's current collection context for AI-generated commands.
   const aiCollection = collectionName ?? 'collection';
 
@@ -956,7 +977,9 @@ export const MongoShell: React.FC<MongoShellProps> = ({
         setTab('console');
         return;
       }
-      const ranExternally = await runExternalMongoshCommand(raw);
+      const ranExternally = raw.includes('\n')
+        ? await runMongoshScriptOnce(raw)
+        : await runExternalMongoshCommand(raw);
       // Whatever follows — a driver call for a recognised command, or nothing —
       // is not something Stop can end. Read live: Stop may have been pressed,
       // and `stopRequested` must not be lost by overwriting the record.

--- a/src/components/__tests__/MongoShell.test.tsx
+++ b/src/components/__tests__/MongoShell.test.tsx
@@ -85,6 +85,9 @@ describe('MongoShell Component', () => {
       if (cmd === 'run_mongosh_command') {
         return Promise.resolve({ stdout: ['mongosh result'], stderr: [] });
       }
+      if (cmd === 'run_mongosh_script') {
+        return Promise.resolve({ stdout: ['script result'], stderr: [] });
+      }
       if (cmd === 'stop_mongosh_session') {
         return Promise.resolve();
       }
@@ -141,6 +144,67 @@ describe('MongoShell Component', () => {
       limit: 50,
       skip: 0,
     }));
+  });
+
+  it('runs a multi-line script one-shot in JavaScript mode, not down the warm session', async () => {
+    // A pasted script is a program, not a typed command. Feeding it to the REPL
+    // a line at a time is what made big scripts — especially ones that call
+    // quit() — unpredictable, so a multi-line run goes to `run_mongosh_script`,
+    // which executes it as one `mongosh --file` program.
+    render(
+      <MongoShell
+        connectionId="conn-1"
+        connectionName="mock"
+        connectionUri="mongodb://prod-replica-set"
+        databaseName="sales_db"
+      />
+    );
+    await screen.findByText(/mongosh session attached/);
+
+    const script = 'print("one")\nprint("two")\nquit(0)';
+    fireEvent.change(screen.getByLabelText('mongosh editor'), { target: { value: script } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+
+    await waitFor(() => {
+      expect(mockInvoke.mock.calls.some((c) => c[0] === 'run_mongosh_script')).toBe(true);
+    });
+    const call = mockInvoke.mock.calls.find((c) => c[0] === 'run_mongosh_script');
+    expect(call?.[1]).toMatchObject({
+      connectionId: 'conn-1',
+      uri: 'mongodb://prod-replica-set',
+      database: 'sales_db',
+      mongoshPath: '/usr/local/bin/mongosh',
+      script,
+    });
+    // The warm session never saw the script.
+    expect(
+      mockInvoke.mock.calls.some(
+        (c) => c[0] === 'run_mongosh_command' && String(c[1]?.command ?? '').includes('print')
+      )
+    ).toBe(false);
+    expect(await screen.findByText('script result')).toBeInTheDocument();
+  });
+
+  it('keeps a single typed command on the warm session', async () => {
+    render(
+      <MongoShell
+        connectionId="conn-1"
+        connectionName="mock"
+        connectionUri="mongodb://prod-replica-set"
+        databaseName="sales_db"
+      />
+    );
+    await screen.findByText(/mongosh session attached/);
+
+    fireEvent.change(screen.getByLabelText('mongosh editor'), { target: { value: 'db.stats()' } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+
+    await waitFor(() => {
+      expect(
+        mockInvoke.mock.calls.some((c) => c[0] === 'run_mongosh_command' && c[1]?.command === 'db.stats()')
+      ).toBe(true);
+    });
+    expect(mockInvoke.mock.calls.some((c) => c[0] === 'run_mongosh_script')).toBe(false);
   });
 
   it('runs edited shell command and renders returned documents', async () => {
@@ -239,7 +303,7 @@ describe('MongoShell Component', () => {
     expect(toggle).not.toHaveTextContent('KI');
   });
 
-  it('runs a multi-statement JS script through the mongosh session', async () => {
+  it('runs a multi-statement JS script one-shot, not down the warm session', async () => {
     render(
       <MongoShell
         connectionId="conn-1"
@@ -260,12 +324,14 @@ describe('MongoShell Component', () => {
 
     await waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith(
-        'run_mongosh_command',
+        'run_mongosh_script',
         // runCommand strips a single trailing semicolon.
-        expect.objectContaining({ command: 'const n = 2;\nprintjson(n)' })
+        expect.objectContaining({ script: 'const n = 2;\nprintjson(n)' })
       );
     });
-    // A script does NOT go through the typed find path.
+    // A multi-line script never touches the warm REPL session...
+    expect(mockInvoke.mock.calls.some((c) => c[0] === 'run_mongosh_command')).toBe(false);
+    // ...nor the typed find path.
     const findCalls = mockInvoke.mock.calls.filter((c) => c[0] === 'execute_mql_query');
     expect(findCalls.length).toBe(0);
   });


### PR DESCRIPTION
## The problem

A pasted script still timed out unpredictably even after the REPL reliability work. The cause is that the shell drives mongosh as an interactive REPL (`mongosh --quiet <uri>` with piped stdin) and feeds a script in a line at a time. A diagnostic script is a **program**, not a sequence of typed commands, and this one even calls `quit(0)`.

I reproduced it against the bundled mongosh 2.9.2 with no server (`--nodb`):

| Same script, `quit(0)` in the middle | Result |
|---|---|
| REPL mode (what the shell does) | prints up to `quit`, the process exits, everything after — including our completion marker — is swallowed |
| `mongosh --file` (JavaScript mode) | runs top to bottom, `quit(0)` is normal, exits clean |

In the REPL, `quit()` tears the session down before the marker returns, so the read loop hits end-of-file and the app reports `mongosh session closed`. That is the "timeout" in the screenshots. It is not slow, it is dead. An unclosed brace in a partial paste produces the same class of failure.

## The fix

A multi-line run now executes as one non-interactive `mongosh --file` program through a new backend command, `run_mongosh_script`:

- Parsed and run as a unit, so an unclosed brace is one reported error, not a hang.
- `quit()` / `exit()` just end the run.
- `use`, `show collections` and the other shell helpers work (verified: they only failed under `--nodb` with a "No connected database" runtime error, not a syntax error).
- A syntax error or a throw is reported once; a non-zero exit is surfaced as an error line.
- None of the marker / `.break` / prompt machinery is involved.

It is one-shot, so it does not need the warm session. The one piece of state that matters in practice, the current database, is passed in and applied with a leading `use`, so `db` still points where the tab expects. The script itself may `use` elsewhere.

**Single typed commands stay on the warm REPL session**, so interactive use keeps its state (a `var` or `use` carries to the next line) and its speed (no per-command process spawn). The routing is simply: input spanning more than one line runs one-shot; a single line stays on the session.

## Tradeoff

A variable defined interactively is not visible to a one-shot script run, and vice versa. This is inherent to running a script as its own program and matches how a script is meant to behave. The current database is preserved across the boundary; ad-hoc cross-run variables are not.

## Known follow-up

Stop does not interrupt a one-shot script yet — Stop restarts the warm session, which a `--file` run does not use. A script now runs to completion and exits on its own rather than hanging, so this is far less pressing than before, but killing the child for a genuinely long script is worth a follow-up.

## Tests

`MongoShell.test.tsx`: a multi-line script routes to `run_mongosh_script` with the connection, uri, current database and script, and never touches the warm session or the typed-find path; a single typed command stays on `run_mongosh_command`. Both mutation-checked. The backend command is classified as a guarded write in `command_coverage.rs`.

Full suite: the same 5 pre-existing environment-dependent failures as clean `dev` on this machine; they pass in CI.

**Not yet exercised in the running app.** The one-shot mechanism is proven against the identical mongosh binary and the exact command line the backend builds, but the editor-to-console path in the app is unverified.
