### PR TITLE
chore: back-merge main into dev after the 0.18.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqlens",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A native desktop GUI for MongoDB, built with Tauri and React.",
   "homepage": "https://mqlens.com",
   "author": "Devesh Kumar <vrshu112@gmail.com>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6441,7 +6441,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "0.18.0"
+version = "0.18.1"
 description = "MQLens — a native desktop GUI for MongoDB."
 authors = ["Devesh Kumar <vrshu112@gmail.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MQLens",
   "mainBinaryName": "MQLens",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "identifier": "com.mqlens.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Brings `main` back into `dev` after the 0.18.1 release.

The Release workflow derives the version from Conventional Commits, bumps the version files, and commits them back to `main` with `[skip ci]`. That commit only exists on `main`, so without this back-merge `dev` keeps claiming the previous version.

## What this carries

Two commits, and the only content change is the version bump:

| File | dev | main |
|---|---|---|
| `package.json` | 0.18.0 | 0.18.1 |
| `src-tauri/Cargo.toml` | 0.18.0 | 0.18.1 |
| `src-tauri/Cargo.lock` | 0.18.0 | 0.18.1 |
| `src-tauri/tauri.conf.json` | 0.18.0 | 0.18.1 |

`dev` has no commits that `main` lacks, so this is a clean merge with nothing to resolve.

## Why it matters

Dev pre-releases take their version from the files on `dev` and are tagged `mqlens-v<version>-<run>`. Left at 0.18.0, the next nightly would cut `mqlens-v0.18.1-<run>` from a 0.18.0 base — colliding with the version just shipped to stable users while not actually being it. Merging this keeps the dev channel ahead of stable rather than alongside it.
