### PR TITLE
fix(mcp): keep the server enabled, on its port, with its token across restarts

### DIFF
--- a/src-tauri/src/biometric.rs
+++ b/src-tauri/src/biometric.rs
@@ -122,6 +122,9 @@ pub async fn biometric_unlock(
         Ok(key) => {
             *state.vault_key.lock_safe()? = Some(key);
             let _ = crate::audit::open_on_unlock(&app, &state, key);
+            // Same restore as the password path: unlocking by fingerprint must
+            // not leave the MCP server down when the user left it on (#350).
+            crate::mcp::restore_on_unlock(&state, app).await;
             Ok(connections::VaultStatus::Unlocked)
         }
         Err(e) => {

--- a/src-tauri/src/connections.rs
+++ b/src-tauri/src/connections.rs
@@ -197,11 +197,36 @@ pub struct AppSettings {
     // UI appearance: theme preset, fonts, font size, spacing density.
     #[serde(default)]
     pub appearance: AppearanceSettings,
+    /// Whether the embedded MCP server should be running (#350).
+    ///
+    /// The server itself needs the vault key, so it cannot come up before the
+    /// vault is unlocked; this records the user's intent and the unlock path
+    /// acts on it. Without it the server came back disabled on every launch.
+    #[serde(default)]
+    pub mcp_enabled: bool,
+    /// The port the MCP server was last enabled on.
+    #[serde(default = "default_mcp_port")]
+    pub mcp_port: u16,
+    /// The bearer token external MCP clients authenticate with.
+    ///
+    /// Kept across restarts so a configured client keeps working: minting a
+    /// fresh one on every enable meant every client had to be reconfigured
+    /// after each launch (#350). Only "Regenerate" replaces it. Encrypted at
+    /// rest with the rest of this file, like the AI provider keys above.
+    #[serde(default)]
+    pub mcp_token: String,
+}
+
+fn default_mcp_port() -> u16 {
+    crate::mcp::DEFAULT_PORT
 }
 
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
+            mcp_enabled: false,
+            mcp_port: default_mcp_port(),
+            mcp_token: String::new(),
             mongosh_path: String::new(),
             locale: default_locale(),
             ai_provider: default_ai_provider(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3039,6 +3039,9 @@ async fn vault_unlock(
     let key = connections::unlock_key(&meta, &password)?;
     *state.vault_key.lock_safe()? = Some(key);
     let _ = audit::open_on_unlock(&app_handle, &state, key);
+    // The MCP server needs the key, so this is the first moment it can come
+    // back up. Best-effort by design — see `restore_on_unlock` (#350).
+    mcp::restore_on_unlock(&state, app_handle).await;
     Ok(connections::VaultStatus::Unlocked)
 }
 
@@ -3300,8 +3303,11 @@ async fn mcp_resolve_write(
 }
 
 #[tauri::command]
-async fn mcp_regenerate_token(state: tauri::State<'_, AppState>) -> Result<mcp::McpStatusUi, String> {
-    mcp::regenerate_token_impl(&state)
+async fn mcp_regenerate_token(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<mcp::McpStatusUi, String> {
+    mcp::regenerate_token_impl(&state, Some(&app_handle))
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -168,6 +168,22 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
+/// The token a server being enabled should serve.
+///
+/// The stored one when there is one, so the MCP clients the user has already
+/// configured keep authenticating across a restart; a fresh one only when
+/// there is nothing to carry forward. Minting on every enable is what made a
+/// restart silently invalidate every client's configuration (#350) — rotating
+/// the credential is now something the user asks for explicitly, via
+/// "Regenerate".
+pub(crate) fn token_for_enable(stored: &str) -> String {
+    if stored.is_empty() {
+        new_token()
+    } else {
+        stored.to_string()
+    }
+}
+
 /// Fresh 32-byte bearer token, base64url-encoded without padding (spec:
 /// "fresh 32-byte base64url bearer token minted on every enable").
 fn new_token() -> String {
@@ -206,6 +222,66 @@ pub fn get_status_impl(state: &AppState) -> Result<McpStatusUi, String> {
     Ok(status_from(&control))
 }
 
+/// The part of the MCP server's state that outlives the process, read and
+/// written as a unit. It lives in the encrypted settings file, so the token is
+/// protected at rest by the same key as the connection profiles (#350).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct McpPersisted {
+    pub enabled: bool,
+    pub port: u16,
+    pub token: String,
+}
+
+impl Default for McpPersisted {
+    fn default() -> Self {
+        Self { enabled: false, port: DEFAULT_PORT, token: String::new() }
+    }
+}
+
+/// Never fails the caller: a missing or unreadable settings file simply means
+/// "nothing persisted yet", which is the same thing a first run looks like.
+pub fn load_persisted(state: &AppState, app_handle: &tauri::AppHandle) -> McpPersisted {
+    let Ok(key) = state.require_key() else { return McpPersisted::default() };
+    let path = crate::connections::get_settings_enc_path(app_handle);
+    match crate::connections::load_settings_encrypted(&path, &key) {
+        Ok(s) => McpPersisted { enabled: s.mcp_enabled, port: s.mcp_port, token: s.mcp_token },
+        Err(_) => McpPersisted::default(),
+    }
+}
+
+/// Merge the MCP fields into the stored settings under the same in-process and
+/// cross-process write locks `patch_app_settings` uses, so a settings edit in
+/// another window (or another MQLens) cannot lose this write, or be lost by it.
+pub fn save_persisted(
+    state: &AppState,
+    app_handle: &tauri::AppHandle,
+    next: &McpPersisted,
+) -> Result<(), String> {
+    let key = state.require_key()?;
+    let path = crate::connections::get_settings_enc_path(app_handle);
+    let _guard = state.settings_write.lock().map_err(|e| e.to_string())?;
+    let _file_lock = crate::connections::lock_settings_for_write(&path)?;
+    let mut settings = crate::connections::load_settings_encrypted(&path, &key)?;
+    settings.mcp_enabled = next.enabled;
+    settings.mcp_port = next.port;
+    settings.mcp_token = next.token.clone();
+    crate::connections::save_settings_encrypted(&path, &key, &settings)
+}
+
+/// Bring the server back up after the vault is unlocked, if it was left
+/// enabled. Deliberately best-effort: a port that something else has taken
+/// since the last run must not stop the user from unlocking their vault, and
+/// the settings still say "enabled" so the UI reports what it finds.
+pub async fn restore_on_unlock(state: &AppState, app_handle: tauri::AppHandle) {
+    let persisted = load_persisted(state, &app_handle);
+    if !persisted.enabled || persisted.token.is_empty() {
+        return;
+    }
+    // `set_enabled_impl` picks the stored token back up, so the server comes
+    // up on the same credentials the user's clients are already configured with.
+    let _ = set_enabled_impl(state, true, Some(persisted.port), Some(app_handle)).await;
+}
+
 /// Enable or disable the embedded server.
 ///
 /// Enabling requires the vault to be unlocked (`state.require_key()` — its
@@ -242,6 +318,15 @@ pub async fn set_enabled_impl(
 ) -> Result<McpStatusUi, String> {
     if !enabled {
         stop_if_running(state).await?;
+        if let Some(app) = &app_handle {
+            // The token is deliberately kept: switching the server off is not
+            // the same as rotating the credential, and re-enabling should not
+            // invalidate every client the user has configured (#350). Only
+            // "Regenerate" replaces it.
+            let mut persisted = load_persisted(state, app);
+            persisted.enabled = false;
+            let _ = save_persisted(state, app, &persisted);
+        }
         return get_status_impl(state);
     }
 
@@ -280,7 +365,15 @@ pub async fn set_enabled_impl(
     // the previous generation's (just-cleared-to-empty, or — pre this fix —
     // stale) value. Storing the token first means the very first request
     // the new task can possibly serve already sees the right one.
-    let token = new_token();
+    // Reuse the stored token when there is one. It used to be minted fresh on
+    // every enable, which meant every restart silently invalidated the token
+    // each configured MCP client was using (#350). The helper token is still
+    // per-start: it never leaves the app, so nothing has to be reconfigured
+    // when it changes.
+    let stored = app_handle.as_ref().map(|app| load_persisted(state, app)).unwrap_or_default();
+    let token = token_for_enable(&stored.token);
+    // Kept for the write below: `token` itself is moved into `McpControl`.
+    let token_for_disk = token.clone();
     let helper_token = new_token();
     {
         let mut control = state.mcp.lock_safe()?;
@@ -289,6 +382,13 @@ pub async fn set_enabled_impl(
         control.token = token;
         // Minted with it and, like it, distinct every time the server starts.
         control.helper_token = helper_token;
+    }
+
+    if let Some(app) = &app_handle {
+        // After the bind succeeded, so a failed enable never records itself as
+        // the state to restore on the next unlock — and before `app_handle` is
+        // handed to the server task below.
+        let _ = save_persisted(state, app, &McpPersisted { enabled: true, port, token: token_for_disk });
     }
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -353,12 +453,25 @@ pub async fn stop_if_running(state: &AppState) -> Result<(), String> {
 /// disabled server can still have a stale token sitting in state from a
 /// previous session, and regenerating it before the next enable is a
 /// reasonable thing for a user to want.
-pub fn regenerate_token_impl(state: &AppState) -> Result<McpStatusUi, String> {
-    let mut control = state.mcp.lock_safe()?;
-    control.token = new_token();
-    // Both, or "regenerate" would leave the older of the two still working.
-    control.helper_token = new_token();
-    Ok(status_from(&control))
+pub fn regenerate_token_impl(
+    state: &AppState,
+    app_handle: Option<&tauri::AppHandle>,
+) -> Result<McpStatusUi, String> {
+    let status = {
+        let mut control = state.mcp.lock_safe()?;
+        control.token = new_token();
+        // Both, or "regenerate" would leave the older of the two still working.
+        control.helper_token = new_token();
+        status_from(&control)
+    };
+    if let Some(app) = app_handle {
+        // Written through, or the next launch would restore the token this call
+        // just replaced — which is the one the user asked to stop honouring.
+        let mut persisted = load_persisted(state, app);
+        persisted.token = status.token.clone();
+        save_persisted(state, app, &persisted)?;
+    }
+    Ok(status)
 }
 
 /// Per-session MCP protocol handler. `rmcp`'s streamable-HTTP service calls
@@ -1277,6 +1390,29 @@ mod tests {
     }
 
     #[test]
+    fn enabling_keeps_the_stored_token_so_configured_clients_still_work() {
+        // The reported bug: every enable minted a new token, so each restart
+        // locked out every MCP client the user had configured (#350).
+        assert_eq!(token_for_enable("already-issued"), "already-issued");
+    }
+
+    #[test]
+    fn a_server_with_no_stored_token_still_gets_a_fresh_one() {
+        let first = token_for_enable("");
+        let second = token_for_enable("");
+        assert!(!first.is_empty(), "a first enable has to mint something");
+        assert_ne!(first, second, "each mint is independent");
+    }
+
+    #[test]
+    fn nothing_persisted_yet_reads_as_a_disabled_server_on_the_default_port() {
+        let fresh = McpPersisted::default();
+        assert!(!fresh.enabled);
+        assert_eq!(fresh.port, DEFAULT_PORT);
+        assert!(fresh.token.is_empty(), "no token means nothing to restore");
+    }
+
+    #[test]
     fn the_audit_summary_carries_no_write_payload() {
         // `summary` is stored verbatim; only `args` passes the payload gate and the
         // redactor. Putting the document or filter in the summary kept and exported
@@ -1868,7 +2004,7 @@ mod tests {
         let status = set_enabled_impl(&state, true, Some(0), None).await.unwrap();
         let original = status.token;
 
-        let regenerated = regenerate_token_impl(&state).unwrap();
+        let regenerated = regenerate_token_impl(&state, None).unwrap();
         assert_ne!(regenerated.token, original);
         assert!(regenerated.enabled, "regenerating must not touch enablement");
 
@@ -1881,9 +2017,9 @@ mod tests {
     #[tokio::test]
     async fn regenerate_token_works_while_disabled() {
         let state = AppState::new();
-        let first = regenerate_token_impl(&state).unwrap();
+        let first = regenerate_token_impl(&state, None).unwrap();
         assert!(!first.token.is_empty());
-        let second = regenerate_token_impl(&state).unwrap();
+        let second = regenerate_token_impl(&state, None).unwrap();
         assert_ne!(first.token, second.token);
         assert!(!second.enabled);
     }
@@ -2050,7 +2186,7 @@ mod tests {
         let mut client = TestClient::new(status.port, &old_token);
         client.initialize().await; // works with the original token
 
-        let regenerated = regenerate_token_impl(&state).unwrap();
+        let regenerated = regenerate_token_impl(&state, None).unwrap();
         assert_ne!(regenerated.token, old_token);
 
         // Same client, same (now-stale) captured token: the *next* request must 401.

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -325,7 +325,14 @@ pub async fn set_enabled_impl(
             // "Regenerate" replaces it.
             let mut persisted = load_persisted(state, app);
             persisted.enabled = false;
-            let _ = save_persisted(state, app, &persisted);
+            // Propagated, unlike the enable path below. The two failures are not
+            // symmetric: an enable that cannot be written down leaves the server
+            // running now and not restored later, which errs towards off. A
+            // disable that cannot be written down stops the listener but leaves
+            // `mcp_enabled = true` on disk, so the next unlock starts the server
+            // again — silently undoing an explicit disable. The user has to be
+            // told that one did not stick (#350 review).
+            save_persisted(state, app, &persisted)?;
         }
         return get_status_impl(state);
     }
@@ -1387,6 +1394,30 @@ mod tests {
             format!("Bearer {token}").parse().unwrap(),
         );
         h
+    }
+
+    #[test]
+    fn a_disable_that_cannot_be_persisted_is_not_reported_as_success() {
+        // Discarding the write here stops the listener but leaves
+        // `mcp_enabled = true` in the settings, so the next unlock starts the
+        // server back up and the user's explicit disable is undone. Checked
+        // against the source, the way `the_audit_summary_carries_no_write_payload`
+        // below does, because the write itself needs a real `AppHandle`.
+        let src = include_str!("mcp.rs");
+        let body = &src[..src.find("\n#[cfg(test)]").unwrap_or(src.len())];
+        let disable = body
+            .split("if !enabled {")
+            .nth(1)
+            .and_then(|s| s.split("return get_status_impl(state);").next())
+            .expect("the disable branch of set_enabled_impl");
+        assert!(
+            disable.contains("save_persisted(state, app, &persisted)?"),
+            "the disable branch must propagate a failed persist"
+        );
+        assert!(
+            !disable.contains("let _ = save_persisted"),
+            "the disable branch discards a failed persist"
+        );
     }
 
     #[test]

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -4060,6 +4060,24 @@ mod tests {
         assert_eq!(legacy.audit_level, "A");
         assert_eq!(legacy.audit_retention_days, 30);
         assert!(!legacy.audit_include_payloads);
+        // A settings file written before #350 has no MCP fields at all; it has
+        // to read as "server off, default port, nothing to restore" rather than
+        // failing to parse.
+        assert!(!legacy.mcp_enabled);
+        assert_eq!(legacy.mcp_port, crate::mcp::DEFAULT_PORT);
+        assert!(legacy.mcp_token.is_empty());
+
+        // And what the MCP panel stores survives a write/read cycle — the whole
+        // point of #350 is that the token outlives the process.
+        let mut with_mcp = AppSettings::default();
+        with_mcp.mcp_enabled = true;
+        with_mcp.mcp_port = 9123;
+        with_mcp.mcp_token = "token-clients-are-configured-with".to_string();
+        let reloaded: AppSettings =
+            serde_json::from_str(&serde_json::to_string(&with_mcp).unwrap()).unwrap();
+        assert!(reloaded.mcp_enabled);
+        assert_eq!(reloaded.mcp_port, 9123);
+        assert_eq!(reloaded.mcp_token, "token-clients-are-configured-with");
 
         // resolve_local_command falls back to built-in defaults when unset.
         assert_eq!(


### PR DESCRIPTION
Closes #350.

## What was happening

`McpControl` lived only in memory (`enabled: false`, empty token at construction), and `set_enabled_impl` minted a fresh token on every enable — the original spec was literally *"fresh 32-byte base64url bearer token minted on every enable"*.

So each restart came back disabled, and enabling again issued a **different** token. Every MCP client the user had configured stopped authenticating and had to be re-pointed at a new token after every launch.

## The fix

The three things that have to outlive the process now live in `AppSettings`, which is already encrypted at rest with the vault key that protects the connection profiles:

| Field | Why |
|---|---|
| `mcp_enabled` | records the user's intent so the server can come back |
| `mcp_port` | the port it was last enabled on |
| `mcp_token` | the credential clients are configured with |

- **Enable** reuses the stored token when there is one (`token_for_enable`), and only mints when there is nothing to carry forward.
- **Disable** records that the server is off but *keeps* the token. Switching the server off is not the same as rotating the credential, so re-enabling does not lock out configured clients.
- **Regenerate** is now the only thing that replaces the token, and it writes through — otherwise the next launch would restore the token the user just asked to stop honouring.
- The write merges into the settings file under the same in-process and cross-process locks `patch_app_settings` uses, so a settings edit in another window or another MQLens cannot lose it, or be lost by it.

## Startup

The server calls `require_key`, so it cannot start before the vault is unlocked. Both unlock paths restore it: `vault_unlock` (password) and `biometric_unlock`. `vault_lock` and `vault_reset` already stop the server and are untouched — they leave the persisted intent alone, so unlocking brings it back.

The restore is deliberately **best-effort**: if the port has been taken by something else since the last run, the user still gets their vault unlocked, and the panel reports what it actually finds.

## Security note

The token is a bearer credential, so it is stored in the encrypted settings file rather than anywhere in plaintext — the same file and key as the AI provider API keys already in `AppSettings`. The helper token (MQLens's own agent) is intentionally **not** persisted: it never leaves the app, so nothing needs reconfiguring when it changes, and keeping it per-start preserves the existing fail-closed behaviour.

## Tests

- `token_for_enable` keeps a stored token, and mints a distinct one when there is none.
- `McpPersisted::default()` reads as "off, default port, nothing to restore".
- Settings back-compat: a settings file written before this change has no MCP fields and must still parse as off / default port / no token, and a round trip preserves all three.

**Not run locally**: the Rust test binary cannot launch on this machine (`STATUS_ENTRYPOINT_NOT_FOUND`, a pre-existing environment problem that has affected every Rust change this cycle), so CI is their first real run. The crate and its test target both compile clean.

**Not verified in the running app** either — the end-to-end check worth doing is: enable MCP, note the token, restart MQLens, unlock, and confirm the panel comes back enabled on the same port with the same token, and that an existing client still authenticates.
