### PR TITLE
feat(logging): persist uncaught frontend errors to a crash log (#379)

### DIFF
--- a/src-tauri/src/command_coverage.rs
+++ b/src-tauri/src/command_coverage.rs
@@ -64,6 +64,8 @@ const READ_COMMANDS: &[&str] = &[
 /// and pure local computation (formatting already-fetched docs, generating
 /// documents from a template with no DB round-trip).
 const LOCAL_COMMANDS: &[&str] = &[
+    // Appends an uncaught-frontend-error report to a local log file; no DB.
+    "log_frontend_error",
     "connect_db",
     "detect_mongo_tools",
     "detect_mongosh_binary",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3554,9 +3554,17 @@ fn log_frontend_error(app_handle: tauri::AppHandle, message: String) {
     let ts = mongodb::bson::DateTime::now()
         .try_to_rfc3339_string()
         .unwrap_or_default();
+    // Bound the record itself, not just the file. The file-size check above
+    // only looks at the pre-existing length, so a single oversized message
+    // would sail past the cap in one write (#381 review). One crash record is
+    // a message plus a stack — a few KB at most — so 64 KiB is generous.
+    const MAX_RECORD_CHARS: usize = 64 * 1024;
     // One record per line; a multi-line stack is indented so it stays part of
     // its own record rather than looking like separate entries.
-    let body = message.replace('\n', "\n    ");
+    let mut body = message.replace('\n', "\n    ");
+    if body.chars().count() > MAX_RECORD_CHARS {
+        body = body.chars().take(MAX_RECORD_CHARS).collect::<String>() + "…(truncated)";
+    }
     let _ = writeln!(file, "[{ts}] {body}");
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3509,6 +3509,57 @@ async fn mcp_regenerate_token(
     mcp::regenerate_token_impl(&state, Some(&app_handle))
 }
 
+/// Append a frontend crash report to a log file the user can find and attach.
+///
+/// The app has no other logging. An uncaught render error (see
+/// `TabErrorBoundary`) or a `window.onerror` / `unhandledrejection` on a
+/// release build — where the webview console is disabled — otherwise leaves no
+/// trace at all, which is why #379 was only ever a blank screen. This gives
+/// those a durable home under the OS log dir (macOS `~/Library/Logs/<id>/`,
+/// Windows `%LOCALAPPDATA%\<id>\logs\`).
+///
+/// Best-effort by contract: logging a crash must never raise one, so every
+/// fallible step is swallowed rather than returned. The file is capped so a
+/// render loop cannot fill the disk.
+#[tauri::command]
+fn log_frontend_error(app_handle: tauri::AppHandle, message: String) {
+    use std::io::Write;
+    use tauri::Manager;
+
+    let Ok(dir) = app_handle.path().app_log_dir() else {
+        return;
+    };
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let path = dir.join("frontend-errors.log");
+
+    // Start fresh once the log grows past this, so an error that fires on every
+    // render can never grow the file without bound.
+    const MAX_LOG_BYTES: u64 = 512 * 1024;
+    let truncate = std::fs::metadata(&path)
+        .map(|m| m.len() > MAX_LOG_BYTES)
+        .unwrap_or(false);
+
+    let opened = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .append(!truncate)
+        .truncate(truncate)
+        .open(&path);
+    let Ok(mut file) = opened else {
+        return;
+    };
+
+    let ts = mongodb::bson::DateTime::now()
+        .try_to_rfc3339_string()
+        .unwrap_or_default();
+    // One record per line; a multi-line stack is indented so it stays part of
+    // its own record rather than looking like separate entries.
+    let body = message.replace('\n', "\n    ");
+    let _ = writeln!(file, "[{ts}] {body}");
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Resolve the user's real shell PATH before anything spawns child processes,
@@ -3556,6 +3607,7 @@ pub fn run() {
         })
         .manage(AppState::new())
         .invoke_handler(tauri::generate_handler![
+            log_frontend_error,
             connect_db,
             detect_mongo_tools,
             detect_mongosh_binary,

--- a/src/components/TabErrorBoundary.tsx
+++ b/src/components/TabErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { logFrontendError } from '@/lib/crashLog';
 
 /**
  * Isolates a render crash to the tab it happened in.
@@ -108,6 +109,14 @@ export class TabErrorBoundary extends React.Component<Props, State> {
     // Keep the crash visible in the console for diagnosis — the fallback shows
     // the message but not the component stack.
     console.error('Tab content crashed:', error, info.componentStack);
+    // React caught this, so it never reached window.onerror — forward it to the
+    // crash log ourselves, or a release build keeps no record of it (#379).
+    // `error` is `unknown` (anything can be thrown), so read a stack only when
+    // it really is an Error and fall back to the normalized message otherwise.
+    const detail = error instanceof Error ? (error.stack ?? `${error.name}: ${error.message}`) : toDisplayMessage(error);
+    logFrontendError(
+      `TabErrorBoundary: ${detail}${info.componentStack ? `\nComponent stack:${info.componentStack}` : ''}`,
+    );
     this.props.onError?.(error, info);
   }
 

--- a/src/components/__tests__/TabErrorBoundary.test.tsx
+++ b/src/components/__tests__/TabErrorBoundary.test.tsx
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { useState } from 'react';
 import { TabErrorBoundary, BoundaryContent } from '../TabErrorBoundary';
+import { logFrontendError } from '@/lib/crashLog';
+
+vi.mock('@/lib/crashLog', () => ({ logFrontendError: vi.fn() }));
 
 // The boundary logs the caught error; silence it so the suite output stays
 // readable, and assert it still fires.
@@ -42,6 +45,12 @@ describe('TabErrorBoundary (#379)', () => {
     expect(screen.getByTestId('tab-error-message')).toHaveTextContent('provider blew up');
     // The crash was surfaced for diagnosis rather than swallowed.
     expect(errSpy).toHaveBeenCalled();
+    // React caught it, so it never reached window.onerror — the boundary must
+    // forward it to the crash log itself, or a release build keeps no record.
+    expect(logFrontendError).toHaveBeenCalled();
+    expect((logFrontendError as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain(
+      'provider blew up',
+    );
   });
 
   it('does not tear down siblings when one child throws', () => {

--- a/src/lib/__tests__/bootstrapCrashHandlers.test.ts
+++ b/src/lib/__tests__/bootstrapCrashHandlers.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted so the mock factory can reference it (vi.mock is lifted above imports).
+const { installMock } = vi.hoisted(() => ({ installMock: vi.fn() }));
+vi.mock('../crashLog', () => ({ installCrashHandlers: installMock }));
+
+describe('bootstrapCrashHandlers (#381 review)', () => {
+  beforeEach(() => {
+    installMock.mockClear();
+    vi.resetModules();
+  });
+
+  it('installs the crash handlers as a side effect of being imported', async () => {
+    // main.tsx imports this module before ./App precisely so the handlers are
+    // up before the app graph evaluates — the value here is that merely
+    // importing it (not calling anything) installs them.
+    await import('../bootstrapCrashHandlers');
+    expect(installMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/__tests__/crashLog.test.ts
+++ b/src/lib/__tests__/crashLog.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const invokeMock = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invokeMock(...a) }));
+
+import { logFrontendError, installCrashHandlers } from '../crashLog';
+
+describe('crashLog (#379)', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+  });
+
+  it('sends the message to the log_frontend_error command', () => {
+    logFrontendError('boom');
+    expect(invokeMock).toHaveBeenCalledWith('log_frontend_error', { message: 'boom' });
+  });
+
+  it('never throws when the invoke rejects — logging a crash must not crash', () => {
+    invokeMock.mockRejectedValue(new Error('ipc down'));
+    expect(() => logFrontendError('boom')).not.toThrow();
+  });
+
+  it('never throws when invoke throws synchronously (no Tauri host)', () => {
+    invokeMock.mockImplementation(() => {
+      throw new Error('not in a webview');
+    });
+    expect(() => logFrontendError('boom')).not.toThrow();
+  });
+
+  describe('installCrashHandlers', () => {
+    // Dispatch on a stand-in EventTarget rather than the real `window`: vitest
+    // installs its own window error listener and treats a dispatched `error`
+    // event as an unhandled error, which fails the whole run. installCrashHandlers
+    // accepts any EventTarget precisely so this can be exercised in isolation.
+    let target: EventTarget;
+    beforeEach(() => {
+      target = new EventTarget();
+    });
+
+    it('logs a window error event with its stack', () => {
+      const cleanup = installCrashHandlers(target);
+      const err = new Error('render exploded');
+      target.dispatchEvent(new ErrorEvent('error', { error: err, message: err.message }));
+      expect(invokeMock).toHaveBeenCalledTimes(1);
+      const [, { message }] = invokeMock.mock.calls[0] as [string, { message: string }];
+      expect(message).toContain('window.onerror');
+      expect(message).toContain('render exploded');
+      cleanup();
+    });
+
+    it('logs an unhandled promise rejection', () => {
+      const cleanup = installCrashHandlers(target);
+      // jsdom does not synthesise unhandledrejection from real promises, so the
+      // event is dispatched directly — the handler wiring is what is under test.
+      const ev: any = new Event('unhandledrejection');
+      ev.reason = new Error('async boom');
+      target.dispatchEvent(ev);
+      expect(invokeMock).toHaveBeenCalledTimes(1);
+      const [, { message }] = invokeMock.mock.calls[0] as [string, { message: string }];
+      expect(message).toContain('unhandledrejection');
+      expect(message).toContain('async boom');
+      cleanup();
+    });
+
+    it('detaches its listeners on cleanup', () => {
+      const cleanup = installCrashHandlers(target);
+      cleanup();
+      target.dispatchEvent(new ErrorEvent('error', { error: new Error('x'), message: 'x' }));
+      expect(invokeMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/bootstrapCrashHandlers.ts
+++ b/src/lib/bootstrapCrashHandlers.ts
@@ -1,0 +1,11 @@
+import { installCrashHandlers } from './crashLog';
+
+// Installed as a side effect of importing this module, so that main.tsx can
+// import it *before* `./App`. ES modules evaluate a module's dependencies, in
+// import order, before its own body — so a call placed in main.tsx's body runs
+// only after App and its whole dependency graph have already initialized. A
+// throw during another module's initialization would then happen before the
+// handlers existed, and the resulting startup blank screen would leave no crash
+// log (#381 review). Importing this first gets the listeners up before the app
+// graph evaluates.
+installCrashHandlers();

--- a/src/lib/crashLog.ts
+++ b/src/lib/crashLog.ts
@@ -1,0 +1,55 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Persist a frontend error to the app's crash log (`log_frontend_error`).
+ *
+ * The app has no other logging, and a release build has no reachable console —
+ * so without this an uncaught error leaves nothing to attach to a bug report
+ * (#379). Best-effort by contract: it must never throw or reject in the middle
+ * of handling a crash, so the invoke is fired and its failure swallowed.
+ */
+export function logFrontendError(message: string): void {
+  try {
+    void invoke('log_frontend_error', { message }).catch(() => {});
+  } catch {
+    // invoke itself can throw synchronously outside a Tauri webview (tests, a
+    // plain browser); logging a crash must not become a second crash.
+  }
+}
+
+/** Render an Error (or unknown thrown value) as message + stack for the log. */
+function describe(value: unknown): string {
+  if (value instanceof Error) {
+    return value.stack ? `${value.name}: ${value.message}\n${value.stack}` : `${value.name}: ${value.message}`;
+  }
+  try {
+    return typeof value === 'string' ? value : JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Route otherwise-uncaught frontend errors into the crash log.
+ *
+ * Covers the two escapes an error boundary cannot: a synchronous `error` event
+ * and an `unhandledrejection`. Errors a React boundary catches are logged by
+ * the boundary itself (they never reach `window`). Returns a cleanup function
+ * so tests can detach the listeners.
+ */
+export function installCrashHandlers(target: EventTarget = window): () => void {
+  const onError = (e: Event) => {
+    const ev = e as ErrorEvent;
+    logFrontendError(`window.onerror: ${describe(ev.error ?? ev.message)}`);
+  };
+  const onRejection = (e: Event) => {
+    const ev = e as PromiseRejectionEvent;
+    logFrontendError(`unhandledrejection: ${describe(ev.reason)}`);
+  };
+  target.addEventListener('error', onError);
+  target.addEventListener('unhandledrejection', onRejection);
+  return () => {
+    target.removeEventListener('error', onError);
+    target.removeEventListener('unhandledrejection', onRejection);
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,11 @@ import "./styles/globals.css";
 import { ThemeProvider } from "./components/theme/ThemeProvider";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { I18nProvider } from "./components/i18n/I18nProvider";
+import { installCrashHandlers } from "./lib/crashLog";
+
+// Route uncaught errors to the crash log before the app mounts — on a release
+// build there is no reachable console, so this is the only record (#379).
+installCrashHandlers();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,9 @@
+// First import, so its side effect (installing the uncaught-error handlers)
+// runs before the app's module graph evaluates — a module-init throw would
+// otherwise happen before any handler existed and leave no crash log (#381
+// review).
+import "./lib/bootstrapCrashHandlers";
+
 // The system webview (WKWebView / WebView2 / WebKitGTK) has no Node `Buffer`,
 // which @mongodb-js/shell-bson-parser needs to parse UUID(…) / BinData(…) in the
 // query bar. Provide it before anything that might parse a query loads.
@@ -13,11 +19,6 @@ import "./styles/globals.css";
 import { ThemeProvider } from "./components/theme/ThemeProvider";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { I18nProvider } from "./components/i18n/I18nProvider";
-import { installCrashHandlers } from "./lib/crashLog";
-
-// Route uncaught errors to the crash log before the app mounts — on a release
-// build there is no reachable console, so this is the only record (#379).
-installCrashHandlers();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
Gives uncaught frontend errors a durable home — the diagnosis gap behind #379.

Stacked on #380 (which adds the error boundary this forwards from); base is `fix/379-tab-crash-error-boundary`, so this diff is only the logging.

### Why
The app has **no logging of any kind**. An uncaught render error, a `window.onerror`, or an `unhandledrejection` left no trace, and a release build has no reachable console — so the user in #379 could only report a blank screen. There was nothing to attach.

### What
- **`log_frontend_error`** (Rust command) appends timestamped records to `frontend-errors.log` under the OS log dir (macOS `~/Library/Logs/<id>/`, Windows `%LOCALAPPDATA%\<id>\logs\`). App-local — no DB connection — so no capability change is needed; classified as such in `command_coverage`. Best-effort and size-capped, so logging a crash can neither raise one nor grow without bound.
- **`installCrashHandlers()`** (from `main.tsx`, before mount) forwards `error` and `unhandledrejection` events.
- **`TabErrorBoundary.componentDidCatch`** forwards what React caught — which by definition never reaches `window.onerror`, i.e. the #379 case itself.

### Verification
`cargo check` clean. Frontend units cover the command bridge swallowing failures, the global handlers logging then detaching, and the boundary forwarding its caught error with the component stack.

**Gap:** what can't be checked here is the file actually landing at the OS log path at runtime — the test binary can't launch in the author's Windows env, and jsdom has no Tauri host. CI compiles the command; a real run on the target OS confirms the write. Worth a manual check before release.
