### PR TITLE
fix(mcp): ask for an external client's write wherever the user is

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
 } from './lib/aiChatRequest';
 import { stopChangeStream } from './lib/changeStream';
 import { startWriteRequests } from './lib/mcpWriteRequests';
+import { McpWriteConfirm } from './components/McpWriteConfirm';
 import {
   appendReplyToChat,
   releaseChatsForTab,
@@ -5057,6 +5058,11 @@ function Workspace() {
           />
 
           <UpdatePrompt />
+
+          {/* A write no conversation asked for — an external MCP client's —
+              is confirmed here rather than in a chat panel, which is not on
+              screen when the user is anywhere but a chat (#352 review). */}
+          <McpWriteConfirm />
 
           <ToolSetupDialog
             open={toolSetupOpen}

--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -821,12 +821,16 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     const refresh = () =>
       setWriteRequests(
         writeRequestsWhere((requester: string | null) => {
-          // Nobody in particular: an external client, or two runs at once. Any
-          // window may answer — it is the app asking, not a conversation.
-          if (requester === null) return true;
           // Addressed by conversation, so this holds in whichever window is
           // showing that chat — including one the tab was moved to mid-run.
-          return requester === activeChatIdRef.current;
+          //
+          // Unaddressed requests — an external client, or two runs at once —
+          // are deliberately NOT claimed here. This panel renders nothing while
+          // closed and is unmounted on a tab switch, so a write with no
+          // conversation to belong to had no visible prompt whenever the user
+          // was anywhere else, and could only time out. `McpWriteConfirm`
+          // shows those at the app level instead (#352 review).
+          return requester !== null && requester === activeChatIdRef.current;
         })
       );
     refresh();

--- a/src/components/McpWriteConfirm.tsx
+++ b/src/components/McpWriteConfirm.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ShieldAlert } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  answerWriteRequest,
+  subscribeWriteRequests,
+  writeRequestsWhere,
+} from '../lib/mcpWriteRequests';
+import type { McpWriteRequest } from '../workspace/workspaceStore';
+
+/**
+ * The prompt for a write no conversation asked for.
+ *
+ * Every MCP route confirms its writes in the app, not just MQLens's own agent:
+ * `_confirm` is a boolean the calling agent supplies, so it was never a gate,
+ * and an external client reaching these tools through its own config would
+ * otherwise write with nobody asked. The backend addresses a request to a
+ * conversation only when it can attribute it to one; an external client's
+ * write is addressed to nobody.
+ *
+ * Those unaddressed requests used to be rendered only inside `AIChatPanel`,
+ * which renders nothing while closed and is unmounted entirely on a tab switch.
+ * So a write from an external client while the user was in Settings — or simply
+ * not in a chat — had no visible prompt at all and could only time out, after
+ * the user had already approved it in the client they were working in (#352
+ * review). It is the app being asked, not a conversation, so the app asks.
+ *
+ * Requests that *are* addressed to a conversation stay with that conversation's
+ * panel, where the user can see what led to them.
+ */
+export function McpWriteConfirm() {
+  const { t } = useTranslation('shell');
+  const [requests, setRequests] = useState<McpWriteRequest[]>([]);
+
+  useEffect(() => {
+    const refresh = () =>
+      // Unaddressed only. A request belonging to a conversation is answered in
+      // that conversation's panel, so claiming it here would put one chat's
+      // operation in front of whoever happened to be looking.
+      setRequests(writeRequestsWhere((requester) => requester === null));
+    refresh();
+    return subscribeWriteRequests(refresh);
+  }, []);
+
+  // Oldest first, one at a time: each answer removes it and the next takes its
+  // place, so a burst is worked through rather than stacked.
+  const request = requests[0];
+  if (!request) return null;
+
+  return (
+    <Dialog open onOpenChange={() => {}}>
+      <DialogContent
+        className="sm:max-w-[560px] [&>button.absolute]:hidden"
+        data-testid="mcp-write-confirm"
+        // Neither dismissal is an answer, and silence is a refusal the caller
+        // waits two minutes for. Make the user choose.
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-sm">
+            <ShieldAlert size={16} className="text-destructive" />
+            {t('mcpWriteConfirm.title')}
+          </DialogTitle>
+          <DialogDescription className="text-xs">
+            {t('mcpWriteConfirm.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2">
+          <div className="font-mono text-[11px] font-semibold text-foreground" data-testid="mcp-write-confirm-tool">
+            {request.tool}
+          </div>
+          {/* The operation itself, not a summary: the backend deliberately sends
+              what will run, because a filter reported as a byte count is useless
+              for deciding. */}
+          <pre
+            className="max-h-64 overflow-auto rounded-md border border-border bg-muted/40 p-2 font-mono text-[10px] leading-relaxed text-foreground"
+            data-testid="mcp-write-confirm-summary"
+          >
+            {request.summary}
+          </pre>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[11px]"
+            data-testid="mcp-write-confirm-refuse"
+            onClick={() => answerWriteRequest(request.id, false)}
+          >
+            {t('mcpWriteConfirm.refuse')}
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            className="h-7 text-[11px]"
+            data-testid="mcp-write-confirm-allow"
+            onClick={() => answerWriteRequest(request.id, true)}
+          >
+            {t('mcpWriteConfirm.allow')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/__tests__/AIChatPanel.test.tsx
+++ b/src/components/__tests__/AIChatPanel.test.tsx
@@ -1700,28 +1700,27 @@ JSON.stringify({ explanation: 'Here are the results.', queryType: 'find', filter
     expect(await screen.findByTestId('chat-write-request')).toHaveTextContent('shop.orders');
   });
 
-  it('recovers a write that arrived before any panel was mounted', async () => {
-    // An external MCP client's write is confirmed too, and it does not come from
-    // a panel. With the listener started lazily by the panel, such a request was
-    // broadcast to nobody and could only fail when the backend gave up two
-    // minutes later. `App` starts it instead, so opening the chat still finds it.
+  it('leaves a write no conversation asked for to the app-level prompt', async () => {
+    // An external MCP client's write is confirmed too, but it belongs to no
+    // conversation — and this panel renders nothing while closed and is
+    // unmounted on a tab switch, so claiming it here meant no prompt at all
+    // whenever the user was anywhere else. `McpWriteConfirm` shows those, and
+    // has its own suite; the panel must not also offer them (#352 review).
     startWriteRequests();
     await act(async () => {});
     expect(writeRequestListeners).not.toHaveLength(0);
 
-    // Unaddressed, as an external client's write always is.
     await act(async () => {
       writeRequestListeners.forEach((fn) =>
         fn({ id: 'ext1', tool: 'delete_many', summary: 'from an external client', requester: null }),
       );
     });
 
-    // Only now does any UI exist. The prompt does not depend on a provider
-    // being configured — the write is already parked in the backend.
     renderPanel('editor');
-    expect(await screen.findByTestId('chat-write-request')).toHaveTextContent(
-      'from an external client',
-    );
+    // The panel is up (its New chat control renders unconditionally); the
+    // unaddressed request is simply not offered here.
+    await screen.findByTestId('ai-chat-new-btn');
+    expect(screen.queryByTestId('chat-write-request')).toBeNull();
   });
 
   it('re-reads its provider list when settings change elsewhere', async () => {

--- a/src/components/__tests__/McpWriteConfirm.test.tsx
+++ b/src/components/__tests__/McpWriteConfirm.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const invokeMock = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
+
+const writeRequestListeners: Array<
+  (r: { id: string; tool: string; summary: string; requester: string | null }) => void
+> = [];
+const writeSettledListeners: Array<(id: string) => void> = [];
+vi.mock('../../workspace/workspaceStore', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../workspace/workspaceStore')>()),
+  subscribeMcpWriteRequest: (fn: (r: any) => void) => {
+    writeRequestListeners.push(fn);
+    return Promise.resolve(() => {
+      const i = writeRequestListeners.indexOf(fn);
+      if (i >= 0) writeRequestListeners.splice(i, 1);
+    });
+  },
+  subscribeMcpWriteSettled: (fn: (id: string) => void) => {
+    writeSettledListeners.push(fn);
+    return Promise.resolve(() => {
+      const i = writeSettledListeners.indexOf(fn);
+      if (i >= 0) writeSettledListeners.splice(i, 1);
+    });
+  },
+}));
+
+import { McpWriteConfirm } from '../McpWriteConfirm';
+import { resetWriteRequestsForTests, startWriteRequests } from '../../lib/mcpWriteRequests';
+
+const emit = async (r: {
+  id: string;
+  tool: string;
+  summary: string;
+  requester: string | null;
+}) => {
+  await act(async () => {
+    writeRequestListeners.forEach((fn) => fn(r));
+  });
+};
+
+describe('McpWriteConfirm — an external MCP write is confirmed app-wide (#352 review)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetWriteRequestsForTests();
+    writeRequestListeners.length = 0;
+    writeSettledListeners.length = 0;
+    invokeMock.mockResolvedValue(undefined);
+  });
+
+  it('prompts for a write no conversation asked for, wherever the user is', async () => {
+    // The panel that used to own this renders nothing while closed and is
+    // unmounted on a tab switch, so an external client's write had no prompt
+    // at all unless the user happened to be sitting in a chat.
+    render(<McpWriteConfirm />);
+    await act(async () => {});
+
+    await emit({
+      id: 'ext1',
+      tool: 'delete_many',
+      summary: '{ "namespace": "shop.orders" }',
+      requester: null,
+    });
+
+    expect(await screen.findByTestId('mcp-write-confirm')).toBeInTheDocument();
+    expect(screen.getByTestId('mcp-write-confirm-tool')).toHaveTextContent('delete_many');
+    // The operation itself, not a byte count: it is what the decision rests on.
+    expect(screen.getByTestId('mcp-write-confirm-summary')).toHaveTextContent('shop.orders');
+  });
+
+  it('recovers a write that arrived before anything was on screen', async () => {
+    // The store listens from app start, so a write parked in the backend before
+    // any UI existed is still answerable rather than left to time out.
+    startWriteRequests();
+    await act(async () => {});
+    expect(writeRequestListeners).not.toHaveLength(0);
+
+    await emit({ id: 'ext2', tool: 'update_many', summary: 'from an external client', requester: null });
+
+    render(<McpWriteConfirm />);
+    expect(await screen.findByTestId('mcp-write-confirm-summary')).toHaveTextContent(
+      'from an external client',
+    );
+  });
+
+  it('carries an approval and a refusal back to the backend', async () => {
+    render(<McpWriteConfirm />);
+    await act(async () => {});
+
+    await emit({ id: 'ext3', tool: 'insert_one', summary: 'doc', requester: null });
+    fireEvent.click(await screen.findByTestId('mcp-write-confirm-allow'));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('mcp_resolve_write', { id: 'ext3', approved: true }),
+    );
+    // Answered, so it stops being offered.
+    await waitFor(() => expect(screen.queryByTestId('mcp-write-confirm')).toBeNull());
+
+    await emit({ id: 'ext4', tool: 'delete_many', summary: 'doc', requester: null });
+    fireEvent.click(await screen.findByTestId('mcp-write-confirm-refuse'));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('mcp_resolve_write', { id: 'ext4', approved: false }),
+    );
+  });
+
+  it('leaves a request addressed to a conversation to that conversation', async () => {
+    // Those stay in the chat that asked, where the user can see what led to them.
+    render(<McpWriteConfirm />);
+    await act(async () => {});
+
+    await emit({ id: 'chat1', tool: 'insert_one', summary: 'doc', requester: 'chat-42' });
+
+    expect(screen.queryByTestId('mcp-write-confirm')).toBeNull();
+  });
+
+  it('stops offering a request another window has already answered', async () => {
+    render(<McpWriteConfirm />);
+    await act(async () => {});
+    await emit({ id: 'ext5', tool: 'delete_many', summary: 'doc', requester: null });
+    expect(await screen.findByTestId('mcp-write-confirm')).toBeInTheDocument();
+
+    await act(async () => {
+      writeSettledListeners.forEach((fn) => fn('ext5'));
+    });
+
+    expect(screen.queryByTestId('mcp-write-confirm')).toBeNull();
+  });
+});

--- a/src/locales/de/shell.json
+++ b/src/locales/de/shell.json
@@ -69,6 +69,12 @@
     "writeRequestRefuse": "Ablehnen",
     "writeRequestTitle": "Der Assistent möchte Daten ändern"
   },
+  "mcpWriteConfirm": {
+    "allow": "Zulassen",
+    "description": "Ein mit MQLens verbundener MCP-Client möchte Daten ändern. Erlaube es nur, wenn du das angefordert hast.",
+    "refuse": "Ablehnen",
+    "title": "Ein MCP-Client möchte Daten ändern"
+  },
   "commandPalette": {
     "buckets": {
       "collections": {

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -125,12 +125,6 @@
     "writeRequestRefuse": "Refuse",
     "writeRequestTitle": "The assistant wants to change data"
   },
-  "mcpWriteConfirm": {
-    "allow": "Allow",
-    "description": "An MCP client connected to MQLens is asking to change data. Approve it only if you asked for this.",
-    "refuse": "Refuse",
-    "title": "An MCP client wants to change data"
-  },
   "commandPalette": {
     "buckets": {
       "collections": {
@@ -311,6 +305,12 @@
     "searchAriaLabel": "Search keyboard shortcuts",
     "searchPlaceholder": "Search shortcuts…",
     "title": "Keyboard shortcuts"
+  },
+  "mcpWriteConfirm": {
+    "allow": "Allow",
+    "description": "An MCP client connected to MQLens is asking to change data. Approve it only if you asked for this.",
+    "refuse": "Refuse",
+    "title": "An MCP client wants to change data"
   },
   "mongoShell": {
     "console": {

--- a/src/locales/en/shell.json
+++ b/src/locales/en/shell.json
@@ -125,6 +125,12 @@
     "writeRequestRefuse": "Refuse",
     "writeRequestTitle": "The assistant wants to change data"
   },
+  "mcpWriteConfirm": {
+    "allow": "Allow",
+    "description": "An MCP client connected to MQLens is asking to change data. Approve it only if you asked for this.",
+    "refuse": "Refuse",
+    "title": "An MCP client wants to change data"
+  },
   "commandPalette": {
     "buckets": {
       "collections": {

--- a/src/locales/zh-Hans/shell.json
+++ b/src/locales/zh-Hans/shell.json
@@ -68,6 +68,12 @@
     "writeRequestRefuse": "拒绝",
     "writeRequestTitle": "助手想要修改数据"
   },
+  "mcpWriteConfirm": {
+    "allow": "允许",
+    "description": "已连接到 MQLens 的 MCP 客户端请求修改数据。仅在这是您发起的操作时才允许。",
+    "refuse": "拒绝",
+    "title": "MCP 客户端请求修改数据"
+  },
   "commandPalette": {
     "buckets": {
       "collections": {


### PR DESCRIPTION
Fixes the P1 Codex raised on #352 (dev → main): [`Surface external MCP confirmations outside the AI panel`](https://github.com/mqlens/mqlens-mongodb/pull/352#discussion_r3947...).

## What was happening

Every MCP route confirms its writes in the app, not just MQLens's own agent. That was deliberate, and the reason is in the code:

> `_confirm` is a boolean the caller supplies, so it was never a gate — and a CLI that found the external route through its own global config reached these tools with no prompt at all, which is the hole the helper path alone could not close.

But the prompt only ever rendered inside `AIChatPanel`, which returns `null` while closed and is unmounted entirely on a tab switch. So an external client's write while the user was in Settings — or simply not sitting in a chat — had **no visible prompt at all** and could only time out after 120 s, even though the user had already approved it in the client they were working in.

The listener was never the problem: `mcpWriteRequests` is app-global and started by `App`. Only the UI was missing.

## The fix

A new `McpWriteConfirm`, mounted for the life of the workspace beside `UpdatePrompt`, renders requests the backend addressed to **nobody** — which is every external client's write. It is the app being asked, not a conversation, so the app asks.

`AIChatPanel` now claims only requests addressed to the conversation it is showing. Those stay in the chat that caused them, where the user can see what led to them.

Codex's other suggestion — restricting the second confirmation to the helper route — would reopen exactly the hole the every-route prompt was written to close, so I did not take it.

## Details

- The dialog refuses outside-click, interact-outside and Escape: none of those is an answer, and silence costs the caller a two-minute wait then a refusal.
- It shows the pretty-printed operation the backend sends, not the call-log summary, for the reason `confirm_write` already documents: a filter reported as a byte count cannot be decided on.
- Oldest request first, one at a time, so a burst is worked through rather than stacked.
- `mcp-write-settled` still clears it, so a request answered in another window stops being offered here.
- Strings added to all three catalogs; German is informal per the catalog rule (the test for that caught my first draft).

## Tests

New `McpWriteConfirm.test.tsx`: prompts for an unaddressed write; recovers one that arrived before anything was on screen; carries approval and refusal back through `mcp_resolve_write`; leaves a conversation-addressed request alone; stops offering one another window answered.

The existing `AIChatPanel` test that asserted the panel shows unaddressed writes has been rewritten to assert it now leaves them to the app-level prompt — the guarantee moved, it did not disappear.

Both halves mutation-checked: making the dialog claim everything fails its "leaves it to the conversation" test, and making the panel claim unaddressed requests again fails the panel's.

Full suite: the same 5 pre-existing environment-dependent failures as clean `dev` on this machine.

## Not verified in the app

Worth doing end-to-end: point an external MCP client at MQLens, send a destructive tool call with `_confirm: true` while sitting in Settings, and confirm the dialog appears and the answer reaches the client.
