### PR TITLE
fix(connections): keep the auth database and mechanism when reopening a connection

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -286,12 +286,6 @@ export const parseUriIntoFields = (uri: string) => {
     const insecure = /(?:^|&)tlsInsecure=true/i.test(query);
     tlsAllowInvalidCerts = insecure || /(?:^|&)tlsAllowInvalidCertificates=true/i.test(query);
     tlsAllowInvalidHosts = insecure || /(?:^|&)tlsAllowInvalidHostnames=true/i.test(query);
-    // `$external` is not a database the user picks; it is what the external
-    // mechanisms authenticate against, and buildUri writes it from the
-    // mechanism rather than from this field. An absent authSource means the
-    // default, which is what buildUri omits it for.
-    const authSource = param('authSource');
-    if (authSource && authSource !== '$external') authDb = authSource;
     // The inverse of the mechanism buildUri writes. Without this a saved
     // SCRAM-SHA-1 or X.509 connection reopened as SCRAM-SHA-256.
     const mechanisms: Record<string, string> = {
@@ -307,6 +301,26 @@ export const parseUriIntoFields = (uri: string) => {
     // X.509 carries no username, so the mechanism alone decides there.
     if (mechanism) authMethod = mechanism;
     else if (authUser) authMethod = 'scram-256';
+    // `$external` is not a database the user picks; it is what the external
+    // mechanisms authenticate against, and buildUri writes it from the
+    // mechanism rather than from this field.
+    const authSource = param('authSource');
+    if (authSource && authSource !== '$external') {
+      authDb = authSource;
+    } else if (!authSource && (authMethod === 'scram-1' || authMethod === 'scram-256')) {
+      // With no authSource, MongoDB authenticates against the path database
+      // and only falls back to admin when the path is empty — the same rule
+      // the backend applies in `strip_path_database`. Reporting admin here
+      // named a database the connection was not using, and left editing the
+      // default database silently moving where authentication happens.
+      let pathDb = defaultDb;
+      try {
+        pathDb = decodeURIComponent(defaultDb);
+      } catch {
+        // A malformed escape is left as written rather than failing the parse.
+      }
+      if (pathDb) authDb = pathDb;
+    }
     // Split on the first colon only: the key never contains one, the value may.
     for (const entry of (param('authMechanismProperties') || '').split(',')) {
       const at = entry.indexOf(':');

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -429,8 +429,18 @@ export const buildUri = (s: typeof BLANK_CONN) => {
     // it already matches that: dropping an explicit `admin` beside a path
     // database moved authentication onto that database on the next save
     // (#349 review).
-    const implied = s.defaultDb || 'admin';
-    if (s.authDb !== implied) params.push(`authSource=${s.authDb}`);
+    // The path is compared decoded, because that is the form the auth database
+    // is held in, and the value is written back encoded: an unescaped `&` in a
+    // database name would start another query option and change what the URI
+    // means (#349 review).
+    let pathDb = s.defaultDb;
+    try {
+      pathDb = decodeURIComponent(s.defaultDb);
+    } catch {
+      // A malformed escape compares as written.
+    }
+    const implied = pathDb || 'admin';
+    if (s.authDb !== implied) params.push(`authSource=${encodeURIComponent(s.authDb)}`);
   }
   // Mechanism-specific properties (M5).
   if (s.authMethod === 'aws' && s.awsSessionToken) {

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -244,7 +244,12 @@ export const summarizeConnectionError = (raw: string): ConnectionErrorSummary =>
 // Used both when editing a saved profile and when importing a pasted URI.
 export const parseUriIntoFields = (uri: string) => {
   const isSrv = /^mongodb\+srv:\/\//i.test(uri);
-  const m = uri.match(/mongodb(?:\+srv)?:\/\/(?:([^:@]+):([^@]*)@)?([^/?]+)(?:\/([^?]*))?(?:\?(.*))?/i);
+  // The password is optional: X.509 and Kerberos authenticate without one and
+  // buildUri emits username-only userinfo for them, which a credentials group
+  // requiring a colon read as part of the hostname. Excluding `/` and `?` from
+  // the username keeps a query string containing `@` from being mistaken for
+  // credentials now that the colon is no longer required (#349 review).
+  const m = uri.match(/mongodb(?:\+srv)?:\/\/(?:([^:@/?]+)(?::([^@/?]*))?@)?([^/?]+)(?:\/([^?]*))?(?:\?(.*))?/i);
   let authUser = '';
   let authPass = '';
   let hostStr = isSrv ? 'localhost' : 'localhost:27017';
@@ -418,8 +423,14 @@ export const buildUri = (s: typeof BLANK_CONN) => {
   const isExternalAuth = ['x509', 'aws', 'kerberos', 'ldap'].includes(s.authMethod);
   if (isExternalAuth) {
     params.push('authSource=$external');
-  } else if (s.authMethod !== 'none' && s.authDb && s.authDb !== 'admin') {
-    params.push(`authSource=${s.authDb}`);
+  } else if (s.authMethod !== 'none' && s.authDb) {
+    // With authSource omitted MongoDB authenticates against the path database,
+    // or admin when there is no path. So the parameter is redundant only when
+    // it already matches that: dropping an explicit `admin` beside a path
+    // database moved authentication onto that database on the next save
+    // (#349 review).
+    const implied = s.defaultDb || 'admin';
+    if (s.authDb !== implied) params.push(`authSource=${s.authDb}`);
   }
   // Mechanism-specific properties (M5).
   if (s.authMethod === 'aws' && s.awsSessionToken) {

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -255,6 +255,14 @@ export const parseUriIntoFields = (uri: string) => {
   let tlsAllowInvalidCerts = false;
   let tlsAllowInvalidHosts = false;
   let authMethod = 'none';
+  // Auth settings default to what a blank form would hold. Everything the
+  // editor rebuilds from a saved URI has to be read back here: a field left
+  // unparsed silently reverts to the blank default when a saved connection is
+  // reopened, which is how a non-admin auth database came back as `admin` and
+  // quietly changed the authSource the connection used (#349).
+  let authDb = 'admin';
+  let awsSessionToken = '';
+  let kerberosServiceName = '';
   let query = '';
   if (m) {
     authUser = m[1] ? decodeURIComponent(m[1]) : '';
@@ -278,7 +286,36 @@ export const parseUriIntoFields = (uri: string) => {
     const insecure = /(?:^|&)tlsInsecure=true/i.test(query);
     tlsAllowInvalidCerts = insecure || /(?:^|&)tlsAllowInvalidCertificates=true/i.test(query);
     tlsAllowInvalidHosts = insecure || /(?:^|&)tlsAllowInvalidHostnames=true/i.test(query);
-    if (authUser) authMethod = 'scram-256';
+    // `$external` is not a database the user picks; it is what the external
+    // mechanisms authenticate against, and buildUri writes it from the
+    // mechanism rather than from this field. An absent authSource means the
+    // default, which is what buildUri omits it for.
+    const authSource = param('authSource');
+    if (authSource && authSource !== '$external') authDb = authSource;
+    // The inverse of the mechanism buildUri writes. Without this a saved
+    // SCRAM-SHA-1 or X.509 connection reopened as SCRAM-SHA-256.
+    const mechanisms: Record<string, string> = {
+      'SCRAM-SHA-1': 'scram-1',
+      'SCRAM-SHA-256': 'scram-256',
+      'MONGODB-X509': 'x509',
+      'MONGODB-AWS': 'aws',
+      GSSAPI: 'kerberos',
+      PLAIN: 'ldap',
+    };
+    const mechanism = mechanisms[(param('authMechanism') || '').toUpperCase()];
+    // A URI with credentials and no mechanism is SCRAM, the server default.
+    // X.509 carries no username, so the mechanism alone decides there.
+    if (mechanism) authMethod = mechanism;
+    else if (authUser) authMethod = 'scram-256';
+    // Split on the first colon only: the key never contains one, the value may.
+    for (const entry of (param('authMechanismProperties') || '').split(',')) {
+      const at = entry.indexOf(':');
+      if (at < 0) continue;
+      const key = entry.slice(0, at).trim().toUpperCase();
+      const value = entry.slice(at + 1);
+      if (key === 'AWS_SESSION_TOKEN') awsSessionToken = value;
+      else if (key === 'SERVICE_NAME') kerberosServiceName = value;
+    }
   }
   const hosts = hostStr.split(',').map((h) => {
     const [host, port] = h.split(':');
@@ -299,6 +336,9 @@ export const parseUriIntoFields = (uri: string) => {
     authUser,
     authPass,
     authMethod,
+    authDb,
+    awsSessionToken,
+    kerberosServiceName,
     tlsMode,
     tlsCa,
     tlsClientCert,

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -140,9 +140,27 @@ describe('parseUriIntoFields (import → form)', () => {
     expect(f.authMethod).toBe('scram-256');
   });
 
-  it('falls back to admin only when the URI carries no authSource', () => {
+  it('reads the auth database from the path when no authSource is given', () => {
+    // MongoDB authenticates against the path database when authSource is
+    // absent, so reporting `admin` would name a database this connection
+    // does not use. The backend applies the same rule in strip_path_database.
     const f = parseUriIntoFields('mongodb://alice:pw@h:27017/shop');
-    expect(f.authDb).toBe('admin');
+    expect(f.authDb).toBe('shop');
+  });
+
+  it('prefers an explicit authSource over the path database', () => {
+    const f = parseUriIntoFields('mongodb://alice:pw@h:27017/shop?authSource=reporting');
+    expect(f.authDb).toBe('reporting');
+  });
+
+  it('falls back to admin when there is no authSource and no path database', () => {
+    expect(parseUriIntoFields('mongodb://alice:pw@h:27017').authDb).toBe('admin');
+    expect(parseUriIntoFields('mongodb://alice:pw@h:27017/').authDb).toBe('admin');
+  });
+
+  it('decodes a percent-encoded path database before using it as the auth source', () => {
+    const f = parseUriIntoFields('mongodb://alice:pw@h:27017/my%20db');
+    expect(f.authDb).toBe('my db');
   });
 
   it('does not put $external in the auth database field', () => {

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -189,6 +189,22 @@ describe('parseUriIntoFields (import → form)', () => {
     expect(krb.kerberosServiceName).toBe('mongodb');
   });
 
+  it('reads username-only credentials for a passwordless mechanism', () => {
+    // buildUri emits `user@host` for X.509 and Kerberos; a credentials group
+    // requiring a colon swallowed the principal into the hostname instead.
+    const f = parseUriIntoFields('mongodb://user%40REALM@kdc.example.com:27017/?authMechanism=GSSAPI');
+    expect(f.authUser).toBe('user@REALM');
+    expect(f.authPass).toBe('');
+    expect(f.authMethod).toBe('kerberos');
+    expect(f.hosts).toEqual([{ host: 'kdc.example.com', port: '27017' }]);
+  });
+
+  it('does not mistake an @ in the query string for credentials', () => {
+    const f = parseUriIntoFields('mongodb://h:27017/db?appName=a@b');
+    expect(f.authUser).toBe('');
+    expect(f.hosts).toEqual([{ host: 'h', port: '27017' }]);
+  });
+
   it('splits multiple hosts and detects a replica set (with its name)', () => {
     const f = parseUriIntoFields('mongodb://h1:27017,h2:27017,h3:27017/?replicaSet=rs0');
     expect(f.hosts).toEqual([
@@ -283,6 +299,47 @@ describe('saving a connection and reopening it keeps its auth settings (#349)', 
     });
     expect(reopened.authMethod).toBe('scram-1');
     expect(reopened.authDb).toBe('reporting');
+  });
+
+  it('keeps an explicit admin auth source when the default database differs', () => {
+    // Omitting it here would hand authentication to the path database on the
+    // next save, while the form still showed admin.
+    const uri = buildUri({
+      ...baseConn,
+      authMethod: 'scram-256',
+      authUser: 'alice',
+      authPass: 'pw',
+      authDb: 'admin',
+      defaultDb: 'shop',
+    });
+    expect(uri).toContain('authSource=admin');
+    expect(parseUriIntoFields(uri).authDb).toBe('admin');
+  });
+
+  it('omits authSource when it would only repeat the path database', () => {
+    const uri = buildUri({
+      ...baseConn,
+      authMethod: 'scram-256',
+      authUser: 'alice',
+      authPass: 'pw',
+      authDb: 'shop',
+      defaultDb: 'shop',
+    });
+    expect(uri).not.toContain('authSource');
+    expect(parseUriIntoFields(uri).authDb).toBe('shop');
+  });
+
+  it('keeps a Kerberos principal and its service name', () => {
+    const uri = buildUri({
+      ...baseConn,
+      authMethod: 'kerberos',
+      authUser: 'user@REALM',
+      kerberosServiceName: 'mongodb',
+    });
+    const reopened = parseUriIntoFields(uri);
+    expect(reopened.authUser).toBe('user@REALM');
+    expect(reopened.authMethod).toBe('kerberos');
+    expect(reopened.kerberosServiceName).toBe('mongodb');
   });
 
   it('leaves an admin auth database as admin', () => {

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -129,6 +129,48 @@ describe('parseUriIntoFields (import → form)', () => {
     expect(f.topology).toBe('standalone');
   });
 
+  it('keeps a non-admin auth database instead of resetting it to admin (#349)', () => {
+    // Reported bug: a SCRAM connection saved with its own authSource came back
+    // showing `admin`, silently changing the authSource the connection used.
+    const f = parseUriIntoFields(
+      'mongodb://appuser:pw@db.example.com:27017/?authSource=reporting&authMechanism=SCRAM-SHA-256'
+    );
+    expect(f.authDb).toBe('reporting');
+    expect(f.authUser).toBe('appuser');
+    expect(f.authMethod).toBe('scram-256');
+  });
+
+  it('falls back to admin only when the URI carries no authSource', () => {
+    const f = parseUriIntoFields('mongodb://alice:pw@h:27017/shop');
+    expect(f.authDb).toBe('admin');
+  });
+
+  it('does not put $external in the auth database field', () => {
+    // buildUri writes $external from the mechanism, not from this field, so
+    // showing it as the auth database would be wrong on the way back.
+    const f = parseUriIntoFields('mongodb://h:27017/?authMechanism=MONGODB-X509&authSource=$external');
+    expect(f.authDb).toBe('admin');
+    expect(f.authMethod).toBe('x509');
+  });
+
+  it('restores the saved auth mechanism rather than assuming SCRAM-SHA-256', () => {
+    expect(parseUriIntoFields('mongodb://u:p@h/?authMechanism=SCRAM-SHA-1').authMethod).toBe('scram-1');
+    expect(parseUriIntoFields('mongodb://u:p@h/?authMechanism=PLAIN').authMethod).toBe('ldap');
+    expect(parseUriIntoFields('mongodb://u:p@h/?authMechanism=GSSAPI').authMethod).toBe('kerberos');
+    expect(parseUriIntoFields('mongodb://u:p@h/?authMechanism=MONGODB-AWS').authMethod).toBe('aws');
+  });
+
+  it('restores the mechanism properties that go with AWS and Kerberos', () => {
+    const aws = parseUriIntoFields(
+      'mongodb://k:s@h/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Atok%3An'
+    );
+    expect(aws.awsSessionToken).toBe('tok:n');
+    const krb = parseUriIntoFields(
+      'mongodb://u@h/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME%3Amongodb'
+    );
+    expect(krb.kerberosServiceName).toBe('mongodb');
+  });
+
   it('splits multiple hosts and detects a replica set (with its name)', () => {
     const f = parseUriIntoFields('mongodb://h1:27017,h2:27017,h3:27017/?replicaSet=rs0');
     expect(f.hosts).toEqual([
@@ -193,6 +235,46 @@ describe('parseUriIntoFields (import → form)', () => {
     const uri = buildUri({ ...baseConn, ...f, authPass: f.authPass });
     expect(uri).toContain('db.example.com:27018');
     expect(uri).toContain('alice');
+  });
+});
+
+describe('saving a connection and reopening it keeps its auth settings (#349)', () => {
+  // The editor rebuilds its fields from the saved URI, so the round trip is
+  // the behaviour that matters: what the user typed has to survive save →
+  // reopen. It did not — a non-admin auth database came back as `admin`.
+  const roundTrip = (state: Record<string, unknown>) =>
+    parseUriIntoFields(buildUri({ ...baseConn, ...state }));
+
+  it('keeps the auth database the user typed', () => {
+    const reopened = roundTrip({
+      authMethod: 'scram-256',
+      authUser: 'adtimabox_cshub_ab_internal_stg',
+      authPass: 'pw',
+      authDb: 'adtimabox_cshub_ab_internal_stg',
+    });
+    expect(reopened.authDb).toBe('adtimabox_cshub_ab_internal_stg');
+    expect(reopened.authUser).toBe('adtimabox_cshub_ab_internal_stg');
+  });
+
+  it('keeps a non-default auth mechanism', () => {
+    const reopened = roundTrip({
+      authMethod: 'scram-1',
+      authUser: 'alice',
+      authPass: 'pw',
+      authDb: 'reporting',
+    });
+    expect(reopened.authMethod).toBe('scram-1');
+    expect(reopened.authDb).toBe('reporting');
+  });
+
+  it('leaves an admin auth database as admin', () => {
+    const reopened = roundTrip({
+      authMethod: 'scram-256',
+      authUser: 'alice',
+      authPass: 'pw',
+      authDb: 'admin',
+    });
+    expect(reopened.authDb).toBe('admin');
   });
 });
 

--- a/src/components/__tests__/ConnectionManager.test.tsx
+++ b/src/components/__tests__/ConnectionManager.test.tsx
@@ -342,6 +342,31 @@ describe('saving a connection and reopening it keeps its auth settings (#349)', 
     expect(reopened.kerberosServiceName).toBe('mongodb');
   });
 
+  it('treats an encoded path database and its decoded auth source as one database', () => {
+    // The path keeps its escapes while the auth database is held decoded, so
+    // comparing them raw called the same database different and emitted a raw
+    // `&` that started another query option.
+    const parsed = parseUriIntoFields('mongodb://u:p@h:27017/sales%26ops');
+    expect(parsed.authDb).toBe('sales&ops');
+    const uri = buildUri({ ...baseConn, ...parsed });
+    expect(uri).not.toContain('authSource');
+    expect(uri).toContain('/sales%26ops');
+    expect(parseUriIntoFields(uri).authDb).toBe('sales&ops');
+  });
+
+  it('percent-encodes an auth source that needs it', () => {
+    const uri = buildUri({
+      ...baseConn,
+      authMethod: 'scram-256',
+      authUser: 'alice',
+      authPass: 'pw',
+      authDb: 'sales&ops',
+      defaultDb: 'shop',
+    });
+    expect(uri).toContain('authSource=sales%26ops');
+    expect(parseUriIntoFields(uri).authDb).toBe('sales&ops');
+  });
+
   it('leaves an admin auth database as admin', () => {
     const reopened = roundTrip({
       authMethod: 'scram-256',


### PR DESCRIPTION
Closes #349.

## What was happening

The connection editor rebuilds its fields from the saved URI. `parseUriIntoFields` never read any of the auth query parameters, so on reopen those fields fell through to the blank form's defaults:

```ts
setEditorState({
  ...BLANK_CONN,   // authDb: 'admin'
  uri: profile.uri,
  ...parsed,       // no authDb, no authMethod from the URI
});
```

`BLANK_CONN.authDb` is `'admin'`, so a connection saved with `authSource=adtimabox_cshub_ab_internal_stg` reopened showing `admin`. Saving again wrote the URI without the authSource, which is what silently changed the authSource the connection actually used — the failure mode the issue describes.

## The same bug, one field over

While confirming the cause I found the mechanism has it too. The parser ended with:

```ts
if (authUser) authMethod = 'scram-256';
```

So a saved SCRAM-SHA-1, X.509, AWS, Kerberos or LDAP connection reopened as SCRAM-SHA-256, and an X.509 connection (which carries no username) reopened as "no auth". Fixing only the auth database would have left the reporter hitting this on the very next save, so both are fixed here — it is one function failing to read one block of parameters.

## The fix

`parseUriIntoFields` now reads the auth block back:

| URI | Field |
|---|---|
| `authSource=<db>` | Authentication Database |
| `authMechanism=...` | Auth method (the inverse of what `buildUri` writes) |
| `authMechanismProperties=AWS_SESSION_TOKEN:...` | AWS session token |
| `authMechanismProperties=SERVICE_NAME:...` | Kerberos service name |

Two deliberate choices:

- **`authSource=$external` does not become the auth database.** It belongs to the external mechanisms, `buildUri` writes it from the mechanism rather than from that field, and the field is only shown for SCRAM. It stays at the default.
- **An absent `authSource` means `admin`.** That is exactly the case `buildUri` omits the parameter for, so the round trip is stable.

Because `parseUriIntoFields` also backs the "Parse URI" button and the import path, both now pick up auth settings from a pasted URI as well.

## Tests

`ConnectionManager.test.tsx`:
- Parse-level: a non-admin authSource is kept; an absent one falls back to `admin`; `$external` is not shown as the auth database; each mechanism maps back; AWS and Kerberos properties are restored.
- Round-trip (`buildUri` → `parseUriIntoFields`), which is the behaviour the user sees: the reported username/auth-database pair survives save and reopen, a non-default mechanism survives, and `admin` stays `admin`.

Mutation-checked: dropping the authSource read fails three tests including the reported case (`expected 'admin' to be 'adtimabox_cshub_ab_internal_stg'`); dropping the mechanism map and the properties parsing each fail their own.

Full suite: the same 5 pre-existing environment-dependent failures as clean `dev` on this machine; they pass in CI.

## An omitted authSource follows the path database

Raised in review and fixed here. With no authSource in the URI, MongoDB authenticates against the path database and only falls back to admin when the path is empty — the rule the backend already documents and applies in `strip_path_database`. The editor reported `admin` regardless, so a connection saved as `.../shop` reopened naming a database it does not authenticate against, and editing the Default Database then moved authentication while the Auth tab still read `admin`.

The parser now applies the same rule: an explicit `authSource` wins; otherwise a SCRAM connection takes its decoded path database; `admin` remains the fallback only when there is no path. External mechanisms are unaffected — buildUri always writes an explicit `$external` for them.
