### PR TITLE
fix(workspace): contain a tab render crash instead of blanking the app (#379)

### DIFF
--- a/src/components/DocumentViewer.tsx
+++ b/src/components/DocumentViewer.tsx
@@ -38,6 +38,7 @@ import {
   ResizableHandle,
 } from '@/components/ui/resizable';
 import { useDefaultLayout, type Layout } from 'react-resizable-panels';
+import { restorableLayout } from '@/lib/restorableLayout';
 import { cn } from '@/lib/utils';
 import { formatShortcut, shortcutById } from '@/lib/shortcuts';
 import {
@@ -1506,6 +1507,14 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       storage: typeof localStorage === 'undefined' ? undefined : localStorage,
     });
 
+  // Only restore a persisted layout when it is safe for the current panel set
+  // (see restorableLayout — a mismatched or sliver layout would crash the group
+  // or render an invisible strip, #379).
+  const safeSavedLayout = useMemo(
+    () => restorableLayout(savedWorkspaceLayout, workspacePanelIds),
+    [savedWorkspaceLayout, workspacePanelIds],
+  );
+
   return (
     <div className="relative flex h-full min-h-0 flex-col min-w-0">
       
@@ -1834,7 +1843,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
       <ResizablePanelGroup
         id="document-viewer-workspace"
         orientation="horizontal"
-        defaultLayout={savedWorkspaceLayout ?? workspaceDefaultLayout}
+        defaultLayout={safeSavedLayout ?? workspaceDefaultLayout}
         onLayoutChanged={saveWorkspaceLayout}
         className="min-h-0 min-w-0 flex-1"
       >

--- a/src/components/TabErrorBoundary.tsx
+++ b/src/components/TabErrorBoundary.tsx
@@ -21,15 +21,39 @@ import { Button } from '@/components/ui/button';
 interface Props {
   children: React.ReactNode;
   resetKey?: unknown;
-  /** Reported for diagnostics; never used to render. */
-  onError?: (error: Error, info: React.ErrorInfo) => void;
+  /** Reported for diagnostics; never used to render. The thrown value is
+   *  `unknown` because JavaScript permits throwing any value, not just Error. */
+  onError?: (error: unknown, info: React.ErrorInfo) => void;
 }
 
 interface State {
-  error: Error | null;
+  // A separate flag rather than `error: X | null`: JS lets code throw a falsy
+  // value (`null`, `''`, `0`), and using the caught value as the sentinel would
+  // treat "a tab threw null" as "no error" and render the crashing child again
+  // (#380 review).
+  hasError: boolean;
+  message: string;
 }
 
-function TabErrorFallback({ error, onRetry }: { error: Error; onRetry: () => void }) {
+/**
+ * A safe, renderable one-line message for any thrown value.
+ *
+ * The fallback renders this as text, so it must be a string no matter what was
+ * thrown — an Error whose `.message` is itself an object would otherwise make
+ * the fallback throw while rendering, which the boundary cannot catch (#380
+ * review).
+ */
+function toDisplayMessage(error: unknown): string {
+  if (error instanceof Error) return String(error.message ?? error.name);
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function TabErrorFallback({ message, onRetry }: { message: string; onRetry: () => void }) {
   const { t } = useTranslation('common');
   return (
     <div
@@ -42,12 +66,12 @@ function TabErrorFallback({ error, onRetry }: { error: Error; onRetry: () => voi
         <p className="text-sm font-semibold text-foreground">{t('errorBoundary.title')}</p>
         <p className="max-w-md text-ui-xs text-muted-foreground">{t('errorBoundary.description')}</p>
       </div>
-      {error.message && (
+      {message && (
         <pre
           className="max-h-32 max-w-md overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-muted/40 px-3 py-2 text-left font-mono text-[10px] leading-relaxed text-muted-foreground"
           data-testid="tab-error-message"
         >
-          {error.message}
+          {message}
         </pre>
       )}
       <Button variant="outline" size="sm" onClick={onRetry} data-testid="tab-error-retry">
@@ -74,13 +98,13 @@ export function BoundaryContent({ render }: { render: () => React.ReactNode }) {
 }
 
 export class TabErrorBoundary extends React.Component<Props, State> {
-  state: State = { error: null };
+  state: State = { hasError: false, message: '' };
 
-  static getDerivedStateFromError(error: Error): State {
-    return { error };
+  static getDerivedStateFromError(error: unknown): State {
+    return { hasError: true, message: toDisplayMessage(error) };
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
     // Keep the crash visible in the console for diagnosis — the fallback shows
     // the message but not the component stack.
     console.error('Tab content crashed:', error, info.componentStack);
@@ -90,14 +114,19 @@ export class TabErrorBoundary extends React.Component<Props, State> {
   componentDidUpdate(prev: Props) {
     // A changed resetKey means the parent swapped what this boundary wraps, so
     // a stale error should not keep hiding fresh, working content.
-    if (this.state.error && prev.resetKey !== this.props.resetKey) {
-      this.setState({ error: null });
+    if (this.state.hasError && prev.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false, message: '' });
     }
   }
 
   render() {
-    if (this.state.error) {
-      return <TabErrorFallback error={this.state.error} onRetry={() => this.setState({ error: null })} />;
+    if (this.state.hasError) {
+      return (
+        <TabErrorFallback
+          message={this.state.message}
+          onRetry={() => this.setState({ hasError: false, message: '' })}
+        />
+      );
     }
     return this.props.children;
   }

--- a/src/components/TabErrorBoundary.tsx
+++ b/src/components/TabErrorBoundary.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Isolates a render crash to the tab it happened in.
+ *
+ * Kept-alive tabs (#240) stay mounted and share the workspace tree, and the app
+ * has no other error boundary — so before this, an exception thrown while
+ * rendering any tab (or on the re-render when a tab is shown/hidden) propagated
+ * all the way up and React unmounted the whole tree, blanking the entire app
+ * (see #379). Wrapping each tab's content means a throwing tab shows a
+ * recoverable message in its own pane while every other tab, the tab strip and
+ * the rest of the window keep working.
+ *
+ * `resetKey` lets a parent clear the error when the thing that was broken has
+ * changed (e.g. the tab id it wraps). Retry is also offered in the fallback, so
+ * a transient failure can be dismissed without touching anything else.
+ */
+interface Props {
+  children: React.ReactNode;
+  resetKey?: unknown;
+  /** Reported for diagnostics; never used to render. */
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+}
+
+interface State {
+  error: Error | null;
+}
+
+function TabErrorFallback({ error, onRetry }: { error: Error; onRetry: () => void }) {
+  const { t } = useTranslation('common');
+  return (
+    <div
+      className="flex h-full min-h-0 w-full flex-col items-center justify-center gap-3 p-6 text-center"
+      data-testid="tab-error-boundary"
+      role="alert"
+    >
+      <AlertTriangle className="h-8 w-8 text-destructive" aria-hidden="true" />
+      <div className="space-y-1">
+        <p className="text-sm font-semibold text-foreground">{t('errorBoundary.title')}</p>
+        <p className="max-w-md text-ui-xs text-muted-foreground">{t('errorBoundary.description')}</p>
+      </div>
+      {error.message && (
+        <pre
+          className="max-h-32 max-w-md overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-muted/40 px-3 py-2 text-left font-mono text-[10px] leading-relaxed text-muted-foreground"
+          data-testid="tab-error-message"
+        >
+          {error.message}
+        </pre>
+      )}
+      <Button variant="outline" size="sm" onClick={onRetry} data-testid="tab-error-retry">
+        <RefreshCw size={12} />
+        <span>{t('errorBoundary.retry')}</span>
+      </Button>
+    </div>
+  );
+}
+
+export class TabErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // Keep the crash visible in the console for diagnosis — the fallback shows
+    // the message but not the component stack.
+    console.error('Tab content crashed:', error, info.componentStack);
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(prev: Props) {
+    // A changed resetKey means the parent swapped what this boundary wraps, so
+    // a stale error should not keep hiding fresh, working content.
+    if (this.state.error && prev.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      return <TabErrorFallback error={this.state.error} onRetry={() => this.setState({ error: null })} />;
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/TabErrorBoundary.tsx
+++ b/src/components/TabErrorBoundary.tsx
@@ -58,6 +58,21 @@ function TabErrorFallback({ error, onRetry }: { error: Error; onRetry: () => voi
   );
 }
 
+/**
+ * Runs a render callback *inside* the boundary's subtree.
+ *
+ * A boundary only catches throws from its descendants' render — not throws in
+ * the parent scope that computes its children. `renderTabContent(tabId)` is
+ * called while PaneView renders, before the boundary mounts, so a synchronous
+ * failure there (the tab renderer does lookups, IIFEs and serialization before
+ * returning) would still escape to the app root. Deferring the call into this
+ * child component moves that work under the boundary, where it is caught (#379
+ * review).
+ */
+export function BoundaryContent({ render }: { render: () => React.ReactNode }) {
+  return <>{render()}</>;
+}
+
 export class TabErrorBoundary extends React.Component<Props, State> {
   state: State = { error: null };
 

--- a/src/components/__tests__/TabErrorBoundary.test.tsx
+++ b/src/components/__tests__/TabErrorBoundary.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { useState } from 'react';
-import { TabErrorBoundary } from '../TabErrorBoundary';
+import { TabErrorBoundary, BoundaryContent } from '../TabErrorBoundary';
 
 // The boundary logs the caught error; silence it so the suite output stays
 // readable, and assert it still fires.
@@ -83,6 +83,25 @@ describe('TabErrorBoundary (#379)', () => {
 
     expect(screen.getByTestId('ok')).toBeInTheDocument();
     expect(screen.queryByTestId('tab-error-boundary')).toBeNull();
+  });
+
+  it('contains a throw from the render callback itself, not just the returned subtree', () => {
+    // The tab renderer runs synchronous work (lookups, IIFEs, serialization)
+    // before it returns a node. Passing its result as children would run that
+    // work in the PARENT's render, above the boundary, so a throw there would
+    // still escape. BoundaryContent defers the call into the boundary's own
+    // subtree, where it is caught (#379 review).
+    render(
+      <TabErrorBoundary>
+        <BoundaryContent
+          render={() => {
+            throw new Error('renderer threw before returning');
+          }}
+        />
+      </TabErrorBoundary>,
+    );
+    expect(screen.getByTestId('tab-error-boundary')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-error-message')).toHaveTextContent('renderer threw before returning');
   });
 
   it('clears a stale error when resetKey changes', () => {

--- a/src/components/__tests__/TabErrorBoundary.test.tsx
+++ b/src/components/__tests__/TabErrorBoundary.test.tsx
@@ -104,6 +104,59 @@ describe('TabErrorBoundary (#379)', () => {
     expect(screen.getByTestId('tab-error-message')).toHaveTextContent('renderer threw before returning');
   });
 
+  it('shows the fallback even when a child throws a falsy value like null', () => {
+    // `null` is a legal throw. If the boundary used the caught value as its
+    // "any error?" flag, null would read as "no error" and it would re-render
+    // the crashing child instead of the fallback (#380 review).
+    function ThrowNull(): never {
+      throw null;
+    }
+    render(
+      <TabErrorBoundary>
+        <ThrowNull />
+      </TabErrorBoundary>,
+    );
+    expect(screen.getByTestId('tab-error-boundary')).toBeInTheDocument();
+  });
+
+  it('does not itself throw when a child throws a non-Error / non-string message', () => {
+    // An Error whose `.message` is an object would make a fallback that renders
+    // `error.message` throw while rendering — uncatchable, blanking the app
+    // (#380 review). The normalized message must stay a renderable string.
+    function ThrowWeird(): never {
+      const e = new Error('x');
+      // @ts-expect-error deliberately corrupting message to a non-string
+      e.message = { nested: 'not a string' };
+      throw e;
+    }
+    // A throw while rendering the fallback would escape this render() call and
+    // fail the test; reaching the assertions means it stayed contained.
+    render(
+      <TabErrorBoundary>
+        <ThrowWeird />
+      </TabErrorBoundary>,
+    );
+    expect(screen.getByTestId('tab-error-boundary')).toBeInTheDocument();
+    // Coerced to a safe string rather than rendered as an object (which would
+    // throw). The exact text isn't the point — that it's a string and the
+    // fallback survived is.
+    const shown = screen.getByTestId('tab-error-message').textContent ?? '';
+    expect(typeof shown).toBe('string');
+    expect(shown.length).toBeGreaterThan(0);
+  });
+
+  it('renders a bare string throw as its message', () => {
+    function ThrowString(): never {
+      throw 'just a string';
+    }
+    render(
+      <TabErrorBoundary>
+        <ThrowString />
+      </TabErrorBoundary>,
+    );
+    expect(screen.getByTestId('tab-error-message')).toHaveTextContent('just a string');
+  });
+
   it('clears a stale error when resetKey changes', () => {
     // Models the pane swapping which tab a boundary wraps: the new tab must not
     // inherit the old tab's error screen.

--- a/src/components/__tests__/TabErrorBoundary.test.tsx
+++ b/src/components/__tests__/TabErrorBoundary.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
+import { TabErrorBoundary } from '../TabErrorBoundary';
+
+// The boundary logs the caught error; silence it so the suite output stays
+// readable, and assert it still fires.
+let errSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  errSpy.mockRestore();
+});
+
+function Boom({ throwNow, message }: { throwNow: boolean; message?: string }) {
+  if (throwNow) throw new Error(message ?? 'kaboom');
+  return <div data-testid="ok">fine</div>;
+}
+
+describe('TabErrorBoundary (#379)', () => {
+  it('renders its children when nothing throws', () => {
+    render(
+      <TabErrorBoundary>
+        <div data-testid="child">hello</div>
+      </TabErrorBoundary>,
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(screen.queryByTestId('tab-error-boundary')).toBeNull();
+  });
+
+  it('contains a render throw instead of letting it escape, and shows the message', () => {
+    // If the boundary did not catch, this render call itself would throw and
+    // fail the test — which is exactly the whole-app blank the boundary exists
+    // to prevent.
+    render(
+      <TabErrorBoundary>
+        <Boom throwNow message="provider blew up" />
+      </TabErrorBoundary>,
+    );
+    expect(screen.getByTestId('tab-error-boundary')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-error-message')).toHaveTextContent('provider blew up');
+    // The crash was surfaced for diagnosis rather than swallowed.
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('does not tear down siblings when one child throws', () => {
+    render(
+      <div>
+        <div data-testid="sibling">still here</div>
+        <TabErrorBoundary>
+          <Boom throwNow />
+        </TabErrorBoundary>
+      </div>,
+    );
+    // The sibling outside the boundary is untouched — a crash in one tab must
+    // not blank the rest of the window.
+    expect(screen.getByTestId('sibling')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-error-boundary')).toBeInTheDocument();
+  });
+
+  it('recovers via Retry once the child stops throwing', () => {
+    function Harness() {
+      const [broken, setBroken] = useState(true);
+      return (
+        <div>
+          <button data-testid="fix" onClick={() => setBroken(false)}>
+            fix
+          </button>
+          <TabErrorBoundary>
+            <Boom throwNow={broken} />
+          </TabErrorBoundary>
+        </div>
+      );
+    }
+    render(<Harness />);
+    expect(screen.getByTestId('tab-error-boundary')).toBeInTheDocument();
+
+    // Make the child able to render, then retry: the boundary clears its error
+    // and re-renders the now-healthy child.
+    fireEvent.click(screen.getByTestId('fix'));
+    fireEvent.click(screen.getByTestId('tab-error-retry'));
+
+    expect(screen.getByTestId('ok')).toBeInTheDocument();
+    expect(screen.queryByTestId('tab-error-boundary')).toBeNull();
+  });
+
+  it('clears a stale error when resetKey changes', () => {
+    // Models the pane swapping which tab a boundary wraps: the new tab must not
+    // inherit the old tab's error screen.
+    const { rerender } = render(
+      <TabErrorBoundary resetKey="tab-a">
+        <Boom throwNow />
+      </TabErrorBoundary>,
+    );
+    expect(screen.getByTestId('tab-error-boundary')).toBeInTheDocument();
+
+    rerender(
+      <TabErrorBoundary resetKey="tab-b">
+        <Boom throwNow={false} />
+      </TabErrorBoundary>,
+    );
+    expect(screen.getByTestId('ok')).toBeInTheDocument();
+    expect(screen.queryByTestId('tab-error-boundary')).toBeNull();
+  });
+});

--- a/src/lib/__tests__/restorableLayout.test.ts
+++ b/src/lib/__tests__/restorableLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { restorableLayout, SIDE_PANEL_MIN } from '../restorableLayout';
+import { restorableLayout, SIDE_PANEL_MIN, SIDE_PANEL_MAX } from '../restorableLayout';
 
 describe('restorableLayout (#379)', () => {
   const aiHelper = ['document-main', 'ai-helper'];
@@ -30,9 +30,27 @@ describe('restorableLayout (#379)', () => {
     expect(restorableLayout(sliver, aiHelper)).toBeUndefined();
   });
 
+  it('discards a layout that would restore the document area as a sliver', () => {
+    // The side panel clears its own minimum here, so a min-only guard would let
+    // this through — but document-main at 2% is unusable (#379 review). It is
+    // also above the side max, another reason to reject.
+    const mainSliver = { 'document-main': 2, 'ai-helper': 98 };
+    expect(restorableLayout(mainSliver, aiHelper)).toBeUndefined();
+  });
+
+  it('discards a side panel restored above its maximum', () => {
+    const tooWide = { 'document-main': 45, 'ai-helper': 55 };
+    expect(restorableLayout(tooWide, aiHelper)).toBeUndefined();
+  });
+
   it('keeps a side panel exactly at the floor', () => {
     const atFloor = { 'document-main': 100 - SIDE_PANEL_MIN, 'ai-helper': SIDE_PANEL_MIN };
     expect(restorableLayout(atFloor, aiHelper)).toBe(atFloor);
+  });
+
+  it('keeps a side panel exactly at the maximum', () => {
+    const atMax = { 'document-main': 100 - SIDE_PANEL_MAX, 'ai-helper': SIDE_PANEL_MAX };
+    expect(restorableLayout(atMax, aiHelper)).toBe(atMax);
   });
 
   it('discards a layout with a non-numeric entry', () => {

--- a/src/lib/__tests__/restorableLayout.test.ts
+++ b/src/lib/__tests__/restorableLayout.test.ts
@@ -48,6 +48,22 @@ describe('restorableLayout (#379)', () => {
     expect(restorableLayout(atFloor, aiHelper)).toBe(atFloor);
   });
 
+  it('discards a layout whose entries do not total 100%', () => {
+    // Each value is individually in-bounds, but they sum to 118%. The library
+    // normalizes proportions, scaling the side panel back under its floor —
+    // the sliver this guard exists to prevent (#380 review).
+    const overSum = { 'document-main': 100, 'ai-helper': 18 };
+    expect(restorableLayout(overSum, aiHelper)).toBeUndefined();
+    // And an under-sum layout is just as wrong.
+    const underSum = { 'document-main': 60, 'ai-helper': 30 };
+    expect(restorableLayout(underSum, aiHelper)).toBeUndefined();
+  });
+
+  it('tolerates the sub-percent float drift a drag can leave', () => {
+    const drifted = { 'document-main': 69.7, 'ai-helper': 30.3 };
+    expect(restorableLayout(drifted, aiHelper)).toBe(drifted);
+  });
+
   it('keeps a side panel exactly at the maximum', () => {
     const atMax = { 'document-main': 100 - SIDE_PANEL_MAX, 'ai-helper': SIDE_PANEL_MAX };
     expect(restorableLayout(atMax, aiHelper)).toBe(atMax);

--- a/src/lib/__tests__/restorableLayout.test.ts
+++ b/src/lib/__tests__/restorableLayout.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { restorableLayout, SIDE_PANEL_MIN } from '../restorableLayout';
+
+describe('restorableLayout (#379)', () => {
+  const aiHelper = ['document-main', 'ai-helper'];
+
+  it('keeps a well-formed layout that matches the current panel set', () => {
+    const saved = { 'document-main': 70, 'ai-helper': 30 };
+    expect(restorableLayout(saved, aiHelper)).toBe(saved);
+  });
+
+  it('returns undefined when nothing is saved', () => {
+    expect(restorableLayout(undefined, aiHelper)).toBeUndefined();
+  });
+
+  it('discards a layout whose entry count differs from the panel set', () => {
+    // A three-entry layout against a two-panel group is exactly what makes
+    // react-resizable-panels throw during render.
+    const stale = { 'document-main': 50, 'ai-helper': 30, 'query-builder': 20 };
+    expect(restorableLayout(stale, aiHelper)).toBeUndefined();
+  });
+
+  it('discards a layout missing one of the current panels', () => {
+    const wrongKeys = { 'document-main': 70, 'query-builder': 30 };
+    expect(restorableLayout(wrongKeys, aiHelper)).toBeUndefined();
+  });
+
+  it('discards a side panel restored below its sliver floor', () => {
+    const sliver = { 'document-main': 98, 'ai-helper': 2 };
+    expect(restorableLayout(sliver, aiHelper)).toBeUndefined();
+  });
+
+  it('keeps a side panel exactly at the floor', () => {
+    const atFloor = { 'document-main': 100 - SIDE_PANEL_MIN, 'ai-helper': SIDE_PANEL_MIN };
+    expect(restorableLayout(atFloor, aiHelper)).toBe(atFloor);
+  });
+
+  it('discards a layout with a non-numeric entry', () => {
+    const bad = { 'document-main': 70, 'ai-helper': '30' } as unknown as Record<string, number>;
+    expect(restorableLayout(bad, aiHelper)).toBeUndefined();
+  });
+
+  it('leaves a single-panel (document-only) layout alone', () => {
+    const only = { 'document-main': 100 };
+    expect(restorableLayout(only, ['document-main'])).toBe(only);
+  });
+});

--- a/src/lib/restorableLayout.ts
+++ b/src/lib/restorableLayout.ts
@@ -1,0 +1,34 @@
+import type { Layout } from 'react-resizable-panels';
+
+/** Side panels (AI helper / query builder) declare an 18% floor in the UI. */
+export const SIDE_PANEL_MIN = 18;
+
+/**
+ * A persisted resizable layout, but only when it is safe to restore.
+ *
+ * `react-resizable-panels` throws *during render* if a `defaultLayout`'s entry
+ * count differs from the number of panels currently rendered, and its restore
+ * path validates that stored values are numbers but does not re-clamp them to
+ * each panel's declared minimum. So a layout persisted under a different panel
+ * set, hand-tampered, or holding a side panel below its floor is unsafe: it
+ * either crashes the group (blanking the tab — #379) or renders the side panel
+ * as an invisible sliver.
+ *
+ * Returns the layout when every check passes, otherwise `undefined` so the
+ * caller falls back to its fixed default. The worst case is a forgotten drag
+ * width, never a crash or a sliver.
+ */
+export function restorableLayout(
+  saved: Layout | undefined,
+  panelIds: string[],
+  sidePanelMin: number = SIDE_PANEL_MIN,
+): Layout | undefined {
+  if (!saved) return undefined;
+  // Exactly the panels rendered now — same set, same count.
+  if (Object.keys(saved).length !== panelIds.length) return undefined;
+  if (!panelIds.every((id) => typeof saved[id] === 'number')) return undefined;
+  // No side panel restored below the floor that would make it a sliver.
+  const side = panelIds.find((id) => id !== 'document-main');
+  if (side && saved[side] < sidePanelMin) return undefined;
+  return saved;
+}

--- a/src/lib/restorableLayout.ts
+++ b/src/lib/restorableLayout.ts
@@ -34,6 +34,13 @@ export function restorableLayout(
   // Exactly the panels rendered now — same set, same count.
   if (Object.keys(saved).length !== panelIds.length) return undefined;
   if (!panelIds.every((id) => typeof saved[id] === 'number')) return undefined;
+  // Panel sizes are proportions of one group, so the per-panel bounds below are
+  // only meaningful if the entries actually total 100%. A layout that sums to,
+  // say, 118% passes each individual check but the library normalizes it back
+  // down — pushing the side panel under its floor again (#380 review). A small
+  // epsilon tolerates the float drift a drag can leave behind.
+  const total = panelIds.reduce((sum, id) => sum + saved[id], 0);
+  if (Math.abs(total - 100) > 0.5) return undefined;
   // The document area must not restore below its floor…
   if ('document-main' in saved && saved['document-main'] < DOCUMENT_MAIN_MIN) {
     return undefined;

--- a/src/lib/restorableLayout.ts
+++ b/src/lib/restorableLayout.ts
@@ -1,7 +1,13 @@
 import type { Layout } from 'react-resizable-panels';
 
-/** Side panels (AI helper / query builder) declare an 18% floor in the UI. */
+/**
+ * Panel size bounds, mirroring what DocumentViewer declares on each
+ * `ResizablePanel`: the document area floors at 30%, and each side panel (AI
+ * helper / query builder) is constrained to 18–50%.
+ */
+export const DOCUMENT_MAIN_MIN = 30;
 export const SIDE_PANEL_MIN = 18;
+export const SIDE_PANEL_MAX = 50;
 
 /**
  * A persisted resizable layout, but only when it is safe to restore.
@@ -9,26 +15,34 @@ export const SIDE_PANEL_MIN = 18;
  * `react-resizable-panels` throws *during render* if a `defaultLayout`'s entry
  * count differs from the number of panels currently rendered, and its restore
  * path validates that stored values are numbers but does not re-clamp them to
- * each panel's declared minimum. So a layout persisted under a different panel
- * set, hand-tampered, or holding a side panel below its floor is unsafe: it
- * either crashes the group (blanking the tab — #379) or renders the side panel
- * as an invisible sliver.
+ * each panel's declared bounds. So a layout persisted under a different panel
+ * set, hand-tampered, or holding any panel outside its bounds is unsafe: it
+ * either crashes the group (blanking the tab — #379) or restores a panel as an
+ * unusable sliver — the document area included, not just the side panel
+ * (#379 review).
  *
- * Returns the layout when every check passes, otherwise `undefined` so the
+ * Every constraint the panels declare is checked, not just the side-panel
+ * minimum. Returns the layout when all pass, otherwise `undefined` so the
  * caller falls back to its fixed default. The worst case is a forgotten drag
  * width, never a crash or a sliver.
  */
 export function restorableLayout(
   saved: Layout | undefined,
   panelIds: string[],
-  sidePanelMin: number = SIDE_PANEL_MIN,
 ): Layout | undefined {
   if (!saved) return undefined;
   // Exactly the panels rendered now — same set, same count.
   if (Object.keys(saved).length !== panelIds.length) return undefined;
   if (!panelIds.every((id) => typeof saved[id] === 'number')) return undefined;
-  // No side panel restored below the floor that would make it a sliver.
-  const side = panelIds.find((id) => id !== 'document-main');
-  if (side && saved[side] < sidePanelMin) return undefined;
+  // The document area must not restore below its floor…
+  if ('document-main' in saved && saved['document-main'] < DOCUMENT_MAIN_MIN) {
+    return undefined;
+  }
+  // …and no side panel outside its declared 18–50% range.
+  for (const id of panelIds) {
+    if (id === 'document-main') continue;
+    const pct = saved[id];
+    if (pct < SIDE_PANEL_MIN || pct > SIDE_PANEL_MAX) return undefined;
+  }
   return saved;
 }

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -3,6 +3,11 @@
   "cancel": "Abbrechen",
   "close": "Schließen",
   "confirm": "Bestätigen",
+  "errorBoundary": {
+    "description": "Der Rest der App funktioniert weiter. Versuche es erneut oder wechsle zu einem anderen Tab.",
+    "retry": "Erneut versuchen",
+    "title": "Bei diesem Tab ist ein Problem aufgetreten"
+  },
   "ok": "OK",
   "passwordInput": {
     "hide": "Ausblenden",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -3,6 +3,11 @@
   "cancel": "Cancel",
   "close": "Close",
   "confirm": "Confirm",
+  "errorBoundary": {
+    "description": "The rest of the app is still working. Retry, or switch to another tab.",
+    "retry": "Retry",
+    "title": "This tab ran into a problem"
+  },
   "ok": "OK",
   "passwordInput": {
     "hide": "Hide",

--- a/src/locales/zh-Hans/common.json
+++ b/src/locales/zh-Hans/common.json
@@ -3,6 +3,11 @@
   "cancel": "取消",
   "close": "关闭",
   "confirm": "确认",
+  "errorBoundary": {
+    "description": "应用的其余部分仍可正常使用。请重试，或切换到其他标签页。",
+    "retry": "重试",
+    "title": "此标签页遇到问题"
+  },
   "ok": "确定",
   "passwordInput": {
     "hide": "隐藏",

--- a/src/workspace/PaneView.tsx
+++ b/src/workspace/PaneView.tsx
@@ -8,7 +8,7 @@ import {
  type KeepAliveLimits,
 } from './keepAlive';
 import { TabVisibleContext } from './tabVisibility';
-import { TabErrorBoundary } from '@/components/TabErrorBoundary';
+import { TabErrorBoundary, BoundaryContent } from '@/components/TabErrorBoundary';
 
 // Re-exported so existing `import { TAB_DRAG_MIME } from '../PaneView'` call sites
 // (e.g. tests) keep working. Owned by WorkspaceTabBar.tsx — see that file.
@@ -157,7 +157,9 @@ export function PaneView({
             className="h-full min-h-0"
           >
             <TabVisibleContext.Provider value={tabId === pane.activeTabId}>
-              <TabErrorBoundary resetKey={tabId}>{renderTabContent(tabId)}</TabErrorBoundary>
+              <TabErrorBoundary resetKey={tabId}>
+                <BoundaryContent render={() => renderTabContent(tabId)} />
+              </TabErrorBoundary>
             </TabVisibleContext.Provider>
           </div>
         ))}

--- a/src/workspace/PaneView.tsx
+++ b/src/workspace/PaneView.tsx
@@ -8,6 +8,7 @@ import {
  type KeepAliveLimits,
 } from './keepAlive';
 import { TabVisibleContext } from './tabVisibility';
+import { TabErrorBoundary } from '@/components/TabErrorBoundary';
 
 // Re-exported so existing `import { TAB_DRAG_MIME } from '../PaneView'` call sites
 // (e.g. tests) keep working. Owned by WorkspaceTabBar.tsx — see that file.
@@ -156,7 +157,7 @@ export function PaneView({
             className="h-full min-h-0"
           >
             <TabVisibleContext.Provider value={tabId === pane.activeTabId}>
-              {renderTabContent(tabId)}
+              <TabErrorBoundary resetKey={tabId}>{renderTabContent(tabId)}</TabErrorBoundary>
             </TabVisibleContext.Provider>
           </div>
         ))}


### PR DESCRIPTION
Fixes the blank-screen crash in #379.

### The crash
A user configured a custom AI provider, opened the AI helper, and then switching tabs blanked the whole app. The severity has a single root cause: **the app has no error boundary anywhere** (a comment in `AppearanceSettings` even notes the absence). Tabs are kept mounted while hidden (#240) and share the workspace tree, so an exception thrown while rendering any tab — or on the re-render when a tab is shown/hidden — propagates uncaught and React unmounts the entire tree.

### What this does
- **`TabErrorBoundary`** wraps each kept-mounted tab's content in `PaneView`. A throwing tab now shows a recoverable message in its own pane while the tab strip, other tabs, and the rest of the window keep working. Retry clears the error; the boundary resets when the tab it wraps changes. This makes *any* tab render throw non-fatal, whatever its cause.
- **`restorableLayout`** hardens `DocumentViewer`'s persisted-layout restore — the most likely trigger here. `react-resizable-panels` throws *during render* if a saved `defaultLayout`'s entry count differs from the live panel count, and its restore path doesn't re-clamp a stored size to the panel's min, so a side panel saved below 18% returns as an invisible sliver (the reporter's "slim section"). The guard only restores a layout matching the current panel set and above the floor, else falls back to the fixed default.

### Verification
jsdom tests: `TabErrorBoundary` contains a child throw without it escaping — 5 cases (children render, containment, sibling survival, Retry recovery, resetKey clear); `restorableLayout` guard — 8 cases. `tsc` and the i18n gate are clean.

### Honest gap
The **exact** throw the reporter hit is not yet identified — every mechanical theory I could fully trace (empty `SelectItem` from the provider/model pickers; a 3-panel/2-entry layout mismatch) I ruled out by reading the code, and pinpointing it needs their DevTools console error, which I've asked for on the issue. The boundary makes the failure non-fatal regardless of which throw it is; if the console error later points at a specific bug, that's a follow-up fix on top of this net.

Closes #379 once the underlying throw is confirmed benign under the boundary; at minimum this stops the app from dying.
