### PR TITLE
fix(connections): narrow the live-profile retarget race on save (part of #371)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3048,8 +3048,15 @@ fn canonical_connection_uri(uri: &str) -> String {
         Some((q, f)) => (q, Some(f)),
         None => (rest, None),
     };
+    // Sort by option KEY only, and stably. Sorting the whole `key=value` string
+    // would reorder repeated `readPreferenceTags`, whose URI order MongoDB
+    // honors as ordered read-routing fallbacks — so a change to that order on a
+    // live profile would wrongly canonicalize as unchanged and slip past the
+    // guard (#384 review). A stable sort by key canonicalizes the order of
+    // distinct options while preserving the relative order of any repeated one.
+    let key_of = |p: &str| p.split_once('=').map(|(k, _)| k).unwrap_or(p).to_string();
     let mut params: Vec<&str> = query.split('&').filter(|p| !p.is_empty()).collect();
-    params.sort_unstable();
+    params.sort_by(|a, b| key_of(a).cmp(&key_of(b)));
     let mut out = format!("{base}?{}", params.join("&"));
     if let Some(f) = fragment {
         out.push('#');

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3017,6 +3017,25 @@ async fn load_connection_profiles(
     connections::load_profiles_encrypted(&connections::get_profiles_enc_path(&app_handle), &key)
 }
 
+/// Whether saving `incoming` over an existing profile would move its server
+/// (uri or ssh) while a live connection still depends on the old one.
+///
+/// The connection editor cannot make connect-and-save atomic across windows
+/// (#371): another window can hold a live connection to this profile while the
+/// save is in flight, and overwriting the server out from under it would leave
+/// that session — and its restored tabs on the next launch — pointing at a
+/// different database than the profile now names. Only a server change matters;
+/// renaming, recolouring or changing the connection mode of a live profile is
+/// harmless and stays allowed.
+fn would_retarget_live_profile(
+    existing: &connections::ConnectionProfile,
+    incoming: &connections::ConnectionProfile,
+    meta: &std::collections::HashMap<String, ConnectionMeta>,
+) -> bool {
+    let server_changed = existing.uri != incoming.uri || existing.ssh != incoming.ssh;
+    server_changed && meta.values().any(|m| m.profile_id == incoming.id)
+}
+
 #[tauri::command]
 async fn save_connection_profile(
     app_handle: tauri::AppHandle,
@@ -3053,6 +3072,15 @@ async fn save_connection_profile_inner(
     let mut profiles = connections::load_profiles_encrypted(&path, &key)?;
     profile.uri = connections::normalize_mongodb_uri_options(&profile.uri);
     if let Some(pos) = profiles.iter().position(|p| p.id == profile.id) {
+        // Refuse to move a live profile's server (#371 / #383 review). See
+        // `would_retarget_live_profile`.
+        let meta = state.connection_meta.lock_safe()?;
+        if would_retarget_live_profile(&profiles[pos], profile, &meta) {
+            return Err(
+                "This connection is open in another window. Close it there before changing its server, so that session isn't left pointing at the old one."
+                    .to_string(),
+            );
+        }
         profiles[pos] = profile.clone();
     } else {
         profiles.push(profile.clone());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3048,14 +3048,26 @@ fn canonical_connection_uri(uri: &str) -> String {
         Some((q, f)) => (q, Some(f)),
         None => (rest, None),
     };
-    // Sort by option KEY only, and stably. Sorting the whole `key=value` string
-    // would reorder repeated `readPreferenceTags`, whose URI order MongoDB
-    // honors as ordered read-routing fallbacks — so a change to that order on a
-    // live profile would wrongly canonicalize as unchanged and slip past the
-    // guard (#384 review). A stable sort by key canonicalizes the order of
-    // distinct options while preserving the relative order of any repeated one.
+    // Lower-case the option KEY (MongoDB option names are case-insensitive, and
+    // the normalizer only lower-cases the ones it rewrites, so `TLS` vs `tls`
+    // would otherwise read as different — #384 review). Values are left as-is,
+    // since option values (tag sets, file paths) are case-sensitive.
+    let canonical_param = |p: &str| match p.split_once('=') {
+        Some((k, v)) => format!("{}={}", k.to_ascii_lowercase(), v),
+        None => p.to_ascii_lowercase(),
+    };
     let key_of = |p: &str| p.split_once('=').map(|(k, _)| k).unwrap_or(p).to_string();
-    let mut params: Vec<&str> = query.split('&').filter(|p| !p.is_empty()).collect();
+    // Sort by key only, and stably. Sorting the whole `key=value` string would
+    // reorder repeated `readPreferenceTags`, whose URI order MongoDB honors as
+    // ordered read-routing fallbacks — so a change to that order on a live
+    // profile would wrongly canonicalize as unchanged and slip past the guard
+    // (#384 review). A stable sort by key canonicalizes the order of distinct
+    // options while preserving the relative order of any repeated one.
+    let mut params: Vec<String> = query
+        .split('&')
+        .filter(|p| !p.is_empty())
+        .map(canonical_param)
+        .collect();
     params.sort_by(|a, b| key_of(a).cmp(&key_of(b)));
     let mut out = format!("{base}?{}", params.join("&"));
     if let Some(f) = fragment {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3027,18 +3027,44 @@ async fn load_connection_profiles(
 /// different database than the profile now names. Only a server change matters;
 /// renaming, recolouring or changing the connection mode of a live profile is
 /// harmless and stays allowed.
+/// A mongodb URI reduced to a form two equivalent URIs share, for deciding
+/// whether a save actually moves the server.
+///
+/// `normalize_mongodb_uri_options` folds equivalent option spellings
+/// (`ssl`→`tls`, …) but keeps option ORDER, so a profile imported or saved with
+/// its query options in a different order than the editor's `buildUri` emits
+/// would otherwise read as a server change on a rename-only edit (#384 review).
+/// Sorting the query options removes that false difference. Host order and
+/// other deeper equivalences are deliberately not canonicalized here — this
+/// stays a conservative comparison whose worst case is asking the user to
+/// disconnect before a metadata edit, never missing a real server change.
+fn canonical_connection_uri(uri: &str) -> String {
+    let normalized = connections::normalize_mongodb_uri_options(uri);
+    let (base, rest) = match normalized.split_once('?') {
+        None => return normalized,
+        Some(parts) => parts,
+    };
+    let (query, fragment) = match rest.split_once('#') {
+        Some((q, f)) => (q, Some(f)),
+        None => (rest, None),
+    };
+    let mut params: Vec<&str> = query.split('&').filter(|p| !p.is_empty()).collect();
+    params.sort_unstable();
+    let mut out = format!("{base}?{}", params.join("&"));
+    if let Some(f) = fragment {
+        out.push('#');
+        out.push_str(f);
+    }
+    out
+}
+
 fn would_retarget_live_profile(
     existing: &connections::ConnectionProfile,
     incoming: &connections::ConnectionProfile,
     meta: &std::collections::HashMap<String, ConnectionMeta>,
 ) -> bool {
-    // Compare normalized forms on both sides. The incoming uri is normalized
-    // before it reaches here, but the stored one may use an older-but-equivalent
-    // spelling (e.g. `?ssl=true` vs `?tls=true`); a raw comparison would read
-    // that as a server change and wrongly refuse a metadata-only edit (#384
-    // review).
-    let server_changed = connections::normalize_mongodb_uri_options(&existing.uri)
-        != connections::normalize_mongodb_uri_options(&incoming.uri)
+    let server_changed = canonical_connection_uri(&existing.uri)
+        != canonical_connection_uri(&incoming.uri)
         || existing.ssh != incoming.ssh;
     server_changed && meta.values().any(|m| m.profile_id == incoming.id)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3032,7 +3032,14 @@ fn would_retarget_live_profile(
     incoming: &connections::ConnectionProfile,
     meta: &std::collections::HashMap<String, ConnectionMeta>,
 ) -> bool {
-    let server_changed = existing.uri != incoming.uri || existing.ssh != incoming.ssh;
+    // Compare normalized forms on both sides. The incoming uri is normalized
+    // before it reaches here, but the stored one may use an older-but-equivalent
+    // spelling (e.g. `?ssl=true` vs `?tls=true`); a raw comparison would read
+    // that as a server change and wrongly refuse a metadata-only edit (#384
+    // review).
+    let server_changed = connections::normalize_mongodb_uri_options(&existing.uri)
+        != connections::normalize_mongodb_uri_options(&incoming.uri)
+        || existing.ssh != incoming.ssh;
     server_changed && meta.values().any(|m| m.profile_id == incoming.id)
 }
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -7300,6 +7300,17 @@ mod change_stream_tests {
         }
 
         #[test]
+        fn allows_a_rename_when_only_option_key_case_differs() {
+            // Option names are case-insensitive; only the ones the normalizer
+            // rewrites get lower-cased, so `TLS` vs `tls` would otherwise read as
+            // a change and refuse a rename-only edit (#384 review).
+            let existing = profile("p1", "mongodb://h:27017/?TLS=true&directConnection=true");
+            let mut incoming = profile("p1", "mongodb://h:27017/?tls=true&directConnection=true");
+            incoming.name = "Prod (renamed)".to_string();
+            assert!(!would_retarget_live_profile(&existing, &incoming, &live("p1")));
+        }
+
+        #[test]
         fn refuses_when_repeated_read_preference_tag_order_changes_while_live() {
             // readPreferenceTags is order-sensitive: MongoDB tries the tag sets
             // in URI order. Reordering them changes which members serve reads,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -7277,6 +7277,17 @@ mod change_stream_tests {
         }
 
         #[test]
+        fn allows_a_rename_when_the_stored_uri_is_an_equivalent_older_spelling() {
+            // Stored with the older `ssl` spelling; the incoming save is already
+            // normalized to `tls`. Same server — a raw string compare would call
+            // it a change and refuse this rename-only edit (#384 review).
+            let existing = profile("p1", "mongodb://server:27017/?ssl=true");
+            let mut incoming = profile("p1", "mongodb://server:27017/?tls=true");
+            incoming.name = "Prod (renamed)".to_string();
+            assert!(!would_retarget_live_profile(&existing, &incoming, &live("p1")));
+        }
+
+        #[test]
         fn refuses_when_only_the_ssh_tunnel_changes_while_live() {
             let existing = profile("p1", "mongodb://server:27017");
             let mut incoming = profile("p1", "mongodb://server:27017");

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -7212,5 +7212,83 @@ mod change_stream_tests {
         );
         retiring.join().expect("retiring thread");
     }
+
+    // ---- save_connection_profile: don't retarget a live profile (#371) -----
+
+    mod retarget_live_profile {
+        use crate::connections::{ConnectionProfile, ConnectionMode};
+        use crate::state::ConnectionMeta;
+        use crate::would_retarget_live_profile;
+        use std::collections::HashMap;
+
+        fn profile(id: &str, uri: &str) -> ConnectionProfile {
+            ConnectionProfile {
+                id: id.to_string(),
+                name: "Prod".to_string(),
+                uri: uri.to_string(),
+                color_tag: None,
+                ssh: None,
+                mcp_enabled: false,
+                connection_mode: ConnectionMode::default(),
+            }
+        }
+
+        /// `profile_id` has a live connection registered.
+        fn live(profile_id: &str) -> HashMap<String, ConnectionMeta> {
+            let mut m = HashMap::new();
+            m.insert(
+                "live-conn-1".to_string(),
+                ConnectionMeta {
+                    profile_id: profile_id.to_string(),
+                    name: "Prod".to_string(),
+                    via_mcp: false,
+                    mode: ConnectionMode::default(),
+                },
+            );
+            m
+        }
+
+        #[test]
+        fn refuses_when_the_server_changes_and_the_profile_is_live() {
+            let existing = profile("p1", "mongodb://old-server:27017");
+            let incoming = profile("p1", "mongodb://new-server:27017");
+            assert!(would_retarget_live_profile(&existing, &incoming, &live("p1")));
+        }
+
+        #[test]
+        fn allows_a_name_only_change_while_live() {
+            let existing = profile("p1", "mongodb://server:27017");
+            let mut incoming = profile("p1", "mongodb://server:27017");
+            incoming.name = "Prod (renamed)".to_string();
+            incoming.color_tag = Some("#fff".to_string());
+            incoming.connection_mode = ConnectionMode::ReadOnly;
+            // Same server — only the label/mode changed — so it must not be blocked.
+            assert!(!would_retarget_live_profile(&existing, &incoming, &live("p1")));
+        }
+
+        #[test]
+        fn allows_a_server_change_when_the_profile_is_not_live() {
+            let existing = profile("p1", "mongodb://old:27017");
+            let incoming = profile("p1", "mongodb://new:27017");
+            // A different profile is live, not this one.
+            assert!(!would_retarget_live_profile(&existing, &incoming, &live("p2")));
+            // And with nothing live at all.
+            assert!(!would_retarget_live_profile(&existing, &incoming, &HashMap::new()));
+        }
+
+        #[test]
+        fn refuses_when_only_the_ssh_tunnel_changes_while_live() {
+            let existing = profile("p1", "mongodb://server:27017");
+            let mut incoming = profile("p1", "mongodb://server:27017");
+            incoming.ssh = Some(crate::ssh_tunnel::SshConfig {
+                enabled: true,
+                host: "bastion.example.com".to_string(),
+                port: 22,
+                user: "deploy".to_string(),
+                auth: crate::ssh_tunnel::SshAuth::Agent,
+            });
+            assert!(would_retarget_live_profile(&existing, &incoming, &live("p1")));
+        }
+    }
 }
 

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -7300,6 +7300,23 @@ mod change_stream_tests {
         }
 
         #[test]
+        fn refuses_when_repeated_read_preference_tag_order_changes_while_live() {
+            // readPreferenceTags is order-sensitive: MongoDB tries the tag sets
+            // in URI order. Reordering them changes which members serve reads,
+            // so it IS a server change and must be caught — the canonical form
+            // must not sort repeated keys against each other (#384 review).
+            let existing = profile(
+                "p1",
+                "mongodb://h:27017/?readPreferenceTags=dc:ny&readPreferenceTags=dc:sf",
+            );
+            let incoming = profile(
+                "p1",
+                "mongodb://h:27017/?readPreferenceTags=dc:sf&readPreferenceTags=dc:ny",
+            );
+            assert!(would_retarget_live_profile(&existing, &incoming, &live("p1")));
+        }
+
+        #[test]
         fn refuses_when_only_the_ssh_tunnel_changes_while_live() {
             let existing = profile("p1", "mongodb://server:27017");
             let mut incoming = profile("p1", "mongodb://server:27017");

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -7288,6 +7288,18 @@ mod change_stream_tests {
         }
 
         #[test]
+        fn allows_a_rename_when_stored_options_are_in_a_different_order() {
+            // Same options, different order (an imported profile vs the editor's
+            // fixed buildUri order). Normalization keeps order, so a plain
+            // compare would call this a server change; canonicalization sorts
+            // the options so a rename-only edit is allowed (#384 review).
+            let existing = profile("p1", "mongodb://h:27017/?tls=true&directConnection=true");
+            let mut incoming = profile("p1", "mongodb://h:27017/?directConnection=true&tls=true");
+            incoming.name = "Prod (renamed)".to_string();
+            assert!(!would_retarget_live_profile(&existing, &incoming, &live("p1")));
+        }
+
+        #[test]
         fn refuses_when_only_the_ssh_tunnel_changes_while_live() {
             let existing = profile("p1", "mongodb://server:27017");
             let mut incoming = profile("p1", "mongodb://server:27017");


### PR DESCRIPTION
Part of #371. **Narrows** (does not fully close) the profile-reservation race the review re-raised on #383.

### The race
The connection editor can't make connect-and-save atomic across windows. While `save_connection_profile` awaits the write, another window can hold a live connection to the same profile; overwriting its `uri`/`ssh` leaves that session — and its restored tabs on next launch — pointing at a different database than the profile now names.

### What this does
`save_connection_profile` refuses to persist a change to an existing profile's **server** (`uri`/`ssh`) while that profile has a live connection registered in `connection_meta`. Renaming, recolouring, or changing the connection mode of a live profile stays allowed. Both URIs are compared in normalized form, so an older-but-equivalent stored spelling (`?ssl=true` vs `?tls=true`) doesn't misfire on a metadata-only edit. Decision extracted as `would_retarget_live_profile`, unit-tested (server change / name-only / not-live / ssh-only / normalized-equivalent).

### Known residual gap (why this narrows, not closes)
`connection_meta` is registered by a **separate** frontend `set_connection_meta` call *after* `connect_db` returns. In the window between connect and register, the guard sees the profile as "not live" and still permits the retarget. Closing that requires reserving the profile **at connect time in the backend**, serialized with the save — a change to `connect_db`'s lifecycle across every connect path and the cross-window meta broadcast. That remains tracked in #371 as a deliberate follow-up with its own multi-window testing; this PR does not attempt it. (Left the corresponding review thread open to reflect that.)

### Behaviour note
Changing the connection string of a profile you're connected to in your own window now asks you to disconnect first — consistent with the profile list already refusing to connect an already-active profile.

### Verification
`cargo check` (lib + tests) clean; CI runs the unit tests. The multi-window path can't be exercised in the author's environment.
